### PR TITLE
temporarily disable deletion of Sites

### DIFF
--- a/src/device-registry/controllers/create-site.js
+++ b/src/device-registry/controllers/create-site.js
@@ -148,25 +148,29 @@ const manageSite = {
       let filter = generateFilter.sites(req);
       logObject("filter", filter);
       let responseFromRemoveSite = await createSiteUtil.delete(tenant, filter);
-      if (responseFromRemoveSite.success == true) {
-        return res.status(HTTPStatus.OK).json({
+      if (responseFromRemoveSite.success === true) {
+        const status = responseFromRemoveSite.status
+          ? responseFromRemoveSite.status
+          : HTTPStatus.OK;
+        return res.status(status).json({
           success: true,
           message: responseFromRemoveSite.message,
           site: responseFromRemoveSite.data,
         });
-      } else if (responseFromRemoveSite.success == false) {
-        if (responseFromRemoveSite.errors) {
-          return res.status(HTTPStatus.BAD_GATEWAY).json({
-            success: false,
-            message: responseFromRemoveSite.message,
-            errors: responseFromRemoveSite.errors,
-          });
-        } else {
-          return res.status(HTTPStatus.BAD_GATEWAY).json({
-            success: false,
-            message: responseFromRemoveSite.message,
-          });
-        }
+      }
+
+      if (responseFromRemoveSite.success === false) {
+        const status = responseFromRemoveSite.status
+          ? responseFromRemoveSite.status
+          : HTTPStatus.INTERNAL_SERVER_ERROR;
+        const errors = responseFromRemoveSite.errors
+          ? responseFromRemoveSite.errors
+          : "";
+        return res.status(status).json({
+          success: false,
+          message: responseFromRemoveSite.message,
+          errors,
+        });
       }
     } catch (error) {
       return res.status(HTTPStatus.INTERNAL_SERVER_ERROR).json({

--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -224,7 +224,6 @@ airqloudSchema.statics = {
           "sites.distance_to_nearest_residential_road": 0,
           "sites.bearing_to_kampala_center": 0,
           "sites.distance_to_kampala_center": 0,
-          "sites.generated_name": 0,
           "sites.updatedAt": 0,
           "sites.nearest_tahmo_station": 0,
           "sites.formatted_name": 0,

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -407,6 +407,25 @@ siteSchema.statics = {
           "airqlouds.sites": 0,
           "airqlouds.__v": 0,
         })
+        .project({
+          "devices.height": 0,
+          "devices.description": 0,
+          "devices.isUsedForCollocation": 0,
+          "devices.isPrimaryInLocation": 0,
+          "devices.createdAt": 0,
+          "devices.updatedAt": 0,
+          "devices.locationName": 0,
+          "devices.siteName": 0,
+          "devices.site_id": 0,
+          "devices.isRetired": 0,
+          "devices.long_name": 0,
+          "devices.nextMaintenance": 0,
+          "devices.readKey": 0,
+          "devices.writeKey": 0,
+          "devices.deployment_date": 0,
+          "devices.recall_date": 0,
+          "devices.maintenance_date": 0,
+        })
         .skip(_skip)
         .limit(_limit)
         .allowDiskUse(true);

--- a/src/device-registry/utils/create-device.js
+++ b/src/device-registry/utils/create-device.js
@@ -380,6 +380,7 @@ const registerDeviceUtil = {
         success: false,
         message: "feature temporarity disabled --coming soon",
         status: HTTPStatus.SERVICE_UNAVAILABLE,
+        errors: { message: "Service Unavailable" },
       };
       const { device_number } = request.query;
       let modifiedRequest = request;

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -635,6 +635,12 @@ const manageSite = {
 
   delete: async (tenant, filter) => {
     try {
+      return {
+        success: false,
+        message: "feature temporarity disabled --coming soon",
+        status: HTTPStatus.SERVICE_UNAVAILABLE,
+        errors: { message: "Service Unavailable" },
+      };
       let responseFromRemoveSite = await getModelByTenant(
         tenant.toLowerCase(),
         "site",


### PR DESCRIPTION
# temporarily disable deletion of Sites

**_WHAT DOES THIS PR DO?_**

- [x] temporarily disable deletion of Sites.
- [x] reduce projected device details when getting sites
- [x] Reintroduces `generated_name` on GET AirQloud Sites.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-create-sites

**_HOW DO I TEST OUT THIS PR?_**
README, staging

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [Delete Site](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/create-sites#delete-site)
- [x] [Get Sites](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/create-sites#get-sites)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


