### PR TITLE
get measurements for specific devices in one go

### DIFF
--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -21,6 +21,7 @@ const generateEventsFilter = (device, frequency, startTime, endTime) => {
       $lte: generateDateFormatWithoutHrs(oneMonthInfront),
     },
     "values.time": { $gte: oneMonthBack, $lte: oneMonthInfront },
+    "values.device": {},
   };
 
   if (startTime) {
@@ -77,7 +78,7 @@ const generateEventsFilter = (device, frequency, startTime, endTime) => {
   }
 
   if (device) {
-    filter["values.device"] = device;
+    filter["values.device"]["$in"] = device;
   }
 
   if (frequency) {


### PR DESCRIPTION
# add support for getting measurements for more than one specific set of devices

**_WHAT DOES THIS PR DO?_**
Resolve [issue-416](https://github.com/airqo-platform/AirQo-api/issues/416)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-621]

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-416

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/device-registry`
`npm install`
`npm run stage-mac` for Linux or `npm run stage-pc` for Windows
Open a new tab in your respective shell environment and ensure that your Redis server is running.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
retrieve events for more than one specific device:
https://docs.airqo.net/airqo-platform-api/device-registry#get-events
Example:

- [ ] http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no&startTime=2021-06-01T13:00:00.000Z&endTime=2021-06-02T12:00:00.000Z&device=aq_53&device=aq_54&limit=100

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A




[PLAT-621]: https://airqoteam.atlassian.net/browse/PLAT-621