### PR TITLE
[AuthService] Hot fix ui issues

### DIFF
--- a/src/auth-service/controllers/join.js
+++ b/src/auth-service/controllers/join.js
@@ -123,6 +123,12 @@ const join = {
       const token = crypto.randomBytes(20).toString("hex");
 
       let query = { email: req.body.email };
+
+      if (!query.email) {
+        return res
+          .status(400)
+          .json({ success: false, message: "email field is required" });
+      }
       let updateDetails = {
         resetPasswordToken: token,
         resetPasswordExpires: Date.now() + 3600000,
@@ -159,7 +165,9 @@ const join = {
             });
             //return res.status(HTTPStatus.OK).json(response);
           } else {
-            return res.status(400).json({ email: "unable to send email" });
+            return res.status(400).json({
+              email: "unable to send email. Please crosscheck the organisation and email information provided."
+            });
           }
         }
       );

--- a/src/auth-service/controllers/join.js
+++ b/src/auth-service/controllers/join.js
@@ -141,7 +141,7 @@ const join = {
         updateDetails,
         (error, response) => {
           if (error) {
-            return res.status(400).json({ email: "Email does not exist" });
+            return res.status(400).json({ message: "Email does not exist" });
           } else if (response) {
             const mailOptions = {
               from: constants.EMAIL,
@@ -160,13 +160,13 @@ const join = {
                 return res.status(500).json({ email: "unable to send email" });
               } else {
                 console.log("here is the res: ", response);
-                return res.status(200).json({ email: "recovery email sent" });
+                return res.status(200).json({ message: "recovery email sent" });
               }
             });
             //return res.status(HTTPStatus.OK).json(response);
           } else {
             return res.status(400).json({
-              email: "unable to send email. Please crosscheck the organisation and email information provided."
+              message: "unable to send email. Please crosscheck the organisation and email information provided."
             });
           }
         }

--- a/src/auth-service/routes/api.js
+++ b/src/auth-service/routes/api.js
@@ -41,7 +41,7 @@ router.put(
 );
 router.put("/updatePassword", jwtAuth, authJWT, joinController.updatePassword);
 router.get("/reset/you", jwtAuth, authJWT, joinController.resetPassword);
-router.post("/forgotPassword", jwtAuth, authJWT, joinController.forgotPassword);
+router.post("/forgotPassword", jwtAuth, joinController.forgotPassword);
 router.put("/", jwtAuth, authJWT, joinController.updateUser);
 router.delete("/", jwtAuth, authJWT, joinController.deleteUser);
 router.put("/defaults/", jwtAuth, authJWT, joinController.updateUserDefaults);


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
- Removes token requirement from forgotPassword
- Improve on response messages

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
- [PLAT-231](https://airqoteam.atlassian.net/browse/PLAT-231)

**_HOW DO I TEST OUT THIS PR?_**
- Fetch and checkout to this branch locally.
-  Change directory to `auth-service` microservice
- Install dependences `npm install`
- Start application `npm run stage-mac` (mac OS) or `npm run stage-pc` (windows platform)

- Hit the forget password endpoint without providing the auth token (POST http://localhost:3000/api/v1/users/forgotPassword?tenant=kcca). This should be successful.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- Yes

**_ARE THERE ANY RELATED PRs?_**
- [Frontend](https://github.com/airqo-platform/AirQo-frontend/pull/160)


