### PR TITLE
[device-uptime] Uptime hourly calculation

### DIFF
--- a/src/device-uptime/config.py
+++ b/src/device-uptime/config.py
@@ -15,14 +15,17 @@ class Config:
     SECRET_KEY = os.getenv("SECRET_KEY")
     DB_NAME = os.getenv("DB_NAME_PROD")
     MONGO_URI = os.getenv('MONGO_GCE_URI')
+    MONITOR_FREQUENCY_MINUTES = os.getenv('MONITOR_FREQUENCY_MINUTES', 60)
     BASE_API_URL = "https://staging-platform.airqo.net/api/v1"
     DAILY_EVENTS_URL = f"{BASE_API_URL}/devices/events"
+    DEVICE_RECENT_EVENTS_URL = f"{BASE_API_URL}/data/feeds/transform/recent"
 
 
 class ProductionConfig(Config):
     DEVELOPMENT = False
     BASE_API_URL = "https://platform.airqo.net/api/v1"
     DAILY_EVENTS_URL = f"{BASE_API_URL}/devices/events"
+    DEVICE_RECENT_EVENTS_URL = f"{BASE_API_URL}/data/feeds/transform/recent"
 
 
 class DevelopmentConfig(Config):
@@ -49,6 +52,7 @@ environment = os.getenv("ENV")
 print("ENVIRONMENT", environment or 'staging')
 
 configuration = app_config.get(environment, TestingConfig)
+
 
 def connect_mongo(tenant):
     client = MongoClient(configuration.MONGO_URI)

--- a/src/device-uptime/device_uptime.py
+++ b/src/device-uptime/device_uptime.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 def get_device_records(tenant, channel_id, device_name, mobility):
     device_channel_records = DeviceChannelRecords(tenant, device_name, channel_id)
     device_records = device_channel_records.get_sensor_readings()
-    uptime, downtime = device_channel_records.calculate_uptime(mobility)
+    uptime, downtime = device_channel_records.calculate_uptime()
     created_at = datetime.now()
     sensor_one_pm2_5 = device_records.sensor_one_pm2_5
     sensor_two_pm2_5 = device_records.sensor_two_pm2_5
@@ -58,7 +58,15 @@ def save_device_uptime(tenant):
         try:
             records.append(future.result())
         except Exception as e:
+            import sys
+            from traceback import print_tb, print_exc
+            from colored import fg, attr
+            color_red = fg('#FF0000')
+            reset = attr('reset')
             print("error occurred while fetching data -", e)
+            print(color_red)
+            print_exc(file=sys.stdout)
+            print(reset)
 
     network_uptime = 0.0
 

--- a/src/device-uptime/device_uptime.py
+++ b/src/device-uptime/device_uptime.py
@@ -61,10 +61,10 @@ def save_device_uptime(tenant):
             import sys
             from traceback import print_tb, print_exc
             from colored import fg, attr
-            color_red = fg('#FF0000')
+            color_warning = fg('#FF6600')
             reset = attr('reset')
             print("error occurred while fetching data -", e)
-            print(color_red)
+            print(color_warning)
             print_exc(file=sys.stdout)
             print(reset)
 
@@ -74,6 +74,8 @@ def save_device_uptime(tenant):
         network_uptime = sum(record.get("uptime", 0.0) for record in records) / len(records)
 
     device_uptime_model = DeviceUptime(tenant)
