### PR TITLE
chore: deploy data-mgt and redis on k8s

### DIFF
--- a/k8s/prod-data-mgt-api.yaml
+++ b/k8s/prod-data-mgt-api.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.service.type: NodePort
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: airqo-data-mgt-api
+  name: airqo-data-mgt-api
+  namespace: production
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      io.kompose.service: airqo-data-mgt-api
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.service.type: NodePort
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: airqo-data-mgt-api
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: us.gcr.io/airqo-250220/airqo-data-mgt-api:latest
+        imagePullPolicy: ""
+        name: airqo-data-mgt-api
+        ports:
+        - containerPort: 3000
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.service.type: NodePort
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: airqo-data-mgt-api
+  name: airqo-data-mgt-api
+  namespace: production
+spec:
+  ports:
+  - protocol: TCP
+    port: 3000
+    targetPort: 3000
+    nodePort: 30001
+  selector:
+    io.kompose.service: airqo-data-mgt-api
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/k8s/prod-redis-server.yaml
+++ b/k8s/prod-redis-server.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: airqo-redis-server
+  name: airqo-redis-server
+  namespace: production
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: airqo-redis-server
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: airqo-redis-server
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: us.gcr.io/airqo-250220/airqo-redis-server:latest
+        imagePullPolicy: ""
+        name: airqo-redis-server
+        ports:
+        - containerPort: 6379
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: airqo-redis-server
+  name: airqo-redis-server
+  namespace: production
+spec:
+  ports:
+  - name: airqo-redis-server
+    port: 6379
+    targetPort: 6379
+  selector:
+    io.kompose.service: airqo-redis-server
+status:
+  loadBalancer: {}

--- a/k8s/stage-data-mgt-api.yaml
+++ b/k8s/stage-data-mgt-api.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.service.type: NodePort
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: airqo-stage-data-mgt-api
+  name: airqo-stage-data-mgt-api
+  namespace: staging
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      io.kompose.service: airqo-stage-data-mgt-api
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.service.type: NodePort
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: airqo-stage-data-mgt-api
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: us.gcr.io/airqo-250220/airqo-stage-data-mgt-api:latest
+        imagePullPolicy: ""
+        name: airqo-stage-data-mgt-api
+        ports:
+        - containerPort: 3000
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.service.type: NodePort
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: airqo-stage-data-mgt-api
+  name: airqo-stage-data-mgt-api
+  namespace: staging
+spec:
+  ports:
+  - protocol: TCP
+    port: 3000
+    targetPort: 3000
+    nodePort: 31001
+  selector:
+    io.kompose.service: airqo-stage-data-mgt-api
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/k8s/stage-device-monitor-api.yaml
+++ b/k8s/stage-device-monitor-api.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: sta-dev-monitor
-          image: us.gcr.io/airqo-250220/airqo-stage-device-monitor:latest
+          image: us.gcr.io/airqo-250220/airqo-stage-device-monitor-api:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 4001

--- a/k8s/stage-redis-server.yaml
+++ b/k8s/stage-redis-server.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: airqo-redis-server
+  name: airqo-redis-server
+  namespace: staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: airqo-redis-server
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: airqo-redis-server
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: us.gcr.io/airqo-250220/airqo-redis-server:latest
+        imagePullPolicy: ""
+        name: airqo-redis-server
+        ports:
+        - containerPort: 6379
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: airqo-redis-server
+  name: airqo-redis-server
+  namespace: staging
+spec:
+  ports:
+  - name: airqo-redis-server
+    port: 6379
+    targetPort: 6379
+  selector:
+    io.kompose.service: airqo-redis-server
+status:
+  loadBalancer: {}

--- a/src/data-mgt/node/.dockerignore
+++ b/src/data-mgt/node/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log 

--- a/src/data-mgt/node/Dockerfile
+++ b/src/data-mgt/node/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:12
+
+# Create app directory
+WORKDIR /usr/src/app
+
+RUN chmod 777 /usr/src/app
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+
+RUN npm install
+# If you are building your code for production
+RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+RUN chmod 777 /usr/src/app/bin/www
+
+EXPOSE 3000
+CMD [ "npm", "run","start" ] 

