### PR TITLE
Kawempe heatmap data

### DIFF
--- a/src/predict/config/constants.py
+++ b/src/predict/config/constants.py
@@ -17,7 +17,7 @@ class Config:
     TESTING = False
     CSRF_ENABLED = True
     SECRET_KEY = os.getenv('SECRET_KEY')
-    DB_NAME = os.getenv('DB_NAME')
+    DB_NAME = os.getenv('DB_NAME_PROD')
     MONGO_URI = os.getenv('MONGO_GCE_URI')
     REDIS_SERVER = os.getenv('REDIS_SERVER_PROD')
 
@@ -33,6 +33,7 @@ class DevelopmentConfig(Config):
     DEBUG = True
     MONGO_URI = os.getenv('MONGO_DEV_URI')
     REDIS_SERVER = os.getenv('REDIS_SERVER_DEV')
+    DB_NAME =os.getenv('DB_NAME_DEV')
 
 class TestingConfig(Config):
     dotenv_path = os.path.join(os.path.dirname(__file__), '.env')

--- a/src/predict/config/constants.py
+++ b/src/predict/config/constants.py
@@ -12,7 +12,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 class Config:
     dotenv_path = os.path.join(BASE_DIR, '.env')
-    #print("dotenv", dotenv_path)
     load_dotenv(dotenv_path)
     DEBUG = False
     TESTING = False

--- a/src/predict/controllers/prediction.py
+++ b/src/predict/controllers/prediction.py
@@ -228,7 +228,9 @@ def predictions_for_heatmap():
     '''
     if request.method == 'POST':
         try:
-            data = get_gp_predictions()
+            json_data = request.get_json()
+            airqloud = json_data['airqloud']
+            data = get_gp_predictions(airqloud)
             return {'success': True, 'data': data}, 200
         except:
             return {'message': 'An error occured. Please try again.', 'success': False}, 400

--- a/src/predict/controllers/prediction.py
+++ b/src/predict/controllers/prediction.py
@@ -221,7 +221,7 @@ def predict_channel_next_24_hours():
 
 
 @ml_app.route(api.route['predict_for_heatmap'], methods=['POST'])
-@cache.cached(timeout=3600)
+#@cache.cached(timeout=3600)
 def predictions_for_heatmap():
     '''
     makes predictions for a specified location at a given time.
@@ -232,8 +232,11 @@ def predictions_for_heatmap():
             airqloud = json_data['airqloud']
             data = get_gp_predictions(airqloud)
             return {'success': True, 'data': data}, 200
-        except:
+        except Exception as e:
             return {'message': 'An error occured. Please try again.', 'success': False}, 400
     else:
         return {'message': 'Wrong request method. This is a GET endpoint.', 'success': False}, 400
+
+if __name__=='__main__':
+    print(predictions_for_heatmap())
 

--- a/src/predict/controllers/prediction.py
+++ b/src/predict/controllers/prediction.py
@@ -220,13 +220,13 @@ def predict_channel_next_24_hours():
             return jsonify({'inputs': json_data, 'errors': errors}), 400
 
 
-@ml_app.route(api.route['predict_for_heatmap'], methods=['GET'])
+@ml_app.route(api.route['predict_for_heatmap'], methods=['POST'])
 @cache.cached(timeout=3600)
 def predictions_for_heatmap():
     '''
     makes predictions for a specified location at a given time.
     '''
-    if request.method == 'GET':
+    if request.method == 'POST':
         try:
             data = get_gp_predictions()
             return {'success': True, 'data': data}, 200

--- a/src/predict/controllers/prediction.py
+++ b/src/predict/controllers/prediction.py
@@ -220,16 +220,14 @@ def predict_channel_next_24_hours():
             return jsonify({'inputs': json_data, 'errors': errors}), 400
 
 
-@ml_app.route(api.route['predict_for_heatmap'], methods=['POST'])
-#@cache.cached(timeout=3600)
+@ml_app.route(api.route['predict_for_heatmap'], methods=['GET'])
 def predictions_for_heatmap():
     '''
     makes predictions for a specified location at a given time.
     '''
-    if request.method == 'POST':
+    if request.method == 'GET':
         try:
-            json_data = request.get_json()
-            airqloud = json_data['airqloud']
+            airqloud = request.args.get('airqloud')
             data = get_gp_predictions(airqloud)
             return {'success': True, 'data': data}, 200
         except Exception as e:

