### PR TITLE
add mobility to the returned fields of the GET devices endpoint

### DIFF
--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -191,6 +191,7 @@ deviceSchema.methods = {
     return {
       id: this._id,
       name: this.name,
+      mobility: this.mobility,
       long_name: this.long_name,
       latitude: this.latitude,
       longitude: this.longitude,
@@ -303,6 +304,7 @@ deviceSchema.statics = {
           readKey: 1,
           pictures: 1,
           height: 1,
+          mobility: 1,
           status: 1,
           site: { $arrayElemAt: ["$site", 0] },
         })


### PR DESCRIPTION
# add mobility to the returned fields of the GET devices endpoint

**_WHAT DOES THIS PR DO?_**
add mobility to the returned fields of the GET devices endpoint.
After running the endpoint, check for the` mobility` field in the details of all devices returned.
This is related to the efforts of trying to ensure that we utilise the `mobility` field when choosing which device to showcase in all our front facing applications.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-create-device

**_HOW DO I TEST OUT THIS PR?_**
README, staging

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [Get devices](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/create-devices#get-devices)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


