### PR TITLE
add an additional sensor (field) in gen 5 devices

### DIFF
--- a/src/data-mgt/node/utils/mappings.js
+++ b/src/data-mgt/node/utils/mappings.js
@@ -22,6 +22,7 @@ const positionsAndLabels = {
   8: "externalTemperature",
   9: "ExternalHumidity",
   10: "ExternalPressure",
+  11: "ExternalAltitude",
 };
 
 function getFieldLabel(field) {


### PR DESCRIPTION
# include undefined sensor for recent Gen 5 devices

**_WHAT DOES THIS PR DO?_**
Defines the `undefined` sensor for recent Gen 5 devices whenever one queries the recent endpoint of data management service.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-extra-field

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/data-mgt/node`
`npm install`
`npm run stage-mac `for Linux OR `npm run stage-pc` for Windows

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
The one for getting the most recent Events (descriptive) as described here: https://docs.airqo.net/airqo-platform-api/data-management#get-last-entry-descriptive

Look out for Gen 5 devices accordingly as you are testing this out, you will recognise that they have an additional field/sensor names _externalAltitude_

![image](https://user-images.githubusercontent.com/1590213/119784063-82b34e80-bed6-11eb-924d-a7d36a4d3ea1.png)


**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


