### PR TITLE
group measurements by site id

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -167,11 +167,15 @@ const measurementsSchema = [
       },
     },
     externalPressure: {
-      value: { type: Number, default: null },
+      value: {
+        type: Number,
+        default: null,
+      },
     },
     externalAltitude: {
       value: {
         type: Number,
+        default: null,
       },
     },
   },
@@ -272,7 +276,7 @@ eventSchema.statics = {
       })
       .sort({ time: -1 })
       .group({
-        _id: "$device",
+        _id: "$site_id",
         time: { $first: "$time" },
         pm2_5: { $first: "$pm2_5" },
         s2_pm2_5: { $first: "$s2_pm2_5" },
@@ -285,6 +289,10 @@ eventSchema.statics = {
         speed: { $first: "$speed" },
         satellites: { $first: "$satellites" },
         hdop: { $first: "$hdop" },
+        site: { $first: "$site" },
+        device: { $first: "$device" },
+        device_number: { $first: "$device_number" },
+        device_id: { $first: "$device_id" },
         internalTemperature: { $first: "$internalTemperature" },
         externalTemperature: { $first: "$externalTemperature" },
         internalHumidity: { $first: "$internalHumidity" },

--- a/src/device-registry/utils/get-measurements.js
+++ b/src/device-registry/utils/get-measurements.js
@@ -21,7 +21,7 @@ const getDetail = require("../utils/get-device-details");
 const isRecentTrue = (recent) => {
   let isRecentEmpty = isEmpty(recent);
   if (isRecentEmpty == true) {
-    return true;
+    return false;
   }
   if (recent.toLowerCase() == "yes" && isRecentEmpty == false) {
     return true;


### PR DESCRIPTION
# group measurements by site id and return site ID details in default mode for Events

**_WHAT DOES THIS PR DO?_**

- [x] group measurements by site id and include site details in default mode for Events
- [x] Change default mode for the endpoint to be `recent=no` 

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-410]

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-events-response

**_HOW DO I TEST OUT THIS PR?_**

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?_**




[PLAT-410]: https://airqoteam.atlassian.net/browse/PLAT-410