### PR TITLE
depoying and updating the Device schema

### DIFF
--- a/src/device-registry/.gcloudignore
+++ b/src/device-registry/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/src/device-registry/app.yaml
+++ b/src/device-registry/app.yaml
@@ -1,0 +1,6 @@
+runtime: nodejs10
+service: device-registry
+env_variables:
+  TS_API_KEY: "JQZOU97VDLX7OTDH"
+  MLAB_USERNAME: "bal"
+  MLAB_PASSWORD: "kanye1"

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -26,7 +26,7 @@ const deviceSchema = new mongoose.Schema({
         trim: true,
     },
     owner: {
-        type: String,
+        type: ObjectId,
         require: [true, 'owner is required']
     },
     description: {
@@ -65,6 +65,9 @@ const deviceSchema = new mongoose.Schema({
             trim: true,
         },
     },
+    sensors: [{
+        type: ObjectId, ref: 'sensor'
+    }],
 }, {
     timestamps: true
 });
@@ -85,7 +88,8 @@ deviceSchema.methods = {
             height: this.height,
             description: this.description,
             mobile: this.mobile,
-            distanceToRoad: this.distanceToRoad
+            distanceToRoad: this.distanceToRoad,
+            sensors: this.sensors
 
         }
     }

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -2,7 +2,9 @@
     "name": "device-registry",
     "version": "0.0.0",
     "private": true,
+    "main": "./bin/www",
     "scripts": {
+        "start": "node ./bin/www",
         "dev": "NODE_ENV=development nodemon ./bin/www",
         "prod": "NODE_ENV=production nodemon ./bin/www",
         "test": "NODE_ENV=test nodemon ./bin/www",


### PR DESCRIPTION
The device registry API can be tested out in production using: https://device-registry-dot-airqo-250220.appspot.com

More details can be found in the **Device Registry** sheet in the [API documentation](https://docs.google.com/spreadsheets/d/1ntm2v21wJHxVK-hwOuOPELWFgMZMjwQT/edit#gid=1463061272)
