### PR TITLE
[Analytics] remove average outliers

### DIFF
--- a/src/analytics/api/models/events.py
+++ b/src/analytics/api/models/events.py
@@ -110,6 +110,7 @@ class EventsModel(BasePyMongoModel):
                     **{f"{pollutant}":1},
                     site_id={"$toString": "$site_id"},
                 )
+                .remove_outliers(pollutant)
                 .group(
                     _id="$site_id",
                     site_id={"$first": "$site_id"},


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
* Removes outliers from averages chart (first chart on the dashboard)

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Change directory to the analytics microservice
* Start redis (in another terminal)
* Create and/or start your `python` virtual env
* Install requirements `pip install -r requirements.txt
* Set the `.env` file. Sample [here](https://airqo.slack.com/archives/C0278FK2EGG/p1626124999013700)
* Start application `flask run`
* Check the swagger docs `http://localhost:5000/apidocs/`
* The averages data  `/dashboard/historical/daily-averages` should not be sending values that exceeds the upper limits of the pollutant. This can easily be observed using the frontend.

