### PR TITLE
Resolving Issue 340

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -203,7 +203,8 @@ eventSchema.statics = {
         updatedAt: 0,
       })
       .skip(skipInt)
-      .limit(limitInt);
+      .limit(limitInt)
+      .allowDiskUse(true);
   },
   listRecent({ skipInt = 0, limitInt = 100, filter = {} } = {}) {
     logObject("the filter", filter);

--- a/src/device-registry/utils/get-measurements.js
+++ b/src/device-registry/utils/get-measurements.js
@@ -1,4 +1,5 @@
 const EventSchema = require("../models/Event");
+const isEmpty = require("is-empty");
 const HTTPStatus = require("http-status");
 const { getModelByTenant } = require("./multitenancy");
 const redis = require("../config/redis");
@@ -19,6 +20,60 @@ const { generateDateFormat, generateDateFormatWithoutHrs } = require("./date");
 
 const getDetail = require("../utils/get-device-details");
 
+const isRecentTrue = (recent) => {
+  let isRecentEmpty = isEmpty(recent);
+  if (isRecentEmpty == true) {
+    return true;
+  }
+  if (recent.toLowerCase() == "yes" && isRecentEmpty == false) {
+    return true;
+  } else if (recent.toLowerCase() == "no" && isRecentEmpty == false) {
+    logText("the value of recent is false");
+    return false;
+  }
+};
+
+const getDevicesCount = async (tenant) => {
+  let deviceDetail = await getDetail(tenant);
+  logElement("number of devices", deviceDetail.length);
+  return deviceDetail.length;
+};
+
+const generateCacheID = (
+  device,
+  day,
+  startTime,
+  endTime,
+  tenant,
+  skip,
+  limit,
+  recent
+) => {
+  return `get_events_device_${device ? device : "noDevice"}_${day}_${
+    startTime ? startTime : "noStartTime"
+  }_${endTime ? endTime : "noEndTime"}_${tenant}_${skip ? skip : 0}_${
+    limit ? limit : 0
+  }_${recent ? recent : "noRecent"}`;
+};
+
+const getEvents = async (tenant, recentFlag, skipInt, limitInt, filter) => {
+  let allEvents = await getModelByTenant(tenant, "event", EventSchema).list({
+    skipInt,
+    limitInt,
+    filter,
+  });
+
+  let recentEvents = await getModelByTenant(
+    tenant,
+    "event",
+    EventSchema
+  ).listRecent({ skipInt, limitInt, filter });
+
+  let events = recentFlag ? recentEvents : allEvents;
+
+  return events;
+};
+
 const getMeasurements = async (
   res,
   recent,
@@ -32,11 +87,16 @@ const getMeasurements = async (
   try {
     const currentTime = new Date().toISOString();
     const day = generateDateFormatWithoutHrs(currentTime);
-    let cacheID = `get_events_device_${device ? device : "noDevice"}_${day}_${
-      startTime ? startTime : "noStartTime"
-    }_${endTime ? endTime : "noEndTime"}_${tenant}_${skip ? skip : 0}_${
-      limit ? limit : 0
-    }_${recent ? recent : "noRecent"}`;
+    let cacheID = generateCacheID(
+      device,
+      day,
+      startTime,
+      endTime,
+      tenant,
+      skip,
+      limit,
+      recent
+    );
 
     redis.get(cacheID, async (err, result) => {
       try {
@@ -48,25 +108,20 @@ const getMeasurements = async (
         } else {
           const filter = generateEventsFilter(startTime, endTime, device);
 
-          let deviceDetail = await getDetail(tenant);
-          logElement("number of devices", deviceDetail.length);
+          let devicesCount = await getDevicesCount(tenant);
 
           let skipInt = skip ? skip : 0;
-          let limitInt = limit ? limit : deviceDetail.length;
+          let limitInt = limit ? limit : devicesCount;
 
-          let allEvents = await getModelByTenant(
+          let recentFlag = isRecentTrue(recent);
+
+          let events = await getEvents(
             tenant,
-            "event",
-            EventSchema
-          ).list({ skipInt, limitInt, filter });
-
-          let recentEvents = await getModelByTenant(
-            tenant,
-            "event",
-            EventSchema
-          ).listRecent({ skipInt, limitInt, filter });
-
-          let events = recent ? recentEvents : allEvents;
+            recentFlag,
+            skipInt,
+            limitInt,
+            filter
+          );
 
           redis.set(
             cacheID,


### PR DESCRIPTION
# Bug when retrieving recent events without the RECENT query parameter

**_WHAT DOES THIS PR DO?_**
Resolves[ issue-340](https://github.com/airqo-platform/AirQo-api/issues/340)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-340

**_HOW DO I TEST OUT THIS PR?_**
Using a separate terminal, start your local REDIS server accordingly.
`cd AirQo-api/src/device-registry`
`npm install`
`npm run stage-mac `OR `npm run prod-pc`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
[GET Events endpoint.](https://docs.airqo.net/airqo-platform-api/device-registry#get-events)
Use port 3000 when testing on localhost.

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A

