### PR TITLE
Enhancements on device schema

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -81,6 +81,7 @@ const defaultConfig = {
   DEFAULT_LIMIT_FOR_QUERYING_SITES: 100,
   DEFAULT_EVENTS_LIMIT: 1000,
   EVENTS_CACHE_LIMIT: 1800,
+  WHITE_SPACES_REGEX: /^\S*$/,
 };
 
 function envConfig(env) {

--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -81,7 +81,7 @@ const defaultConfig = {
   DEFAULT_LIMIT_FOR_QUERYING_SITES: 100,
   DEFAULT_EVENTS_LIMIT: 1000,
   EVENTS_CACHE_LIMIT: 1800,
-  WHITE_SPACES_REGEX: /^\S*$/,
+  WHITE_SPACES_REGEX: /^\S+$/,
 };
 
 function envConfig(env) {

--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -81,7 +81,7 @@ const defaultConfig = {
   DEFAULT_LIMIT_FOR_QUERYING_SITES: 100,
   DEFAULT_EVENTS_LIMIT: 1000,
   EVENTS_CACHE_LIMIT: 1800,
-  WHITE_SPACES_REGEX: /^\S+$/,
+  WHITE_SPACES_REGEX: /^\S*$/,
 };
 
 function envConfig(env) {

--- a/src/device-registry/controllers/create-device.js
+++ b/src/device-registry/controllers/create-device.js
@@ -28,11 +28,15 @@ const updateDeviceUtil = require("../utils/update-device");
 const nearestDevices = require("../utils/nearest-device");
 const generateFilter = require("../utils/generate-filter");
 
+const { validationResult } = require("express-validator");
+
 const {
   tryCatchErrors,
   axiosError,
   missingQueryParams,
   callbackErrors,
+  missingOrInvalidValues,
+  badRequest,
 } = require("../utils/errors");
 
 const { deleteFromCloudinary } = require("../utils/delete-cloudinary-image");
@@ -580,6 +584,11 @@ const device = {
 
   createOne: async (req, res) => {
     try {
+      const hasErrors = !validationResult(req).isEmpty();
+      if (hasErrors) {
+        let nestedErrors = validationResult(req).errors[0].nestedErrors;
+        return badRequest(res, "bad request errors", nestedErrors);
+      }
       const { tenant } = req.query;
       if (tenant) {
         console.log("creating one device....");

--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -87,7 +87,8 @@ const createEvent = {
       if (Array.isArray(req.query.device)) {
         return badRequest(
           res,
-          "multiple Device query params not supported, please use one comma separated one"
+          "multiple Device query params not supported, please use one comma separated one",
+          []
         );
       }
       const limitInt = parseInt(limit, 0);

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -3,6 +3,17 @@ const ObjectId = mongoose.Schema.Types.ObjectId;
 const uniqueValidator = require("mongoose-unique-validator");
 const tranformDeviceName = require("../utils/transform-device-name");
 const { logObject, logElement } = require("../utils/log");
+const { monthsInfront } = require("../utils/date");
+
+const maxLength = [
+  9,
+  "The value of path `{PATH}` (`{VALUE}`) exceeds the maximum allowed length ({MAXLENGTH}).",
+];
+
+const minLength = [
+  5,
+  "The value of path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).",
+];
 
 const deviceSchema = new mongoose.Schema(
   {
@@ -25,7 +36,9 @@ const deviceSchema = new mongoose.Schema(
       type: String,
       required: [true, "Device name is required!"],
       trim: true,
+      maxlength: maxLength,
       unique: true,
+      minlength: minLength,
     },
     visibility: {
       type: Boolean,
@@ -39,7 +52,7 @@ const deviceSchema = new mongoose.Schema(
       type: Number,
     },
     owner: {
-      type: String,
+      type: ObjectId,
     },
     description: {
       type: String,
@@ -57,6 +70,8 @@ const deviceSchema = new mongoose.Schema(
     mountType: {
       type: String,
       trim: true,
+      default: "wall",
+      lowercase: true,
     },
     ISP: {
       type: String,
@@ -72,35 +87,41 @@ const deviceSchema = new mongoose.Schema(
     },
     device_manufacturer: {
       type: String,
+      default: "airqo",
     },
     product_name: {
       type: String,
+      default: "gen1",
     },
     powerType: {
       type: String,
+      lowercase: true,
     },
-    locationID: {
-      type: String,
+    isRetired: {
+      type: Boolean,
+      default: false,
     },
-    host: {
-      name: String,
-      phone: Number,
+    host_id: {
+      type: ObjectId,
     },
     site_id: {
       type: ObjectId,
     },
     isPrimaryInLocation: {
       type: Boolean,
+      default: false,
     },
     isUsedForCollocation: {
       type: Boolean,
+      default: false,
     },
     nextMaintenance: {
       type: Date,
+      default: monthsInfront(3),
     },
-    channelID: {
+    device_number: {
       type: Number,
-      required: [true, "Channel ID is required!"],
+      required: [true, "device_number is required!"],
       trim: true,
       unique: true,
     },
@@ -168,16 +189,16 @@ deviceSchema.methods = {
       isPrimaryInLocation: this.isPrimaryInLocation,
       isUsedForCollocation: this.isUsedForCollocation,
       nextMaintenance: this.nextMaintenance,
-      channelID: this.channelID,
+      device_number: this.device_number,
       powerType: this.powerType,
       mountType: this.mountType,
-      locationID: this.locationID,
       isActive: this.isActive,
       writeKey: this.writeKey,
+      isRetired: this.isRetired,
       readKey: this.readKey,
       pictures: this.pictures,
-      siteName: this.siteName,
       site_id: this.site_id,
+      siteName: this.siteName,
       locationName: this.locationName,
       height: this.height,
     };
@@ -238,7 +259,7 @@ deviceSchema.statics = {
           isPrimaryInLocation: 1,
           isUsedForCollocation: 1,
           nextMaintenance: 1,
-          channelID: 1,
+          device_number: 1,
           powerType: 1,
           mountType: 1,
           locationID: 1,

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -15,6 +15,8 @@ const minLength = [
   "The value of path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).",
 ];
 
+const noSpaces = /^\S*$/;
+
 const deviceSchema = new mongoose.Schema(
   {
     latitude: {
@@ -39,6 +41,7 @@ const deviceSchema = new mongoose.Schema(
       maxlength: maxLength,
       unique: true,
       minlength: minLength,
+      match: noSpaces,
     },
     visibility: {
       type: Boolean,

--- a/src/device-registry/routes/api.js
+++ b/src/device-registry/routes/api.js
@@ -25,9 +25,9 @@ router.post(
       body("visibility").exists(),
       body("name").exists(),
       body("device_number").exists(),
-      body("name").matches(constants.WHITE_SPACES_REGEX, "i"),
-      body("mountType").isIn(["pole", "wall", "motor"]),
-      body("powerType").isIn(["solar", "mains", "alternator"]),
+      check("name").matches(constants.WHITE_SPACES_REGEX, "i"),
+      check("mountType").isIn(["pole", "wall", "motor"]),
+      check("powerType").isIn(["solar", "mains", "alternator"]),
     ],
   ]),
   deviceController.createThing

--- a/src/device-registry/routes/api.js
+++ b/src/device-registry/routes/api.js
@@ -21,13 +21,36 @@ router.post(
   "/ts",
   oneOf([
     [
-      query("tenant").exists(),
-      body("visibility").exists(),
-      body("name").exists(),
-      body("device_number").exists(),
-      check("name").matches(constants.WHITE_SPACES_REGEX, "i"),
-      check("mountType").isIn(["pole", "wall", "motor"]),
-      check("powerType").isIn(["solar", "mains", "alternator"]),
+      query("tenant")
+        .exists()
+        .withMessage("tenant does not exist"),
+      body("visibility")
+        .exists()
+        .withMessage("visibility does not exist"),
+      body("name")
+        .exists()
+        .withMessage("name does not exist"),
+      body("device_number")
+        .exists()
+        .withMessage("device_number does not exist"),
+      body("name")
+        .matches(constants.WHITE_SPACES_REGEX, "i")
+        .withMessage("the device name should not have spaces in it"),
+      body("mountType")
+        .isIn(["pole", "wall", "motor"])
+        .withMessage(
+          "the mountType value is not among the expected ones of pole, walll and motor"
+        ),
+      body("powerType")
+        .isIn(["solar", "mains", "alternator"])
+        .withMessage(
+          "the powerType value is not among the expected ones of solar, mains and alternator"
+        ),
+      body("name")
+        .isLength({ min: 5, max: 9 })
+        .withMessage(
+          "minimum length should be 5 characters and maximum length should be 9 characters"
+        ),
     ],
   ]),
   deviceController.createThing
@@ -46,10 +69,22 @@ router.put(
   "/ts/update",
   oneOf([
     [
-      query("tenant").exists(),
-      query("name").exists(),
-      body("mountType").isIn(["pole", "wall", "motor"]),
-      body("powerType").isIn(["solar", "mains", "alternator"]),
+      query("tenant")
+        .exists()
+        .withMessage("tenant does not exist"),
+      query("device")
+        .exists()
+        .withMessage("device does not exist"),
+      body("mountType")
+        .isIn(["pole", "wall", "motor"])
+        .withMessage(
+          "the mountType value is not among the expected ones of pole, walll and motor"
+        ),
+      body("powerType")
+        .isIn(["solar", "mains", "alternator"])
+        .withMessage(
+          "the powerType value is not among the expected ones of solar, mains and alternator"
+        ),
     ],
   ]),
   deviceController.updateThingSettings
@@ -59,7 +94,44 @@ router.get(
   "/by/nearest-coordinates",
   deviceController.listAllByNearestCoordinates
 );
-router.post("/", deviceController.createOne);
+router.post(
+  "/",
+  oneOf([
+    [
+      query("tenant")
+        .exists()
+        .withMessage("tenant does not exist"),
+      body("visibility")
+        .exists()
+        .withMessage("visibility does not exist"),
+      body("name")
+        .exists()
+        .withMessage("name does not exist"),
+      body("device_number")
+        .exists()
+        .withMessage("device_number does not exist"),
+      body("name")
+        .matches(constants.WHITE_SPACES_REGEX, "i")
+        .withMessage("the device name should not have spaces in it"),
+      body("mountType")
+        .isIn(["pole", "wall", "motor"])
+        .withMessage(
+          "the mountType value is not among the expected ones of pole, walll and motor"
+        ),
+      body("powerType")
+        .isIn(["solar", "mains", "alternator"])
+        .withMessage(
+          "the powerType value is not among the expected ones of solar, mains and alternator"
+        ),
+      body("name")
+        .isLength({ min: 5, max: 9 })
+        .withMessage(
+          "minimum length should be 5 characters and maximum length should be 9 characters"
+        ),
+    ],
+  ]),
+  deviceController.createOne
+);
 router.delete("/photos", deviceController.deletePhotos);
 router.delete("/delete", deviceController.delete);
 router.put("/update", deviceController.updateDevice);

--- a/src/device-registry/routes/api.js
+++ b/src/device-registry/routes/api.js
@@ -16,11 +16,44 @@ const constants = require("../config/constants");
 middlewareConfig(router);
 
 /******************* create device ***************************/
-router.get("/", deviceController.listAll);
-router.post("/ts", deviceController.createThing);
-router.delete("/ts/delete", deviceController.deleteThing);
-router.delete("/ts/clear", deviceController.clearThing);
-router.put("/ts/update", deviceController.updateThingSettings);
+router.get("/", oneOf([[query("tenant").exists()]]), deviceController.listAll);
+router.post(
+  "/ts",
+  oneOf([
+    [
+      query("tenant").exists(),
+      body("visibility").exists(),
+      body("name").exists(),
+      body("device_number").exists(),
+      body("name").matches(constants.WHITE_SPACES_REGEX, "i"),
+      body("mountType").isIn(["pole", "wall", "motor"]),
+      body("powerType").isIn(["solar", "mains", "alternator"]),
+    ],
+  ]),
+  deviceController.createThing
+);
+router.delete(
+  "/ts/delete",
+  oneOf([[query("tenant").exists(), query("name").exists()]]),
+  deviceController.deleteThing
+);
+router.delete(
+  "/ts/clear",
+  oneOf([[query("tenant").exists(), query("name").exists()]]),
+  deviceController.clearThing
+);
+router.put(
+  "/ts/update",
+  oneOf([
+    [
+      query("tenant").exists(),
+      query("name").exists(),
+      body("mountType").isIn(["pole", "wall", "motor"]),
+      body("powerType").isIn(["solar", "mains", "alternator"]),
+    ],
+  ]),
+  deviceController.updateThingSettings
+);
 router.get("/by/location", deviceController.listAllByLocation);
 router.get(
   "/by/nearest-coordinates",

--- a/src/device-registry/utils/errors.js
+++ b/src/device-registry/utils/errors.js
@@ -64,8 +64,8 @@ const unclearError = (res) => {
     .json({ success: false, message: "unclear server error" });
 };
 
-const badRequest = (res, message) => {
-  res.status(HTTPStatus.BAD_REQUEST).json({ success: false, message });
+const badRequest = (res, message, errors) => {
+  res.status(HTTPStatus.BAD_REQUEST).json({ success: false, message, errors });
 };
 
 module.exports = {


### PR DESCRIPTION
# Enhancements on Device schema

**_WHAT DOES THIS PR DO?_**

- [x] This PR adds a new field (isRetired) to the Device schema. It also replaces channelID with device_number field.
- [x] adds a default some fields like next device maintenance date (3 months).
- [x] Adds request body validations for the create device use case.
- [x] With the validations, partially resolves this [frontend-issue-285](https://github.com/airqo-platform/AirQo-frontend/issues/285)


**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/enhancement-device-schema

**_HOW DO I TEST OUT THIS PR?_**
```
cd AirQo-api/src/device-registry
npm install
```
`npm run dev-mac `OR` npm run dev-pc`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] device creation: https://docs.airqo.net/airqo-platform-api/device-registry#create-device

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


