### PR TITLE
[device-registry] fix device deploy

### DIFF
--- a/src/device-registry/controllers/device.js
+++ b/src/device-registry/controllers/device.js
@@ -148,8 +148,8 @@ const isDeviceModelNotDeployed = async (deviceName, tenant) => {
     logText("....................");
     logText("checking isDeviceModelNotDeployed....");
     logObject("device is here", device[0]._doc);
-    const isNotDeployed = isEmpty(device[0]._doc.locationID) ? true : false;
-    logElement("locationID", device[0]._doc.locationID);
+    const isNotDeployed = !device[0]._doc.isActive;
+    logElement("isActive", device[0]._doc.isActive);
     logElement("isNotDeployed", isNotDeployed);
     return isNotDeployed;
   } catch (e) {
@@ -169,7 +169,7 @@ const isDeviceModelNotRecalled = async (deviceName, tenant) => {
     logText("....................");
     logText("checking isDeviceModelNotRecalled....");
     logObject("device is here", device[0]._doc);
-    const isNotRecalled = device[0]._doc.isActive == true ? true : false;
+    const isNotRecalled = !!device[0]._doc.isActive;
     logElement("isActive", device[0]._doc.isActive);
     logElement("isNotRecalled", isNotRecalled);
     return isNotRecalled;


### PR DESCRIPTION

**_WHAT DOES THIS PR DO?_**
- fixes device deploy endpoint to avoid redeploying deployed devices.

**_HOW DO I TEST OUT THIS PR?_**
- cd to `device-registry` folder
- run `npm install`
- start application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows)
- try deploying a device with the endpoint `http://localhost:3000/api/v1/devices/ts/activity?type=deploy&tenant=airqo`
sample body: 
```
{
"deviceName": "aq_86",
"height": "",
"mountType": "",
"powerType": "",
"date": "2020-07-07T16:09:24.611Z",
"latitude": "0.423",
"longitude": "0.21",
"isPrimaryInLocation": true,
"isUserForCollocaton": false
}
````
for already deployed device, this should not be successful.



