### PR TITLE
use the provided name for the default description during creation

### DIFF
--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -293,8 +293,10 @@ siteSchema.methods = {
 siteSchema.statics = {
   async register(args) {
     try {
+      let modifiedArgs = args;
+      modifiedArgs.description = modifiedArgs.name;
       let data = await this.create({
-        ...args,
+        ...modifiedArgs,
       });
       if (!isEmpty(data)) {
         return {

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -151,10 +151,6 @@ const manageSite = {
       let generated_name = null;
       let requestBodyForCreatingSite = {};
 
-      /**
-       * could move this name validation to the route level
-       * using a custom validator
-       */
       let isNameValid = manageSite.validateSiteName(name);
       if (!isNameValid) {
         return {


### PR DESCRIPTION
#Adds a default description value during site creation

**_WHAT DOES THIS PR DO?_**
Adds a default description during site creation, uses the provided name

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-site-creation

**_HOW DO I TEST OUT THIS PR?_**
check out the README, please use the dev ENV

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [ ] create site
[POST]  http://localhost:3000/api/v1/devices/sites?tenant=airqo
_THE BODY:_
```
{
    "latitude": 32.247412,
    "longitude":0.32355312,
    "name": "we good here"
}
```

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


