### PR TITLE
Site Tahmo Attribute

### DIFF
--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -162,6 +162,28 @@ const siteSchema = new Schema(
       type: String,
       trim: true,
     },
+    nearest_tahmo_station: {
+      id: {
+        type: Number,
+        required: [true, "station id is required!"],
+      },
+      code: {
+        type: String,
+        required: [true, "station code is required!"],
+      },
+      longitude: {
+        type: Number,
+        required: [true, "longitude is required!"],
+      },
+      latitude: {
+        type: Number,
+        required: [true, "latitude is required!"],
+      },
+      timezone: {
+        type: String,
+        required: [true, "timezone is required!"],
+      },
+    },
   },
   {
     timestamps: true,
@@ -240,6 +262,7 @@ siteSchema.methods = {
         .distance_to_nearest_residential_area,
       bearing_to_kampala_center: this.bearing_to_kampala_center,
       distance_to_kampala_center: this.distance_to_kampala_center,
+      nearest_tahmo_station: this.nearest_tahmo_station,
     };
   },
   createSite(args) {
@@ -328,6 +351,7 @@ siteSchema.statics = {
           distance_to_nearest_residential_area: 1,
           bearing_to_kampala_center: 1,
           distance_to_kampala_center: 1,
+          nearest_tahmo_station: 1,
           devices: "$devices",
         })
         .skip(_skip)

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -166,22 +166,32 @@ const siteSchema = new Schema(
       id: {
         type: Number,
         required: [true, "station id is required!"],
+        trim: true,
+        default: -1
       },
       code: {
         type: String,
         required: [true, "station code is required!"],
+        trim: true,
+        default: ""
       },
       longitude: {
         type: Number,
         required: [true, "longitude is required!"],
+        trim: true,
+        default: -1
       },
       latitude: {
         type: Number,
         required: [true, "latitude is required!"],
+        trim: true,
+        default: -1
       },
       timezone: {
         type: String,
         required: [true, "timezone is required!"],
+        trim: true,
+        default: ""
       },
     },
   },


### PR DESCRIPTION
# Tahmo station attributes

**_WHAT DOES THIS PR DO?_**
Adds tahmo station attributes to a site.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
None 

**_WHAT IS THE LINK TO THE PR BRANCH_**
[site-model-tahmo-attribute](https://github.com/airqo-platform/AirQo-api/tree/site-model-tahmo-attribute)

**_HOW DO I TEST OUT THIS PR?_**
```
cd device-registry
npm install
npm run stage-mac
```
Make a request to the [Get Sites](https://staging-platform.airqo.net/api/v1/devices/sites?tenant=airqo) endpoint with `tenant=airqo`, you should be able to see `nearest_tahmo_station` attached to each site

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
[Get Sites](https://staging-platform.airqo.net/api/v1/devices/sites?tenant=airqo)
[Update Sites](https://staging-platform.airqo.net/api/v1/devices/sites?tenant=airqo)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
None

**_ARE THERE ANY RELATED PRs?_**
#481 
