### PR TITLE
add more validations for login endpoint

### DIFF
--- a/src/auth-service/routes/api-v1.js
+++ b/src/auth-service/routes/api-v1.js
@@ -41,6 +41,12 @@ router.post(
       .isIn(["kcca", "airqo"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
+  oneOf([
+    [
+      body("userName").exists().withMessage("the userName must be provided"),
+      body("password").exists().withMessage("the password must be provided"),
+    ],
+  ]),
   setLocalAuth,
   authLocal,
   joinController.login

--- a/src/auth-service/routes/api-v2.js
+++ b/src/auth-service/routes/api-v2.js
@@ -41,6 +41,12 @@ router.post(
       .isIn(["kcca", "airqo"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
+  oneOf([
+    [
+      body("userName").exists().withMessage("the userName must be provided"),
+      body("password").exists().withMessage("the password must be provided"),
+    ],
+  ]),
   setLocalAuth,
   authLocal,
   joinController.login


### PR DESCRIPTION
# add more validations for login endpoint

**_WHAT DOES THIS PR DO?_**
adds more validations for login endpoint.
This resolves this[ issue-605](https://github.com/airqo-platform/AirQo-api/issues/605)

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-login-validation

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/auth-service
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [ ] [Login](https://app.gitbook.com/@airqo/s/airqo-platform-api/auth-service/create-user#login)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


