### PR TITLE
Updates cronjob for checking device status

### DIFF
--- a/src/device-monitoring/jobs/check_device_status.py
+++ b/src/device-monitoring/jobs/check_device_status.py
@@ -125,7 +125,7 @@ def get_device_channel_status():
 
         print(device_status_results)
 
-        #save_hourly_device_status_check_results(device_status_results)       
+        save_hourly_device_status_check_results(device_status_results)       
         
 
 

--- a/src/device-monitoring/jobs/check_device_status.py
+++ b/src/device-monitoring/jobs/check_device_status.py
@@ -70,7 +70,7 @@ def get_all_devices():
     return active_devices
 
 def get_device_channel_status():
-        BASE_API_URL='https://data-manager-dot-airqo-250220.appspot.com/api/v1/data/'
+        BASE_API_URL='https://data-manager-dot-airqo-250220.uc.r.appspot.com/api/v1/data/'
         
         api_url = '{0}{1}'.format(BASE_API_URL,'channels')
         print(api_url)         
@@ -89,21 +89,21 @@ def get_device_channel_status():
                 result = latest_device_status_response.json()
                 count += 1
                 current_datetime=   datetime.now()
-                if 'feed' in result:
-                    date_time_difference = current_datetime - datetime.strptime(result['feed']['created_at'], '%Y-%m-%dT%H:%M:%SZ')
-                    date_time_difference_in_hours = date_time_difference.total_seconds() / 3600
-                    date_time_difference_in_seconds = date_time_difference.total_seconds()
-                    print(date_time_difference_in_hours)
-                    if date_time_difference_in_hours >24: 
-                        count_of_offline_devices += 1
-                        time_offline = convert_seconds_to_days_hours_minutes_seconds(date_time_difference_in_seconds)
-                        time_offline_in_hours = date_time_difference_in_hours
-                        channel['time_offline'] = time_offline
-                        channel['time_offline_in_hours'] = time_offline_in_hours
-                        offline_devices.append(channel)
-                    else : 
-                        count_of_online_devices +=1
-                        online_devices.append(channel)
+                
+                date_time_difference = current_datetime - datetime.strptime(result['created_at'], '%Y-%m-%dT%H:%M:%SZ')
+                date_time_difference_in_hours = date_time_difference.total_seconds() / 3600
+                date_time_difference_in_seconds = date_time_difference.total_seconds()
+                print(date_time_difference_in_hours)
+                if date_time_difference_in_hours >24: 
+                    count_of_offline_devices += 1
+                    time_offline = convert_seconds_to_days_hours_minutes_seconds(date_time_difference_in_seconds)
+                    time_offline_in_hours = date_time_difference_in_hours
+                    channel['time_offline'] = time_offline
+                    channel['time_offline_in_hours'] = time_offline_in_hours
+                    offline_devices.append(channel)
+                else : 
+                    count_of_online_devices +=1
+                    online_devices.append(channel)
 
         print(count)
         print(count_of_online_devices)
@@ -125,7 +125,7 @@ def get_device_channel_status():
 
         print(device_status_results)
 
-        save_hourly_device_status_check_results(device_status_results)       
+        #save_hourly_device_status_check_results(device_status_results)       
         
 
 
@@ -140,8 +140,9 @@ def save_hourly_device_status_check_results(data):
 
 
 if __name__ == '__main__':    
-    #get_device_channel_status()
-    results = get_all_devices()
-    print(len(results))
-    for result in results:
-        print(result)
+    get_device_channel_status()
+    #results = get_all_devices()
+    #print(len(results))
+    #for result in results:
+        #print(result)
+        #print('\n -----------------\n')


### PR DESCRIPTION
**What does this PR do?**
  - This PR addresses the issues that have been preventing visuals i.e graphs & devices on netmanager for offline and online devices to display. It updates job for checking device status to use updated response from data-manager get last entry api.
**What JIRA task is related to this PR?**
   N/A
**How do I test out this PR?**
-  simply check the netmanager device-management visuals and map are showing correctly , since I updated job in the cloud 
or
 - git fetch branch fix-netmanager-device-status
 - change directory to device-monitoring (device monitoring service)
 - run pip install -r requirements.txt to get all the relevant packages.
 - Afterwards update mongo uri  in  jobs\check_device_status.py
-  then on the terminal (in the active environment) run python jobs\check_device_status.py and you should observe computations on the console.
- Confirm that when device management page is opened, map shows devices that are offline/online and piechart for offline/online devices shows up and the table listing offline devices.
**Which end points should are ready for testing?**
   - n/a
![image](https://user-images.githubusercontent.com/8258229/91335540-36b56b00-e7d9-11ea-9b6e-9d6270fd91ca.png)
