### PR TITLE
[Analytics] enable sorting of downloaded data by time field

### DIFF
--- a/src/analytics/api/models/base/model_operations.py
+++ b/src/analytics/api/models/base/model_operations.py
@@ -65,6 +65,9 @@ class BaseMongoOperations:
 
 
 class ChainableMongoOperations(BaseMongoOperations):
+    ASCENDING = 1
+    DESCENDING = -1
+
     def __init__(self):
         self.stages = []
         self.init_match_expr = "$and"

--- a/src/analytics/api/models/events.py
+++ b/src/analytics/api/models/events.py
@@ -84,6 +84,7 @@ class EventsModel(BasePyMongoModel):
                 .project(site_id={"$toObjectId": "$site_id"}, time=1, pm2_5=1, pm10=1, no2=1)
                 .lookup("sites", local_field="site_id", foreign_field="_id", col_as="site")
                 .unwind('site')
+                .sort(time=self.ASCENDING)
                 .project(
                     _id=0,
                     time=1,


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
* Sort downloaded data by time field

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Change directory to the analytics microservice
* Start redis (in another terminal)
* Create and/or start your `python` virtual env
* Install requirements `pip install -r requirements.txt
* Set the `.env` file. Sample [here](https://airqo.slack.com/archives/C0278FK2EGG/p1626124999013700)
* Start application `flask run`
* Check the swagger docs `http://localhost:5000/apidocs/`
* The download data endpoint `POST` `http://localhost:5000/api/v1/analytics/data/download` should be returning sorted data.

###### Endpoint

    POST http://localhost:5000/api/v1/analytics/data/download?tenant=airqo&downloadType=csv

###### Sample data
```
{
  "endDate": "2021-09-22T21:00:00.000Z",
  "frequency": "hourly",
  "pollutants": [
    "pm2_5"
  ],
  "sites": [
    "60d058c8048305120d2d6133"
  ],
  "startDate": "2021-09-08T21:00:00.000Z"
}
```
