### PR TITLE
return device details alongside the device measurements

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -211,6 +211,12 @@ eventSchema.statics = {
       .unwind("values")
       .match(filter)
       .replaceRoot("values")
+      .lookup({
+        from: "devices",
+        localField: "device",
+        foreignField: "name",
+        as: "deviceDetails",
+      })
       .sort({ time: -1 })
       .group({
         _id: "$device",
@@ -233,6 +239,7 @@ eventSchema.statics = {
         externalHumidity: { $first: "$externalHumidity" },
         pm1: { $first: "$pm1" },
         no2: { $first: "$no2" },
+        deviceDetails: { $first: "$deviceDetails" },
       })
       .skip(skipInt)
       .limit(limitInt)


### PR DESCRIPTION
# return device details alongside the device measurements

**_WHAT DOES THIS PR DO?_**
This PR enhances the endpoint for returning the recent device measurements by addling the device details accordingly. In summary, this PR addresses this[ issue-354](https://github.com/airqo-platform/AirQo-api/issues/354)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-354

**_HOW DO I TEST OUT THIS PR?_**
cd AirQo-api/src/device-registry
npm install
npm run stage-mac

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
The endpoint for the most recent events. You can leave the recent query parameter since the default is always **yes**. You can also use **no** as a value in case you want to just randomly return any values just based on entry age (a rare use-case).
**GET:** http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=yes

![image](https://user-images.githubusercontent.com/1590213/117126806-f5cc1800-ada3-11eb-9f58-83349aa241d9.png)


**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


