### PR TITLE
[enhancement] k8s deployment config

### DIFF
--- a/k8s/prod-analytics-api.yaml
+++ b/k8s/prod-analytics-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 5000
               name: analytics-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 5000

--- a/k8s/prod-analytics-api.yaml
+++ b/k8s/prod-analytics-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 5000
               name: analytics-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 5000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-analytics-api.yaml
+++ b/k8s/prod-analytics-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: analytics-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/prod-auth-api.yaml
+++ b/k8s/prod-auth-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 3000
               name: auth-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 3000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-auth-api.yaml
+++ b/k8s/prod-auth-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 3000
               name: auth-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 3000

--- a/k8s/prod-auth-api.yaml
+++ b/k8s/prod-auth-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: auth-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/prod-calibrate-api.yaml
+++ b/k8s/prod-calibrate-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 4001
               name: calibrate
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 4001
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-calibrate-api.yaml
+++ b/k8s/prod-calibrate-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 4001
               name: calibrate
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 4001

--- a/k8s/prod-calibrate-api.yaml
+++ b/k8s/prod-calibrate-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: calibrate
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/prod-data-mgt-api.yaml
+++ b/k8s/prod-data-mgt-api.yaml
@@ -37,6 +37,13 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 3000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-data-mgt-api.yaml
+++ b/k8s/prod-data-mgt-api.yaml
@@ -15,7 +15,12 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: airqo-data-mgt-api
-  strategy: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       annotations:

--- a/k8s/prod-data-mgt-api.yaml
+++ b/k8s/prod-data-mgt-api.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 3000

--- a/k8s/prod-device-monitor-api.yaml
+++ b/k8s/prod-device-monitor-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 4001
               name: dev-monitor-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 4001

--- a/k8s/prod-device-monitor-api.yaml
+++ b/k8s/prod-device-monitor-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 4001
               name: dev-monitor-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 4001
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-device-monitor-api.yaml
+++ b/k8s/prod-device-monitor-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: device-monitor-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/prod-device-registry-api.yaml
+++ b/k8s/prod-device-registry-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: device-reg-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/prod-device-registry-api.yaml
+++ b/k8s/prod-device-registry-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 3000
               name: device-reg-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 3000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-device-registry-api.yaml
+++ b/k8s/prod-device-registry-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 3000
               name: device-reg-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 3000

--- a/k8s/prod-device-status-cronjob.yaml
+++ b/k8s/prod-device-status-cronjob.yaml
@@ -11,6 +11,12 @@ metadata:
   name: prod-device-status-job
   namespace: production
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/k8s/prod-device-uptime-cronjob.yaml
+++ b/k8s/prod-device-uptime-cronjob.yaml
@@ -11,6 +11,12 @@ metadata:
   name: prod-device-uptime-job
   namespace: production
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/k8s/prod-locate-api.yaml
+++ b/k8s/prod-locate-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 4001
               name: locate-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 4001

--- a/k8s/prod-locate-api.yaml
+++ b/k8s/prod-locate-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: locate-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/prod-locate-api.yaml
+++ b/k8s/prod-locate-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 4001
               name: locate-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 4001
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-location-registry-api.yaml
+++ b/k8s/prod-location-registry-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 8080
               name: loc-registry
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 8080

--- a/k8s/prod-location-registry-api.yaml
+++ b/k8s/prod-location-registry-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: location-registry-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/prod-location-registry-api.yaml
+++ b/k8s/prod-location-registry-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 8080
               name: loc-registry
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 8080
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-network-uptime-cronjob.yaml
+++ b/k8s/prod-network-uptime-cronjob.yaml
@@ -13,6 +13,12 @@ metadata:
   selfLink: /apis/batch/v1beta1/namespaces/default/cronjobs/airqo-predict-job
   uid: 9b71a693-43e2-4559-aff2-d821fc3bfe80
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/k8s/prod-predict-cronjob.yaml
+++ b/k8s/prod-predict-cronjob.yaml
@@ -13,6 +13,12 @@ metadata:
   selfLink: /apis/batch/v1beta1/namespaces/default/cronjobs/airqo-predict-job
   uid: 9b71a693-43e2-4559-aff2-d821fc3bfe80
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/k8s/prod-prediction-api.yaml
+++ b/k8s/prod-prediction-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 5000
               name: prediction-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 5000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/prod-prediction-api.yaml
+++ b/k8s/prod-prediction-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: prediction-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/prod-prediction-api.yaml
+++ b/k8s/prod-prediction-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 5000
               name: prediction-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 5000

--- a/k8s/prod-redis-server.yaml
+++ b/k8s/prod-redis-server.yaml
@@ -14,7 +14,12 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: airqo-redis-server
-  strategy: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       annotations:

--- a/k8s/stage-analytics-api.yaml
+++ b/k8s/stage-analytics-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 5000
               name: sta-alytics-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 5000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/stage-analytics-api.yaml
+++ b/k8s/stage-analytics-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: sta-alytics-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/stage-analytics-api.yaml
+++ b/k8s/stage-analytics-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 5000
               name: sta-alytics-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 5000

--- a/k8s/stage-auth-api.yaml
+++ b/k8s/stage-auth-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: sta-auth-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/stage-auth-api.yaml
+++ b/k8s/stage-auth-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 3000
               name: sta-auth-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 3000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/stage-auth-api.yaml
