### PR TITLE
[bug] Unexpected new rows in Events collection

### DIFF
--- a/src/device-registry/controllers/component.js
+++ b/src/device-registry/controllers/component.js
@@ -33,6 +33,22 @@ const getApiKeys = async (deviceName, tenant) => {
 
 const getArrayLength = async (array, model, event) => {};
 
+const generateDateFormat = async (ISODate) => {
+  date = new Date(ISODate);
+  year = date.getFullYear();
+  month = date.getMonth() + 1;
+  dt = date.getDate();
+
+  if (dt < 10) {
+    dt = "0" + dt;
+  }
+  if (month < 10) {
+    month = "0" + month;
+  }
+
+  return `${year}-${month}-${dt}`;
+};
+
 const doesDeviceExist = async (deviceName, tenant) => {
   try {
     logText(".......................................");
@@ -550,7 +566,7 @@ const Component = {
             uncertaintyValue,
             standardDeviationValue,
           };
-          const day = new Date(time);
+          const day = await generateDateFormat(time);
           const eventBody = {
             componentName: component,
             deviceName: device,
@@ -635,7 +651,8 @@ const Component = {
 
         if (isComponentPresent) {
           const samples = values;
-          const day = new Date(time);
+          // const day = new Date(time);
+          const day = generateDateFormat(time);
           const eventBody = {
             componentName: component,
             deviceName: device,


### PR DESCRIPTION
# Unexpected new rows in Events collection

**Description**
This addresses the recently observed issue of new rows during data insertion into the Events table.
As long as measurements for a given component fall on the same day - but different times, the corresponding values array will be updated up to 200 records before a new row is created.

JIRA ID: https://airqoteam.atlassian.net/browse/PLAT-228?atlOrigin=eyJpIjoiNzZiYjQ2YjBkZTE5NGQ1Mjg0YTM5OWZkYjVjNjUwYTMiLCJwIjoiaiJ9

Unit tests completed?: (Y)

**PR Branch**
https://github.com/airqo-platform/AirQo-api/tree/bug-event-entries

**Procedure**
`cd AirQo-api/src/device-registry`
`npm install`

> for Windows

`npm run stage-pc`

> for MAC

`npm run stage-mac`

**Existing endpoints?:** (Y)

- [ ] [POST] http://localhost:3000/api/v1/devices/components/add/values?device={DEVICE_NAME}2&component={COMPONENT_NAME}&tenant={ORGANISATION} 

- [ ] [POST]  http://localhost:3000/api/v1/devices/components/add/values/bulk?device={DEVICE_NAME}2&component={COMPONENT_NAME}&tenant={ORGANISATION} 

More details can be found in the [API documentation](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=897606332).


