### PR TITLE
hotfix GET specific AirQloud details

### DIFF
--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -6,6 +6,7 @@ const jsonify = require("../utils/jsonify");
 const isEmpty = require("is-empty");
 const constants = require("../config/constants");
 const HTTPStatus = require("http-status");
+const createSiteUtil = require("../utils/create-site");
 
 const polygonSchema = new Schema({
   type: {
@@ -83,8 +84,12 @@ airqloudSchema.methods = {
 airqloudSchema.statics = {
   async register(args) {
     try {
+      let body = args;
+      body["long_name"] = args.name;
+      body["name"] = createSiteUtil.sanitiseName(args.name);
+
       let createdAirQloud = await this.create({
-        ...args,
+        ...body,
       });
       let data = jsonify(createdAirQloud);
       if (!isEmpty(data)) {
@@ -109,7 +114,7 @@ airqloudSchema.statics = {
       message = "validation errors for some of the provided fields";
       status = HTTPStatus.CONFLICT;
       Object.entries(err.errors).forEach(([key, value]) => {
-        return (response[key] = value.message);
+        return (response[value.path] = value.message);
       });
 
       return {

--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -106,21 +106,12 @@ airqloudSchema.statics = {
       let e = jsonify(err);
       let response = {};
       logObject("the err", e);
-      let errors = {};
-      let message = "Internal Server Error";
-      let status = HTTPStatus.INTERNAL_SERVER_ERROR;
-      if (err.code === 11000 || err.code === 11001) {
-        errors = err.keyValue;
-        message = "duplicate values provided";
-        status = HTTPStatus.CONFLICT;
-      } else {
-        message = "validation errors for some of the provided fields";
-        status = HTTPStatus.CONFLICT;
-        errors = err.errors;
-        Object.entries(err.errors).forEach(([key, value]) => {
-          return (response[key] = value.message);
-        });
-      }
+      message = "validation errors for some of the provided fields";
+      status = HTTPStatus.CONFLICT;
+      Object.entries(err.errors).forEach(([key, value]) => {
+        return (response[key] = value.message);
+      });
+
       return {
         errors: response,
         message,
@@ -175,11 +166,6 @@ airqloudSchema.statics = {
       let errors = { message: err.message };
       let message = "Internal Server Error";
       let status = HTTPStatus.INTERNAL_SERVER_ERROR;
-      if (err.code === 11000 || err.code === 11001) {
-        errors = err.keyValue;
-        message = "duplicate values provided";
-        status = HTTPStatus.CONFLICT;
-      }
       return {
         errors,
         message,
@@ -219,14 +205,9 @@ airqloudSchema.statics = {
         };
       }
     } catch (err) {
-      let errors = {};
+      let errors = { message: err.message };
       let message = "Internal Server Error";
       let status = HTTPStatus.INTERNAL_SERVER_ERROR;
-      if (err.code === 11000 || err.code === 11001) {
-        errors = err.keyValue;
-        message = "duplicate values provided";
-        status = HTTPStatus.CONFLICT;
-      }
       return {
         errors,
         message,
@@ -265,14 +246,10 @@ airqloudSchema.statics = {
         };
       }
     } catch (err) {
-      let errors = {};
+      let errors = { message: err.message };
       let message = err.message;
       let status = HTTPStatus.INTERNAL_SERVER_ERROR;
-      if (err.code === 11000 || err.code === 11001) {
-        errors = err.keyValue;
-        message = "duplicate values provided";
-        status = HTTPStatus.CONFLICT;
-      }
+
       return {
         success: false,
         message,

--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -26,16 +26,12 @@ const airqloudSchema = new Schema(
       type: String,
       trim: true,
       required: [true, "name is required!"],
+      unique: true,
     },
     long_name: {
       type: String,
       trim: true,
       default: null,
-    },
-    generated_name: {
-      type: String,
-      trim: true,
-      unique: true,
     },
     description: {
       type: String,
@@ -76,7 +72,7 @@ airqloudSchema.methods = {
     return {
       _id: this._id,
       name: this.name,
-      generated_name: this.generated_name,
+      long_name: this.long_name,
       description: this.description,
       airqloud_tags: this.airqloud_tags,
       location: this.location,
@@ -148,7 +144,7 @@ airqloudSchema.statics = {
         .project({
           _id: 1,
           name: 1,
-          generated_name: 1,
+          long_name: 1,
           description: 1,
           airqloud_tags: 1,
           location: 1,

--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -1599,10 +1599,6 @@ router.post(
         .bail()
         .notEmpty()
         .withMessage("the name should not be empty")
-        .bail()
-        .customSanitizer((value) => {
-          return createSiteUtil.sanitiseName(value);
-        })
         .trim(),
       body("description")
         .if(body("description").exists())

--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -1604,10 +1604,6 @@ router.post(
         .bail()
         .notEmpty()
         .withMessage("the name should not be empty")
-        .bail()
-        .customSanitizer((value) => {
-          return createSiteUtil.sanitiseName(value);
-        })
         .trim(),
       body("description")
         .if(body("description").exists())

--- a/src/device-registry/utils/create-airqloud.js
+++ b/src/device-registry/utils/create-airqloud.js
@@ -58,11 +58,10 @@ const createAirqloud = {
         };
       }
     } catch (err) {
-      logElement("create AirQlouds util", err.message);
+      logElement(" the util server error,", err.message);
       return {
         success: false,
         message: "unable to create airqloud",
-        errors: err.message,
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -298,7 +298,7 @@ const manageSite = {
       let nameWithoutWhiteSpaces = name.replace(/\s/g, "");
       let shortenedName = nameWithoutWhiteSpaces.substring(0, 15);
       let trimmedName = shortenedName.trim();
-      return trimmedName;
+      return trimmedName.toLowerCase();
     } catch (error) {
       logger.error(`sanitiseName -- create site util -- ${error.message}`);
     }

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -622,25 +622,15 @@ const generateFilter = {
     return filter;
   },
   airqlouds: (req) => {
-    let { id, generated_name, name } = req.query;
+    let { id, name } = req.query;
     let filter = {};
 
     if (name) {
-      let regexExpression = generateFilter.generateRegexExpressionFromStringElement(
-        name
-      );
-      filter["name"] = { $regex: regexExpression, $options: "i" };
+      filter["name"] = name;
     }
 
     if (id) {
       filter["_id"] = ObjectId(id);
-    }
-
-    if (generated_name) {
-      let regexExpression = generateFilter.generateRegexExpressionFromStringElement(
-        generated_name
-      );
-      filter["generated_name"] = { $regex: regexExpression, $options: "i" };
     }
 
     return filter;


### PR DESCRIPTION
# update AirQlouds schema and hotfix GET specific AirQloud details

**_WHAT DOES THIS PR DO?_**

- [x] Removes the `generated_name` from the Schema which leaves the unique `name` and non unique `long_name`.
- [x] Refactors the query by specific AirQloud name, ensure that it always returns one result.


**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-airqlouds

**_HOW DO I TEST OUT THIS PR?_**
check the README and do things from dev or stage environment. Avoid production.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] Create AirQlouds
[POST] http://localhost:3000/api/v1/devices/airqlouds?tenant={TENANT}
_BODY:_
```
{
    "name": "testin_airg",
    "airqloud_tags": [
        "good weather",
        "yours",
        "ours"
    ],
    "location": {
        "type": "polygon",
        "coordinates": [
            [
                -109,
                41
            ],
            [
                -102,
                41
            ]
        ]
    }
}
```
- [x] Get specific AirQloud
[GET] http://localhost:3000/api/v1/devices/airqlouds?tenant={TENANT}&name={AIRQLOUD_NAME}

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


