### PR TITLE
fix a bug for device already exists

### DIFF
--- a/src/device-registry/controllers/create-device.js
+++ b/src/device-registry/controllers/create-device.js
@@ -52,7 +52,7 @@ const device = {
         const deviceDetails = await getDetail(tenant, device);
         const doesDeviceExist = !isEmpty(deviceDetails);
         logElement("isDevicePresent ?", doesDeviceExist);
-        if (!doesDeviceExist) {
+        if (doesDeviceExist) {
           logText("adding device on TS...");
           let channel;
           if (tenant.toLowerCase() === "airqo") {

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -116,7 +116,7 @@ deviceSchema.plugin(uniqueValidator, {
 
 deviceSchema.pre("save", function(next) {
   if (this.isModified("name")) {
-    this.name = this._transformDeviceName(this.name);
+    // this.name = this._transformDeviceName(this.name);
     let n = this.name;
     console.log({ n });
   }
@@ -125,7 +125,7 @@ deviceSchema.pre("save", function(next) {
 
 deviceSchema.pre("update", function(next) {
   if (this.isModified("name")) {
-    this.name = this._transformDeviceName(this.name);
+    // this.name = this._transformDeviceName(this.name);
     let n = this.name;
     console.log({ n });
   }

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -178,8 +178,8 @@ deviceSchema.methods = {
 
   toUpdateJSON() {
     return {
-      deviceName: this.deviceName,
-      locationID: this.locationName,
+      name: this.name,
+      locationID: this.locationID,
       height: this.height,
       mountType: this.mountType,
       powerType: this.powerType,
@@ -187,7 +187,7 @@ deviceSchema.methods = {
       latitude: this.latitude,
       longitude: this.longitude,
       isPrimaryInLocation: this.isPrimaryInLocation,
-      isUserForCollocaton: this.isUsedForCollocation,
+      isUsedForCollocaton: this.isUsedForCollocation,
       updatedAt: this.updatedAt,
       siteName: this.siteName,
       locationName: this.locationName,

--- a/src/device-registry/utils/does-device-exist.js
+++ b/src/device-registry/utils/does-device-exist.js
@@ -161,10 +161,10 @@ const updateThingBodies = (req, res) => {
     upsert: true,
   };
 
-  let transformedName = tranformDeviceName(name);
+  // let transformedName = tranformDeviceName(name);
 
   let tsBody = {
-    ...(!isEmpty(name) && { name: transformedName }),
+    ...(!isEmpty(name) && { name: name }),
     ...(!isEmpty(elevation) && { elevation: elevation }),
     ...(!isEmpty(tags) && { tags: tags }),
     ...(!isEmpty(latitude) && { latitude: latitude }),


### PR DESCRIPTION
# fix a bug for device already exists on the platform

**_WHAT DOES THIS PR DO?_**

- Fixes an issue present in the frontend for "device already exists". Clearly defined here in a frontend [issue-242](https://github.com/airqo-platform/AirQo-frontend/issues/242).
- Also removes the transformation of the device name (enforcing naming convention) during creation.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/bug-device-already-exists

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/device-registry`
`npm install`
`npm run dev-mac` for MAC or `npm run dev-pc` for Windows

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
the one for creating a new device. Please remember to delete it afterwards. Since the delete endpoint is disabled, please send a Slack DM to to the author (@Baalmart ) after successfully creating a new device so that they can manually delete it accordingly. 
[POST] http://localhost:3000/api/v1/devices/ts?tenant=airqo
_The Request Body:_
```
{
    "name": "AirQo-G88998 UNIT ACTIVE",
    "latitude": "1.234",
    "longitude": "0.413",
    "visibility": false,
    "device_manufacturer": "AirQo",
    "product_name": "Gen8",
    "owner": "AirQo",
    "ISP": "Airtel",
    "phoneNumber": "1434235252",
    "description": "an AirQo device"
}
```

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
None


