### PR TITLE
Staging dockerfile for auth & device-registry microservices

### DIFF
--- a/src/auth-service/Dockerfile.stage.txt
+++ b/src/auth-service/Dockerfile.stage.txt
@@ -1,0 +1,23 @@
+FROM node:12
+
+# Create app directory
+WORKDIR /usr/src/app
+
+RUN chmod 777 /usr/src/app
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+RUN chmod 777 /usr/src/app/bin/www
+
+EXPOSE 3000
+CMD [ "npm", "run", "stage-mac" ]

--- a/src/device-registry/Dockerfile.stage.txt
+++ b/src/device-registry/Dockerfile.stage.txt
@@ -1,0 +1,23 @@
+FROM node:12
+
+# Create app directory
+WORKDIR /usr/src/app
+
+RUN chmod 777 /usr/src/app
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+RUN chmod 777 /usr/src/app/bin/www
+
+EXPOSE 3000
+CMD [ "npm", "run", "stage-mac" ]


### PR DESCRIPTION
# Chore

**_WHAT DOES THIS PR DO?_**
Just adding docker file for the staging environment
**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_HOW DO I TEST OUT THIS PR?_**
Git clone this repo cd AirQo-api/src/auth-service 
`docker build -t stage-auth-service -f Docker.stage.txt .` and `docker run -it -p 4444:3000 stage-auth-service`
Git clone this repo cd AirQo-api/src/device-registry 
`docker build -t stage-device-reg -f Docker.stage.txt .` and `docker run -it -p 5555:3000 stage-device-reg`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
All the endpoint available in the [API documentation](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=897606332)