+++ b/k8s/stage-auth-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 3000
               name: sta-auth-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 3000

--- a/k8s/stage-calibrate-api.yaml
+++ b/k8s/stage-calibrate-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 4001
               name: sta-calibrate
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 4001
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/stage-calibrate-api.yaml
+++ b/k8s/stage-calibrate-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: sta-calibrate
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/stage-calibrate-api.yaml
+++ b/k8s/stage-calibrate-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 4001
               name: sta-calibrate
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 4001

--- a/k8s/stage-data-mgt-api.yaml
+++ b/k8s/stage-data-mgt-api.yaml
@@ -37,6 +37,13 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 3000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/stage-data-mgt-api.yaml
+++ b/k8s/stage-data-mgt-api.yaml
@@ -15,7 +15,12 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: airqo-stage-data-mgt-api
-  strategy: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       annotations:

--- a/k8s/stage-data-mgt-api.yaml
+++ b/k8s/stage-data-mgt-api.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 3000

--- a/k8s/stage-device-monitor-api.yaml
+++ b/k8s/stage-device-monitor-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 4001
               name: sta-dev-monitor
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 4001
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/stage-device-monitor-api.yaml
+++ b/k8s/stage-device-monitor-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: sta-device-monitor
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/stage-device-monitor-api.yaml
+++ b/k8s/stage-device-monitor-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 4001
               name: sta-dev-monitor
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 4001

--- a/k8s/stage-device-registry-api.yaml
+++ b/k8s/stage-device-registry-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 3000
               name: sta-dev-reg-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 3000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/stage-device-registry-api.yaml
+++ b/k8s/stage-device-registry-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 3000
               name: sta-dev-reg-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 3000

--- a/k8s/stage-device-registry-api.yaml
+++ b/k8s/stage-device-registry-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: sta-device-reg-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/stage-device-status-cronjob.yaml
+++ b/k8s/stage-device-status-cronjob.yaml
@@ -11,6 +11,12 @@ metadata:
   name: stage-device-status-job
   namespace: staging
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/k8s/stage-device-uptime-cronjob.yaml
+++ b/k8s/stage-device-uptime-cronjob.yaml
@@ -11,6 +11,12 @@ metadata:
   name: stage-device-uptime-job
   namespace: staging
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/k8s/stage-locate-api.yaml
+++ b/k8s/stage-locate-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: sta-locate-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/stage-locate-api.yaml
+++ b/k8s/stage-locate-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 4001
               name: sta-locate-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 4001

--- a/k8s/stage-locate-api.yaml
+++ b/k8s/stage-locate-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 4001
               name: sta-locate-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 4001
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/stage-location-registry-api.yaml
+++ b/k8s/stage-location-registry-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: sta-location-registry-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/stage-location-registry-api.yaml
+++ b/k8s/stage-location-registry-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 8080
               name: sta-loc-reg
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 8080

--- a/k8s/stage-location-registry-api.yaml
+++ b/k8s/stage-location-registry-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 8080
               name: sta-loc-reg
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 8080
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
             - name: GET_HOSTS_FROM
               value: dns

--- a/k8s/stage-network-uptime-cronjob.yaml
+++ b/k8s/stage-network-uptime-cronjob.yaml
@@ -14,6 +14,12 @@ metadata:
   selfLink: /apis/batch/v1beta1/namespaces/default/cronjobs/airqo-predict-job
   uid: 9b71a693-43e2-4559-aff2-d821fc3bfe80
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/k8s/stage-prediction-api.yaml
+++ b/k8s/stage-prediction-api.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 5000
               name: prediction-api
+          # readynessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: 5000
+          #   initialDelaySecond: 5
+          #   periodSeconds: 3
+          #   successThreshold: 1
           env:
           - name: GET_HOSTS_FROM
             value: dns

--- a/k8s/stage-prediction-api.yaml
+++ b/k8s/stage-prediction-api.yaml
@@ -11,6 +11,12 @@ spec:
     matchLabels:
       app: prediction-api
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/k8s/stage-prediction-api.yaml
+++ b/k8s/stage-prediction-api.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 5000
               name: prediction-api
-          # readynessProbe:
+          # readinessProbe:
           #   httpGet:
           #     path: /health
           #     port: 5000

--- a/k8s/stage-redis-server.yaml
+++ b/k8s/stage-redis-server.yaml
@@ -14,7 +14,12 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: airqo-redis-server
-  strategy: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  minReadySeconds: 5
   template:
     metadata:
       annotations:


### PR DESCRIPTION
# [Enhancement] update k8s deployment configuration
**_WHAT DOES THIS PR DO?_**
This PR updates Kubernetes deployment configuration to include the rolling update deployment strategy and readiness probes. This is to prevent downtime during deployment update and to ensure that a service is ready before receiving requests.
Readiness probe functionality is currently disabled but can be activated once the endpoint is added to the different microservices
**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-329]
**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/k8-enhancements-PLAT-329
**_HOW DO I TEST OUT THIS PR?_**
N/A
**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
N/A
**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A
**_ARE THERE ANY RELATED PRs?_**
- [PLAT-331]
- [PLAT-430]


[PLAT-329]: https://airqoteam.atlassian.net/browse/PLAT-329
[PLAT-331]: https://airqoteam.atlassian.net/browse/PLAT-331
[PLAT-430]: https://airqoteam.atlassian.net/browse/PLAT-430