--- a/src/data-mgt/node/Dockerfile.stage.txt
+++ b/src/data-mgt/node/Dockerfile.stage.txt
@@ -1,0 +1,23 @@
+FROM node:12
+
+# Create app directory
+WORKDIR /usr/src/app
+
+RUN chmod 777 /usr/src/app
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+RUN chmod 777 /usr/src/app/bin/www
+
+EXPOSE 3000
+CMD [ "npm", "run", "stage-mac" ]

--- a/src/data-mgt/node/config/constants.js
+++ b/src/data-mgt/node/config/constants.js
@@ -2,16 +2,22 @@ const devConfig = {
   MONGO_URI: "mongodb://localhost/",
   JWT_SECRET: process.env.JWT_SECRET,
   DB_NAME: process.env.MONGO_DEV,
+  REDIS_SERVER: process.env.REDIS_SERVER_DEV,
+  REDIS_PORT: process.env.REDIS_PORT,
 };
 const stageConfig = {
   MONGO_URI: process.env.MONGO_GCE_URI,
   JWT_SECRET: process.env.JWT_SECRET,
   DB_NAME: process.env.MONGO_STAGE,
+  REDIS_SERVER: process.env.REDIS_SERVER,
+  REDIS_PORT: process.env.REDIS_PORT,
 };
 const prodConfig = {
   MONGO_URI: process.env.MONGO_GCE_URI,
   JWT_SECRET: process.env.JWT_SECRET,
   DB_NAME: process.env.MONGO_PROD,
+  REDIS_SERVER: process.env.REDIS_SERVER,
+  REDIS_PORT: process.env.REDIS_PORT,
 };
 const defaultConfig = {
   PORT: process.env.PORT || 3000,

--- a/src/data-mgt/node/config/redis.js
+++ b/src/data-mgt/node/config/redis.js
@@ -1,6 +1,15 @@
 const redis = require("redis");
+const constants = require("./constants");
+const { logElement, logText, logObject } = require("../utils/log");
+const REDIS_SERVER = constants.REDIS_SERVER;
+const REDIS_PORT = constants.REDIS_PORT;
+logElement("redis URL", REDIS_SERVER.concat(":", REDIS_PORT));
 
-const client = redis.createClient();
+const client = redis.createClient({
+  host: REDIS_SERVER,
+  port: REDIS_PORT
+}
+);
 
 client.on("error", (error) => {
   console.error(error);

--- a/src/data-mgt/node/docker-compose.yaml
+++ b/src/data-mgt/node/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "2"
+
+services:
+
+  airqo-redis-server:
+    image: us.gcr.io/airqo-250220/airqo-redis-server:latest
+    ports:
+      - "6379"
+    environment:
+      - GET_HOSTS_FROM=dns
+
+  airqo-stage-data-mgt-api:
+    image: us.gcr.io/airqo-250220/airqo-stage-data-mgt-api:latest
+    ports:
+      - "31001:3000"
+    environment:
+      - GET_HOSTS_FROM=dns
+    labels:
+      kompose.service.type: NodePort

--- a/src/data-mgt/node/package-lock.json
+++ b/src/data-mgt/node/package-lock.json
@@ -19,11 +19,11 @@
             }
         },
         "ajv": {
-            "version": "6.10.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "requires": {
-                "fast-deep-equal": "^2.0.1",
+                "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
@@ -133,9 +133,9 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+            "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
         },
         "axios": {
             "version": "0.19.2",
@@ -221,6 +221,24 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "bl": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+            "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+            "requires": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
+            }
+        },
         "bluebird": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -244,9 +262,9 @@
             }
         },
         "bowser": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.7.0.tgz",
-            "integrity": "sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w=="
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.9.0.tgz",
+            "integrity": "sha512-2ld76tuLBNFekRgmJfT2+3j5MIrP6bFict8WAIT3beq+srz1gcKNAdNKMqHqauQt63NmAa88HfP1/Ypa9Er3HA=="
         },
         "boxen": {
             "version": "1.3.0",
@@ -299,9 +317,9 @@
             }
         },
         "bson": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
