### PR TITLE
remove the counter document in the list of returned sites

### DIFF
--- a/src/device-registry/controllers/create-site.js
+++ b/src/device-registry/controllers/create-site.js
@@ -173,14 +173,17 @@ const manageSite = {
         limit,
         skip,
       });
-      logObject("responseFromListSites", responseFromListSites);
-      if (responseFromListSites.success == true) {
+      logElement(
+        "has the response for listing sites been successful?",
+        responseFromListSites.success
+      );
+      if (responseFromListSites.success === true) {
         res.status(HTTPStatus.OK).json({
           success: true,
           message: responseFromListSites.message,
           sites: responseFromListSites.data,
         });
-      } else if (responseFromListSites.success == false) {
+      } else if (responseFromListSites.success === false) {
         if (responseFromListSites.error) {
           res.status(HTTPStatus.BAD_GATEWAY).json({
             success: false,

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -307,7 +307,6 @@ const manageSite = {
         _limit,
         _skip,
       });
-      logObject("responseFromListSite in util", responseFromListSite);
       if (responseFromListSite.success == false) {
         if (responseFromListSite.error) {
           return {
@@ -322,10 +321,13 @@ const manageSite = {
           };
         }
       } else {
+        data = responseFromListSite.filter(function(obj) {
+          return obj.lat_long !== "4_4";
+        });
         return {
           success: true,
           message: "successfully listed the site(s)",
-          data: responseFromListSite,
+          data,
         };
       }
     } catch (e) {


### PR DESCRIPTION
# remove the counter document in the list of returned sites

**_WHAT DOES THIS PR DO?_**
Just removes the counter document among the sites returned. This document is just used when generating site names so should not be returned in our list of sites.
<img width="317" alt="Screenshot 2021-07-16 at 11 09 40" src="https://user-images.githubusercontent.com/1590213/125914997-ebcabfa4-c964-44f6-af0b-73073e88fb2f.png">


**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-site-list

**_HOW DO I TEST OUT THIS PR?_**
```
cd device-registry
npm install
npm run stage-mac

```
**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
GET SITES:  http://localhost:3000/api/v1/devices/sites?tenant=airqo

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


