### PR TITLE
updating device registry

### DIFF
--- a/src/device-registry/Dockerfile
+++ b/src/device-registry/Dockerfile
@@ -20,4 +20,4 @@ COPY . .
 RUN chmod 777 /usr/src/app/bin/www
 
 EXPOSE 3000
-CMD [ "npm", "run","prod" ] 
+CMD [ "npm", "run","start" ] 

--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -24,32 +24,6 @@ const devConfig = {
     field8: "SO3",
   },
 };
-const testConfig = {
-  MONGO_URL: `mongodb://localhost/`,
-  DB_NAME: process.env.MONGO_TEST,
-  JWT_SECRET: process.env.JWT_SECRET,
-  REGION: "europe-west1",
-  MQTT_BRIDGE_HOST_NAME: "mqtt.googleapis.com",
-  MQTT_BRIDGE_PORT: 8883,
-  NUM_MESSAGES: 5,
-  TOKEN_EXP_MINS: 360,
-  ALGORITHM: "RS256",
-  HTTP_BRIDGE_ADDRESS: "cloudiotdevice.googleapis.com",
-  MESSAGE_TYPE: "events",
-  MINIMUM_BACKOFF_TIME: 1,
-  MAXIMUM_BACKOFF_TIME: 32,
-  DEVICE_CREATION: {
-    field1: "Sensor1 PM2.5",
-    field2: "Sensor1 PM10",
-    field3: "Sensor2 PM2.5",
-    field4: "Sensor2 PM10",
-    field5: "Humidity",
-    field5: "Battery Voltage",
-    field6: "Temperature",
-    field7: "NO2",
-    field8: "SO3",
-  },
-};
 const prodConfig = {
   REGION: "europe-west1",
   MQTT_BRIDGE_HOST_NAME: "mqtt.googleapis.com",
@@ -112,8 +86,6 @@ function envConfig(env) {
   switch (env) {
     case "development":
       return devConfig;
-    case "test":
-      return testConfig;
     case "staging":
       return stageConfig;
     default:

--- a/src/device-registry/controllers/device.js
+++ b/src/device-registry/controllers/device.js
@@ -113,18 +113,27 @@ const device = {
       ...constants.DEVICE_CREATION,
     };
     try {
-      console.log("creating one device....");
-      const device = await Device.createDevice(req.body);
       await axios
         .post(baseUrl, bodyPrep)
         .then((response) => {
           console.log("the response...");
           console.dir(response.data);
-          let output = response.data;
-          return res.status(HTTPStatus.CREATED).json({
-            success: true,
-            message: "successfully created the device",
-            device,
+          let channelID = response.data.id;
+          let deviceBody = {
+            ...req.body,
+            channelID: channelID,
+          };
+
+          console.log("creating one device....");
+          const device = Device.createDevice(deviceBody);
+          device.then((device) => {
+            console.log("the device...");
+            console.dir(device);
+            return res.status(HTTPStatus.CREATED).json({
+              success: true,
+              message: "successfully created the device",
+              device,
+            });
           });
         })
         .catch((e) => {

--- a/src/device-registry/controllers/sense.js
+++ b/src/device-registry/controllers/sense.js
@@ -1,0 +1,80 @@
+const Sensor = require("../models/Sensor");
+const HTTPStatus = require("http-status");
+
+const sense = {
+  listAll: async (req, res) => {
+    const limit = parseInt(req.query.limit, 0);
+    const skip = parseInt(req.query.skip, 0);
+
+    try {
+      const sensors = await Sensor.list({ limit, skip });
+      return res.status(HTTPStatus.OK).json(sensors);
+    } catch (e) {
+      return res.status(HTTPStatus.BAD_REQUEST).json(e);
+    }
+  },
+
+  addSensor: async (req, res) => {
+    try {
+      const sensor = await Sensor.createSensor(req.body, req.params.d_id);
+      return res.status(HTTPStatus.CREATED).json(sensor);
+    } catch (e) {
+      return res.status(HTTPStatus.BAD_REQUEST).json(e);
+    }
+  },
+
+  listOne: async (req, res) => {
+    try {
+      const sensor = await Sensor.findById(req.params.s_id);
+      return res.status(HTTPStatus.OK).json(sensor);
+    } catch (e) {
+      return res.status(HTTPStatus.BAD_REQUEST).json(e);
+    }
+  },
+
+  delete: async (req, res) => {
+    try {
+      const sensor = await Sensor.findById(req.params.s_id);
+      const device = await Device.findById(req.params.d_id);
+      if (!sensor.owner.equals(req.user._id)) {
+        return res.status(HTTPStatus.UNAUTHORIZED);
+      }
+      await device._sensors.remove(req.params.s_id);
+      await sensor.remove();
+      return res.status(HTTPStatus.OK);
+    } catch (e) {
+      return res.status(HTTPStatus.BAD_REQUEST).json(e);
+    }
+  },
+
+  update: async (req, res) => {
+    console.log("we are updating...1");
+    try {
+      console.log("we are updating...2");
+      const sensor = await Sensor.findById(req.params.s_id);
+      if (!sensor.owner.equals(req.user)) {
+        return res.status(HTTPStatus.UNAUTHORIZED);
+      }
+      Object.keys(req.body).forEach((key) => {
+        sensor[key] = req.body[key];
+      });
+      return res.status(HTTPStatus.OK).json(await sensor.save());
+    } catch (e) {
+      return res.status(HTTPStatus.BAD_REQUEST).json(e);
+    }
+  },
+
+  addValue: async (req, res) => {
+    try {
+      //check the rights of the current user
+      if (!sensor.owner.equals(req.user._id)) {
+        res.status(HTTPStatus.UNAUTHORIZED);
+      }
+      //update the events schema with the value
+    } catch (e) {
+      res.status(HTTPStatus.BAD_REQUEST).json(e);
+    }
+  },
+};
+
+module.exports = sense;

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -99,6 +99,10 @@ const deviceSchema = new mongoose.Schema(
     nextMaintenance: {
       type: Date,
     },
+    channelID: {
+      type: Number,
+      required: [true, "Channel ID is required!"],
+    },
   },
   {
     timestamps: true,
@@ -127,6 +131,7 @@ deviceSchema.methods = {
       isPrimaryInLocation: this.isPrimaryInLocation,
       isUsedForCollocation: this.isUsedForCollocation,
       nextMaintenance: this.nextMaintenance,
+      channelID: this.channelID,
     };
   },
 };

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -81,6 +81,7 @@ const deviceSchema = new mongoose.Schema(
     },
     location_id: {
       type: String,
+      default: "none",
     },
     host: {
       name: String,
@@ -128,6 +129,9 @@ deviceSchema.methods = {
       isUsedForCollocation: this.isUsedForCollocation,
       nextMaintenance: this.nextMaintenance,
       channelID: this.channelID,
+      powerType: this.powerType,
+      mountType: this.mountType,
+      location_id: this.location_id,
     };
   },
 };

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -58,10 +58,6 @@ const deviceSchema = new mongoose.Schema(
       type: Number,
       default: 0,
     },
-    distanceToRoad: {
-      type: Number,
-      default: 0,
-    },
     mountType: {
       type: String,
       default: "pole",

--- a/src/device-registry/models/Sensor.js
+++ b/src/device-registry/models/Sensor.js
@@ -4,69 +4,23 @@ const ObjectId = Schema.Types.ObjectId;
 
 const sensorSchema = new Schema(
   {
-    quantity_kind: {
-      type: String,
-      required: [true, "The quantity kind is required"],
-      trim: true,
-    },
+    quantityKind: [
+      {
+        type: String,
+        required: [true, "The quantity kind is required"],
+        trim: true,
+      },
+    ],
     name: {
       type: String,
       required: [true, "The name is required"],
       trim: true,
+    },
+    sensorID: {
+      type: String,
+      required: [true, "The sensorID is required"],
+      trim: true,
       unique: true,
-    },
-    unit: {
-      type: String,
-      required: [true, "The unit is required"],
-      trim: true,
-    },
-    kind: {
-      type: String,
-      required: [true, "The sensor kind is required"],
-      trim: true,
-    },
-    description: {
-      type: String,
-      required: [true, "description is required"],
-      trim: true,
-    },
-    model: {
-      type: String,
-      required: [true, "the sensor model is required"],
-    },
-    date_manufactured: {
-      type: String,
-      required: [true, "date of manufature is needed"],
-    },
-    serial_number: {
-      type: String,
-      required: [true, "this serial number is also required"],
-    },
-    device: {
-      type: ObjectId,
-      required: [true, "the device is required"],
-      ref: "device",
-    },
-    owner: {
-      type: ObjectId,
-      required: [true, "owner is required"],
-      ref: "user",
-    },
-    values: {
-      type: ObjectId,
-      required: [true, "the value of the sensor is required"],
-      ref: "event",
-    },
-    linear: {
-      enabled: false,
-      value_max: {
-        sensor_value: { type: Number, default: 0 },
-        real_value: { type: Number, default: 0 },
-      },
-      value_min: {
-        sensor_value: { type: Number, default: 0 },
-        real_value: { type: Number, default: 0 },
-      },
     },
   },
   {
@@ -88,15 +42,9 @@ sensorSchema.methods = {
     return {
       _id: this._id,
       name: this.name,
-      kind: this.kind,
-      quantity_kind: this.quantity_kind,
-      unit: this.unit,
+      sensorID: this.sensorID,
+      quantityKind: this.quantityKind,
       createdAt: this.createdAt,
-      owner: this.owner,
-      description: this.description,
-      model: this.model,
-      device: this.device,
-      values: this.values,
     };
   },
 };

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -5,10 +5,12 @@
     "main": "./bin/www",
     "scripts": {
         "start": "node ./bin/www",
-        "dev": "NODE_ENV=development nodemon ./bin/www",
-        "prod": "NODE_ENV=production nodemon ./bin/www",
-        "test": "NODE_ENV=test nodemon ./bin/www",
-        "stage": "NODE_ENV=staging nodemon ./bin/www",
+        "dev-mac": "NODE_ENV=development nodemon ./bin/www",
+        "prod-mac": "NODE_ENV=production nodemon ./bin/www",
+        "stage-mac": "NODE_ENV=staging nodemon ./bin/www",
+        "dev-pc": "set NODE_ENV=development nodemon ./bin/www",
+        "prod-pc": "set NODE_ENV=production nodemon ./bin/www",
+        "stage-pc": "set NODE_ENV=staging nodemon ./bin/www",
         "prettier": "prettier --single-quote --print-width 80 --trailing-comma all --write 'src/**/*.js'"
     },
     "dependencies": {

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -6,11 +6,11 @@
     "scripts": {
         "start": "node ./bin/www",
         "dev-mac": "NODE_ENV=development nodemon ./bin/www",
-        "prod-mac": "NODE_ENV=production nodemon ./bin/www",
-        "stage-mac": "NODE_ENV=staging nodemon ./bin/www",
-        "dev-pc": "set NODE_ENV=development nodemon ./bin/www",
-        "prod-pc": "set NODE_ENV=production nodemon ./bin/www",
-        "stage-pc": "set NODE_ENV=staging nodemon ./bin/www",
+        "prod-mac": "NODE_ENV=production node ./bin/www",
+        "stage-mac": "NODE_ENV=staging node ./bin/www",
+        "dev-pc": "set NODE_ENV=development node ./bin/www",
+        "prod-pc": "set NODE_ENV=production node ./bin/www",
+        "stage-pc": "set NODE_ENV=staging node ./bin/www",
         "prettier": "prettier --single-quote --print-width 80 --trailing-comma all --write 'src/**/*.js'"
     },
     "dependencies": {

--- a/src/device-registry/routes/api.js
+++ b/src/device-registry/routes/api.js
@@ -7,6 +7,7 @@ const deviceValidation = require("../utils/validations");
 const validate = require("express-validation");
 const mqttBridge = require("../controllers/mqtt-bridge");
 const httpBridge = require("../controllers/http-bridge");
+const sensorController = require("../controllers/sense");
 
 middlewareConfig(router);
 
@@ -40,6 +41,7 @@ router.delete("/ts/delete", deviceController.deleteThing);
 router.delete("/ts/clear", deviceController.clearThing);
 router.put("/ts/update", deviceController.updateThingSettings);
 router.post("/ts/deploy/device", deviceController.deployDevice);
+router.get("/get/sensors", sensorController.listAll);
 
 //configuration of devices
 // router.get('/mqtt/config/gcp', mqttBridge.reviewConfigs);


### PR DESCRIPTION
- What does this PR do?
This PR introduces new endpoints for device registry

- What JIRA task is related to this PR?
No link available

- How do I test out this PR?
Git clone this repo `cd AirQo-api/src/device-registry`
Create a docker image locally: `docker build -t us.gcr.io/airqo-250220/airqo-device-registry-api .`
Afterwards, run the newly created image: `docker run -d -p 5000:3000 us.gcr.io/airqo-250220/airqo-device-registry-api`
Using your REST client, test out all the endpoints for the` device-registry`, use port 5000 as specified above or change to what you would like to use.

**Alternatively.......**
 `cd AirQo-api/src/device-registry`
`npm install`

For MAC users....
`npm run prod-mac` for "production"
`npm run dev-mac` for "development"

For Windows users
`npm run prod-pc` for  "production"
`npm run dev-pc` for  "development"


- Which end points should are ready for testing?
`Get All Sensors` and `Create Thing` inside the `device-registry` sheet of the [API documentation](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=897606332).

- **OPTIONAL for testing:** 
One could also push to the Google Container Registry using `docker push us.gcr.io/airqo-250220/airqo-device-registry-api`