### PR TITLE
remove double email notifs during forgot password process

### DIFF
--- a/src/auth-service/utils/join.js
+++ b/src/auth-service/utils/join.js
@@ -318,36 +318,38 @@ const join = {
         responseFromGenerateResetToken
       );
       logObject("filter", filter);
-      if (responseFromGenerateResetToken.success == true) {
+      if (responseFromGenerateResetToken.success === true) {
         let token = responseFromGenerateResetToken.data;
         let update = {
           resetPasswordToken: token,
           resetPasswordExpires: Date.now() + 3600000,
         };
-        let responseFromUpdateUser = await join.update(tenant, filter, update);
-        logObject(
-          "responseFromUpdateUser in forgotPassword",
-          responseFromUpdateUser
-        );
-        if (responseFromUpdateUser.success == true) {
+        let responseFromModifyUser = await UserModel(
+          tenant.toLowerCase()
+        ).modify({
+          filter,
+          update,
+        });
+        if (responseFromModifyUser.success === true) {
           let responseFromSendEmail = await mailer.forgot(
             filter.email,
             token,
             tenant
           );
           logObject("responseFromSendEmail", responseFromSendEmail);
-          if (responseFromSendEmail.success == true) {
+          if (responseFromSendEmail.success === true) {
             return {
               success: true,
-              message: "email successfully sent",
-              data: responseFromSendEmail.data,
+              message: "forgot email successfully sent",
             };
-          } else if (responseFromSendEmail.success == false) {
+          }
+
+          if (responseFromSendEmail.success === false) {
             if (responseFromSendEmail.error) {
               return {
                 success: false,
                 error: responseFromSendEmail.error,
-                message: responseFromSendEmail.message,
+                message: "unable to send the email request",
               };
             } else {
               return {
@@ -356,21 +358,25 @@ const join = {
               };
             }
           }
-        } else if (responseFromUpdateUser.success == false) {
-          if (responseFromUpdateUser.error) {
+        }
+
+        if (responseFromModifyUser.success === false) {
+          if (responseFromModifyUser.error) {
             return {
               success: false,
-              error: responseFromUpdateUser.error,
-              message: responseFromUpdateUser.message,
+              error: responseFromModifyUser.error,
+              message: responseFromModifyUser.message,
             };
           } else {
             return {
               success: false,
-              message: responseFromUpdateUser.message,
+              message: responseFromModifyUser.message,
             };
           }
         }
-      } else if (responseFromGenerateResetToken.success == false) {
+      }
+
+      if (responseFromGenerateResetToken.success === false) {
         if (responseFromGenerateResetToken.error) {
           return {
             success: false,


### PR DESCRIPTION
# remove double email notifs during forgot password process

**_WHAT DOES THIS PR DO?_**

- removes the double email notifs on forgot password
- remove the extra logging technical information on email success response.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-forgot-password

**_HOW DO I TEST OUT THIS PR?_**
```
cd AirQo-api/src/auth-service
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] forgot password:
[POST] http://localhost:3000/api/v1/users/forgotPassword?tenant=airqo
_You will not receive any double email notifications after "forgetting password"_
_BODY:_
`{"email":"{EMAIL}"}`

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A

