### PR TITLE
Do not drop old photos when updating device pictures

### DIFF
--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -337,10 +337,9 @@ deviceSchema.statics = {
       };
     }
   },
-  async modify({ filter = {}, update = {} } = {}) {
+  async modify({ filter = {}, update = {}, opts = {} } = {}) {
     try {
-      logObject("the filter", filter);
-      let options = { new: true };
+      let options = { new: true, ...opts };
       let modifiedUpdate = update;
       delete modifiedUpdate.name;
       delete modifiedUpdate.device_number;

--- a/src/device-registry/utils/create-device.js
+++ b/src/device-registry/utils/create-device.js
@@ -801,11 +801,16 @@ const registerDeviceUtil = {
           errors,
         };
       }
+      let opts = {};
+      update["$addToSet"] = {};
+      update["$addToSet"]["pictures"] = update.pictures;
+      delete update.pictures;
+
       let responseFromModifyDevice = await getModelByTenant(
         tenant,
         "device",
         DeviceSchema
-      ).modify({ filter, update });
+      ).modify({ filter, update, opts });
 
       logObject("responseFromModifyDevice ", responseFromModifyDevice);
 


### PR DESCRIPTION
# Ensures that old photos are not dropped when updating pictures for a device

**_WHAT DOES THIS PR DO?_**
Ensures that old photos are not dropped when updating pictures for a device

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/bug-device-pictures

**_HOW DO I TEST OUT THIS PR?_**
README, use dev ENV

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [Update device](https://docs.airqo.net/airqo-platform-api/-Mi1WIQAGi40qdPmLrM7/device-registry/create-devices#update-device)
_Body:_
```
{
    "pictures": [
        "we are here"
    ]
}
```
**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


