### PR TITLE
Fx refactor device monitoring

### DIFF
--- a/src/device-monitoring/.gitignore
+++ b/src/device-monitoring/.gitignore
@@ -6,3 +6,4 @@ __init__test.py
 .vscode
 .DS_Store
 airqo-250220-642e046f4223.json
+jobs/Mar_sep11_2020.csv

--- a/src/device-monitoring/controllers/device_status.py
+++ b/src/device-monitoring/controllers/device_status.py
@@ -259,7 +259,7 @@ def get_device_uptime():
     model = device_status.DeviceStatus()
     if request.method == 'GET':
         tenant = request.args.get('tenant')
-        device_channel_id = request.args.get('device_channel_id')
+        device_channel_id = request.args.get('channel_id')
         device_id = request.args.get('device_id')
         device_name = request.args.get('device_name')
 
@@ -299,7 +299,7 @@ def get_device_battery_voltage():
     model = device_status.DeviceStatus()
     if request.method == 'GET':
         tenant = request.args.get('tenant')
-        device_channel_id = request.args.get('device_channel_id')
+        device_channel_id = request.args.get('channel_id')
         device_id = request.args.get('device_id')
         device_name = request.args.get('device_name')
 
@@ -339,7 +339,7 @@ def get_device_sensor_correlation():
     model = device_status.DeviceStatus()
     if request.method == 'GET':
         tenant = request.args.get('tenant')
-        device_channel_id = request.args.get('device_channel_id')
+        device_channel_id = request.args.get('channel_id')
         device_id = request.args.get('device_id')
         device_name = request.args.get('device_name')
 

--- a/src/device-monitoring/controllers/device_status.py
+++ b/src/device-monitoring/controllers/device_status.py
@@ -292,20 +292,34 @@ def get_device_uptime():
 
 
 @device_status_bp.route(api.route['device_battery_voltage'], methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])
-def get_device_battery_voltage(device_channel_id):
+def get_device_battery_voltage():
     '''
     Get device uptime
     '''
     model = device_status.DeviceStatus()
     if request.method == 'GET':
         tenant = request.args.get('tenant')
+        device_channel_id = request.args.get('device_channel_id')
+        device_id = request.args.get('device_id')
+        device_name = request.args.get('device_name')
+
+        if (not device_id and not device_name and not device_channel_id):
+            return jsonify({"message": "please specify one of the following query parameters i.e.device_channel_id , device_name ,device_id. Refer to the API documentation for details.", "success": False}), 400
+
         if not tenant:
             return jsonify({"message": "please specify the organization name. Refer to the API documentation for details.", "success": False}), 400
-        if type(device_channel_id) is not int:
+        if type(device_channel_id) is not int and device_channel_id:
             device_channel_id = int(device_channel_id)
+            filter_param = device_channel_id
+
+        if not device_channel_id:
+            if device_name:
+                filter_param = device_name
+            else:
+                filter_param = device_id
 
         result = model.get_device_battery_voltage_results(
-            tenant, device_channel_id)
+            tenant, filter_param)
         if result:
             response = result
         else:
@@ -318,20 +332,34 @@ def get_device_battery_voltage(device_channel_id):
 
 
 @device_status_bp.route(api.route['device_sensor_correlation'], methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])
-def get_device_sensor_correlation(device_channel_id):
+def get_device_sensor_correlation():
     '''
     Get device uptime
     '''
     model = device_status.DeviceStatus()
     if request.method == 'GET':
         tenant = request.args.get('tenant')
+        device_channel_id = request.args.get('device_channel_id')
+        device_id = request.args.get('device_id')
+        device_name = request.args.get('device_name')
+
+        if (not device_id and not device_name and not device_channel_id):
+            return jsonify({"message": "please specify one of the following query parameters i.e.device_channel_id , device_name ,device_id. Refer to the API documentation for details.", "success": False}), 400
+
         if not tenant:
             return jsonify({"message": "please specify the organization name. Refer to the API documentation for details.", "success": False}), 400
-        if type(device_channel_id) is not int:
+        if device_channel_id and type(device_channel_id) is not int :
             device_channel_id = int(device_channel_id)
