### PR TITLE
enable insertion of device measurements for various frequencies

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -203,6 +203,7 @@ eventSchema.index(
     "values.time": 1,
     "values.device": 1,
     "values.device_id": 1,
+    "values.site_id": 1,
     day: 1,
     "values.frequency": 1,
   },

--- a/src/device-registry/utils/insert-measurements.js
+++ b/src/device-registry/utils/insert-measurements.js
@@ -20,6 +20,9 @@ const insert = async (tenant, transformedMeasurements) => {
         $or: [
           { "values.time": { $ne: measurement.time } },
           { "values.device": { $ne: measurement.device } },
+          { "values.frequency": { $ne: measurement.frequency } },
+          { "values.device_id": { $ne: measurement.device_id } },
+          { "values.site_id": { $ne: measurement.site_id } },
           { day: { $ne: measurement.day } },
         ],
       };
@@ -67,7 +70,6 @@ const insert = async (tenant, transformedMeasurements) => {
       valuesAdded: eventsAdded,
     };
   }
-
 };
 
 module.exports = insert;


### PR DESCRIPTION
# enable insertion of device measurements for various frequencies like daily, hourly and raw

**_WHAT DOES THIS PR DO?_**]
Resolves[ issue-426](https://github.com/airqo-platform/AirQo-api/issues/426)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-426

**_HOW DO I TEST OUT THIS PR?_**
```
cd AirQo-api/src/device-registry
npm install
```
`npm run dev-mac` OR `npm run dev-pc`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

The one for add Events: https://docs.airqo.net/airqo-platform-api/device-registry#add-events
While at it, please keep on switching the `frequencies` accordingly....


POST: `http://localhost:3000/api/v1/devices/events/add?device={DEVICE_ID}&tenant={TENANT}`
BODY:
```
[
    {
        "frequency": "montho",
        "time": "2021-06-14T23:59:00.000Z",
        "device_id": "60d2afbe7e9018a1a8d38c0f",
        "device_number": 234243,
        "pm2_5": {
            "value": 47.590949058532715
        },
        "pm1": {
            "value": 31.18145751953125
        },
        "pm10": {
            "value": 59.783132553100586
        }
    }
]
```

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