+    print("records", len(records))
+    print(records)
     device_uptime_model.save_device_uptime(records)
 
     network_uptime_record = {

--- a/src/device-uptime/requirements.txt
+++ b/src/device-uptime/requirements.txt
@@ -1,4 +1,6 @@
+colored
 pandas
 pymongo
+python-dateutil
 python-dotenv
 requests

--- a/src/device-uptime/utils/device_hourly_records.py
+++ b/src/device-uptime/utils/device_hourly_records.py
@@ -12,10 +12,10 @@ urllib3.disable_warnings()
 
 @dataclass
 class DeviceSensorReadings:
-    sensor_one_pm2_5: list
-    sensor_two_pm2_5: list
-    battery_voltage: list
-    time: list
+    sensor_one_pm2_5: int
+    sensor_two_pm2_5: int
+    battery_voltage: int
+    time: datetime
 
 
 class DeviceChannelRecords:
@@ -40,10 +40,10 @@ class DeviceChannelRecords:
         if not self.record:
             print(f"Device {self.device_name} has no records")
             return DeviceSensorReadings(
-                time=[datetime.now()],
-                sensor_one_pm2_5=[],
-                sensor_two_pm2_5=[],
-                battery_voltage=[]
+                time=datetime.utcnow(),
+                sensor_one_pm2_5=0,
+                sensor_two_pm2_5=0,
+                battery_voltage=0
             )
 
         return DeviceSensorReadings(

--- a/src/device-uptime/utils/device_hourly_records.py
+++ b/src/device-uptime/utils/device_hourly_records.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timedelta
-import pandas as pd
+from datetime import datetime
+from dateutil import parser as date_parser
+from dateutil.tz import UTC
 import requests
 import urllib3
 from dataclasses import dataclass
@@ -23,35 +24,20 @@ class DeviceChannelRecords:
         self.tenant = tenant
         self.device_name = device_name
         self.channel_id = channel_id
-        self.records = self.get_device_daily_events()
-        self.df = pd.DataFrame(self.flatten_records())
+        self.record = self.get_recent_event()
 
-    def get_device_daily_events(self):
-        yesterday = datetime.strftime(datetime.now() - timedelta(1), '%Y-%m-%d')
+    def get_recent_event(self):
+        api_url = f'{configuration.DEVICE_RECENT_EVENTS_URL}?tenant={self.tenant}&channel={self.channel_id}'
 
-        api_url = f'{configuration.DAILY_EVENTS_URL}?tenant={self.tenant}&device={self.device_name}'
-        api_url = f'{api_url}&startTime={yesterday}&endTime={yesterday}&recent=no'
+        recent_event = requests.get(api_url, verify=False)
 
-        device_events = requests.get(api_url, verify=False)
+        if recent_event.status_code != 200:
+            return {}
 
-        if device_events.status_code != 200:
-            return []
-
-        return device_events.json().get("measurements", [])
-
-    def flatten_records(self):
-        return [
-            {
-              "time": record["time"],
-              "s1_pm2_5": record["pm2_5"]["value"],
-              "s2_pm2_5": record["s2_pm2_5"]["value"],
-              "voltage": record["battery"]["value"],
-            }
-            for record in self.records
-        ]
+        return recent_event.json()
 
     def get_sensor_readings(self):
-        if not self.records:
+        if not self.record:
             print(f"Device {self.device_name} has no records")
             return DeviceSensorReadings(
                 time=[datetime.now()],
@@ -60,56 +46,27 @@ class DeviceChannelRecords:
                 battery_voltage=[]
             )
 
-        self.df['time'] = pd.to_datetime(self.df['time'])
-        time_indexed_data = self.df.set_index('time')
-
-        # change frequency to hours
-        hourly_data = time_indexed_data.resample('H').mean().round(2)
-        daily_data = hourly_data.resample('D').mean().dropna()
-        sensor_one_pm2_5 = daily_data['s1_pm2_5'].tolist()
-        sensor_two_pm2_5 = daily_data['s2_pm2_5'].tolist()
-        battery_voltage = daily_data['voltage'].tolist()
-        time = daily_data.index.tolist()
-
         return DeviceSensorReadings(
-            time=time,
-            sensor_one_pm2_5=sensor_one_pm2_5,
-            sensor_two_pm2_5=sensor_two_pm2_5,
-            battery_voltage=battery_voltage,
+            time=self.record.get("created_at"),
+            sensor_one_pm2_5=self.record.get("pm2_5"),
+            sensor_two_pm2_5=self.record.get("s2_om2_5"),
+            battery_voltage=self.record.get("voltage")
         )
 
-    def get_record_count(self):
+    def calculate_uptime(self):
+        time = self.record.get("created_at")
+        uptime, downtime = 0, 100
 
-        if not self.records:
-            return 0
+        if not time:
+            return uptime, downtime
 
-        time_indexed_data = self.df.set_index('time')
+        time = date_parser.isoparse(time)
+        now = datetime.utcnow()
+        now = now.replace(tzinfo=UTC)
+        minutes_diff = (now - time).total_seconds() / 60
 
-        # change frequency to hours
-        hourly_data = time_indexed_data.resample('H').mean().round(2)
+        if minutes_diff > configuration.MONITOR_FREQUENCY_MINUTES:
+            return uptime, downtime
+        uptime, downtime = 100, 0
 
-        return hourly_data.dropna().reset_index().shape[0]
-
-    @staticmethod
-    def get_expected_records_count(mobility):
-        """
-        We are considering hourly values
-        So that means that in a day, a static device should generate 24 records
-        Mobile devices should generate 12 (half of that)
-        """
-        total_records_per_day = 24
-        if str(mobility).lower() == 'mobile' or str(mobility).lower() == "true":
-            return total_records_per_day / 2
-        return total_records_per_day
-
-    def calculate_uptime(self, mobility):
-        percent_100 = 100
-        expected_records = self.get_expected_records_count(mobility)
-        actual_records = self.get_record_count()
-        uptime = round((actual_records / expected_records) * percent_100, 2)
-
-        if uptime > percent_100:
-            uptime = percent_100
-
-        downtime = percent_100 - uptime
         return uptime, downtime

--- a/src/device-uptime/utils/device_hourly_records.py
+++ b/src/device-uptime/utils/device_hourly_records.py
@@ -49,7 +49,7 @@ class DeviceChannelRecords:
         return DeviceSensorReadings(
             time=self.record.get("created_at"),
             sensor_one_pm2_5=self.record.get("pm2_5"),
-            sensor_two_pm2_5=self.record.get("s2_om2_5"),
+            sensor_two_pm2_5=self.record.get("s2_pm2_5"),
             battery_voltage=self.record.get("voltage")
         )
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Enable hourly calculation of device and network uptime (can be customised too using the `MONITOR_FREQUENCY_MINUTES` env key)
- 
#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch this branch locally.
* Change directory to the `device-uptime` micro-service directory.
* Follow the steps in the `README.md` file to run the script.
* The script should run successfully.

#### What are the relevant tickets?
- [PLAT-626](https://airqoteam.atlassian.net/browse/PLAT-626)

#### Screenshots (optional)


