### PR TITLE
ensure Events are returned when device query params are not provided

### DIFF
--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -84,15 +84,11 @@ const createEvent = {
         startTime,
         endTime,
       } = req.query;
-      if (req.query.device) {
-        let numberOfDeviceParams = Object.keys(req.query.device).length;
-        logElement("numberOfDeviceParams", numberOfDeviceParams);
-        if (numberOfDeviceParams > 1) {
-          return badRequest(
-            res,
-            "multiple Device query params not supported, please use one comma separated one"
-          );
-        }
+      if (Array.isArray(req.query.device)) {
+        return badRequest(
+          res,
+          "multiple Device query params not supported, please use one comma separated one"
+        );
       }
       const limitInt = parseInt(limit, 0);
       const skipInt = parseInt(skip, 0);

--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -9,6 +9,7 @@ const {
   missingQueryParams,
   callbackErrors,
   invalidParamsValue,
+  badRequest,
 } = require("../utils/errors");
 
 const getDetail = require("../utils/get-device-details");
@@ -83,6 +84,13 @@ const createEvent = {
         startTime,
         endTime,
       } = req.query;
+      let numberOfDeviceParams = Object.keys(req.query.device).length;
+      if (numberOfDeviceParams > 1) {
+        return badRequest(
+          res,
+          "multiple Device query params not supported, please use one comma separated one"
+        );
+      }
       const limitInt = parseInt(limit, 0);
       const skipInt = parseInt(skip, 0);
       logText(".......getting values.......");

--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -84,12 +84,15 @@ const createEvent = {
         startTime,
         endTime,
       } = req.query;
-      let numberOfDeviceParams = Object.keys(req.query.device).length;
-      if (numberOfDeviceParams > 1) {
-        return badRequest(
-          res,
-          "multiple Device query params not supported, please use one comma separated one"
-        );
+      if (req.query.device) {
+        let numberOfDeviceParams = Object.keys(req.query.device).length;
+        logElement("numberOfDeviceParams", numberOfDeviceParams);
+        if (numberOfDeviceParams > 1) {
+          return badRequest(
+            res,
+            "multiple Device query params not supported, please use one comma separated one"
+          );
+        }
       }
       const limitInt = parseInt(limit, 0);
       const skipInt = parseInt(skip, 0);

--- a/src/device-registry/utils/errors.js
+++ b/src/device-registry/utils/errors.js
@@ -23,9 +23,11 @@ const axiosError = (error, req, res) => {
 };
 
 const tryCatchErrors = (res, error) => {
-  res
-    .status(HTTPStatus.BAD_GATEWAY)
-    .json({ success: false, message: "server error", error: error.message });
+  res.status(HTTPStatus.BAD_GATEWAY).json({
+    success: false,
+    message: "internal server error",
+    error: error.message,
+  });
 };
 
 const missingQueryParams = (req, res) => {
@@ -54,11 +56,16 @@ const unclearError = (res) => {
     .json({ success: false, message: "unclear server error" });
 };
 
+const badRequest = (res, message) => {
+  res.status(HTTPStatus.BAD_REQUEST).json({ success: false, message });
+};
+
 module.exports = {
   axiosError,
   tryCatchErrors,
   missingQueryParams,
   callbackErrors,
   unclearError,
-  invalidParamsValue
+  invalidParamsValue,
+  badRequest,
 };

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -7,14 +7,13 @@ const {
   generateDateFormatWithoutHrs,
 } = require("./date");
 
-const { logElement } = require("./log");
+const { logElement, logObject } = require("./log");
 
 const generateEventsFilter = (device, frequency, startTime, endTime) => {
   let oneMonthBack = monthsBehind(1);
   let oneMonthInfront = monthsInfront(1);
   logElement("defaultStartTime", oneMonthBack);
   logElement(" defaultEndTime", oneMonthInfront);
-
   let filter = {
     day: {
       $gte: generateDateFormatWithoutHrs(oneMonthBack),
@@ -78,7 +77,12 @@ const generateEventsFilter = (device, frequency, startTime, endTime) => {
   }
 
   if (device) {
-    filter["values.device"]["$in"] = device;
+    deviceArray = device.split(",");
+    filter["values.device"]["$in"] = deviceArray;
+  }
+
+  if (!device) {
+    delete filter["values.device"];
   }
 
   if (frequency) {


### PR DESCRIPTION
# ensure Events are returned when device query param is not provided

**_WHAT DOES THIS PR DO?_**

- [x] Resolves[ issue-434](https://github.com/airqo-platform/AirQo-api/issues/434)
- [x] Add validation for the usage of the device query parameter

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-434

**_HOW DO I TEST OUT THIS PR?_**
```
cd AirQo-api/src/device-registry
npm install
npm run stage-mac OR npm run stage-pc
```
Please ensure that Redis is running in the background
the latest .ENV is[ here](https://docs.google.com/document/d/1R0ux6i4WaK-NssVQE_9IcTxfUs3ZYIUhSP1Aa7s_hqg/edit?usp=sharing)

Test all three use cases below

- [ ] http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no&startTime=2021-06-01T13:00:00.000Z&endTime=2021-06-14T12:00:00.000Z&device=aq_23&device=aq_32
- [ ] http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no&startTime=2021-06-01T13:00:00.000Z&endTime=2021-06-14T12:00:00.000Z&device=aq_23,aq_32
- [ ] http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no&startTime=2021-06-01T13:00:00.000Z&endTime=2021-06-14T12:00:00.000Z


**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
Just one endpoint, the one for GET events: https://docs.airqo.net/airqo-platform-api/device-registry#get-events

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


