### PR TITLE
Getting devices without forecast

### DIFF
--- a/src/data-mgt/python/devices-tranformation/Readme.md
+++ b/src/data-mgt/python/devices-tranformation/Readme.md
@@ -1,41 +1,68 @@
 # Device Transformations
-Contains Utils for performing transformations on devices
+
+Contains Utils for manipulating devices' data
+
 ## Setup your Environment
+
 ```bash
     python3 -m venv venv
     source venv/bin/activate
     pip install -r requirements.txt
 ```
+
 Obtain and add the `.env` to this directory.
 
-In scenarios where the output is  **csv** or **json**, a file named `output.json` or `output.csv` is generated with the data.
+In scenarios where the output is  **csv** or **json**, a file named `output.json` or `output.csv` is generated with the
+data.
+
 ## Get active devices with invalid measurements
+
 ```bash
     python main.py get_devices_with_invalid_measurements csv
 ```
+
 ## Map sites to nearest Tahmo stations
-Update sites to include the nearest Tahmo Station. 
+
+Update sites to include the nearest Tahmo Station.
+
 ### API post request to microservice managing sites
+
 ```bash
     python main.py site_tahmo_mapping api
 ```
+
 ### CSV output
+
 ```bash
     python main.py site_tahmo_mapping csv
 ```
+
 ## Map devices to nearest Tahmo stations
+
 ```bash
     python main.py device_tahmo_mapping json
 ```
+
 ## Get devices on Netmanager but missing on bigquery
+
 ```bash
     python main.py missing_devices_on_bigquery json
 ```
+
 ## Get sites without primary devices
+
 ```bash
     python main.py sites_without_a_primary_device csv
 ```
+
 ## Update primary devices based on csv file
+
 ```bash
     python main.py update_primary_devices
+```
+
+## Get devices without forecast
+
+```bash
+    python main.py devices_without_forecast csv
 ```

--- a/src/data-mgt/python/devices-tranformation/airqoApi.py
+++ b/src/data-mgt/python/devices-tranformation/airqoApi.py
@@ -25,7 +25,24 @@ class AirQoApi:
 
         return []
 
-    def get_airqo_device_current_measurements(self, device_number ):
+    def get_forecast(self, tenant, longitude, latitude, selected_datetime):
+        params = {
+            "tenant": tenant,
+        }
+        body = {
+            "longitude": longitude,
+            "latitude": latitude,
+            "selected_datetime": selected_datetime,
+        }
+        response = self.__request(endpoint="predict", params=params, body=body, method="post")
+
+        if response is not None and "formatted_results" in response:
+            formatted_results = response["formatted_results"]
+            return formatted_results["predictions"]
+
+        return []
+
+    def get_airqo_device_current_measurements(self, device_number):
         response = self.__request("data/feeds/transform/recent", {"channel": device_number})
         return response
 
@@ -74,12 +91,21 @@ class AirQoApi:
                 data=json.dumps(body),
                 verify=False,
             )
+        elif method == "post":
+            headers['Content-Type'] = 'application/json'
+            api_request = requests.post(
+                '%s%s/' % (self.AIRQO_BASE_URL, endpoint),
+                params=params,
+                headers=headers,
+                data=json.dumps(body),
+                verify=False,
+            )
         else:
-            return handle_api_error("Invalid")
+            handle_api_error("Invalid")
+            return None
 
         if api_request.status_code == 200:
-            print(api_request.request.url)
             return api_request.json()
         else:
-            return handle_api_error(api_request)
-
+            handle_api_error(api_request)
+            return None

--- a/src/data-mgt/python/devices-tranformation/main.py
+++ b/src/data-mgt/python/devices-tranformation/main.py
@@ -41,6 +41,9 @@ if __name__ == '__main__':
     elif action.lower().strip() == "update_primary_devices":
         transformation.update_primary_devices()
 
+    elif action.lower().strip() == "devices_without_forecast":
+        transformation.get_devices_without_forecast()
+
     else:
         print("Invalid Arguments. Check the Readme.md for valid arguments")
         exit()

--- a/src/data-mgt/python/devices-tranformation/transformation.py
+++ b/src/data-mgt/python/devices-tranformation/transformation.py
@@ -6,7 +6,7 @@ from google.cloud import bigquery
 
 from airqoApi import AirQoApi
 from tahmo import TahmoApi