+            filter_param = device_channel_id
+
+        if not device_channel_id:
+            if device_name:
+                filter_param = device_name
+            else:
+                filter_param = device_id
 
         result = model.get_device_sensor_correlation_results(
-            tenant, device_channel_id)
+            tenant, filter_param)
         if result:
             response = result
         else:

--- a/src/device-monitoring/controllers/device_status.py
+++ b/src/device-monitoring/controllers/device_status.py
@@ -252,20 +252,34 @@ def get_worst_performing_devices():
 
 
 @device_status_bp.route(api.route['device_uptime'], methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])
-def get_device_uptime(device_channel_id):
+def get_device_uptime():
     '''
     Get device uptime
     '''
     model = device_status.DeviceStatus()
     if request.method == 'GET':
         tenant = request.args.get('tenant')
+        device_channel_id = request.args.get('device_channel_id')
+        device_id = request.args.get('device_id')
+        device_name = request.args.get('device_name')
+
+        if (not device_id and not device_name and not device_channel_id):
+            return jsonify({"message": "please specify one of the following query parameters i.e.device_channel_id , device_name ,device_id. Refer to the API documentation for details.", "success": False}), 400
+
         if not tenant:
             return jsonify({"message": "please specify the organization name. Refer to the API documentation for details.", "success": False}), 400
-        if type(device_channel_id) is not int:
+        if device_channel_id and type(device_channel_id) is not int:
             device_channel_id = int(device_channel_id)
+            filter_param = device_channel_id
+
+        if not device_channel_id:
+            if device_name:
+                filter_param = device_name
+            else:
+                filter_param = device_id
 
         result = model.get_device_uptime_analysis_results(
-            tenant, device_channel_id)
+            tenant, filter_param)
         if result:
             response = result
         else:

--- a/src/device-monitoring/jobs/calculate_devices_uptime.py
+++ b/src/device-monitoring/jobs/calculate_devices_uptime.py
@@ -15,7 +15,7 @@ import os
 MONGO_URI = os.getenv("MONGO_URI")
 print(MONGO_URI)
 client = MongoClient(MONGO_URI)
-db = client['airqo_netmanager']
+db = client['airqo_netmanager_airqo']
 
 
 def function_to_execute(event, context):
@@ -59,10 +59,12 @@ def date_to_formated_str(date):
 
 
 def get_all_devices():
-    results = list(db.devices.find({"locationID":{ '$ne': '' } },{'_id':0}))
+    results = list(db.devices.find({"locationID":{ '$ne': '' } }))
     active_devices = []
     for device in results:
         print(device['name'])
+        device_id = device['_id']
+        print(device_id)
         if(device['isActive'] == True):
             active_devices.append(device)
     return active_devices
@@ -181,6 +183,8 @@ def compute_uptime_for_all_devices():
         for device in results:
             channel_id = device['channelID']
             mobililty = device['mobility']
+            device_id = device['_id']
+            device_name = device['name']
 
             if time_period['label'] == 'twelve_months':
                 device_registration_date = device['createdAt']
@@ -217,7 +221,7 @@ def compute_uptime_for_all_devices():
             all_devices_uptime_series.append(device_uptime_in_percentage)
             device_uptime_record = {"device_uptime_in_percentage": device_uptime_in_percentage,
                                     "device_downtime_in_percentage": device_downtime_in_percentage, "created_at": created_at,
-                                    "device_channel_id": channel_id, "specified_time_in_hours": specified_hours }
+                                    "device_channel_id": channel_id, "specified_time_in_hours": specified_hours, "device_name":device_name, "device_id":device_id }
 
             if time_period['label'] == 'twenty_eight_days':
                 device_uptime_record["device_sensor_one_pm2_5_readings"] = sensor_one_pm2_5_readings
@@ -303,3 +307,4 @@ def save_network_uptime_analysis_results(data):
 
 if __name__ == '__main__':
     compute_uptime_for_all_devices()
+    

--- a/src/device-monitoring/models/device_status.py
+++ b/src/device-monitoring/models/device_status.py
@@ -215,7 +215,7 @@ class DeviceStatus():
                 "message": "Uptime data not available for the specified device", "success": False}
         return uptime_result
 
