### PR TITLE
resolve runtime errors in create-device usecase

### DIFF
--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -245,8 +245,7 @@ deviceSchema.statics = {
         status: HTTPStatus.OK,
       };
     } catch (err) {
-      let e = jsonify(err);
-      logObject("the error", e);
+      logObject("the error", err);
       let response = {};
       let message = "validation errors for some of the provided fields";
       let status = HTTPStatus.CONFLICT;
@@ -312,9 +311,9 @@ deviceSchema.statics = {
         .limit(_limit)
         .allowDiskUse(true);
 
-      let data = jsonify(response);
-      logger.info(`the data produced in the model -- ${JSON.stringify(data)}`);
-      if (!isEmpty(data)) {
+      logger.info(`the data produced in the model -- ${response}`);
+      if (!isEmpty(response)) {
+        let data = response;
         return {
           success: true,
           message: "successfully retrieved the device details",
@@ -332,7 +331,7 @@ deviceSchema.statics = {
       return {
         success: false,
         message: "unable to retrieve devices",
-        errors: error.message,
+        errors: { message: error.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
@@ -352,8 +351,9 @@ deviceSchema.statics = {
         modifiedUpdate,
         options
       ).exec();
-      let data = jsonify(updatedDevice);
-      if (!isEmpty(data)) {
+
+      if (!isEmpty(updatedDevice)) {
+        let data = updatedDevice._doc;
         return {
           success: true,
           message: "successfully modified the device",
@@ -372,7 +372,7 @@ deviceSchema.statics = {
       return {
         success: false,
         message: "Device model server error - modify",
-        errors: error.message,
+        errors: { message: error.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
@@ -413,8 +413,9 @@ deviceSchema.statics = {
         modifiedUpdate,
         options
       ).exec();
-      let data = jsonify(updatedDevice);
-      if (!isEmpty(data)) {
+
+      if (!isEmpty(updatedDevice)) {
+        let data = updatedDevice._doc;
         return {
           success: true,
           message: "successfully modified the device",
@@ -433,7 +434,7 @@ deviceSchema.statics = {
       return {
         success: false,
         message: "Internal Server Error",
-        errors: error.message,
+        errors: { message: error.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
@@ -444,8 +445,9 @@ deviceSchema.statics = {
         projection: { _id: 1, name: 1, device_number: 1, long_name: 1 },
       };
       let removedDevice = await this.findOneAndRemove(filter, options).exec();
-      let data = jsonify(removedDevice);
-      if (!isEmpty(data)) {
+
+      if (!isEmpty(removedDevice)) {
+        let data = removedDevice._doc;
         return {
           success: true,
           message: "successfully deleted device from the platform",
@@ -457,13 +459,14 @@ deviceSchema.statics = {
           success: false,
           message: "device does not exist, please crosscheck",
           status: HTTPStatus.NOT_FOUND,
+          errors: { message: "device does not exist, please crosscheck" },
         };
       }
     } catch (error) {
       return {
         success: false,
         message: "Device model server error - remove",
-        error: error.message,
+        errors: { message: error.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }

--- a/src/device-registry/utils/create-device.js
+++ b/src/device-registry/utils/create-device.js
@@ -67,7 +67,7 @@ const registerDeviceUtil = {
       return {
         success: false,
         message: "unable to generate the QR code --server side error",
-        errors: err.message,
+        errors: { message: err.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
@@ -85,18 +85,14 @@ const registerDeviceUtil = {
       );
 
       logger.info(
-        `responseFromCreateOnThingspeak -- ${jsonify(
-          responseFromCreateOnThingspeak
-        )}`
+        `responseFromCreateOnThingspeak -- ${responseFromCreateOnThingspeak}`
       );
 
       let enrichmentDataForDeviceCreation = responseFromCreateOnThingspeak.data
         ? responseFromCreateOnThingspeak.data
         : {};
       logger.info(
-        `enrichmentDataForDeviceCreation -- ${jsonify(
-          enrichmentDataForDeviceCreation
-        )}`
+        `enrichmentDataForDeviceCreation -- ${enrichmentDataForDeviceCreation}`
       );
 
       if (!isEmpty(enrichmentDataForDeviceCreation)) {
@@ -112,9 +108,7 @@ const registerDeviceUtil = {
 
         if (responseFromCreateDeviceOnPlatform.success === true) {
           logger.info(
-            `successfully create the device --  ${jsonify(
-              responseFromCreateDeviceOnPlatform.data
-            )}`
+            `successfully create the device --  ${responseFromCreateDeviceOnPlatform.data}`
           );
           let status = responseFromCreateDeviceOnPlatform.status
             ? responseFromCreateDeviceOnPlatform.status
@@ -132,15 +126,13 @@ const registerDeviceUtil = {
           deleteRequest["query"] = {};
           deleteRequest["query"]["device_number"] =
             enrichmentDataForDeviceCreation.device_number;
-          logger.info(`deleteRequest -- ${jsonify(deleteRequest)}`);
+          logger.info(`deleteRequest -- ${deleteRequest}`);
           let responseFromDeleteDeviceFromThingspeak = await registerDeviceUtil.deleteOnThingspeak(
             deleteRequest
           );
 
           logger.info(
-            ` responseFromDeleteDeviceFromThingspeak -- ${jsonify(
-              responseFromDeleteDeviceFromThingspeak
-            )}`
+            ` responseFromDeleteDeviceFromThingspeak -- ${responseFromDeleteDeviceFromThingspeak}`
           );
 
           if (responseFromDeleteDeviceFromThingspeak.success === true) {
@@ -206,7 +198,7 @@ const registerDeviceUtil = {
       return {
         success: false,
         message: "server error",
-        errors: error.message,
+        errors: { message: error.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
@@ -219,9 +211,7 @@ const registerDeviceUtil = {
       if (isEmpty(device_number)) {
         logger.info(`the device_number is not present`);
         let responseFromListDevice = await registerDeviceUtil.list(request);
-        logger.info(
-          `responseFromListDevice -- ${jsonify(responseFromListDevice)}`
-        );
+        logger.info(`responseFromListDevice -- ${responseFromListDevice}`);
         if (responseFromListDevice.success === false) {
           let errors = responseFromListDevice.errors
             ? responseFromListDevice.errors
@@ -237,23 +227,19 @@ const registerDeviceUtil = {
         modifiedRequest["query"]["device_number"] = device_number;
       }
       logger.info(`the modifiedRequest -- ${modifiedRequest} `);
-      logObject("the UnmodifiedRequest ", jsonify(request));
+      logObject("the UnmodifiedRequest ", request);
       let responseFromUpdateDeviceOnThingspeak = await registerDeviceUtil.updateOnThingspeak(
         modifiedRequest
       );
       logger.info(
-        `responseFromUpdateDeviceOnThingspeak -- ${jsonify(
-          responseFromUpdateDeviceOnThingspeak
-        )}`
+        `responseFromUpdateDeviceOnThingspeak -- ${responseFromUpdateDeviceOnThingspeak}`
       );
       if (responseFromUpdateDeviceOnThingspeak.success === true) {
         let responseFromUpdateDeviceOnPlatform = await registerDeviceUtil.updateOnPlatform(
           request
         );
         logger.info(
-          `responseFromUpdateDeviceOnPlatform -- ${jsonify(
-            responseFromUpdateDeviceOnPlatform
-          )}`
+          `responseFromUpdateDeviceOnPlatform -- ${responseFromUpdateDeviceOnPlatform}`
         );
         if (responseFromUpdateDeviceOnPlatform.success === true) {
           let status = responseFromUpdateDeviceOnPlatform.status
@@ -318,7 +304,7 @@ const registerDeviceUtil = {
         "is responseFromFilter in util a success?",
         responseFromFilter.success
       );
-      logger.info(`the filter ${jsonify(responseFromFilter.data)}`);
+      logger.info(`the filter ${responseFromFilter.data}`);
       if (responseFromFilter.success === true) {
         logObject("the filter", responseFromFilter.data);
         filter = responseFromFilter.data;
@@ -375,7 +361,7 @@ const registerDeviceUtil = {
         success: false,
         message: "Internal Server Error",
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
-        errors: error.message,
+        errors: { message: error.message },
       };
     }
   },
@@ -391,9 +377,7 @@ const registerDeviceUtil = {
       if (isEmpty(device_number)) {
         logger.info(`the device_number is not present`);
         let responseFromListDevice = await registerDeviceUtil.list(request);
-        logger.info(
-          `responseFromListDevice -- ${jsonify(responseFromListDevice)}`
-        );
+        logger.info(`responseFromListDevice -- ${responseFromListDevice}`);
         if (responseFromListDevice.success === false) {
           let errors = responseFromListDevice.errors
             ? responseFromListDevice.errors
@@ -413,16 +397,14 @@ const registerDeviceUtil = {
         modifiedRequest["query"]["device_number"] = device_number;
       }
       logger.info(`the modifiedRequest -- ${modifiedRequest} `);
-      logObject("the UnModifiedRequest ", jsonify(request));
+      logObject("the UnModifiedRequest ", request);
 
       let responseFromDeleteDeviceFromThingspeak = await registerDeviceUtil.deleteOnThingspeak(
         modifiedRequest
       );
 
       logger.info(
-        `responseFromDeleteDeviceFromThingspeak -- ${jsonify(
-          responseFromDeleteDeviceFromThingspeak
-        )}`
+        `responseFromDeleteDeviceFromThingspeak -- ${responseFromDeleteDeviceFromThingspeak}`
       );
       if (responseFromDeleteDeviceFromThingspeak.success === true) {
         let responseFromDeleteDeviceOnPlatform = await registerDeviceUtil.deleteOnPlatform(
@@ -430,9 +412,7 @@ const registerDeviceUtil = {
         );
 
         logger.info(
-          `responseFromDeleteDeviceOnPlatform -- ${jsonify(
-            responseFromDeleteDeviceOnPlatform
-          )}`
+          `responseFromDeleteDeviceOnPlatform -- ${responseFromDeleteDeviceOnPlatform}`
         );
 
         if (responseFromDeleteDeviceOnPlatform.success === true) {
@@ -498,12 +478,12 @@ const registerDeviceUtil = {
       const skip = parseInt(request.query.skip, 0);
       let filter = {};
       let responseFromFilter = generateFilter.devices(request);
-      logger.info(`responseFromFilter -- ${jsonify(responseFromFilter)}`);
+      logger.info(`responseFromFilter -- ${responseFromFilter}`);
 
       if (responseFromFilter.success === true) {
         logObject("the filter", responseFromFilter.data);
         filter = responseFromFilter.data;
-        logger.info(`the filter in list -- ${jsonify(filter)}`);
+        logger.info(`the filter in list -- ${filter}`);
       }
 
       if (responseFromFilter.success === false) {
@@ -529,9 +509,7 @@ const registerDeviceUtil = {
       });
 
       logger.info(
-        `the responseFromListDevice in list -- ${jsonify(
-          responseFromListDevice
-        )} `
+        `the responseFromListDevice in list -- ${responseFromListDevice} `
       );
 
       if (responseFromListDevice.success === false) {
@@ -603,9 +581,7 @@ const registerDeviceUtil = {
 
       logObject("responseFromRegisterDevice", responseFromRegisterDevice);
       logger.info(
-        `the responseFromRegisterDevice --${jsonify(
-          responseFromRegisterDevice
-        )} `
+        `the responseFromRegisterDevice --${responseFromRegisterDevice} `
       );
 
       if (responseFromRegisterDevice.success === true) {
@@ -633,7 +609,7 @@ const registerDeviceUtil = {
       logger.error("server error - createOnPlatform util");
       return {
         success: false,
-        errors: error.message,
+        errors: { message: error.message },
         message: "Internal Server Error",
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
@@ -647,7 +623,7 @@ const registerDeviceUtil = {
       const data = body;
       const map = constants.DEVICE_THINGSPEAK_MAPPINGS;
       const context = constants.THINGSPEAK_FIELD_DESCRIPTIONS;
-      logger.info(`the context -- ${jsonify(context)}`);
+      logger.info(`the context -- ${context}`);
       const responseFromTransformRequestBody = await registerDeviceUtil.transform(
         {
           data,
@@ -656,9 +632,7 @@ const registerDeviceUtil = {
         }
       );
       logger.info(
-        `responseFromTransformRequestBody -- ${jsonify(
-          responseFromTransformRequestBody
-        )}`
+        `responseFromTransformRequestBody -- ${responseFromTransformRequestBody}`
       );
       let transformedBody = responseFromTransformRequestBody.success
         ? responseFromTransformRequestBody.data
@@ -703,14 +677,14 @@ const registerDeviceUtil = {
         success: false,
         message: "Internal Server Error",
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
-        errors: error.message,
+        errors: { message: error.message },
       };
     }
   },
 
   updateOnThingspeak: async (request) => {
     try {
-      logger.info(`  updateOnThingspeak's request -- ${jsonify(request)}`);
+      logger.info(`  updateOnThingspeak's request -- ${request}`);
       const { device_number } = request.query;
       logElement("device_number", device_number);
       const { body } = request;
@@ -722,7 +696,7 @@ const registerDeviceUtil = {
       const data = body;
       const map = constants.DEVICE_THINGSPEAK_MAPPINGS;
       const context = constants.THINGSPEAK_FIELD_DESCRIPTIONS;
-      logger.info(`the context -- ${jsonify(context)}`);
+      logger.info(`the context -- ${context}`);
       const responseFromTransformRequestBody = await registerDeviceUtil.transform(
         {
           data,
@@ -730,15 +704,13 @@ const registerDeviceUtil = {
         }
       );
       logger.info(
-        `responseFromTransformRequestBody -- ${jsonify(
-          responseFromTransformRequestBody
-        )}`
+        `responseFromTransformRequestBody -- ${responseFromTransformRequestBody}`
       );
       let transformedBody = responseFromTransformRequestBody.success
         ? responseFromTransformRequestBody.data
         : {};
 
-      logger.info(`transformedBody -- ${jsonify(transformedBody)}`);
+      logger.info(`transformedBody -- ${transformedBody}`);
 
       const response = await axios.put(
         constants.UPDATE_THING(device_number),
@@ -755,13 +727,12 @@ const registerDeviceUtil = {
       };
     } catch (error) {
       logger.error(`updateOnThingspeak util -- ${error.message}`);
-      let e = jsonify(error);
       return {
         success: false,
         message:
           "corresponding device_number does not exist on external system, consider SOFT update",
         status: HTTPStatus.NOT_FOUND,
-        errors: e.message,
+        errors: { message: error.message },
       };
     }
   },
@@ -784,7 +755,7 @@ const registerDeviceUtil = {
         "is responseFromFilter in util a success?",
         responseFromFilter.success
       );
-      logger.info(`the filter ${jsonify(responseFromFilter.data)}`);
+      logger.info(`the filter ${responseFromFilter.data}`);
       if (responseFromFilter.success === true) {
         logObject("the filter", responseFromFilter.data);
         filter = responseFromFilter.data;
@@ -846,7 +817,7 @@ const registerDeviceUtil = {
         success: false,
         message: "Internal Server Error",
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
-        errors: error.message,
+        errors: { message: error.message },
       };
     }
   },
@@ -874,7 +845,7 @@ const registerDeviceUtil = {
         });
 
       if (!isEmpty(response.success) && !response.success) {
-        logger.info(`the response from thingspeak -- ${jsonify(response)}`);
+        logger.info(`the response from thingspeak -- ${response}`);
         return {
           success: false,
           message: `${response.message}`,
@@ -884,9 +855,7 @@ const registerDeviceUtil = {
       }
       if (!isEmpty(response.data)) {
         logger.info(
-          `successfully deleted the device on thingspeak -- ${jsonify(
-            response.data
-          )}`
+          `successfully deleted the device on thingspeak -- ${response.data}`
         );
         return {
           success: true,
@@ -908,7 +877,7 @@ const registerDeviceUtil = {
       let filter = {};
       let responseFromFilter = generateFilter.devices(request);
       if (responseFromFilter.success === true) {
-        logger.info(`the filter ${jsonify(responseFromFilter.data)}`);
+        logger.info(`the filter ${responseFromFilter.data}`);
         filter = responseFromFilter.data;
       }
 
@@ -931,9 +900,7 @@ const registerDeviceUtil = {
         DeviceSchema
       ).remove({ filter });
 
-      logger.info(
-        `responseFromRemoveDevice --- ${jsonify(responseFromRemoveDevice)}`
-      );
+      logger.info(`responseFromRemoveDevice --- ${responseFromRemoveDevice}`);
       if (responseFromRemoveDevice.success === true) {
         let status = responseFromRemoveDevice.status
           ? responseFromRemoveDevice.status
@@ -965,7 +932,7 @@ const registerDeviceUtil = {
       return {
         success: false,
         message: "Internal Server Error",
-        errors: error.message,
+        errors: { message: error.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
@@ -1005,7 +972,7 @@ const registerDeviceUtil = {
       return {
         success: false,
         message: "unable to decrypt the key",
-        errors: err.message,
+        errors: { message: err.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
@@ -1035,7 +1002,7 @@ const registerDeviceUtil = {
       return {
         success: false,
         message: "server error - trasform util",
-        errors: error.message,
+        errors: { message: error.message },
       };
     }
   },


### PR DESCRIPTION
# resolve runtime errors in create-device usecase

**_WHAT DOES THIS PR DO?_**

- [x] removes the utilisation of the jsonify util--this resolves many runtime errors
- [x] Refactors all error responses to have the errors key as an object and in plural

Important to note that this PR does not introduce any new implementations, it just refactors and resolves a runtime error during the create device use-case.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfixes-create-device

**_HOW DO I TEST OUT THIS PR?_**
READ ME, you can use the staging environment

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] soft create device
- [x] soft update device
- [x] soft delete device
[The API reference](https://docs.airqo.net/airqo-platform-api/-Mi1WIQAGi40qdPmLrM7/device-registry/create-devices)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


