### PR TITLE
[Auth Service] Remove case sensitivity from tenant ID

### DIFF
--- a/src/auth-service/controllers/candidate.js
+++ b/src/auth-service/controllers/candidate.js
@@ -29,13 +29,19 @@ const candidate = {
       text: msgs.joinRequest,
     };
 
-    register(req, res, mailOptions, req.body, CandidateModel(tenant));
+    register(
+      req,
+      res,
+      mailOptions,
+      req.body,
+      CandidateModel(tenant.toLowerCase())
+    );
   },
 
   getAllCandidates: async (req, res) => {
     try {
       const { tenant } = req.query;
-      const users = await CandidateModel(tenant).find();
+      const users = await CandidateModel(tenant.toLowerCase()).find();
       return res.status(HTTPStatus.OK).json({
         success: true,
         message: "Candidates fetched successfully",

--- a/src/auth-service/controllers/join.js
+++ b/src/auth-service/controllers/join.js
@@ -38,7 +38,7 @@ const join = {
       const { tenant } = req.query;
       const { body } = req;
       logObject("checking the body", body);
-      const user = await UserModel(tenant).createUser(body);
+      const user = await UserModel(tenant.toLowerCase()).createUser(body);
       if (user) {
         return res.status(HTTPStatus.OK).json({
           success: true,
@@ -66,7 +66,7 @@ const join = {
       if (tenant && id) {
         logElement("the tenant", tenant);
         logElement("the id", id);
-        const user = await UserModel(tenant).findOne({ _id: id });
+        const user = await UserModel(tenant.toLowerCase()).findOne({ _id: id });
         logObject("the user", user);
         if (!isEmpty(user)) {
           return res.status(HTTPStatus.OK).json({
@@ -81,7 +81,7 @@ const join = {
           });
         }
       } else if (tenant && !id) {
-        const users = await UserModel(tenant).find();
+        const users = await UserModel(tenant.toLowerCase()).find();
         if (!isEmpty(users)) {
           return res.status(HTTPStatus.OK).json({
             success: true,
@@ -130,7 +130,7 @@ const join = {
       //get the model based on tenant
       const { tenant } = req.query;
 
-      await UserModel(tenant).findOneAndUpdate(
+      await UserModel(tenant.toLowerCase()).findOneAndUpdate(
         query,
         updateDetails,
         (error, response) => {
@@ -199,7 +199,14 @@ const join = {
           )}`,
         };
       }
-      register(req, res, mailOptions, req.body, UserModel(tenant), tenant);
+      register(
+        req,
+        res,
+        mailOptions,
+        req.body,
+        UserModel(tenant.toLowerCase()),
+        tenant
+      );
     } catch (e) {
       logElement("the error", e);
       return res.status(500).json({
@@ -213,7 +220,7 @@ const join = {
   confirmEmail: async (req, res) => {
     try {
       const { tenant, id } = req.query;
-      UserModel(tenant)
+      UserModel(tenant.toLowerCase())
         .findById(id)
         .then((user) => {
           //when the user does not exist in the DB
@@ -260,7 +267,7 @@ const join = {
 
   deleteUser: (req, res, next) => {
     const { tenant, id } = req.query;
-    UserModel(tenant).findByIdAndRemove(id, (err, user) => {
+    UserModel(tenant.toLowerCase()).findByIdAndRemove(id, (err, user) => {
       if (err) {
         return res.status(400).json({
           success: false,
@@ -285,7 +292,7 @@ const join = {
     const { tenant, id } = req.query;
     delete req.body.password;
     delete req.body.email;
-    UserModel(tenant).findByIdAndUpdate(
+    UserModel(tenant.toLowerCase()).findByIdAndUpdate(
       id,
       req.body,
       { new: true },
@@ -330,7 +337,7 @@ const join = {
         delete req.body.user;
         let update = req.body,
           options = { upsert: true, new: true };
-        let doc = await DefaultModel(tenant)
+        let doc = await DefaultModel(tenant.toLowerCase())
           .findOneAndUpdate(filter, update, options)
           .exec();
 
@@ -372,7 +379,9 @@ const join = {
       if (tenant && user && !chartTitle) {
         logElement("the tenant", tenant);
         logElement("the user", user);
-        const defaults = await DefaultModel(tenant).find({ user: user }).exec();
+        const defaults = await DefaultModel(tenant.toLowerCase())
+          .find({ user: user })
+          .exec();
         logObject("the defaults", defaults);
         return res.status(HTTPStatus.OK).json({
           success: true,
@@ -380,7 +389,7 @@ const join = {
           defaults,
         });
       } else if (tenant && user && chartTitle) {
-        const userdefault = await DefaultModel(tenant)
+        const userdefault = await DefaultModel(tenant.toLowerCase())
           .find({
             user: user,
             chartTitle: chartTitle,
@@ -416,13 +425,13 @@ const join = {
   updateLocations: (req, res) => {
     const { tenant, id } = req.query;
     let response = {};
-    UserModel(tenant).find({ _id: id }, (error, user) => {
+    UserModel(tenant.toLowerCase()).find({ _id: id }, (error, user) => {
       if (error) {
         response.success = false;
         response.message = "Internal Server Error";
         res.status(500).json(response);
       } else if (user.length) {
-        let location = new LocationModel(tenant)(req.body);
+        let location = new LocationModel(tenant.toLowerCase())(req.body);
         location.user = user[0]._id;
         location.save((error, savedLocation) => {
           if (error) {
@@ -430,7 +439,7 @@ const join = {
             response.message = "Internal Server Error";
             res.status(500).json(response);
           } else {
-            UserModel(tenant).findByIdAndUpdate(
+            UserModel(tenant.toLowerCase()).findByIdAndUpdate(
               req.params.id,
               { $push: { pref_locations: savedLocation._id } },
               { new: true },
@@ -458,7 +467,7 @@ const join = {
     const { tenant, resetPasswordToken } = req.query;
     console.log("inside the reset password function...");
     console.log(`${resetPasswordToken}`);
-    await UserModel(tenant).findOne(
+    await UserModel(tenant.toLowerCase()).findOne(
       {
         resetPasswordToken: resetPasswordToken,
         resetPasswordExpires: {
@@ -489,7 +498,7 @@ const join = {
 
     const { userName, password, resetPasswordToken } = req.body;
 
-    UserModel(tenant)
+    UserModel(tenant.toLowerCase())
       .findOne({
         userName: userName,
         resetPasswordToken: resetPasswordToken,
@@ -534,7 +543,7 @@ const join = {
       const { tenant, id } = req.query;
       const { password, password2, old_pwd } = req.body;
       if ((password, password2, old_pwd)) {
-        UserModel(tenant)
+        UserModel(tenant.toLowerCase())
           .findOne({
             _id: id,
           })

--- a/src/auth-service/services/auth.js
+++ b/src/auth-service/services/auth.js
@@ -25,7 +25,7 @@ const jwtOpts = {
 const userLocalStrategy = (tenant, req, res, next) =>
   new LocalStrategy(localOpts, async (userName, password, done) => {
     try {
-      const user = await UserModel(tenant)
+      const user = await UserModel(tenant.toLowerCase())
         .findOne({
           userName,
         })
@@ -33,7 +33,7 @@ const userLocalStrategy = (tenant, req, res, next) =>
       if (!user) {
         return res.status(401).json({
           success: false,
-          message: "incorrect username or password",
+          message: `username or password does not exist in this organisation (${tenant})`,
         });
       } else if (!user.authenticateUser(password)) {
         return res.status(401).json({
@@ -55,7 +55,9 @@ const userLocalStrategy = (tenant, req, res, next) =>
 const jwtStrategy = (tenant, req, res, next) =>
   new JwtStrategy(jwtOpts, async (payload, done) => {
     try {
-      const user = await UserModel(tenant).findOne({ _id: payload._id }).exec();
+      const user = await UserModel(tenant.toLowerCase())
+        .findOne({ _id: payload._id })
+        .exec();
       if (!user) {
         return done(null, false);
         // return res.status(401).json({


### PR DESCRIPTION
# Hotfix

**_WHAT DOES THIS PR DO?_**

This PR addresses [this issue](https://github.com/airqo-platform/AirQo-api/issues/172).

- [ ] Removes the case sensitivity from the tenant ID. Means that one can provide airQo, AirQo, airQO, etc as a tenant and still proceed with their current operations without any hustle. 

- [ ] Also makes the error messages for user Login a little more descriptive without removing the ambiguity (incorrect username or password) encouraged in the best practices of information security.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-239](https://airqoteam.atlassian.net/browse/PLAT-239?atlOrigin=eyJpIjoiNTZlODBmMTYwNTI3NGZjZjlhZWI2Y2QxNDI1ZDYxZTEiLCJwIjoiaiJ9)

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-172

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/auth-service`
`npm install`

> For Windows

`npm run stage-pc`

> For Linux

`npm run stage-mac`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
You can test out using any endpoint of choice in the auth-service. I recommend starting with the one for user Login.
[POST] http://localhost:3000/api/v1/users/loginUser?tenant=AirQoto
More details can be found in the [API documentation](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=2081265667).

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