-from utils import array_to_csv, array_to_json, is_valid_double, str_to_date
+from utils import array_to_csv, array_to_json, is_valid_double, str_to_date, date_to_str_v2
 
 
 class Transformation:
@@ -65,7 +65,7 @@ class Transformation:
                 summarized_updated_devices.append(
                     dict({
                         "_id": device_dict.get("_id"),
-                        "device_number":  device_dict.get("device_number"),
+                        "device_number": device_dict.get("device_number"),
                         "name": device_dict.get("name"),
                         "latitude": device_dict.get("latitude"),
                         "longitude": device_dict.get("longitude"),
@@ -117,7 +117,7 @@ class Transformation:
                 summarized_updated_sites.append(
                     dict({
                         "_id": site_dict.get("_id"),
-                        "name":  site_dict.get("name"),
+                        "name": site_dict.get("name"),
                         "description": site_dict.get("name"),
                         "latitude": site_dict.get("latitude"),
                         "longitude": site_dict.get("longitude"),
@@ -158,6 +158,30 @@ class Transformation:
                 sites_without_primary_devices.append(site_dict)
 
         self.__print(data=sites_without_primary_devices)
+
+    def get_devices_without_forecast(self):
+
+        devices = self.airqo_api.get_devices(tenant=self.tenant, active=True)
+        devices_without_forecast = []
+        date_time = date_to_str_v2(datetime.utcnow())
+
+        for device in devices:
+            device_dict = dict(device)
+            latitude = device_dict.get("latitude", None)
+            longitude = device_dict.get("longitude", None)
+
+            if longitude and latitude:
+                forecast = self.airqo_api.get_forecast(tenant=self.tenant, latitude=latitude,
+                                                       longitude=longitude, selected_datetime=date_time)
+                if not forecast:
+                    device_details = {
+                        "device_number": device_dict.get("device_number", None),
+                        "name": device_dict.get("name", None)
+                    }
+                    print(device_details)
+                    devices_without_forecast.append(device_details)
+
+        self.__print(data=devices_without_forecast)
 
     def get_devices_invalid_measurement_values(self):
         devices = self.airqo_api.get_devices(tenant='airqo', active=True)
@@ -224,7 +248,8 @@ class Transformation:
                         error[key] = value
 
             if len(error.keys()) > 5:
-                error["self_link"] = f"{os.getenv('AIRQO_BASE_URL')}data/feeds/transform/recent?channel={device_data['device_number']}"
+                error[
+                    "self_link"] = f"{os.getenv('AIRQO_BASE_URL')}data/feeds/transform/recent?channel={device_data['device_number']}"
                 errors.append(error)
 
         self.__print(data=errors)
@@ -257,4 +282,3 @@ class Transformation:
             self.airqo_api.update_sites(updated_sites=data)
         else:
             array_to_json(data=data)
-

--- a/src/data-mgt/python/devices-tranformation/utils.py
+++ b/src/data-mgt/python/devices-tranformation/utils.py
@@ -20,6 +20,13 @@ def date_to_str(date):
     return datetime.strftime(date, '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
+def date_to_str_v2(date):
+    """
+    Converts datetime to a string
+    """
+    return datetime.strftime(date, '%Y-%m-%d %H:%M')
+
+
 def is_valid_double(value):
     try:
         float(value)
@@ -35,13 +42,14 @@ def handle_api_error(api_request):
         json = api_request.json()
         print(api_request.request.url)
         print(api_request.request.body)
+    except Exception as ex:
+        print(ex)
     finally:
         if json and 'error' in json and 'message' in json['error']:
-            print(json)
-            raise Exception(json['error']['message'])
+            print(json['error']['message'])
         else:
             print(api_request.content)
-            raise Exception('API request failed with status code %s' % api_request.status_code)
+            print('API request failed with status code %s' % api_request.status_code)
 
 
 def array_to_csv(data):


### PR DESCRIPTION
# Feature

**_WHAT DOES THIS PR DO?_**
Adds functionality for getting devices without forecast data.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
None

**_WHAT IS THE LINK TO THE PR BRANCH_**
[devices-without-forecast](https://github.com/airqo-platform/AirQo-api/tree/devices-without-forecast)
**_HOW DO I TEST OUT THIS PR?_**
Follow instructions in the [Readme file](src/data-mgt/python/devices-tranformation/Readme.md) to setup your enviri=onment then jump to the `Get devices without forecast` section of the same file

**NB**: The process takes long 

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
None

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
None

**_ARE THERE ANY RELATED PRs?_**
None

