### PR TITLE
return the ID every after carrying out a SITE activity

### DIFF
--- a/src/device-registry/models/location_activity.js
+++ b/src/device-registry/models/location_activity.js
@@ -30,7 +30,7 @@ const activitySchema = new Schema(
 activitySchema.methods = {
   toJSON() {
     return {
-      _id: this._id,
+      id: this._id,
       device: this.device,
       location: this.location,
       date: this.date,

--- a/src/device-registry/models/location_activity.js
+++ b/src/device-registry/models/location_activity.js
@@ -18,6 +18,7 @@ const activitySchema = new Schema(
     activityType: { type: String, trim: true },
     tags: [{ type: String }],
     nextMaintenance: { type: Date, default: threeMonthsFromNow },
+    maintenanceType: { type: String },
     createdAt: {
       type: Date,
     },
@@ -36,6 +37,7 @@ activitySchema.methods = {
       date: this.date,
       description: this.description,
       activityType: this.activityType,
+      maintenanceType: this.maintenanceType,
       nextMaintenance: this.nextMaintenance,
       createdAt: this.createdAt,
       tags: this.tags,

--- a/src/device-registry/models/location_activity.js
+++ b/src/device-registry/models/location_activity.js
@@ -30,7 +30,7 @@ const activitySchema = new Schema(
 activitySchema.methods = {
   toJSON() {
     return {
-      id: this._id,
+      _id: this._id,
       device: this.device,
       location: this.location,
       date: this.date,

--- a/src/device-registry/utils/doActivityHelpers.js
+++ b/src/device-registry/utils/doActivityHelpers.js
@@ -108,15 +108,15 @@ const doLocationActivity = async (
             });
           } else if (updatedDevice) {
             //then log the operation
-            const log = getModelByTenant(
+            const activityLog = getModelByTenant(
               tenant.toLowerCase(),
               "activity",
               LocationActivitySchema
             ).createLocationActivity(activityBody);
-            log.then((log) => {
+            activityLog.then((activityLog) => {
               return res.status(HTTPStatus.OK).json({
                 message: `${type} successfully carried out`,
-                activityBody,
+                activityLog,
                 updatedDevice,
                 success: true,
               });

--- a/src/device-registry/utils/doActivityHelpers.js
+++ b/src/device-registry/utils/doActivityHelpers.js
@@ -180,6 +180,7 @@ const locationActivityRequestBodies = (req, res) => {
       tags,
       isPrimaryInLocation,
       isUserForCollocaton,
+      maintenanceType,
     } = req.body;
 
     //location and device body to be used for deploying....
@@ -269,6 +270,7 @@ const locationActivityRequestBodies = (req, res) => {
         description: description,
         activityType: "maintenance",
         nextMaintenance: threeMonthsFromNow(date),
+        maintenanceType: maintenanceType,
         // $addToSet: { tags: { $each: tags } },
         tags: tags,
       };

--- a/src/device-registry/utils/doActivityHelpers.js
+++ b/src/device-registry/utils/doActivityHelpers.js
@@ -274,12 +274,12 @@ const locationActivityRequestBodies = (req, res) => {
         // $addToSet: { tags: { $each: tags } },
         tags: tags,
       };
-      if (description == "preventive") {
+      if (maintenanceType == "preventive") {
         deviceBody = {
           name: deviceName,
           nextMaintenance: threeMonthsFromNow(date),
         };
-      } else if (description == "corrective") {
+      } else if (maintenanceType == "corrective") {
         deviceBody = {
           name: deviceName,
         };


### PR DESCRIPTION
# Hotfix

**_WHAT DOES THIS PR DO?_**

- [x] This just includes the _id to the returned data after creating a maintenance log.
- [x] Also adds a new optional field (maintenanceType) to the activity Schema ....all to cater for maintenance activities.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
N/A

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/device-registry`
`npm install`
`npm run dev-mac` for Linux OR `npm run dev-pc` for Windows

Alternatively, one can use docker :
`docker build -t us.gcr.io/airqo-250220/airqo-location-registry-api .`
`docker run -d -p 6000:3000 us.gcr.io/airqo-250220/airqo-device-registry-api`
Since it runs Redis, you might need to use Docker compose for this, please get in touch with @danielogen  on this approach for more assistance.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
BASE_URL: http://localhost:3000/api/v1/devices/ts/activity?type=maintain&tenant=airqo
BODY:
```
{
  "deviceName": "aq_501",
  "locationName": "loc_1",
  "date": "2020-07-07T16:09:24.611Z",
  "tags":["blowing", "dusting", "sensor placement", "damn"],
   "description":"preventive"
}
```

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


