### PR TITLE
filter events by frequency

### DIFF
--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -79,6 +79,7 @@ const createEvent = {
         skip,
         key,
         recent,
+        frequency,
       } = req.query;
       const limitInt = parseInt(limit, 0);
       const skipInt = parseInt(skip, 0);

--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -92,6 +92,7 @@ const createEvent = {
           device,
           skipInt,
           limitInt,
+          frequency,
           tenant
         );
       } else {

--- a/src/device-registry/utils/date.js
+++ b/src/device-registry/utils/date.js
@@ -68,8 +68,8 @@ const removeMonthsFromProvidedDate = (date, number) => {
 
 const monthsBehind = (number) => {
   try {
-    var d = new Date();
-    var targetMonth = d.getMonth() - number;
+    let d = new Date();
+    let targetMonth = d.getMonth() - number;
     d.setMonth(targetMonth);
     if (d.getMonth() !== targetMonth % 12) {
       d.setDate(0);
@@ -82,8 +82,8 @@ const monthsBehind = (number) => {
 
 const monthsInfront = (number) => {
   try {
-    var d = new Date();
-    var targetMonth = d.getMonth() + number;
+    let d = new Date();
+    let targetMonth = d.getMonth() + number;
     d.setMonth(targetMonth);
     if (d.getMonth() !== targetMonth % 12) {
       d.setDate(0);

--- a/src/device-registry/utils/date.js
+++ b/src/device-registry/utils/date.js
@@ -1,3 +1,5 @@
+const { logText, logObject, logElement } = require("./log");
+
 const generateDateFormat = (ISODate) => {
   try {
     let date = new Date(ISODate);
@@ -38,50 +40,65 @@ const generateDateFormatWithoutHrs = (ISODate) => {
   }
 };
 
-const threeMonthsBehind = () => {
-  var d = new Date();
-  var targetMonth = d.getMonth() - 3;
-  d.setMonth(targetMonth);
-  if (d.getMonth() !== targetMonth % 12) {
-    d.setDate(0);
+const addMonthsToProvidedDate = (date, number) => {
+  try {
+    let year = date.split("-")[0];
+    let month = date.split("-")[1];
+    let day = date.split("-")[2];
+    let newMonth = parseInt(month, 10) + number;
+    let modifiedMonth = "0" + newMonth;
+    return `${year}-${modifiedMonth}-${day}`;
+  } catch (e) {
+    console.log("server side error: ", e.message);
   }
-  return d;
 };
 
-const twoMonthsBehind = () => {
-  var d = new Date();
-  var targetMonth = d.getMonth() - 2;
-  d.setMonth(targetMonth);
-  if (d.getMonth() !== targetMonth % 12) {
-    d.setDate(0);
+const removeMonthsFromProvidedDate = (date, number) => {
+  try {
+    let year = date.split("-")[0];
+    let month = date.split("-")[1];
+    let day = date.split("-")[2];
+    let newMonth = parseInt(month, 10) - number;
+    let modifiedMonth = "0" + newMonth;
+    return `${year}-${modifiedMonth}-${day}`;
+  } catch (e) {
+    console.log("server side error: ", e.message);
   }
-  return d;
 };
 
-const oneMonthBehind = () => {
-  var d = new Date();
-  var targetMonth = d.getMonth() - 1;
-  d.setMonth(targetMonth);
-  if (d.getMonth() !== targetMonth % 12) {
-    d.setDate(0);
+const monthsBehind = (number) => {
+  try {
+    var d = new Date();
+    var targetMonth = d.getMonth() - number;
+    d.setMonth(targetMonth);
+    if (d.getMonth() !== targetMonth % 12) {
+      d.setDate(0);
+    }
+    return d;
+  } catch (e) {
+    console.log("server side error: ", e.message);
   }
-  return d;
 };
-const threeMonthsInfront = () => {
-  var d = new Date();
-  var targetMonth = d.getMonth() + 3;
-  d.setMonth(targetMonth);
-  if (d.getMonth() !== targetMonth % 12) {
-    d.setDate(0);
+
+const monthsInfront = (number) => {
+  try {
+    var d = new Date();
+    var targetMonth = d.getMonth() + number;
+    d.setMonth(targetMonth);
+    if (d.getMonth() !== targetMonth % 12) {
+      d.setDate(0);
+    }
+    return d;
+  } catch (e) {
+    console.log("server side error: ", e.message);
   }
-  return d;
 };
 
 module.exports = {
   generateDateFormat,
   generateDateFormatWithoutHrs,
-  threeMonthsBehind,
-  twoMonthsBehind,
-  oneMonthBehind,
-  threeMonthsInfront,
+  removeMonthsFromProvidedDate,
+  addMonthsToProvidedDate,
+  monthsBehind,
+  monthsInfront,
 };

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -51,6 +51,44 @@ const generateEventsFilter = (
       "values.device": device,
       "values.frequency": frequency,
     };
+  } else if (queryStartTime && queryEndTime && !device && frequency) {
+    return {
+      day: { $gte: queryStartTime, $lte: queryEndTime },
+      "values.frequency": frequency,
+    };
+  } else if (queryStartTime && queryEndTime && device && !frequency) {
+    return {
+      day: { $gte: queryStartTime, $lte: queryEndTime },
+      "values.device": device,
+    };
+  } else if (!queryStartTime && !queryEndTime && device && !frequency) {
+    return {
+      "values.device": device,
+    };
+  } else if (queryStartTime && !queryEndTime && !device && frequency) {
+    return {
+      day: { $gte: queryStartTime },
+      "values.frequency": frequency,
+    };
+  } else if (!queryStartTime && queryEndTime && !device && frequency) {
+    return {
+      day: { $lte: queryEndTime },
+      "values.frequency": frequency,
+    };
+  } else if (!queryStartTime && queryEndTime && device && !frequency) {
+    return {
+      day: { $lte: queryEndTime },
+      "values.device": device,
+    };
+  } else if (queryStartTime && !queryEndTime && device && !frequency) {
+    return {
+      day: { $gte: queryStartTime },
+      "values.device": device,
+    };
+  } else if (!queryStartTime && !queryEndTime && !device && frequency) {
+    return {
+      "values.frequency": frequency,
+    };
   } else {
     let oneMonthBack = oneMonthBehind();
     let startTime = generateDateFormatWithoutHrs(oneMonthBack);

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -1,10 +1,10 @@
 const {
   generateDateFormat,
   generateDateFormatWithoutHrs,
-  threeMonthsBehind,
-  twoMonthsBehind,
-  oneMonthBehind,
-  threeMonthsInfront,
+  monthsBehind,
+  monthsInfront,
+  removeMonthsFromProvidedDate,
+  addMonthsToProvidedDate,
 } = require("./date");
 
 const { logObject, logElement, logText } = require("./log");
@@ -15,6 +15,13 @@ const generateEventsFilter = (
   device,
   frequency
 ) => {
+  let oneMonthBack = monthsBehind(1);
+  let oneMonthInfront = monthsInfront(1);
+  let defaultStartTime = generateDateFormatWithoutHrs(oneMonthBack);
+  let defaultEndTime = generateDateFormatWithoutHrs(oneMonthInfront);
+  logElement("defaultStartTime", defaultStartTime);
+  logElement("defaultEndTime", defaultEndTime);
+
   if (queryStartTime && queryEndTime && !device && !frequency) {
     return {
       day: { $gte: queryStartTime, $lte: queryEndTime },
@@ -29,25 +36,37 @@ const generateEventsFilter = (
     return {
       "values.device": device,
       "values.frequency": frequency,
+      day: { $gte: defaultStartTime },
     };
   } else if (queryStartTime && !queryEndTime && !device && !frequency) {
     return {
-      day: { $gte: queryStartTime },
-      "values.frequency": frequency,
+      day: {
+        $gte: queryStartTime,
+        $lte: addMonthsToProvidedDate(queryStartTime, 1),
+      },
     };
   } else if (!queryStartTime && queryEndTime && !device && !frequency) {
     return {
-      day: { $lte: queryEndTime },
+      day: {
+        $lte: queryEndTime,
+        $gte: removeMonthsFromProvidedDate(queryEndTime, 1),
+      },
     };
   } else if (!queryStartTime && queryEndTime && device && frequency) {
     return {
-      day: { $lte: queryEndTime },
+      day: {
+        $lte: queryEndTime,
+        $gte: removeMonthsFromProvidedDate(queryEndTime, 1),
+      },
       "values.device": device,
       "values.frequency": frequency,
     };
   } else if (queryStartTime && !queryEndTime && device && frequency) {
     return {
-      day: { $gte: queryStartTime },
+      day: {
+        $gte: queryStartTime,
+        $lte: addMonthsToProvidedDate(queryStartTime, 1),
+      },
       "values.device": device,
       "values.frequency": frequency,
     };
@@ -64,37 +83,48 @@ const generateEventsFilter = (
   } else if (!queryStartTime && !queryEndTime && device && !frequency) {
     return {
       "values.device": device,
+      day: { $gte: defaultStartTime, $lte: defaultEndTime },
     };
   } else if (queryStartTime && !queryEndTime && !device && frequency) {
     return {
-      day: { $gte: queryStartTime },
+      day: {
+        $gte: queryStartTime,
+        $lte: addMonthsToProvidedDate(queryStartTime, 1),
+      },
       "values.frequency": frequency,
     };
   } else if (!queryStartTime && queryEndTime && !device && frequency) {
     return {
-      day: { $lte: queryEndTime },
+      day: {
+        $lte: queryEndTime,
+        $gte: removeMonthsFromProvidedDate(queryEndTime, 1),
+      },
       "values.frequency": frequency,
     };
   } else if (!queryStartTime && queryEndTime && device && !frequency) {
     return {
-      day: { $lte: queryEndTime },
+      day: {
+        $lte: queryEndTime,
+        $gte: removeMonthsFromProvidedDate(queryEndTime, 1),
+      },
       "values.device": device,
     };
   } else if (queryStartTime && !queryEndTime && device && !frequency) {
     return {
-      day: { $gte: queryStartTime },
+      day: {
+        $gte: queryStartTime,
+        $lte: addMonthsToProvidedDate(queryStartTime, 1),
+      },
       "values.device": device,
     };
   } else if (!queryStartTime && !queryEndTime && !device && frequency) {
     return {
       "values.frequency": frequency,
+      day: { $gte: defaultStartTime },
     };
   } else {
-    let oneMonthBack = oneMonthBehind();
-    let startTime = generateDateFormatWithoutHrs(oneMonthBack);
-    logElement("startTime", startTime);
     return {
-      day: { $gte: startTime },
+      day: { $gte: defaultStartTime },
     };
   }
 };

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -28,7 +28,6 @@ const generateEventsFilter = (
   };
 
   if (queryStartTime && !queryEndTime) {
-    filter["day"]["$gte"] = queryStartTime;
     filter["day"]["$lte"] = addMonthsToProvidedDate(queryStartTime, 1);
   }
 
@@ -42,7 +41,6 @@ const generateEventsFilter = (
 
   if (!queryStartTime && queryEndTime) {
     filter["day"]["$gte"] = removeMonthsFromProvidedDate(queryEndTime, 1);
-    filter["day"]["$lte"] = queryEndTime;
   }
 
   if (device) {
@@ -62,7 +60,6 @@ const generateRegexExpressionFromStringElement = (element) => {
 };
 
 const generateDeviceFilter = (
-  tenant,
   name,
   channel,
   location,
@@ -71,70 +68,52 @@ const generateDeviceFilter = (
   primary,
   active
 ) => {
-
-  if(!tenant){
-    return {}
-  }
-
   let filter = {};
 
-  if(name){
+  if (name) {
     let regexExpression = generateRegexExpressionFromStringElement(name);
-    filter['name'] = { $regex: regexExpression, $options: "i" };
+    filter["name"] = { $regex: regexExpression, $options: "i" };
   }
 
-  if(channel){
-    filter['channelID'] = channel;
+  if (channel) {
+    filter["channelID"] = channel;
   }
 
-  if(location){
-    filter['locationID'] = location;
+  if (location) {
+    filter["locationID"] = location;
   }
 
-  if(siteName){
+  if (siteName) {
     let regexExpression = generateRegexExpressionFromStringElement(siteName);
-    filter['siteName'] = { $regex: regexExpression, $options: "i" };
+    filter["siteName"] = { $regex: regexExpression, $options: "i" };
   }
 
-  if(mapAddress){
+  if (mapAddress) {
     let regexExpression = generateRegexExpressionFromStringElement(mapAddress);
-    filter['locationName'] = { $regex: regexExpression, $options: "i" };
+    filter["locationName"] = { $regex: regexExpression, $options: "i" };
   }
 
-  if (primary) { 
-
+  if (primary) {
     const primaryStr = primary + "";
-    
-    if(primaryStr.toLowerCase() == 'yes'){
-      filter['isPrimaryInLocation'] = true;
+    if (primaryStr.toLowerCase() == "yes") {
+      filter["isPrimaryInLocation"] = true;
+    } else if (primaryStr.toLowerCase() == "no") {
+      filter["isPrimaryInLocation"] = false;
+    } else {
     }
-    else if(primaryStr.toLowerCase() == 'no'){
-      filter['isPrimaryInLocation'] = false;
-    }
-    else{
-
-    }
-
   }
 
-  if (active) { 
-
+  if (active) {
     const activeStr = active + "";
-    
-    if(activeStr.toLowerCase() == 'yes'){
-      filter['isActive'] = true;
+    if (activeStr.toLowerCase() == "yes") {
+      filter["isActive"] = true;
+    } else if (activeStr.toLowerCase() == "no") {
+      filter["isActive"] = false;
+    } else {
     }
-    else if(activeStr.toLowerCase() == 'no'){
-      filter['isActive'] = false;
-    }
-    else{
-
-    }
-
   }
 
   return filter;
-
 };
 
 module.exports = { generateEventsFilter, generateDeviceFilter };

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -22,111 +22,37 @@ const generateEventsFilter = (
   logElement("defaultStartTime", defaultStartTime);
   logElement("defaultEndTime", defaultEndTime);
 
-  if (queryStartTime && queryEndTime && !device && !frequency) {
-    return {
-      day: { $gte: queryStartTime, $lte: queryEndTime },
-    };
-  } else if (queryStartTime && queryEndTime && device && frequency) {
-    return {
-      day: { $gte: queryStartTime, $lte: queryEndTime },
-      "values.device": device,
-      "values.frequency": frequency,
-    };
-  } else if (!queryStartTime && !queryEndTime && device && frequency) {
-    return {
-      "values.device": device,
-      "values.frequency": frequency,
-      day: { $gte: defaultStartTime },
-    };
-  } else if (queryStartTime && !queryEndTime && !device && !frequency) {
-    return {
-      day: {
-        $gte: queryStartTime,
-        $lte: addMonthsToProvidedDate(queryStartTime, 1),
-      },
-    };
-  } else if (!queryStartTime && queryEndTime && !device && !frequency) {
-    return {
-      day: {
-        $lte: queryEndTime,
-        $gte: removeMonthsFromProvidedDate(queryEndTime, 1),
-      },
-    };
-  } else if (!queryStartTime && queryEndTime && device && frequency) {
-    return {
-      day: {
-        $lte: queryEndTime,
-        $gte: removeMonthsFromProvidedDate(queryEndTime, 1),
-      },
-      "values.device": device,
-      "values.frequency": frequency,
-    };
-  } else if (queryStartTime && !queryEndTime && device && frequency) {
-    return {
-      day: {
-        $gte: queryStartTime,
-        $lte: addMonthsToProvidedDate(queryStartTime, 1),
-      },
-      "values.device": device,
-      "values.frequency": frequency,
-    };
-  } else if (queryStartTime && queryEndTime && !device && frequency) {
-    return {
-      day: { $gte: queryStartTime, $lte: queryEndTime },
-      "values.frequency": frequency,
-    };
-  } else if (queryStartTime && queryEndTime && device && !frequency) {
-    return {
-      day: { $gte: queryStartTime, $lte: queryEndTime },
-      "values.device": device,
-    };
-  } else if (!queryStartTime && !queryEndTime && device && !frequency) {
-    return {
-      "values.device": device,
-      day: { $gte: defaultStartTime, $lte: defaultEndTime },
-    };
-  } else if (queryStartTime && !queryEndTime && !device && frequency) {
-    return {
-      day: {
-        $gte: queryStartTime,
-        $lte: addMonthsToProvidedDate(queryStartTime, 1),
-      },
-      "values.frequency": frequency,
-    };
-  } else if (!queryStartTime && queryEndTime && !device && frequency) {
-    return {
-      day: {
-        $lte: queryEndTime,
-        $gte: removeMonthsFromProvidedDate(queryEndTime, 1),
-      },
-      "values.frequency": frequency,
-    };
-  } else if (!queryStartTime && queryEndTime && device && !frequency) {
-    return {
-      day: {
-        $lte: queryEndTime,
-        $gte: removeMonthsFromProvidedDate(queryEndTime, 1),
-      },
-      "values.device": device,
-    };
-  } else if (queryStartTime && !queryEndTime && device && !frequency) {
-    return {
-      day: {
-        $gte: queryStartTime,
-        $lte: addMonthsToProvidedDate(queryStartTime, 1),
-      },
-      "values.device": device,
-    };
-  } else if (!queryStartTime && !queryEndTime && !device && frequency) {
-    return {
-      "values.frequency": frequency,
-      day: { $gte: defaultStartTime },
-    };
-  } else {
-    return {
-      day: { $gte: defaultStartTime },
-    };
+  let filter = {
+    day: { $gte: defaultStartTime, $lte: defaultEndTime },
+  };
+
+  if (queryStartTime && !queryEndTime) {
+    filter["day"]["$gte"] = queryStartTime;
+    filter["day"]["$lte"] = addMonthsToProvidedDate(queryStartTime, 1);
   }
+
+  if (queryStartTime) {
+    filter["day"]["$gte"] = queryStartTime;
+  }
+
+  if (queryEndTime) {
+    filter["day"]["$lte"] = queryEndTime;
+  }
+
+  if (!queryStartTime && queryEndTime) {
+    filter["day"]["$gte"] = removeMonthsFromProvidedDate(queryEndTime, 1);
+    filter["day"]["$lte"] = queryEndTime;
+  }
+
+  if (device) {
+    filter["values.device"] = device;
+  }
+
+  if (frequency) {
+    filter["values.frequency"] = frequency;
+  }
+
+  return filter;
 };
 
 const generateRegexExpressionFromStringElement = (element) => {

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -9,37 +9,47 @@ const {
 
 const { logObject, logElement, logText } = require("./log");
 
-const generateEventsFilter = (queryStartTime, queryEndTime, device) => {
-  if (queryStartTime && queryEndTime && !device) {
+const generateEventsFilter = (
+  queryStartTime,
+  queryEndTime,
+  device,
+  frequency
+) => {
+  if (queryStartTime && queryEndTime && !device && !frequency) {
     return {
       day: { $gte: queryStartTime, $lte: queryEndTime },
     };
-  } else if (queryStartTime && queryEndTime && device) {
+  } else if (queryStartTime && queryEndTime && device && frequency) {
     return {
       day: { $gte: queryStartTime, $lte: queryEndTime },
       "values.device": device,
+      "values.frequency": frequency,
     };
-  } else if (!queryStartTime && !queryEndTime && device) {
+  } else if (!queryStartTime && !queryEndTime && device && frequency) {
     return {
       "values.device": device,
+      "values.frequency": frequency,
     };
-  } else if (queryStartTime && !queryEndTime && !device) {
+  } else if (queryStartTime && !queryEndTime && !device && !frequency) {
     return {
       day: { $gte: queryStartTime },
+      "values.frequency": frequency,
     };
-  } else if (!queryStartTime && queryEndTime && !device) {
+  } else if (!queryStartTime && queryEndTime && !device && !frequency) {
     return {
       day: { $lte: queryEndTime },
     };
-  } else if (!queryStartTime && queryEndTime && device) {
+  } else if (!queryStartTime && queryEndTime && device && frequency) {
     return {
       day: { $lte: queryEndTime },
       "values.device": device,
+      "values.frequency": frequency,
     };
-  } else if (queryStartTime && !queryEndTime && device) {
+  } else if (queryStartTime && !queryEndTime && device && frequency) {
     return {
       day: { $gte: queryStartTime },
       "values.device": device,
+      "values.frequency": frequency,
     };
   } else {
     let oneMonthBack = oneMonthBehind();

--- a/src/device-registry/utils/get-device-details.js
+++ b/src/device-registry/utils/get-device-details.js
@@ -27,7 +27,6 @@ const getDetail = async (
     const limit = parseInt(limitValue, 0);
     const skip = parseInt(skipValue, 0);
     const filter = generateDeviceFilter(
-      tenant.toLowerCase(),
       name,
       chid,
       loc,

--- a/src/device-registry/utils/get-measurements.js
+++ b/src/device-registry/utils/get-measurements.js
@@ -47,6 +47,7 @@ const generateCacheID = (
   tenant,
   skip,
   limit,
+  frequency,
   recent
 ) => {
   return `get_events_device_${device ? device : "noDevice"}_${day}_${
@@ -82,6 +83,7 @@ const getMeasurements = async (
   device,
   skip,
   limit,
+  frequency,
   tenant
 ) => {
   try {
@@ -95,6 +97,7 @@ const getMeasurements = async (
       tenant,
       skip,
       limit,
+      frequency,
       recent
     );
 
@@ -106,7 +109,12 @@ const getMeasurements = async (
         } else if (err) {
           callbackErrors(err, req, res);
         } else {
-          const filter = generateEventsFilter(startTime, endTime, device);
+          const filter = generateEventsFilter(
+            startTime,
+            endTime,
+            device,
+            frequency
+          );
 
           let devicesCount = await getDevicesCount(tenant);
 

--- a/src/device-registry/utils/get-measurements.js
+++ b/src/device-registry/utils/get-measurements.js
@@ -53,7 +53,7 @@ const generateCacheID = (
     startTime ? startTime : "noStartTime"
   }_${endTime ? endTime : "noEndTime"}_${tenant}_${skip ? skip : 0}_${
     limit ? limit : 0
-  }_${recent ? recent : "noRecent"}`;
+  }_${recent ? recent : "noRecent"}_${frequency ? frequency : "noFrequency"}`;
 };
 
 const getEvents = async (tenant, recentFlag, skipInt, limitInt, filter) => {

--- a/src/device-registry/utils/get-measurements.js
+++ b/src/device-registry/utils/get-measurements.js
@@ -28,7 +28,6 @@ const isRecentTrue = (recent) => {
   if (recent.toLowerCase() == "yes" && isRecentEmpty == false) {
     return true;
   } else if (recent.toLowerCase() == "no" && isRecentEmpty == false) {
-    logText("the value of recent is false");
     return false;
   }
 };


### PR DESCRIPTION
# filter events by frequency

**_WHAT DOES THIS PR DO?_**

- [x] Enable user to filter events by their frequency. This addresses this[ issue-357](https://github.com/airqo-platform/AirQo-api/issues/357)
- [x] As a way of improving query performance, incorporates more default time periods (one month gaps) in cases where they are not provided.


**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-357

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/device-registry`
`npm install`
`npm run stage-mac` for Linux OR `npm run stage-pc `for Windows machines

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
The one for [GET Events](https://docs.airqo.net/airqo-platform-api/device-registry#get-events)
And query using the `frequency `parameter. Frequency can be any of the following:
- minute
- hourly
- daily

_Sample:_ http://localhost:3000/api/v1/devices/events?tenant=airqo&frequency=minutes

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


