### PR TITLE
appropriate response when the username does not exist in org

### DIFF
--- a/src/auth-service/services/auth.js
+++ b/src/auth-service/services/auth.js
@@ -31,9 +31,11 @@ const userLocalStrategy = (tenant, req, res, next) =>
         })
         .exec();
       if (!user) {
-        return done(null, false, { message: "bad man" });
+        return res.status(401).json({
+          success: false,
+          message: "incorrect username or password",
+        });
       } else if (!user.authenticateUser(password)) {
-        // return done(null, false, { message: "bad girl" });
         return res.status(401).json({
           success: false,
           message: "incorrect username or password",
@@ -42,10 +44,10 @@ const userLocalStrategy = (tenant, req, res, next) =>
       return done(null, user);
     } catch (e) {
       logElement("error in services/auth/userLocalStrategy", e.message);
-      // return done(e, false, { message: "bad boy" });
       return res.status(500).json({
         success: false,
         message: "organization does not exist",
+        error: e.message,
       });
     }
   });


### PR DESCRIPTION
# wrong error response when username does not exist in org

**Description**
_The PR updates the response and status code for cases where the username is incorrect_

**JIRA ID:** _https://airqoteam.atlassian.net/browse/PLAT-180?atlOrigin=eyJpIjoiZmJmYjZlOWIyODZkNDRlMGE3ZjA3ZTlkZDFmM2IyMTUiLCJwIjoiaiJ9_

**Unit tests completed?**: (Y)

**PR Branch**
_https://github.com/airqo-platform/AirQo-api/tree/bug-invalid-username_

**Procedure**
`cd AirQo-api/src/auth-service`
`npm install`

> for Windows:

npm run stage-pc

> for Linux

npm run stage-mac

Using an appropriate REST API client, go ahead and try to login with an incorrect username

**Existing endpoints?:** (Y)
http://localhost:3000/api/v1/users/loginUser?tenant={ORGANISATION_NAME}
[API documentation](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=2081265667)


