### PR TITLE
Get events when query "timestamps" are zero or not provided

### DIFF
--- a/src/device-registry/utils/date.js
+++ b/src/device-registry/utils/date.js
@@ -1,4 +1,5 @@
 const { logText, logObject, logElement } = require("./log");
+const isEmpty = require("is-empty");
 
 const generateDateFormat = (ISODate) => {
   try {
@@ -30,10 +31,15 @@ const isTimeEmpty = (dateTime) => {
   logElement("mins", mins);
   logElement("secs", secs);
   logElement("millisecs", millisecs);
-  if (hrs == 00 && mins == 00 && secs == 00 && millisecs == 00) {
-    return true;
+  if (
+    Number.isInteger(hrs) &&
+    Number.isInteger(mins) &&
+    Number.isInteger(secs) &&
+    Number.isInteger(millisecs)
+  ) {
+    return false;
   }
-  return false;
+  return true;
 };
 
 const generateDateFormatWithoutHrs = (ISODate) => {


### PR DESCRIPTION
# in case the query times are zero or not provided, only consider the times between the provided dates

**_WHAT DOES THIS PR DO?_**
This resolves [issue-413](https://github.com/airqo-platform/AirQo-api/issues/413)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-644]

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/issue-413

**_HOW DO I TEST OUT THIS PR?_**
```
cd AirQo-api/src/device-registry
npm install
```
`npm run stage-mac` OR `npm run stage-pc`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
GET Events where time is not provided as shown in the example below.
http://localhost:3000/api/v1/devices/events?tenant=airqo&device=aq_53&startTime=2021-06-26T00:00:00.000Z&endTime=2021-06-27T05:00:00.000Z

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A




[PLAT-644]: https://airqoteam.atlassian.net/browse/PLAT-644