### PR TITLE
[Analytics] Approximate data export coordinates

### DIFF
--- a/src/analytics/api/utils/coordinates.py
+++ b/src/analytics/api/utils/coordinates.py
@@ -1,0 +1,17 @@
+from random import random
+
+DITHER = 0.001
+DIFF = 0.6
+DECIMAL_PLACES = 6
+
+
+def approximate_coordinates(data):
+	RANDOM_FLOAT = random()
+	for item in data:
+		if item.get("latitude"):
+			item["latitude"] = round(item["latitude"] + (RANDOM_FLOAT-DIFF)*DITHER, DECIMAL_PLACES)
+
+		if item.get("longitude"):
+			item["longitude"] = round(item["longitude"] + (RANDOM_FLOAT-DIFF)*DITHER, DECIMAL_PLACES)
+
+	return data

--- a/src/analytics/api/views/dashboard.py
+++ b/src/analytics/api/views/dashboard.py
@@ -14,6 +14,7 @@ from api.models import (
 )
 
 from api.utils.http import create_response, Status
+from api.utils.coordinates import approximate_coordinates
 from api.utils.request_validators import validate_request_params, validate_request_json
 from api.utils.pollutants import (
     generate_pie_chart_data,
@@ -42,7 +43,7 @@ class DownloadCustomisedDataResource(Resource):
         pollutants = json_data["pollutants"]
 
         events_model = EventsModel(tenant)
-        data = events_model.get_downloadable_events(sites, start_date, end_date, frequency, pollutants)
+        data = approximate_coordinates(events_model.get_downloadable_events(sites, start_date, end_date, frequency, pollutants))
 
         if download_type == 'json':
             return create_response("air-quality data download successful", data=data), Status.HTTP_200_OK


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
* approximate site coordinates to about (40 metres way) [PLAT-862](https://airqoteam.atlassian.net/browse/PLAT-862)
#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Change directory to the analytics microservice
* Start redis (in another terminal)
* Create and/or start your `python` virtual env
* Install requirements `pip install -r requirements.txt
* Set the `.env` file. Sample [here](https://airqo.slack.com/archives/C0278FK2EGG/p1626124999013700)
* Start application `flask run`
* Check the swagger docs `http://localhost:5000/apidocs/`
* The download data endpoint `POST` `http://localhost:5000/api/v1/analytics/data/download` should be returning sorted data.

###### Endpoint

    POST http://localhost:5000/api/v1/analytics/data/download?tenant=airqo&downloadType=csv

###### Sample data
```
{
  "endDate": "2021-09-22T21:00:00.000Z",
  "frequency": "hourly",
  "pollutants": [
    "pm2_5"
  ],
  "sites": [
    "60d058c8048305120d2d6133"
  ],
  "startDate": "2021-09-08T21:00:00.000Z"
}
```
