### PR TITLE
in case devices are not available, return appropriate response

### DIFF
--- a/src/device-registry/controllers/create-device.js
+++ b/src/device-registry/controllers/create-device.js
@@ -285,11 +285,19 @@ const device = {
           skip
         );
         logObject("the devices", devices);
-        return res.status(HTTPStatus.OK).json({
-          success: true,
-          message: "Devices fetched successfully",
-          devices,
-        });
+        if (devices.length) {
+          return res.status(HTTPStatus.OK).json({
+            success: true,
+            message: "Devices fetched successfully",
+            devices,
+          });
+        } else {
+          return res.status(HTTPStatus.OK).json({
+            success: true,
+            message: "Device(s) not available",
+            devices,
+          });
+        }
       } else {
         missingQueryParams(req, res);
       }


### PR DESCRIPTION
# in case devices are not available, return appropriate response

**_WHAT DOES THIS PR DO?_**
Addresses the issues raised here in [issue-337](https://github.com/airqo-platform/AirQo-api/issues/337)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-337

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/device-registry`
`npm install`
`npm run stage-mac` OR `npm run stage-pc`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
The one for [GET Devices](https://docs.airqo.net/airqo-platform-api/device-registry#list-device-s)
To test out the PR well, use a device that is not present in the system while utilising the `name` query parameter.
![image](https://user-images.githubusercontent.com/1590213/116239066-e11bce80-a76a-11eb-892a-a6da0f5b9db5.png)


**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


