### PR TITLE
[Analytics] add GPS coordinates to downloaded data

### DIFF
--- a/src/analytics/api/models/events.py
+++ b/src/analytics/api/models/events.py
@@ -93,6 +93,8 @@ class EventsModel(BasePyMongoModel):
                     site_id={"$toString": "$site_id"},
                     site_name="$site.name",
                     site_description="$site.description",
+                    latitude="$site.latitude",
+                    longitude="$site.longitude",
                 )
 
                 .exec()

--- a/src/analytics/api/models/site.py
+++ b/src/analytics/api/models/site.py
@@ -8,13 +8,16 @@ class SiteModel(BasePyMongoModel):
         super().__init__(tenant, collection_name="sites")
 
     @cache.memoize()
-    def get_sites(self):
+    def get_sites(self, sites=None):
+        if sites:
+            return self.get_specific_sites(sites, id_key="site_id")
+
         return self.project(_id=0, site_id={"$toString": "$_id"}, name=1, description=1, generated_name=1).exec()
 
-    def get_specific_sites(self, sites):
+    def get_specific_sites(self, sites, id_key="_id"):
         return (
-            self.project(_id={"$toString": "$_id"}, name=1, description=1, generated_name=1)
-                .match_in(_id=sites)
+            self.project(**{id_key: {"$toString": "$_id"}}, name=1, description=1, generated_name=1)
+                .match_in(**{id_key: sites})
                 .exec()
         )
 

--- a/src/analytics/api/utils/request_validators.py
+++ b/src/analytics/api/utils/request_validators.py
@@ -42,6 +42,7 @@ class Validator(OrderedDict):
         super().__init__()
         self.validation_type = validation_type
         self['required'] = self.type_validator(self.none_checker, "is required")
+        self['optional'] = self.type_validator(self.optional_checker, "is optional")
         self['int'] = self.type_validator(int, "{} is not a valid integer")
         self['float'] = self.type_validator(float, "{} is not a valid float")
         self['list'] = self.type_validator(self.list_checker, "{} is not a valid list/array")
@@ -109,6 +110,10 @@ class Validator(OrderedDict):
     def none_checker(value):
         if not value:
             raise TypeError("value can not be none/falsy")
+
+    @staticmethod
+    def optional_checker(value):
+        pass
 
     @classmethod
     def email_checker(cls, value):

--- a/src/analytics/api/views/dashboard.py
+++ b/src/analytics/api/views/dashboard.py
@@ -163,17 +163,20 @@ class MonitoringSiteResource(Resource):
 class DailyAveragesResource(Resource):
 
     @swag_from('/api/docs/dashboard/device_daily_measurements_get.yml')
-    @validate_request_json('pollutant|required:str', 'startDate|required:datetime', 'endDate|required:datetime')
+    @validate_request_json(
+        'pollutant|required:str', 'startDate|required:datetime',
+        'endDate|required:datetime', 'sites|optional:list')
     def post(self):
         tenant = request.args.get('tenant')
         json_data = request.get_json()
         pollutant = json_data["pollutant"]
         start_date = json_data["startDate"]
         end_date = json_data["endDate"]
+        sites = json_data.get("sites", None)
 
         events_model = EventsModel(tenant)
         site_model = SiteModel(tenant)
-        sites = site_model.get_sites()
+        sites = site_model.get_sites(sites)
         data = events_model.get_averages_by_pollutant(start_date, end_date, pollutant)
 
         values = []
@@ -228,7 +231,7 @@ class ExceedancesResource(Resource):
 
         exc_model = ExceedanceModel(tenant)
 
-        data = exc_model.get_exceedances(start_date, end_date, pollutant, standard)
+        print('data', data)
 
         return create_response(
             "exceedance data successfully fetched",

--- a/src/analytics/api/views/dashboard.py
+++ b/src/analytics/api/views/dashboard.py
@@ -218,7 +218,8 @@ class ExceedancesResource(Resource):
     @swag_from('/api/docs/dashboard/exceedances_post.yml')
     @validate_request_json(
         'pollutant|required:str', 'standard|required:str',
-        'startDate|required:datetime', 'endDate|required:datetime'
+        'startDate|required:datetime', 'endDate|required:datetime',
+        'sites|optional:list'
     )
     def post(self):
         tenant = request.args.get('tenant')
@@ -228,8 +229,11 @@ class ExceedancesResource(Resource):
         standard = json_data["standard"]
         start_date = json_data["startDate"]
         end_date = json_data["endDate"]
+        sites = json_data.get("sites", None)
 
         exc_model = ExceedanceModel(tenant)
+        print("raw sites", sites)
+        data = exc_model.get_exceedances(start_date, end_date, pollutant, standard, sites=sites)
 
         print('data', data)
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
* Add GPS data on downloaded data

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Change directory to the analytics microservice
* Start redis (in another terminal)
* Create and/or start your `python` virtual env
* Install requirements `pip install -r requirements.txt
* Set the `.env` file. Sample [here](https://airqo.slack.com/archives/C0278FK2EGG/p1626124999013700)
* Start application `flask run`
* Check the swagger docs `http://localhost:5000/apidocs/`
* The download data endpoint `POST` `http://localhost:5000/api/v1/analytics/data/download` should be returning sorted data.

###### Endpoint

    POST http://localhost:5000/api/v1/analytics/data/download?tenant=airqo&downloadType=csv

###### Sample data
```
{
  "endDate": "2021-09-22T21:00:00.000Z",
  "frequency": "hourly",
  "pollutants": [
    "pm2_5"
  ],
  "sites": [
    "60d058c8048305120d2d6133"
  ],
  "startDate": "2021-09-08T21:00:00.000Z"
}
```



