### PR TITLE
refactor error handling and entity fields for Sites use case

### DIFF
--- a/src/device-registry/controllers/create-site.js
+++ b/src/device-registry/controllers/create-site.js
@@ -91,9 +91,7 @@ const manageSite = {
           manipulateArraysUtil.convertErrorArrayToObject(nestedErrors)
         );
       }
-      const { tenant } = req.query;
       let responseFromGenerateMetadata = await createSiteUtil.generateMetadata(
-        tenant,
         req
       );
       logObject(

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -66,10 +66,6 @@ const siteSchema = new Schema(
       type: Number,
       trim: true,
     },
-    distance_to_nearest_residential_area: {
-      type: Number,
-      trim: true,
-    },
     distance_to_nearest_residential_road: {
       type: Number,
       trim: true,
@@ -113,6 +109,9 @@ const siteSchema = new Schema(
       type: String,
     },
     aspect: {
+      type: String,
+    },
+    status: {
       type: String,
     },
     landform_90: {
@@ -215,6 +214,9 @@ siteSchema.pre("save", function(next) {
   if (this.isModified("_id")) {
     delete this._id;
   }
+  if (this.isModified("generated_name")) {
+    delete this.generated_name;
+  }
   return next();
 });
 
@@ -227,6 +229,9 @@ siteSchema.pre("update", function(next) {
   }
   if (this.isModified("_id")) {
     delete this._id;
+  }
+  if (this.isModified("generated_name")) {
+    delete this.generated_name;
   }
   return next();
 });
@@ -267,6 +272,7 @@ siteSchema.methods = {
       landform_270: this.landform_270,
       landform_90: this.landform_90,
       aspect: this.aspect,
+      status: this.status,
       distance_to_nearest_road: this.distance_to_nearest_road,
       distance_to_nearest_primary_road: this.distance_to_nearest_primary_road,
       distance_to_nearest_secondary_road: this
@@ -274,8 +280,6 @@ siteSchema.methods = {
       distance_to_nearest_tertiary_road: this.distance_to_nearest_tertiary_road,
       distance_to_nearest_unclassified_road: this
         .distance_to_nearest_unclassified_road,
-      distance_to_nearest_residential_area: this
-        .distance_to_nearest_residential_area,
       bearing_to_kampala_center: this.bearing_to_kampala_center,
       distance_to_kampala_center: this.distance_to_kampala_center,
       distance_to_nearest_residential_road: this
@@ -370,12 +374,12 @@ siteSchema.statics = {
           landform_270: 1,
           landform_90: 1,
           aspect: 1,
+          status: 1,
           distance_to_nearest_road: 1,
           distance_to_nearest_primary_road: 1,
           distance_to_nearest_secondary_road: 1,
           distance_to_nearest_tertiary_road: 1,
           distance_to_nearest_unclassified_road: 1,
-          distance_to_nearest_residential_area: 1,
           distance_to_nearest_residential_road: 1,
           bearing_to_kampala_center: 1,
           distance_to_kampala_center: 1,
@@ -423,6 +427,9 @@ siteSchema.statics = {
       }
       if (modifiedUpdateBody.longitude) {
         delete modifiedUpdateBody.longitude;
+      }
+      if (modifiedUpdateBody.generated_name) {
+        delete modifiedUpdateBody.generated_name;
       }
       let udpatedUser = await this.findOneAndUpdate(
         filter,

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -431,12 +431,15 @@ siteSchema.statics = {
       if (modifiedUpdateBody.generated_name) {
         delete modifiedUpdateBody.generated_name;
       }
-      let udpatedUser = await this.findOneAndUpdate(
+      if (modifiedUpdateBody.lat_long) {
+        delete modifiedUpdateBody.lat_long;
+      }
+      let updatedSite = await this.findOneAndUpdate(
         filter,
         modifiedUpdateBody,
         options
       ).exec();
-      let data = jsonify(udpatedUser);
+      let data = jsonify(updatedSite);
       if (!isEmpty(data)) {
         return {
           success: true,

--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -1556,7 +1556,59 @@ router.delete(
   ]),
   siteController.delete
 );
-router.get("/sites/nearest", siteController.findNearestSite);
+router.get(
+  "/sites/nearest",
+  oneOf([
+    query("tenant")
+      .exists()
+      .withMessage("tenant should be provided")
+      .bail()
+      .trim()
+      .toLowerCase()
+      .isIn(["kcca", "airqo"])
+      .withMessage("the tenant value is not among the expected ones"),
+  ]),
+  oneOf([
+    [
+      query("longitude")
+        .exists()
+        .withMessage("the longitude is missing in request")
+        .bail()
+        .trim()
+        .matches(constants.LONGITUDE_REGEX, "i")
+        .withMessage("please provide valid longitude value")
+        .bail()
+        .customSanitizer((value) => {
+          return numeral(value).format("0.00000");
+        })
+        .isDecimal({ decimal_digits: 5 })
+        .withMessage("the longitude must have atleast 5 decimal places in it"),
+      query("radius")
+        .exists()
+        .withMessage("the radius is missing in request")
+        .bail()
+        .trim()
+        .isFloat()
+        .withMessage("the radius must be a number")
+        .bail()
+        .toFloat(),
+      query("latitude")
+        .exists()
+        .withMessage("the latitude is missing in the request")
+        .bail()
+        .trim()
+        .matches(constants.LATITUDE_REGEX, "i")
+        .withMessage("please provide valid latitude value")
+        .bail()
+        .customSanitizer((value) => {
+          return numeral(value).format("0.00000");
+        })
+        .isDecimal({ decimal_digits: 5 })
+        .withMessage("the latitude must have atleast 5 decimal places in it"),
+    ],
+  ]),
+  siteController.findNearestSite
+);
 
 /******************* create-component use-case **************************/
 router.get("/list/components/", componentController.listAll);

--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -1209,14 +1209,6 @@ router.post(
   "/sites/metadata",
   oneOf([
     [
-      query("tenant")
-        .exists()
-        .withMessage("tenant should be provided")
-        .bail()
-        .trim()
-        .toLowerCase()
-        .isIn(["kcca", "airqo"])
-        .withMessage("the tenant value is not among the expected ones"),
       body("latitude")
         .exists()
         .withMessage("the latitude should be provided")
@@ -1286,6 +1278,208 @@ router.put(
       )
       .bail()
       .trim(),
+  ]),
+  oneOf([
+    [
+      body("status")
+        .if(body("status").exists())
+        .notEmpty()
+        .trim()
+        .toLowerCase()
+        .isIn(["active", "decommissioned"])
+        .withMessage(
+          "the status value is not among the expected ones which include: decommissioned, active"
+        ),
+      body("nearest_tahmo_station")
+        .if(body("nearest_tahmo_station").exists())
+        .notEmpty()
+        .custom((value) => {
+          return typeof value === "object";
+        })
+        .bail()
+        .withMessage("the nearest_tahmo_station should be an object"),
+      body("createdAt")
+        .if(body("createdAt").exists())
+        .notEmpty()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("createdAt date must be a valid datetime."),
+      body("airqloud_id")
+        .if(body("airqloud_id").exists())
+        .notEmpty()
+        .trim()
+        .isMongoId()
+        .withMessage("the airqloud_id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
+      body("distance_to_nearest_road")
+        .if(body("distance_to_nearest_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_primary_road")
+        .if(body("distance_to_nearest_primary_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_primary_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_secondary_road")
+        .if(body("distance_to_nearest_secondary_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_secondary_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_tertiary_road")
+        .if(body("distance_to_nearest_tertiary_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_tertiary_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_unclassified_road")
+        .if(body("distance_to_nearest_unclassified_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_unclassified_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_residential_road")
+        .if(body("distance_to_nearest_residential_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_residential_road must be a number")
+        .bail()
+        .toFloat(),
+      body("bearing_to_kampala_center")
+        .if(body("bearing_to_kampala_center").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("bearing_to_kampala_center must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_kampala_center")
+        .if(body("distance_to_kampala_center").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_kampala_center must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_residential_road")
+        .if(body("distance_to_nearest_residential_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_residential_road must be a number")
+        .bail()
+        .toFloat(),
+      body(" distance_to_nearest_city")
+        .if(body(" distance_to_nearest_city").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage(" distance_to_nearest_city must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_motorway")
+        .if(body("distance_to_nearest_motorway").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_motorway must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_road")
+        .if(body("distance_to_nearest_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_road must be a number")
+        .bail()
+        .toFloat(),
+      body("landform_270")
+        .if(body("landform_270").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("landform_270 must be a number")
+        .bail()
+        .toFloat(),
+      body("landform_90")
+        .if(body("landform_90").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("landform_90 must be a number")
+        .bail()
+        .toFloat(),
+      body("greenness")
+        .if(body("greenness").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("greenness must be a number")
+        .bail()
+        .toFloat(),
+      body("altitude")
+        .if(body("altitude").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("altitude must be a number")
+        .bail()
+        .toFloat(),
+      body("city")
+        .if(body("city").exists())
+        .notEmpty()
+        .trim(),
+      body("street")
+        .if(body("street").exists())
+        .notEmpty()
+        .trim(),
+      body("latitude")
+        .if(body("latitude").exists())
+        .notEmpty()
+        .trim()
+        .matches(constants.LATITUDE_REGEX, "i")
+        .withMessage("please provide valid latitude value")
+        .bail()
+        .customSanitizer((value) => {
+          return numeral(value).format("0.00000");
+        })
+        .isDecimal({ decimal_digits: 5 })
+        .withMessage("the latitude must have atleast 5 decimal places in it"),
+      body("longitude")
+        .if(body("longitude").exists())
+        .notEmpty()
+        .trim()
+        .matches(constants.LONGITUDE_REGEX, "i")
+        .withMessage("please provide valid longitude value")
+        .bail()
+        .customSanitizer((value) => {
+          return numeral(value).format("0.00000");
+        })
+        .isDecimal({ decimal_digits: 5 })
+        .withMessage("the longitude must have atleast 5 decimal places in it"),
+      body("description")
+        .if(body("description").exists())
+        .notEmpty()
+        .trim(),
+    ],
   ]),
   siteController.update
 );

--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -1207,14 +1207,6 @@ router.post(
   "/sites/metadata",
   oneOf([
     [
-      query("tenant")
-        .exists()
-        .withMessage("tenant should be provided")
-        .bail()
-        .trim()
-        .toLowerCase()
-        .isIn(["kcca", "airqo"])
-        .withMessage("the tenant value is not among the expected ones"),
       body("latitude")
         .exists()
         .withMessage("the latitude should be provided")
@@ -1284,6 +1276,208 @@ router.put(
       )
       .bail()
       .trim(),
+  ]),
+  oneOf([
+    [
+      body("status")
+        .if(body("status").exists())
+        .notEmpty()
+        .trim()
+        .toLowerCase()
+        .isIn(["active", "decommissioned"])
+        .withMessage(
+          "the status value is not among the expected ones which include: decommissioned, active"
+        ),
+      body("nearest_tahmo_station")
+        .if(body("nearest_tahmo_station").exists())
+        .notEmpty()
+        .custom((value) => {
+          return typeof value === "object";
+        })
+        .bail()
+        .withMessage("the nearest_tahmo_station should be an object"),
+      body("createdAt")
+        .if(body("createdAt").exists())
+        .notEmpty()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("createdAt date must be a valid datetime."),
+      body("airqloud_id")
+        .if(body("airqloud_id").exists())
+        .notEmpty()
+        .trim()
+        .isMongoId()
+        .withMessage("the airqloud_id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
+      body("distance_to_nearest_road")
+        .if(body("distance_to_nearest_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_primary_road")
+        .if(body("distance_to_nearest_primary_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_primary_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_secondary_road")
+        .if(body("distance_to_nearest_secondary_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_secondary_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_tertiary_road")
+        .if(body("distance_to_nearest_tertiary_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_tertiary_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_unclassified_road")
+        .if(body("distance_to_nearest_unclassified_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_unclassified_road must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_residential_road")
+        .if(body("distance_to_nearest_residential_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_residential_road must be a number")
+        .bail()
+        .toFloat(),
+      body("bearing_to_kampala_center")
+        .if(body("bearing_to_kampala_center").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("bearing_to_kampala_center must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_kampala_center")
+        .if(body("distance_to_kampala_center").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_kampala_center must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_residential_road")
+        .if(body("distance_to_nearest_residential_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_residential_road must be a number")
+        .bail()
+        .toFloat(),
+      body(" distance_to_nearest_city")
+        .if(body(" distance_to_nearest_city").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage(" distance_to_nearest_city must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_motorway")
+        .if(body("distance_to_nearest_motorway").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_motorway must be a number")
+        .bail()
+        .toFloat(),
+      body("distance_to_nearest_road")
+        .if(body("distance_to_nearest_road").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("distance_to_nearest_road must be a number")
+        .bail()
+        .toFloat(),
+      body("landform_270")
+        .if(body("landform_270").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("landform_270 must be a number")
+        .bail()
+        .toFloat(),
+      body("landform_90")
+        .if(body("landform_90").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("landform_90 must be a number")
+        .bail()
+        .toFloat(),
+      body("greenness")
+        .if(body("greenness").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("greenness must be a number")
+        .bail()
+        .toFloat(),
+      body("altitude")
+        .if(body("altitude").exists())
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("altitude must be a number")
+        .bail()
+        .toFloat(),
+      body("city")
+        .if(body("city").exists())
+        .notEmpty()
+        .trim(),
+      body("street")
+        .if(body("street").exists())
+        .notEmpty()
+        .trim(),
+      body("latitude")
+        .if(body("latitude").exists())
+        .notEmpty()
+        .trim()
+        .matches(constants.LATITUDE_REGEX, "i")
+        .withMessage("please provide valid latitude value")
+        .bail()
+        .customSanitizer((value) => {
+          return numeral(value).format("0.00000");
+        })
+        .isDecimal({ decimal_digits: 5 })
+        .withMessage("the latitude must have atleast 5 decimal places in it"),
+      body("longitude")
+        .if(body("longitude").exists())
+        .notEmpty()
+        .trim()
+        .matches(constants.LONGITUDE_REGEX, "i")
+        .withMessage("please provide valid longitude value")
+        .bail()
+        .customSanitizer((value) => {
+          return numeral(value).format("0.00000");
+        })
+        .isDecimal({ decimal_digits: 5 })
+        .withMessage("the longitude must have atleast 5 decimal places in it"),
+      body("description")
+        .if(body("description").exists())
+        .notEmpty()
+        .trim(),
+    ],
   ]),
   siteController.update
 );

--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -1556,46 +1556,54 @@ router.delete(
 );
 router.get(
   "/sites/nearest",
-  query("tenant")
-    .exists()
-    .withMessage("tenant should be provided")
-    .bail()
-    .trim()
-    .toLowerCase()
-    .isIn(["kcca", "airqo"])
-    .withMessage("the tenant value is not among the expected ones"),
   oneOf([
-    query("latitude")
+    query("tenant")
       .exists()
-      .withMessage("the latitude is missing in request")
+      .withMessage("tenant should be provided")
       .bail()
       .trim()
-      .matches(constants.LATITUDE_REGEX, "i")
-      .withMessage("please provide valid latitude value")
-      .bail()
-      .customSanitizer((value) => {
-        return numeral(value).format("0.00000");
-      })
-      .isDecimal({ decimal_digits: 5 })
-      .withMessage("the latitude must have atleast 5 decimal places in it"),
-    query("longitude")
-      .exists()
-      .withMessage("the longitude is missing in this request")
-      .bail()
-      .trim()
-      .matches(constants.LONGITUDE_REGEX, "i")
-      .withMessage("the longitude should be provided")
-      .bail()
-      .customSanitizer((value) => {
-        return numeral(value).format("0.00000");
-      })
-      .isDecimal({ decimal_digits: 5 })
-      .withMessage("the longitude must have atleast 5 decimal places in it"),
-    query("radius")
-      .exists()
-      .withMessage("the radius is missing in this request")
-      .bail()
-      .trim(),
+      .toLowerCase()
+      .isIn(["kcca", "airqo"])
+      .withMessage("the tenant value is not among the expected ones"),
+  ]),
+  oneOf([
+    [
+      query("longitude")
+        .exists()
+        .withMessage("the longitude is missing in request")
+        .bail()
+        .trim()
+        .matches(constants.LONGITUDE_REGEX, "i")
+        .withMessage("please provide valid longitude value")
+        .bail()
+        .customSanitizer((value) => {
+          return numeral(value).format("0.00000");
+        })
+        .isDecimal({ decimal_digits: 5 })
+        .withMessage("the longitude must have atleast 5 decimal places in it"),
+      query("radius")
+        .exists()
+        .withMessage("the radius is missing in request")
+        .bail()
+        .trim()
+        .isFloat()
+        .withMessage("the radius must be a number")
+        .bail()
+        .toFloat(),
+      query("latitude")
+        .exists()
+        .withMessage("the latitude is missing in the request")
+        .bail()
+        .trim()
+        .matches(constants.LATITUDE_REGEX, "i")
+        .withMessage("please provide valid latitude value")
+        .bail()
+        .customSanitizer((value) => {
+          return numeral(value).format("0.00000");
+        })
+        .isDecimal({ decimal_digits: 5 })
+        .withMessage("the latitude must have atleast 5 decimal places in it"),
+    ],
   ]),
   siteController.findNearestSite
 );

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -182,7 +182,6 @@ const manageSite = {
       }
 
       let responseFromGenerateMetadata = await manageSite.generateMetadata(
-        tenant,
         request
       );
       logObject("responseFromGenerateMetadata", responseFromGenerateMetadata);
@@ -301,7 +300,7 @@ const manageSite = {
     }
   },
 
-  generateMetadata: async (tenant, req) => {
+  generateMetadata: async (req) => {
     try {
       let { latitude, longitude } = req.body;
       let body = req.body;
@@ -459,7 +458,6 @@ const manageSite = {
       }
 
       let responseFromGenerateMetadata = await manageSite.generateMetadata(
-        tenant,
         request
       );
 

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -861,6 +861,9 @@ const manageSite = {
 
       if (responseFromListSites.success === true) {
         let sites = responseFromListSites.data;
+        let status = responseFromListSites.status
+          ? responseFromListSites.status
+          : "";
         let nearest_sites = [];
         sites.forEach((site) => {
           if ("latitude" in site && "longitude" in site) {
@@ -881,21 +884,27 @@ const manageSite = {
           success: true,
           data: nearest_sites,
           message: "successfully retrieved the nearest sites",
-          status: HTTPStatus.OK,
+          status,
         };
       }
       if (responseFromListSites.success === false) {
+        let status = responseFromListSites.status
+          ? responseFromListSites.status
+          : "";
+        let errors = responseFromListSites.errors
+          ? responseFromListSites.errors
+          : "";
         return {
           success: false,
-          error: responseFromListSites.error,
+          errors,
           message: responseFromListSites.message,
-          status: responseFromListSites.status,
+          status,
         };
       }
     } catch (error) {
       return {
         success: false,
-        message: "internal server error",
+        message: "Internal Server Error",
         error: error.message,
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };


### PR DESCRIPTION
# hotfix error handling and entity fields for Sites use case

**_WHAT DOES THIS PR DO?_**

- [x] refactor error handling for update Site
- [x] Add input validation for Update Site endpoint. Field checks for things like `airqloud_id` and etc.
- [x] Add `status` field for Sites. 
- [x] Rename `distance_to_nearest_residential_area` to `distance_to_nearest_residential_road`. Later, shall need to also do some manual data update in the DB to rename the field. Also require the frontend to make some changes accordingly.
- [x] Removes tenant requirement/validation on generate site metadata. It was not needed since it does not hit any DB
- [x] Add input validation and error handling for nearest Site endpoint


**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-create-sites

**_HOW DO I TEST OUT THIS PR?_**
Check the README, you can use the staging ENV.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [Update Site](https://docs.airqo.net/airqo-platform-api/-Mi1WIQAGi40qdPmLrM7/device-registry/create-sites#update-site)
- [x] [Generate Site metadata ](https://docs.airqo.net/airqo-platform-api/-Mi1WIQAGi40qdPmLrM7/device-registry/create-sites#generate-site-metadata)without tenant query parameter
- [x] [Get nearest Site](https://docs.airqo.net/airqo-platform-api/-Mi1WIQAGi40qdPmLrM7/device-registry/create-sites#get-nearest-site)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


