### PR TITLE
[DeviceUptime] retain last battery voltage when device is offline

### DIFF
--- a/src/device-uptime/utils/device_hourly_records.py
+++ b/src/device-uptime/utils/device_hourly_records.py
@@ -58,7 +58,7 @@ class DeviceChannelRecords:
                 time=time,
                 sensor_one_pm2_5=0,
                 sensor_two_pm2_5=0,
-                battery_voltage=0
+                battery_voltage=self.record.get("battery")
             )
 
         return DeviceSensorReadings(


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- retain last battery voltage when device is offline

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Set the `.env` file for `device-uptime` micro-service. Here is the [.env](https://airqo.slack.com/archives/C0278FK2EGG/p1626899933018300)
* Run the job following the instructions in the `README.md` file
* The Job should run successfully. You can also check the db for fun!

#### What are the relevant tickets?
- [PLAT-798](https://airqoteam.atlassian.net/browse/PLAT-798)

#### Screenshots (optional)