-            "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+            "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         },
         "bytes": {
             "version": "3.0.0",
@@ -440,11 +458,11 @@
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
         },
         "compressible": {
-            "version": "2.0.17",
-            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
-            "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
             "requires": {
-                "mime-db": ">= 1.40.0 < 2"
+                "mime-db": ">= 1.43.0 < 2"
             }
         },
         "compression": {
@@ -467,11 +485,11 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "configstore": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-            "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
+            "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
             "requires": {
-                "dot-prop": "^4.1.0",
+                "dot-prop": "^4.2.1",
                 "graceful-fs": "^4.1.2",
                 "make-dir": "^1.0.0",
                 "unique-string": "^1.0.0",
@@ -498,16 +516,16 @@
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
         "cookie": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
         },
         "cookie-parser": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
-            "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+            "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
             "requires": {
-                "cookie": "0.3.1",
+                "cookie": "0.4.0",
                 "cookie-signature": "1.0.6"
             }
         },
@@ -637,11 +655,6 @@
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
         },
-        "dns-prefetch-control": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.2.0.tgz",
-            "integrity": "sha512-hvSnros73+qyZXhHFjx2CMLwoj3Fe7eR9EJsFsqmcI1bB2OBWL/+0YzaEaKssCHnj/6crawNnUyw74Gm2EKe+Q=="
-        },
         "dont-sniff-mimetype": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
@@ -745,11 +758,6 @@
                 }
             }
         },
-        "expect-ct": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.2.0.tgz",
-            "integrity": "sha512-6SK3MG/Bbhm8MsgyJAylg+ucIOU71/FzyFalcfu5nY19dH8y/z0tBJU0wrNBXD4B27EoQtqPF/9wqH0iYAd04g=="
-        },
         "express": {
             "version": "4.17.1",
             "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -808,11 +816,6 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
                     "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-                },
-                "cookie": {
-                    "version": "0.4.0",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-                    "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
                 },
                 "http-errors": {
                     "version": "1.7.2",
@@ -946,19 +949,25 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "feature-policy": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
             "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ=="
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "optional": true
         },
         "fill-range": {
             "version": "4.0.0",
@@ -1046,495 +1055,19 @@
                 "map-cache": "^0.2.2"
             }
         },
