### PR TITLE
Hotfix for getting most recent events when query is made shortly after mid-night

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -235,7 +235,8 @@ eventSchema.statics = {
         no2: { $first: "$no2" },
       })
       .skip(skipInt)
-      .limit(limitInt);
+      .limit(limitInt)
+      .allowDiskUse(true);
   },
 };
 

--- a/src/device-registry/utils/date.js
+++ b/src/device-registry/utils/date.js
@@ -38,4 +38,50 @@ const generateDateFormatWithoutHrs = (ISODate) => {
   }
 };
 
-module.exports = { generateDateFormat, generateDateFormatWithoutHrs };
+const threeMonthsBehind = () => {
+  var d = new Date();
+  var targetMonth = d.getMonth() - 3;
+  d.setMonth(targetMonth);
+  if (d.getMonth() !== targetMonth % 12) {
+    d.setDate(0);
+  }
+  return d;
+};
+
+const twoMonthsBehind = () => {
+  var d = new Date();
+  var targetMonth = d.getMonth() - 2;
+  d.setMonth(targetMonth);
+  if (d.getMonth() !== targetMonth % 12) {
+    d.setDate(0);
+  }
+  return d;
+};
+
+const oneMonthBehind = () => {
+  var d = new Date();
+  var targetMonth = d.getMonth() - 1;
+  d.setMonth(targetMonth);
+  if (d.getMonth() !== targetMonth % 12) {
+    d.setDate(0);
+  }
+  return d;
+};
+const threeMonthsInfront = () => {
+  var d = new Date();
+  var targetMonth = d.getMonth() + 3;
+  d.setMonth(targetMonth);
+  if (d.getMonth() !== targetMonth % 12) {
+    d.setDate(0);
+  }
+  return d;
+};
+
+module.exports = {
+  generateDateFormat,
+  generateDateFormatWithoutHrs,
+  threeMonthsBehind,
+  twoMonthsBehind,
+  oneMonthBehind,
+  threeMonthsInfront,
+};

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -42,8 +42,8 @@ const generateEventsFilter = (queryStartTime, queryEndTime, device) => {
       "values.device": device,
     };
   } else {
-    let threeMonthsBack = threeMonthsBehind();
-    let startTime = generateDateFormatWithoutHrs(threeMonthsBack);
+    let oneMonthBack = oneMonthBehind();
+    let startTime = generateDateFormatWithoutHrs(oneMonthBack);
     logElement("startTime", startTime);
     return {
       day: { $gte: startTime },

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -1,3 +1,14 @@
+const {
+  generateDateFormat,
+  generateDateFormatWithoutHrs,
+  threeMonthsBehind,
+  twoMonthsBehind,
+  oneMonthBehind,
+  threeMonthsInfront,
+} = require("./date");
+
+const { logObject, logElement, logText } = require("./log");
+
 const generateEventsFilter = (queryStartTime, queryEndTime, device) => {
   if (queryStartTime && queryEndTime && !device) {
     return {
@@ -31,7 +42,12 @@ const generateEventsFilter = (queryStartTime, queryEndTime, device) => {
       "values.device": device,
     };
   } else {
-    return {};
+    let threeMonthsBack = threeMonthsBehind();
+    let startTime = generateDateFormatWithoutHrs(threeMonthsBack);
+    logElement("startTime", startTime);
+    return {
+      day: { $gte: startTime },
+    };
   }
 };
 


### PR DESCRIPTION
#  Getting most recent events when query is made shortly after mid-night

**_WHAT DOES THIS PR DO?_**
This addresses the concern raised in this [issue-331](https://github.com/airqo-platform/AirQo-api/issues/331)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-500](https://airqoteam.atlassian.net/browse/PLAT-500?atlOrigin=eyJpIjoiN2YwZjcwMTM5MjUxNDIyMDlkZDVkY2NhYWE0MjliNzgiLCJwIjoiaiJ9)

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/api-issue-331

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/device-registry`
`npm install`
`npm run stage-mac` for Linux and `npm run stage-pc` for Windows.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
The one for GET Events. While at it, please do not provide any query parameters so that you can utilise the default settings accordingly.
More about this endpoint can be found here: https://docs.airqo.net/airqo-platform-api/device-registry#get-events

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


