### PR TITLE
remove authentication from the forgot password endpoint

### DIFF
--- a/src/auth-service/routes/api.js
+++ b/src/auth-service/routes/api.js
@@ -39,7 +39,7 @@ router.put(
   authJWT,
   joinController.updateKnownPassword
 );
-router.post("/forgotPassword", setJWTAuth, authJWT, joinController.forgot);
+router.post("/forgotPassword", joinController.forgot);
 router.put("/", setJWTAuth, authJWT, joinController.update);
 router.delete("/", setJWTAuth, authJWT, joinController.delete);
 


### PR DESCRIPTION
# remove authentication from the forgot password endpoint

**_WHAT DOES THIS PR DO?_**

- [x] remove authentication from the forgot password endpoint
- [x] should address this[ frontend issue-378](https://github.com/airqo-platform/AirQo-frontend/issues/378)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-forgot-password

**_HOW DO I TEST OUT THIS PR?_**
```
cd AirQo-api/src/auth-service
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] Forgot Password
[POST] http://localhost:3000/api/v1/users/forgotPassword?tenant=airqo
_BODY:_
`{"email":"martin@airqo.net"}`

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


