### PR TITLE
add default values for Event attributes

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -54,6 +54,7 @@ const measurementsSchema = [
       value: {
         type: Number,
         trim: true,
+        default: null,
       },
       calibratedValue: { type: Number, default: null },
       uncertaintyValue: { type: Number, default: null },
@@ -63,6 +64,7 @@ const measurementsSchema = [
       value: {
         type: Number,
         trim: true,
+        default: null,
       },
       calibratedValue: { type: Number, default: null },
       uncertaintyValue: { type: Number, default: null },

--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -11,6 +11,7 @@ const measurementsSchema = [
     frequency: {
       type: String,
       required: [true, "the frequency is required"],
+      trim: true,
     },
     device: {
       type: String,
@@ -20,118 +21,132 @@ const measurementsSchema = [
     channelID: {
       type: Number,
       trim: true,
+      default: null,
     },
     pm1: {
       value: {
         type: Number,
+        default: null,
       },
-      calibratedValue: { type: Number },
-      uncertaintyValue: { type: Number },
-      standardDeviationValue: { type: Number },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
     },
     pm2_5: {
       value: {
         type: Number,
-        required: [true, "the raw value is required"],
+        default: null,
       },
-      calibratedValue: { type: Number },
-      uncertaintyValue: { type: Number },
-      standardDeviationValue: { type: Number },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
     },
     s2_pm2_5: {
       value: {
         type: Number,
-        required: [true, "the raw value is required"],
+        default: null,
       },
-      calibratedValue: { type: Number },
-      uncertaintyValue: { type: Number },
-      standardDeviationValue: { type: Number },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
     },
     pm10: {
       value: {
         type: Number,
-        required: [true, "the raw value is required"],
+        trim: true,
       },
-      calibratedValue: { type: Number },
-      uncertaintyValue: { type: Number },
-      standardDeviationValue: { type: Number },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
     },
     s2_pm10: {
       value: {
         type: Number,
-        required: [true, "the raw value is required"],
+        trim: true,
       },
-      calibratedValue: { type: Number },
-      uncertaintyValue: { type: Number },
-      standardDeviationValue: { type: Number },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
     },
     no2: {
       value: {
         type: Number,
+        default: null,
       },
-      calibratedValue: { type: Number },
-      uncertaintyValue: { type: Number },
-      standardDeviationValue: { type: Number },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
     },
     battery: {
       value: {
         type: Number,
+        default: null,
       },
     },
     location: {
       latitude: {
         value: {
           type: Number,
+          default: null,
         },
       },
       longitude: {
         value: {
           type: Number,
+          default: null,
         },
       },
     },
     altitude: {
       value: {
         type: Number,
+        default: null,
       },
     },
     speed: {
       value: {
         type: Number,
+        default: null,
       },
     },
     satellites: {
       value: {
         type: Number,
+        default: null,
       },
     },
     hdop: {
       value: {
         type: Number,
+        default: null,
       },
     },
     internalTemperature: {
       value: {
         type: Number,
+        default: null,
       },
     },
     internalHumidity: {
       value: {
         type: Number,
+        default: null,
       },
     },
     externalTemperature: {
       value: {
         type: Number,
+        default: null,
       },
     },
     externalHumidity: {
       value: {
         type: Number,
+        default: null,
       },
     },
     externalPressure: {
-      value: { type: Number },
+      value: { type: Number, default: null },
     },
   },
 ];
@@ -140,9 +155,13 @@ const eventSchema = new Schema(
   {
     day: {
       type: String,
+      required: [true, "the day is required"],
     },
-    first: { type: Date },
-    last: { type: Date },
+    first: {
+      type: Date,
+      required: [true, "the first day's event is required"],
+    },
+    last: { type: Date, required: [true, "the last day's event is required"] },
     nValues: {
       type: Number,
     },
@@ -240,7 +259,7 @@ eventSchema.statics = {
         externalHumidity: { $first: "$externalHumidity" },
         pm1: { $first: "$pm1" },
         no2: { $first: "$no2" },
-        deviceDetails: { $first: {$arrayElemAt: [ "$deviceDetails", 0 ]} },
+        deviceDetails: { $first: { $arrayElemAt: ["$deviceDetails", 0] } },
       })
       .skip(skipInt)
       .limit(limitInt)


### PR DESCRIPTION
# add default values for Event attributes 

**_WHAT DOES THIS PR DO?_**
This PR resolves [issue-414](https://github.com/airqo-platform/AirQo-api/issues/414)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-619]

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-414

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/device-registry/`
`npm install`
`npm run dev-mac` for Linux and `npm run dev-pc` for Windows

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] create a new event that misses most of the sensor values
https://docs.airqo.net/airqo-platform-api/device-registry#add-events

- [x] retrieve that newly created event
-https://docs.airqo.net/airqo-platform-api/device-registry#get-events

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A



[PLAT-619]: https://airqoteam.atlassian.net/browse/PLAT-619