-    def get_device_battery_voltage_results(self, tenant, device_channel_id):
+    def get_device_battery_voltage_results(self, tenant, filter_param):
         "gets the latest device batery voltage for the device with the specifided channel id"
         db = db_helpers.connect_mongo(tenant)
         results = list(db.network_uptime_analysis_results.find(
@@ -230,9 +230,9 @@ class DeviceStatus():
 
         twenty_eight_days_devices = result['average_uptime_for_entire_network_for_twenty_eight_days']['device_uptime_records']
         device_twenty_eight_days_battery_voltage = [d['device_battery_voltage_readings']
-                                                    for d in twenty_eight_days_devices if d['device_channel_id'] == device_channel_id]
+                                                    for d in twenty_eight_days_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
         device_twenty_eight_days_labels = [d['device_time_readings']
-                                           for d in twenty_eight_days_devices if d['device_channel_id'] == device_channel_id]
+                                           for d in twenty_eight_days_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
 
         if twenty_eight_days_devices:
             labels = [utils.convert_to_date(
@@ -246,7 +246,7 @@ class DeviceStatus():
                 "message": "device battery voltage data not available for the specified device", "success": False}
         return uptime_result
 
-    def get_device_sensor_correlation_results(self, tenant, device_channel_id):
+    def get_device_sensor_correlation_results(self, tenant, filter_param):
         "gets the latest device sensor correlations for the device with the specifided channel id"
         db = db_helpers.connect_mongo(tenant)
         results = list(db.network_uptime_analysis_results.find(
@@ -261,11 +261,11 @@ class DeviceStatus():
 
         twenty_eight_days_devices = result['average_uptime_for_entire_network_for_twenty_eight_days']['device_uptime_records']
         device_twenty_eight_days_sensor_one_readings = [d['device_sensor_one_pm2_5_readings']
-                                                        for d in twenty_eight_days_devices if d['device_channel_id'] == device_channel_id]
+                                                        for d in twenty_eight_days_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
         device_twenty_eight_days_sensor_two_readings = [d['device_sensor_two_pm2_5_readings']
-                                                        for d in twenty_eight_days_devices if d['device_channel_id'] == device_channel_id]
+                                                        for d in twenty_eight_days_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
         device_twenty_eight_days_labels = [d['device_time_readings']
-                                           for d in twenty_eight_days_devices if d['device_channel_id'] == device_channel_id]
+                                           for d in twenty_eight_days_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
 
         datasets = []  # for displaying multiple sensor data on graph
         colors = ['#7F7F7F', '#E377C2', '#17BECF', '#BCBD22', '#3f51b5']

--- a/src/device-monitoring/models/device_status.py
+++ b/src/device-monitoring/models/device_status.py
@@ -165,13 +165,16 @@ class DeviceStatus():
 
         return ranking_results
 
-    def get_device_uptime_analysis_results(self, tenant, device_channel_id):
-        "gets the latest device uptime for the device with the specifided channel id"
+    def get_device_uptime_analysis_results(self, tenant, filter_param):
+        "gets the latest device uptime for the device with either the specifided channel id or device name or device id as filter param"
         db = db_helpers.connect_mongo(tenant)
+        
         results = list(db.network_uptime_analysis_results.find(
-            {}, {'_id': 0}).sort([('$natural', -1)]).limit(1))
+            {}, {'_id': 0}).sort([('created_at', -1)]).limit(1))
 
+        print('filter-params:{}'.format(filter_param))
         # basic exception handling
+        print(str(len(results)))
         if len(results) != 0:
             result = results[0]
         else:
@@ -182,23 +185,24 @@ class DeviceStatus():
 
         twenty_four_hour_devices = result['average_uptime_for_entire_network_for_twentyfour_hours']['device_uptime_records']
         device_twenty_four_hour_uptime = [d['device_uptime_in_percentage']
-                                          for d in twenty_four_hour_devices if d['device_channel_id'] == device_channel_id]
+                                          for d in twenty_four_hour_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
+
 
         seven_days_devices = result['average_uptime_for_entire_network_for_seven_days']['device_uptime_records']
         device_seven_days_uptime = [d['device_uptime_in_percentage']
-                                    for d in seven_days_devices if d['device_channel_id'] == device_channel_id]
+                                    for d in seven_days_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
 
         twenty_eight_days_devices = result['average_uptime_for_entire_network_for_twenty_eight_days']['device_uptime_records']
         device_twenty_eight_days_uptime = [d['device_uptime_in_percentage']
-                                           for d in twenty_eight_days_devices if d['device_channel_id'] == device_channel_id]
+                                           for d in twenty_eight_days_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
 
         twelve_months_devices = result['average_uptime_for_entire_network_for_twelve_months']['device_uptime_records']
         device_twelve_months_uptime = [d['device_uptime_in_percentage']
-                                       for d in twelve_months_devices if d['device_channel_id'] == device_channel_id]
+                                       for d in twelve_months_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
 
         all_time_devices = result['average_uptime_for_entire_network_for_all_time']['device_uptime_records']
         device_all_time_uptime = [d['device_uptime_in_percentage']
-                                  for d in all_time_devices if d['device_channel_id'] == device_channel_id]
+                                  for d in all_time_devices if d['device_channel_id'] == filter_param or d['device_name']==filter_param or d['device_id']==filter_param]
 
         if device_twenty_four_hour_uptime and device_seven_days_uptime and twenty_eight_days_devices and twelve_months_devices and device_all_time_uptime:
             values = [round(device_twenty_four_hour_uptime[0], 2), round(device_seven_days_uptime[0], 2),

--- a/src/device-monitoring/routes/api.py
+++ b/src/device-monitoring/routes/api.py
@@ -14,7 +14,7 @@ route = {
     'worst_performing_devices': base_url + '/monitor/network/devices/worstperforming',
     'device_uptime': base_url + '/monitor/device/uptime',
     'online_offline': base_url + '/monitor/devices/online_offline',
-    'device_battery_voltage': base_url + '/monitor/device/batteryvoltage/<int:device_channel_id>',
-    'device_sensor_correlation': base_url + '/monitor/device/sensors/correlation/<int:device_channel_id>',
+    'device_battery_voltage': base_url + '/monitor/device/batteryvoltage',
+    'device_sensor_correlation': base_url + '/monitor/device/sensors/correlation',
 
 }

--- a/src/device-monitoring/routes/api.py
+++ b/src/device-monitoring/routes/api.py
@@ -12,7 +12,7 @@ route = {
     'network_uptime': base_url + '/monitor/network/uptime',
     'best_performing_devices': base_url + '/monitor/network/devices/bestperforming',
     'worst_performing_devices': base_url + '/monitor/network/devices/worstperforming',
-    'device_uptime': base_url + '/monitor/device/uptime/<int:device_channel_id>',
+    'device_uptime': base_url + '/monitor/device/uptime',
     'online_offline': base_url + '/monitor/devices/online_offline',
     'device_battery_voltage': base_url + '/monitor/device/batteryvoltage/<int:device_channel_id>',
     'device_sensor_correlation': base_url + '/monitor/device/sensors/correlation/<int:device_channel_id>',


### PR DESCRIPTION
# <Refactor  device-monitoring service>

**_WHAT DOES THIS PR DO?_**
Refactors  device-monitoring service so that it uses query params on endpoints that require channel ID and ensures that user is able to use either all or one of the available unique field under Devices entity - channel ID ,name and Object ID
**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[https://airqoteam.atlassian.net/jira/software/projects/PLAT/boards/41?assignee=5d922cc14258550c23a16713&selectedIssue=PLAT-281](https://airqoteam.atlassian.net/jira/software/projects/PLAT/boards/41?assignee=5d922cc14258550c23a16713&selectedIssue=PLAT-281)
**_WHAT IS THE LINK TO THE PR BRANCH_**
[https://github.com/airqo-platform/AirQo-api/compare/fx-refactor-device-monitoring](https://github.com/airqo-platform/AirQo-api/compare/fx-refactor-device-monitoring)
**_HOW DO I TEST OUT THIS PR?_**
 - git fetch branch fx-refactor-device-monitoring
 - run pip install -r requirements/dev.txt to get all the relevant packages.
 - Afterwards run flask run to test out the end points using any REST client tool available to you.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
   - [device_uptime](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=1063367751)
  - [ device_sensor_correlations](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=1063367751)
- [ device_battery_voltate](https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=1063367751)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
NO
**_ARE THERE ANY RELATED PRs?_**
NO


