### PR TITLE
add k8s deployment scripts for cronjobs

### DIFF
--- a/k8s/prod-network-uptime-cronjob.yaml
+++ b/k8s/prod-network-uptime-cronjob.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  creationTimestamp: "2020-08-13T11:00:12Z"
+  managedFields:
+    - apiVersion: batch/v1beta1
+      manager: kubectl
+      operation: Update
+      time: "2020-08-13T11:00:12Z"
+  name: airqo-network-uptime
+  namespace: production
+  resourceVersion: "11584449"
+  selfLink: /apis/batch/v1beta1/namespaces/default/cronjobs/airqo-predict-job
+  uid: 9b71a693-43e2-4559-aff2-d821fc3bfe80
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+      name: airqo-network-uptime
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+            - image: us.gcr.io/airqo-250220/airqo-network-uptime:latest
+              imagePullPolicy: Always
+              name: airqo-network-uptime
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: 0 22 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status: {}

--- a/k8s/prod-predict-cronjob.yaml
+++ b/k8s/prod-predict-cronjob.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  creationTimestamp: "2020-08-13T11:00:12Z"
+  managedFields:
+    - apiVersion: batch/v1beta1
+      manager: kubectl
+      operation: Update
+      time: "2020-08-13T11:00:12Z"
+  name: airqo-predict-job
+  namespace: production
+  resourceVersion: "11584449"
+  selfLink: /apis/batch/v1beta1/namespaces/default/cronjobs/airqo-predict-job
+  uid: 9b71a693-43e2-4559-aff2-d821fc3bfe80
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+      name: airqo-predict-job
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+            - image: us.gcr.io/airqo-250220/airqo-predict-job:latest
+              imagePullPolicy: Always
+              name: airqo-predict-job
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: 0 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status: {}

--- a/k8s/stage-network-uptime-cronjob.yaml
+++ b/k8s/stage-network-uptime-cronjob.yaml
@@ -1,0 +1,43 @@
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  creationTimestamp: "2020-08-13T11:00:12Z"
+  managedFields:
+    - apiVersion: batch/v1beta1
+      manager: kubectl
+      operation: Update
+      time: "2020-08-13T11:00:12Z"
+  name: stage-network-uptime-demo
+  namespace: staging
+  resourceVersion: "11584449"
+  selfLink: /apis/batch/v1beta1/namespaces/default/cronjobs/airqo-predict-job
+  uid: 9b71a693-43e2-4559-aff2-d821fc3bfe80
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+      name: airqo-network-uptime
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+            - name: network-uptime-demo
+              image: us.gcr.io/airqo-250220/airqo-stage-network-uptime-demo:latest
+              imagePullPolicy: Always
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: 00 22 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status: {}


### PR DESCRIPTION
# add k8s deployment scripts for cronjobs

**_WHAT DOES THIS PR DO?_**
This PR adds cronjob k8s deployment scripts. The jobs are already up and running on Kubernetes
**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A
**_WHAT IS THE LINK TO THE PR BRANCH_**
N/A
**_HOW DO I TEST OUT THIS PR?_**
[Optional] - Access the Kubernetes cluster and run `kubectl get cronjobs -n production` or `kubectl get cronjobs -n staging`.  See sample output attached
**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
N/A
**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A
**_ARE THERE ANY RELATED PRs?_**
N/A

![Screenshot 2020-11-03 at 17 25 44](https://user-images.githubusercontent.com/15224992/97997317-e3275500-1df9-11eb-8b67-48e29762791a.png)



