### PR TITLE
set default limit when fetching for device measurements to 1000

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -70,6 +70,7 @@ const defaultConfig = {
     field8: "GpsData",
   },
   N_VALUES: 120000,
+  DEFAULT_EVENTS_LIMIT: 1000,
 };
 
 function envConfig(env) {

--- a/src/device-registry/utils/date.js
+++ b/src/device-registry/utils/date.js
@@ -156,6 +156,16 @@ const monthsInfront = (number) => {
   }
 };
 
+const getDifferenceInMonths = (d1, d2) => {
+  let months;
+  let start = new Date(d1);
+  let end = new Date(d2);
+  months = (end.getFullYear() - start.getFullYear()) * 12;
+  months -= start.getMonth();
+  months += end.getMonth();
+  return months <= 0 ? 0 : months;
+};
+
 module.exports = {
   generateDateFormat,
   generateDateFormatWithoutHrs,
@@ -164,4 +174,5 @@ module.exports = {
   monthsBehind,
   monthsInfront,
   isTimeEmpty,
+  getDifferenceInMonths,
 };

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -5,6 +5,7 @@ const {
   addMonthsToProvideDateTime,
   isTimeEmpty,
   generateDateFormatWithoutHrs,
+  getDifferenceInMonths,
 } = require("./date");
 
 const { logElement, logObject } = require("./log");
@@ -79,6 +80,28 @@ const generateEventsFilter = (device, frequency, startTime, endTime) => {
   if (device) {
     deviceArray = device.split(",");
     filter["values.device"]["$in"] = deviceArray;
+  }
+
+  if (startTime && endTime) {
+    let months = getDifferenceInMonths(startTime, endTime);
+    logElement("the number of months", months);
+    if (months > 2) {
+      if (isTimeEmpty(endTime) == false) {
+        filter["values.time"]["$gte"] = removeMonthsFromProvideDateTime(
+          endTime,
+          1
+        );
+      } else {
+        delete filter["values.time"];
+      }
+      let removedOneMonthFromProvidedDateTime = removeMonthsFromProvideDateTime(
+        endTime,
+        1
+      );
+      filter["day"]["$gte"] = generateDateFormatWithoutHrs(
+        removedOneMonthFromProvidedDateTime
+      );
+    }
   }
 
   if (!device) {

--- a/src/device-registry/utils/get-measurements.js
+++ b/src/device-registry/utils/get-measurements.js
@@ -3,6 +3,7 @@ const isEmpty = require("is-empty");
 const HTTPStatus = require("http-status");
 const { getModelByTenant } = require("./multitenancy");
 const redis = require("../config/redis");
+const constants = require("../config/constants");
 const {
   axiosError,
   tryCatchErrors,
@@ -119,16 +120,25 @@ const getMeasurements = async (
 
           let devicesCount = await getDevicesCount(tenant);
 
-          let skipInt = skip ? skip : 0;
-          let limitInt = limit ? limit : devicesCount;
+          let _skip = skip ? skip : 0;
+          let _limit = limit ? limit : constants.DEFAULT_EVENTS_LIMIT;
+          let options = {
+            skipInt: _skip,
+            limitInt: _limit,
+          };
+
+          if (!device) {
+            options["skipInt"] = 0;
+            options["limitInt"] = devicesCount;
+          }
 
           let recentFlag = isRecentTrue(recent);
 
           let events = await getEvents(
             tenant,
             recentFlag,
-            skipInt,
-            limitInt,
+            options.skipInt,
+            options.limitInt,
             filter
           );
 


### PR DESCRIPTION
# set default limit when fetching for device measurements to 1000 

**_WHAT DOES THIS PR DO?_**
This PR resolves [issue-432](https://github.com/airqo-platform/AirQo-api/issues/432)
- [x] Always return some (few) recent values in case query requests for large data
- [x]  set default limit when fetching for device measurements to 1000 
- [ ] Increases caching expiry policy for the Events GET to 30 minutes

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-432

**_HOW DO I TEST OUT THIS PR?_**
cd AirQo-api/src/device-registry
npm install
npm run stage-mac OR npm run stage-pc

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

`GET Events`, three scenarios:
- one with` device` query parameter
http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no&startTime=2021-06-01T13:00:00.000Z&endTime=2021-06-14T12:00:00.000Z&device=aq_64
- and another without one.
http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no&startTime=2021-06-01T13:00:00.000Z&endTime=2021-06-14T12:00:00.000Z
- Also another with a huge time difference.
Also test out using a wide range and always return the default values irrespective of request being made.
http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no&startTime=2021-01-01T13:00:00.000Z&endTime=2021-06-14T12:00:00.000Z&device=aq_64

More details about the GET Events can be found [HERE ](https://docs.airqo.net/airqo-platform-api/device-registry#get-events)
The .ENV is also [HERE](https://docs.google.com/document/d/1R0ux6i4WaK-NssVQE_9IcTxfUs3ZYIUhSP1Aa7s_hqg/edit?usp=sharing).

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


