### PR TITLE
send emails to some addresses whenever anyone requests for data access

### DIFF
--- a/src/auth-service/config/constants.js
+++ b/src/auth-service/config/constants.js
@@ -28,6 +28,7 @@ const defaultConfig = {
   BCRYPT_SALT_ROUNDS: 12,
   JWT_SECRET: process.env.JWT_SECRET,
   EMAIL: process.env.MAIL_USER,
+  REQUEST_ACCESS_EMAILS: process.env.REQUEST_ACCESS_EMAILS,
   YOUTUBE_CHANNEL: "https://www.youtube.com/channel/UCx7YtV55TcqKGeKsDdT5_XQ",
   ACCOUNT_UPDATED: "The AirQo Platform account has successfully been updated",
   RANDOM_PASSWORD_CONFIGURATION: {

--- a/src/auth-service/services/mailer.js
+++ b/src/auth-service/services/mailer.js
@@ -12,6 +12,7 @@ const mailer = {
         to: `${email}`,
         subject: "AirQo Platform JOIN request",
         text: msgs.joinRequest(firstName, lastName),
+        cc: constants.REQUEST_ACCESS_EMAILS,
       };
 
       let response = transporter.sendMail(mailOptions);

--- a/src/auth-service/services/mailer.js
+++ b/src/auth-service/services/mailer.js
@@ -12,7 +12,7 @@ const mailer = {
         to: `${email}`,
         subject: "AirQo Platform JOIN request",
         text: msgs.joinRequest(firstName, lastName),
-        cc: constants.REQUEST_ACCESS_EMAILS,
+        bcc: constants.REQUEST_ACCESS_EMAILS,
       };
 
       let response = transporter.sendMail(mailOptions);


### PR DESCRIPTION
# send emails to some addresses whenever anyone requests for data acce

**_WHAT DOES THIS PR DO?_**
send emails to some addresses whenever anyone request for data acce

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/enhancement-email-notifs

**_HOW DO I TEST OUT THIS PR?_**
```
cd AirQo-api/src/auth-service
npm install
npm run stage-mac
```
Please ensure that you update the `.env` with the  `comma separated list of email addresses` you want to receive these email notifications. Use the variable:  ` REQUEST_ACCESS_EMAILS`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] Request access
[POST] http://localhost:3000/api/v1/users/candidates/register?tenant={TENANT}
_THE BODY:_
```
{
    "firstName": "matoto",
    "category": "business",
    "website": "airqo.net",
    "description": "gott",
    "organization": "airqo member",
    "jobTitle": "yea-me",
    "lastName": "dafa",
    "email": "{EMAIL_ADDRESS}"
}
```

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


