### PR TITLE
chore: staging dockerfile for location-registry

### DIFF
--- a/src/location-registry/Dockerfile.stage.txt
+++ b/src/location-registry/Dockerfile.stage.txt
@@ -1,0 +1,36 @@
+FROM gcr.io/google-appengine/python
+
+RUN apt-get update && apt-get install -y \
+  binutils \
+  gdal-bin \
+  python-gdal \
+  libspatialindex-dev
+
+
+# Create a virtualenv for dependencies. This isolates these packages from
+# system-level packages.
+RUN virtualenv /env -p python3.7
+
+# Setting these environment variables are the same as running
+# source /env/bin/activate.
+ENV VIRTUAL_ENV /env
+ENV PATH /env/bin:$PATH
+
+#Setting running environment to production
+ENV FLASK_ENV=testing
+
+# Copy the application's requirements.txt and run pip to install all
+# dependencies into the virtualenv.
+ADD requirements.txt /app/requirements.txt
+RUN pip install -r /app/requirements.txt
+
+# Add the application source code.
+ADD . /app
+
+# Run a WSGI server to serve the application. gunicorn must be declared as
+# a dependency in requirements.txt.
+# CMD gunicorn -t 280 -b :$PORT app:app
+# EXPOSE 4000
+
+CMD gunicorn -t 280 -b :$PORT app:app
+# CMD ["flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
- **What does this PR do?**
Add dockerfile which points to staging DB
- **What JIRA task is related to this PR?**
The link to the JIRA board task is [here](https://airqoteam.atlassian.net/browse/PLAT-73).
- **How do I test out this PR?**
Git clone this repo `cd AirQo-api/src/location_registry`. 
```
**using docker**
**Staging:** `docker build -t stage-location-registry -f Docker.stage.txt .` and `docker run -it -p 5555:8080 stage-location-registry`
```

- **Which endpoints should or are ready for testing?**
All endpoints as shown [in this documentation](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=1270588885).