--- a/src/predict/controllers/prediction.py
+++ b/src/predict/controllers/prediction.py
@@ -227,7 +227,7 @@ def predictions_for_heatmap():
     '''
     if request.method == 'GET':
         try:
-            airqloud = request.args.get('airqloud')
+            airqloud = request.args.get('airqloud').lower()
             data = get_gp_predictions(airqloud)
             return {'success': True, 'data': data}, 200
         except Exception as e:

--- a/src/predict/helpers/utils.py
+++ b/src/predict/helpers/utils.py
@@ -192,7 +192,7 @@ def get_gp_predictions(airqloud):
     except pymongo.errors.ConnectionFailure as e:
         return {'message':'unable to connect to database', 'success':False}, 400
 
-    db = client['airqo_netmanager_airqo']
+    db = client[DB_NAME]
     query = {'airqloud':airqloud}
     projection = {'_id': 0, 'latitude': 1, 'longitude': 1, 'predicted_value': 1, 'variance': 1, 'interval': 1, 'created_at':1}
     records = list(db.gp_predictions.find(query, projection))

--- a/src/predict/helpers/utils.py
+++ b/src/predict/helpers/utils.py
@@ -194,7 +194,7 @@ def get_gp_predictions(airqloud):
 
     db = client[DB_NAME]
     query = {'airqloud':airqloud}
-    projection = {'_id': 0, 'latitude': 1, 'longitude': 1, 'predicted_value': 1, 'variance': 1, 'interval': 1, 'created_at':1}
+    projection = {'_id': 0, 'latitude': 1, 'longitude': 1, 'predicted_value': 1, 'variance': 1, 'interval': 1, 'airqloud':1, 'created_at':1}
     records = list(db.gp_predictions.find(query, projection))
     return records
 

--- a/src/predict/helpers/utils.py
+++ b/src/predict/helpers/utils.py
@@ -182,9 +182,9 @@ def string_to_hourly_datetime(my_list):
     return my_list
 
 
-def get_gp_predictions():
+def get_gp_predictions(airqloud):
     '''
-    returns pm 2.5 predictions given an array of space and time inputs
+    returns pm 2.5 predictions for a particular airqloud
     '''
     try:
         client = MongoClient(MONGO_URI)
@@ -193,7 +193,7 @@ def get_gp_predictions():
 
     db = client['airqo_netmanager_airqo']
     query = {}
-    projection = {'_id': 0, 'latitude': 1, 'longitude': 1, 'predicted_value': 1, 'variance': 1, 'interval': 1}
+    projection = {'_id': 0, 'latitude': 1, 'longitude': 1, 'predicted_value': 1, 'variance': 1, 'interval': 1, 'created_at':1}
     records = list(db.gp_predictions.find(query, projection))
     return records
 

--- a/src/predict/helpers/utils.py
+++ b/src/predict/helpers/utils.py
@@ -192,7 +192,7 @@ def get_gp_predictions(airqloud):
         return {'message':'unable to connect to database', 'success':False}, 400
 
     db = client['airqo_netmanager_airqo']
-    query = {}
+    query = {'airqloud':airqloud}
     projection = {'_id': 0, 'latitude': 1, 'longitude': 1, 'predicted_value': 1, 'variance': 1, 'interval': 1, 'created_at':1}
     records = list(db.gp_predictions.find(query, projection))
     return records

--- a/src/predict/helpers/utils.py
+++ b/src/predict/helpers/utils.py
@@ -22,6 +22,7 @@ MET_API_CLIENT_SECRET =os.getenv('MET_API_CLIENT_SECRET')
 
 app_configuration = constants.app_config.get(os.getenv('FLASK_ENV'))
 MONGO_URI = app_configuration.MONGO_URI
+DB_NAME = app_configuration.DB_NAME
 
 def get_hourly_met_forecasts():
     """


### PR DESCRIPTION
# <Modifying Heatmap Endpoint>

**_WHAT DOES THIS PR DO?_**
This PR modifies the heatmap endpoint to return predictions for both the Kampala and Kawempe AirQlouds.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[DP-66](https://airqoteam.atlassian.net/browse/DP-66)

**_WHAT IS THE LINK TO THE PR BRANCH_**

**_HOW DO I TEST OUT THIS PR?_**
Please note that before you run this PR, you must have run [another PR](https://github.com/airqo-platform/AirQo-api/pull/507) in the gp-model microservice.

`Git clone this repo`
`cd predict`
`py -m venv env` to create an environment if you don't already have one
`env\scripts\activate` or `source env/bin/activate` for MacOS
`pip install -r requirements.txt`
`flask run` 

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
http://localhost:5000/api/v1/predict/heatmap
NOTE: Please add the airqloud parameter and set it to either kampala or kawempe

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?_**


