### PR TITLE
Updating nearest-device endpoint to return only primary devices

### DIFF
--- a/src/device-registry/utils/nearest-device.js
+++ b/src/device-registry/utils/nearest-device.js
@@ -10,11 +10,10 @@ const nearestDevices = {
 
             devices.forEach(device => {
 
-                if ('latitude' in device && 'longitude' in device && device['isActive'] == true) {
+                if ('latitude' in device && 'longitude' in device && device['isActive'] == true && device['isPrimaryInLocation'] == true) {
                     distance = nearestDevices.calculateDistance(latitude, longitude, device['latitude'], device['longitude']);
 
                     if (distance < radius) {
-                        logElement("Found a node ", distance);
                         device['distance'] = distance;
                         nearest_devices.push(device);
                     }


### PR DESCRIPTION
# Hotfix
**_WHAT DOES THIS PR DO?_**
Returns only primary devices when searching for nearest devices

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**

**_WHAT IS THE LINK TO THE PR BRANCH_**
[fix-search-by-primary-devices](https://github.com/airqo-platform/AirQo-api/tree/fix-search-by-primary-devices)
**_HOW DO I TEST OUT THIS PR?_**

Setup your environment pointing to staging. Instructions are in the Readme.me

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
Perform a GET request to 

```http
http://localhost:3000/api/v1/devices/by/nearest-coordinates?tenant=airqo&radius=1&latitude=0.332269&longitude=32.570077
```

The endpoint should return only primary devices

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?_**
