### PR TITLE
Optimise query performance for the GET events endpoint

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -71,6 +71,7 @@ const defaultConfig = {
   },
   N_VALUES: 120000,
   DEFAULT_EVENTS_LIMIT: 1000,
+  EVENTS_CACHE_LIMIT: 1800,
 };
 
 function envConfig(env) {

--- a/src/device-registry/utils/date.js
+++ b/src/device-registry/utils/date.js
@@ -156,6 +156,16 @@ const monthsInfront = (number) => {
   }
 };
 
+const addDays = (number) => {
+  try {
+    let d = new Date();
+    let target = d.setDate(d.getDate() + number);
+    return d;
+  } catch (e) {
+    console.log("server side error: ", e.message);
+  }
+};
+
 const getDifferenceInMonths = (d1, d2) => {
   let months;
   let start = new Date(d1);
@@ -175,4 +185,5 @@ module.exports = {
   monthsInfront,
   isTimeEmpty,
   getDifferenceInMonths,
+  addDays,
 };

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -6,6 +6,7 @@ const {
   isTimeEmpty,
   generateDateFormatWithoutHrs,
   getDifferenceInMonths,
+  addDays,
 } = require("./date");
 
 const { logElement, logObject } = require("./log");
@@ -13,14 +14,14 @@ const { logElement, logObject } = require("./log");
 const generateEventsFilter = (device, frequency, startTime, endTime) => {
   let oneMonthBack = monthsBehind(1);
   let oneMonthInfront = monthsInfront(1);
-  logElement("defaultStartTime", oneMonthBack);
-  logElement(" defaultEndTime", oneMonthInfront);
+  let today = monthsInfront(0);
+  let oneWeekBack = addDays(-7);
   let filter = {
     day: {
-      $gte: generateDateFormatWithoutHrs(oneMonthBack),
-      $lte: generateDateFormatWithoutHrs(oneMonthInfront),
+      $gte: generateDateFormatWithoutHrs(oneWeekBack),
+      $lte: generateDateFormatWithoutHrs(today),
     },
-    "values.time": { $gte: oneMonthBack, $lte: oneMonthInfront },
+    "values.time": { $gte: oneWeekBack, $lte: today },
     "values.device": {},
   };
 

--- a/src/device-registry/utils/get-measurements.js
+++ b/src/device-registry/utils/get-measurements.js
@@ -151,7 +151,7 @@ const getMeasurements = async (
               measurements: events,
             })
           );
-          redis.expire(cacheID, 30);
+          redis.expire(cacheID, constants.EVENTS_CACHE_LIMIT);
           return res.status(HTTPStatus.OK).json({
             success: true,
             isCache: false,


### PR DESCRIPTION
# Optimise query performance for the GET events endpoint

**_WHAT DOES THIS PR DO?_**

- [x] increase caching to 30 mins and 
- [x] reduce default search range to one week back in order to optimise performance

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-643]

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-query-optimisation

**_HOW DO I TEST OUT THIS PR?_**
`cd AirQo-api/src/device-registry`
`npm install`
`npm run stage-mac OR npm run stage-pc`
Please remember to have Redis running in the background...

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
GET Events using various default use cases, example:

- http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no&device=aq_33
- http://localhost:3000/api/v1/devices/events?tenant=airqo&recent=no
- http://localhost:3000/api/v1/devices/events?tenant=airqo

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A




[PLAT-643]: https://airqoteam.atlassian.net/browse/PLAT-643