### PR TITLE
make site name not required

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -36,7 +36,7 @@ const measurementsSchema = [
     },
     site: {
       type: String,
-      required: [true, "the site name is required"],
+      default: "",
     },
     site_id: {
       type: ObjectId,

--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -272,7 +272,6 @@ eventSchema.statics = {
       .sort({ time: -1 })
       .group({
         _id: "$device",
-        channelID: { $first: "$channelID" },
         time: { $first: "$time" },
         pm2_5: { $first: "$pm2_5" },
         s2_pm2_5: { $first: "$s2_pm2_5" },


### PR DESCRIPTION
# hotfix that makes site name not required when inserting Events

**_WHAT DOES THIS PR DO?_**

-  hotfix that makes site name not required
- removes channel ID from the projected fields since it was removed from the attributes list

**_HOW DO I TEST OUT THIS PR?_**
`cd into device-registry`
`npm install`
`npm run dev-mac `or` npm run dev-pc`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
the endpoint for adding Events:
https://docs.airqo.net/airqo-platform-api/device-registry#add-events

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


