### PR TITLE
disable editing of unique name for AirQlouds

### DIFF
--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -186,8 +186,8 @@ airqloudSchema.statics = {
       if (modifiedUpdateBody._id) {
         delete modifiedUpdateBody._id;
       }
-      if (modifiedUpdateBody.generated_name) {
-        delete modifiedUpdateBody.generated_name;
+      if (modifiedUpdateBody.name) {
+        delete modifiedUpdateBody.name;
       }
       let udpatedUser = await this.findOneAndUpdate(
         filter,


### PR DESCRIPTION
# disable editing of unique name

**_WHAT DOES THIS PR DO?_**
This PR is meant to disable the editing of the unique name. Implementation was already there but it was targeting a recently removed attribute/field.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-airqloud

**_HOW DO I TEST OUT THIS PR?_**
Please check out the README.
You can then run staging

1. create an AirQloud
2. Then use the ID of that AirQloud to update the name attribute. It should not be updated.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [Create AirQloud](https://docs.airqo.net/airqo-platform-api/-Mi1WIQAGi40qdPmLrM7/device-registry/airqlouds#create-airqloud)
- [x] [Update AirQloud](https://docs.airqo.net/airqo-platform-api/-Mi1WIQAGi40qdPmLrM7/device-registry/airqlouds#update-airqloud).

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