-        "frameguard": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.1.0.tgz",
-            "integrity": "sha512-TxgSKM+7LTA6sidjOiSZK9wxY0ffMPY3Wta//MqwmX0nZuEHc8QrkV8Fh3ZhMJeiH+Uyh/tcaarImRy8u77O7g=="
-        },
         "fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
         "fsevents": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
             "optional": true,
             "requires": {
-                "nan": "^2.12.1",
-                "node-pre-gyp": "^0.12.0"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "aproba": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "chownr": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "detect-libc": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "optional": true
-                },
-                "fs-minipass": {
-                    "version": "1.2.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.3",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "ignore-walk": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minimatch": "^3.0.4"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
-                },
-                "ini": {
-                    "version": "1.3.5",
-                    "bundled": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true,
-                    "optional": true
-                },
-                "minipass": {
-                    "version": "2.3.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.2.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "needle": {
-                    "version": "2.3.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "^4.1.0",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.12.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.1",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.2.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
-                    }
-                },
-                "npm-bundled": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "optional": true
-                },
-                "npm-packlist": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.8",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "^0.6.0",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.3",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "bundled": true,
-                    "optional": true
-                },
-                "semver": {
-                    "version": "5.7.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "4.4.8",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "chownr": "^1.1.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.3.4",
-                        "minizlib": "^1.1.1",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "wide-align": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "^1.0.2 || 2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "yallist": {
-                    "version": "3.0.3",
-                    "bundled": true,
-                    "optional": true
-                }
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
             }
         },
         "get-stream": {
@@ -1601,9 +1134,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "har-schema": {
             "version": "2.0.0",
@@ -1611,11 +1144,11 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "requires": {
-                "ajv": "^6.5.5",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
             }
         },
@@ -1654,22 +1187,18 @@
             }
         },
         "helmet": {
-            "version": "3.21.2",
-            "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.21.2.tgz",
-            "integrity": "sha512-okUo+MeWgg00cKB8Csblu8EXgcIoDyb5ZS/3u0W4spCimeVuCUvVZ6Vj3O2VJ1Sxpyb8jCDvzu0L1KKT11pkIg==",
+            "version": "3.23.3",
+            "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.23.3.tgz",
+            "integrity": "sha512-U3MeYdzPJQhtvqAVBPntVgAvNSOJyagwZwyKsFdyRa8TV3pOKVFljalPOCxbw5Wwf2kncGhmP0qHjyazIdNdSA==",
             "requires": {
                 "depd": "2.0.0",
-                "dns-prefetch-control": "0.2.0",
                 "dont-sniff-mimetype": "1.1.0",
-                "expect-ct": "0.2.0",
                 "feature-policy": "0.3.0",
-                "frameguard": "3.1.0",
                 "helmet-crossdomain": "0.4.0",
-                "helmet-csp": "2.9.4",
+                "helmet-csp": "2.10.0",
                 "hide-powered-by": "1.1.0",
                 "hpkp": "2.0.0",
                 "hsts": "2.2.0",
-                "ienoopen": "1.1.0",
                 "nocache": "2.1.0",
                 "referrer-policy": "1.2.0",
                 "x-xss-protection": "1.3.0"
@@ -1688,11 +1217,11 @@
             "integrity": "sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA=="
         },
         "helmet-csp": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.9.4.tgz",
-            "integrity": "sha512-qUgGx8+yk7Xl8XFEGI4MFu1oNmulxhQVTlV8HP8tV3tpfslCs30OZz/9uQqsWPvDISiu/NwrrCowsZBhFADYqg==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.10.0.tgz",
+            "integrity": "sha512-Rz953ZNEFk8sT2XvewXkYN0Ho4GEZdjAZy4stjiEQV3eN7GDxg1QKmYggH7otDyIA7uGA6XnUMVSgeJwbR5X+w==",
             "requires": {
-                "bowser": "^2.7.0",
+                "bowser": "2.9.0",
                 "camelize": "1.0.0",
                 "content-security-policy-builder": "2.1.0",
                 "dasherize": "2.0.0"
@@ -1745,9 +1274,9 @@
             }
         },
         "http-status": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/http-status/-/http-status-1.4.0.tgz",
-            "integrity": "sha512-3w5/ENDYWShP1TmpDYwuX7QPKV8/xE7fdvr/XtGy8njDSjKljCjhHel7HJD7sR/FHEeVpAssDfsU5ntoyhquqw=="
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/http-status/-/http-status-1.4.2.tgz",
+            "integrity": "sha512-mBnIohUwRw9NyXMEMMv8/GANnzEYUj0Y8d3uL01zDWFkxUjYyZ6rgCaAI2zZ1Wb34Oqtbx/nFZolPRDc8Xlm5A=="
         },
         "iconv-lite": {
             "version": "0.4.23",
@@ -1756,11 +1285,6 @@
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
-        },
-        "ienoopen": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
-            "integrity": "sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ=="
         },
         "ignore-by-default": {
             "version": "1.0.1",
@@ -2128,16 +1652,16 @@
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "mime-db": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
         },
         "mime-types": {
-            "version": "2.1.24",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+            "version": "2.1.27",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
             "requires": {
-                "mime-db": "1.40.0"
+                "mime-db": "1.44.0"
             }
         },
         "minimatch": {
@@ -2173,30 +1697,32 @@
             }
         },
         "mongodb": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.3.tgz",
