### PR TITLE
schema changes to the AirQloud entity

### DIFF
--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -38,6 +38,14 @@ const airqloudSchema = new Schema(
       type: String,
       trim: true,
     },
+    admin_level: {
+      type: String,
+      required: [true, "admin_level is required!"],
+    },
+    isCustom: {
+      type: Boolean,
+      required: [true, "isCustom is required!"],
+    },
     airqloud_tags: {
       type: Array,
       default: [],
@@ -62,8 +70,6 @@ airqloudSchema.pre("update", function(next) {
   return next();
 });
 
-airqloudSchema.index({ name: 1 }, { unique: true });
-
 airqloudSchema.plugin(uniqueValidator, {
   message: `{VALUE} is a duplicate value!`,
 });
@@ -76,6 +82,8 @@ airqloudSchema.methods = {
       long_name: this.long_name,
       description: this.description,
       airqloud_tags: this.airqloud_tags,
+      admin_level: this.admin_level,
+      isCustom: this.isCustom,
       location: this.location,
     };
   },
@@ -144,6 +152,8 @@ airqloudSchema.statics = {
           description: 1,
           airqloud_tags: 1,
           location: 1,
+          admin_level: 1,
+          isCustom: 1,
           sites: "$sites",
         })
         .skip(_skip)
@@ -227,9 +237,11 @@ airqloudSchema.statics = {
         projection: {
           _id: 1,
           name: 1,
-          generated_name: 1,
+          long_name: 1,
           airqloud_tags: 1,
           description: 1,
+          admin_level: 1,
+          isCustom: 1,
         },
       };
       let removedAirqloud = await this.findOneAndRemove(filter, options).exec();


### PR DESCRIPTION
# makes slight changes to the AirQloud entity's schema

**_WHAT DOES THIS PR DO?_**

- [x] Remove the unique constraint on the AirQloud name
- [x] Adds new fields (isCustom and admin_level) to the Schema

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-create-airqlouds

**_HOW DO I TEST OUT THIS PR?_**
README, use staging ENV.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
None now, probably just use [GET AirQlouds](https://app.gitbook.com/@airqo/s/airqo-platform-api/~/drafts/-Mk8AGGsDE_YtRcw9pKH/device-registry/airqlouds#get-airqlouds).

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A

