### PR TITLE
[device-uptime] fix devices with no daily events

### DIFF
--- a/src/device-uptime/utils/device_hourly_records.py
+++ b/src/device-uptime/utils/device_hourly_records.py
@@ -52,7 +52,13 @@ class DeviceChannelRecords:
 
     def get_sensor_readings(self):
         if not self.records:
-            raise Exception(f"Device {self.device_name} has no records")
+            print(f"Device {self.device_name} has no records")
+            return DeviceSensorReadings(
+                time=[datetime.now()],
+                sensor_one_pm2_5=[],
+                sensor_two_pm2_5=[],
+                battery_voltage=[]
+            )
 
         self.df['time'] = pd.to_datetime(self.df['time'])
         time_indexed_data = self.df.set_index('time')
@@ -69,10 +75,13 @@ class DeviceChannelRecords:
             time=time,
             sensor_one_pm2_5=sensor_one_pm2_5,
             sensor_two_pm2_5=sensor_two_pm2_5,
-            battery_voltage=battery_voltage
+            battery_voltage=battery_voltage,
         )
 
     def get_record_count(self):
+
+        if not self.records:
+            return 0
 
         time_indexed_data = self.df.set_index('time')
 
@@ -103,5 +112,5 @@ class DeviceChannelRecords:
             uptime = percent_100
 
         downtime = percent_100 - uptime
-
+        print("device uptime downtime", self.device_name, uptime, downtime)
         return uptime, downtime

--- a/src/device-uptime/utils/device_hourly_records.py
+++ b/src/device-uptime/utils/device_hourly_records.py
@@ -112,5 +112,4 @@ class DeviceChannelRecords:
             uptime = percent_100
 
         downtime = percent_100 - uptime
-        print("device uptime downtime", self.device_name, uptime, downtime)
         return uptime, downtime


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Currently devices with no daily events are not recorded as an uptime of 0% hence affecting the overall network uptime. This PR fixes this issue

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch this branch locally.
* Change directory to the `device-uptime` micro-service directory.
* Follow the steps in the `README.md` file to run the script.
* The script should run successfully.

#### What are the relevant tickets?
- [PLAT-613](https://airqoteam.atlassian.net/browse/PLAT-613)

#### Screenshots (optional)