-            "integrity": "sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+            "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
             "requires": {
-                "bson": "^1.1.1",
+                "bl": "^2.2.1",
+                "bson": "^1.1.4",
+                "denque": "^1.4.1",
                 "require_optional": "^1.0.1",
                 "safe-buffer": "^5.1.2",
                 "saslprep": "^1.0.0"
             }
         },
         "mongoose": {
-            "version": "5.7.7",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.7.7.tgz",
-            "integrity": "sha512-FU59waB4LKBa9KOnqBUcCcMIVRc09TFo1F8nMxrzSiIWATaJpjxxSSH5FBVUDxQfNdJLfg9uFHxaTxhhwjsZOQ==",
+            "version": "5.10.11",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.11.tgz",
+            "integrity": "sha512-R5BFitKW94/S/Z48w+X+qi/eto66jWBcVEVA8nYVkBoBAPFGq7JSYP/0uso+ZHs+7XjSzTuui+SUllzxIrf9yA==",
             "requires": {
-                "bson": "~1.1.1",
+                "bson": "^1.1.4",
                 "kareem": "2.3.1",
-                "mongodb": "3.3.3",
+                "mongodb": "3.6.2",
                 "mongoose-legacy-pluralize": "1.0.2",
-                "mpath": "0.6.0",
+                "mpath": "0.7.0",
                 "mquery": "3.2.2",
                 "ms": "2.1.2",
                 "regexp-clone": "1.0.0",
-                "safe-buffer": "5.1.2",
+                "safe-buffer": "5.2.1",
                 "sift": "7.0.1",
                 "sliced": "1.0.1"
             },
@@ -2205,6 +1731,11 @@
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 }
             }
         },
@@ -2235,9 +1766,9 @@
             }
         },
         "mpath": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
-            "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
+            "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg=="
         },
         "mquery": {
             "version": "3.2.2",
@@ -2267,9 +1798,9 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+            "version": "2.14.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
             "optional": true
         },
         "nanomatch": {
@@ -2511,14 +2042,14 @@
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-            "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
         },
         "pstree.remy": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
-            "integrity": "sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A=="
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+            "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
         },
         "punycode": {
             "version": "2.1.1",
@@ -2558,9 +2089,9 @@
             }
         },
         "readable-stream": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2593,9 +2124,9 @@
             }
         },
         "redis-commands": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
-            "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+            "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
         },
         "redis-errors": {
             "version": "1.2.0",
@@ -2662,9 +2193,9 @@
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "requires": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -2673,7 +2204,7 @@
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
                 "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
+                "har-validator": "~5.1.3",
                 "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
@@ -2683,7 +2214,7 @@
                 "performance-now": "^2.1.0",
                 "qs": "~6.5.2",
                 "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
+                "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^3.3.2"
             }
@@ -2866,9 +2397,9 @@
             "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
         },
         "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
         "sliced": {
             "version": "1.0.1",
@@ -2978,11 +2509,11 @@
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+            "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
             "requires": {
-                "atob": "^2.1.1",
+                "atob": "^2.1.2",
                 "decode-uri-component": "^0.2.0",
                 "resolve-url": "^0.2.1",
                 "source-map-url": "^0.4.0",
@@ -3159,19 +2690,12 @@
             }
         },
         "tough-cookie": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-                }
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "tunnel-agent": {
@@ -3197,9 +2721,9 @@
             }
         },
         "undefsafe": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
-            "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
+            "integrity": "sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==",
             "requires": {
                 "debug": "^2.2.0"
             }
@@ -3292,9 +2816,9 @@
             }
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -3328,9 +2852,9 @@
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "uuid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-            "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "vary": {
             "version": "1.1.2",


### PR DESCRIPTION
# Deploy data-mgt & redis on k8s

**_WHAT DOES THIS PR DO?_**
This PR adds configurations for the deployment of `data-mgt` and `redis` on k8s 
**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A
**_WHAT IS THE LINK TO THE PR BRANCH_**
N/A
**_HOW DO I TEST OUT THIS PR?_**
Locally: `npm run stage-mac` or `npm run stage-pc`. Make sure redis is running 
Docker (stage). `docker-compose up`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
All (endpoints)[https://docs.google.com/spreadsheets/d/1-NGTDBtTcIi8Fg2UYSWjcK6geKrZdopz5kxRFsCEMPs/edit#gid=757070984] of data management microservice.
Example endpoint: `http://34.78.78.202:31001/api/v1/data/feeds/transform/recent?channel=689750`
**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A
**_ARE THERE ANY RELATED PRs?_**
N/A

