### PR TITLE
increase the server timeout periods and disable automatic process exit

### DIFF
--- a/src/device-registry/config/database.js
+++ b/src/device-registry/config/database.js
@@ -1,5 +1,11 @@
 const mongoose = require("mongoose");
 mongoose.set("useFindAndModify", false);
+mongoose.set("useNewUrlParser", true);
+mongoose.set("useCreateIndex", true);
+mongoose.set("debug", false);
+mongoose.set("serverSelectionTimeoutMS", 3600000);
+mongoose.set("connectTimeoutMS", 1200000);
+mongoose.set("socketTimeoutMS", 600000);
 const constants = require("./constants");
 const { logElement, logText, logObject } = require("../utils/log");
 const URI = constants.MONGO_URI;
@@ -13,8 +19,9 @@ const options = {
   autoIndex: true,
   poolSize: 10,
   bufferMaxEntries: 0,
-  connectTimeoutMS: 10000,
-  socketTimeoutMS: 30000,
+  connectTimeoutMS: 1200000,
+  socketTimeoutMS: 600000,
+  serverSelectionTimeoutMS: 3600000,
   dbName: constants.DB_NAME,
   autoIndex: false,
 };
@@ -29,7 +36,7 @@ const connectToMongoDB = () => {
 
   db.on("error", (err) => {
     logElement("Mongoose connection error" + err);
-    process.exit(0);
+    // process.exit(0);
   });
 
   process.on("unlimitedRejection", (reason, p) => {


### PR DESCRIPTION
# increase the server timeout periods and also disable the termination of process on database connection errors

**_WHAT DOES THIS PR DO?_**
Generally resolves[ issue-422](https://github.com/airqo-platform/AirQo-api/issues/422)
- increases the server timeout periods
- disables the automatic process exit on database connection errors.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-620]

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-422

**_HOW DO I TEST OUT THIS PR?_**
cd AirQo-api/src/device-registry
npm install
`npm run dev-mac` and `npm run dev-pc` for Windows

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
Query events over a large time period and notice the performance.

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


