### PR TITLE
Returning dictionary for device details 

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -240,7 +240,7 @@ eventSchema.statics = {
         externalHumidity: { $first: "$externalHumidity" },
         pm1: { $first: "$pm1" },
         no2: { $first: "$no2" },
-        deviceDetails: { $first: "$deviceDetails" },
+        deviceDetails: { $first: {$arrayElemAt: [ "$deviceDetails", 0 ]} },
       })
       .skip(skipInt)
       .limit(limitInt)


### PR DESCRIPTION
# Returns a dictionary for device details 

**_WHAT DOES THIS PR DO?_**
This PR changes the data type of `deviceDetails` in the endpoint that returns the recent device measurements from an array to a dictionary. Resolves #376

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
None

**_WHAT IS THE LINK TO THE PR BRANCH_**
[one-value-for-device-details](https://github.com/airqo-platform/AirQo-api/tree/one-value-for-device-details)

**_HOW DO I TEST OUT THIS PR?_**
```
cd AirQo-api/src/device-registry
npm install
npm run stage-mac
```
**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
GET: http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=yes
![device](https://user-images.githubusercontent.com/37845280/117614280-c6852480-b170-11eb-869d-56b7e89903ab.png)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
None 

**_ARE THERE ANY RELATED PRs?_**
#360 

