### PR TITLE
updated get_pm25_category_location_count_for_the_lasthour function

### DIFF
--- a/src/analytics/models/dashboard.py
+++ b/src/analytics/models/dashboard.py
@@ -95,11 +95,7 @@ class Dashboard():
         Returns:
             A list of the number of daily exceedences for the specified pollutant and standard in the past 28 days.
         """       
-        created_at = helpers.str_to_date(helpers.date_to_str(datetime.now().replace(microsecond=0, second=0, minute=0)-timedelta(hours=1)))
-        #print(created_at)        
-        query = {'$match':{ 'created_at': {'$gte': created_at}, 'Organisation':organisation_name }}
-        projection = { '$project': { '_id': 0 }}
-        results = list(app.mongo.db.pm25_location_categorycount.aggregate([query, projection]) )       
+        results = list(app.mongo.db.pm25_location_categorycount.find().sort([('$natural',-1)]).limit(1))        
         return results
 
         


### PR DESCRIPTION
**What does this PR do?**
This PR just updates the endpoint for displaying the pm25 category count 
**What JIRA task is related to this PR?**
No card
**How do I test out this PR?**
 -Git clone this repo cd AirQo-api/src/analytics
- checkout branch  fix-dashboard-cards 
- run flask app to test out the end points using any REST client tool available to you.
**Which end points should are ready for testing?**
Base url: http://127.0.0.1:5000/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA