### PR TITLE
adjust the startTime for getting greenness to one month ago

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -65,9 +65,10 @@ const defaultConfig = {
   },
   KEY_ENCRYPTION_KEY: process.env.KEY_ENCRYPTION_KEY,
   GET_ROAD_METADATA: ({ path, latitude, longitude } = {}) => {
-    let today = monthsInfront(0);
-    let endDate = generateDateFormatWithoutHrs(today);
-    let startDate = generateDateFormatWithoutHrs(today);
+    const today = monthsInfront(0);
+    const oneMonthAgo = monthsInfront(-1);
+    const endDate = generateDateFormatWithoutHrs(today);
+    const startDate = generateDateFormatWithoutHrs(oneMonthAgo);
     if (path === "greenness") {
       return `https://platform.airqo.net/api/v1/datawarehouse/${path}?lat=${latitude}&lon=${longitude}&startDate=${startDate}&endDate=${endDate}`;
     }


### PR DESCRIPTION
# adjust the startTime for getting greenness to one month ago

**_WHAT DOES THIS PR DO?_**
adjust the startTime for getting greenness to one month ago.
_Context:_
While creating new Sites, it was discovered that some fields were not automatically generated by the system despite the backend system integrations that were already done.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-create-site

**_HOW DO I TEST OUT THIS PR?_**
README, staging

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [generate Site metadata](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/create-sites#generate-site-metadata)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A

**_SCREENSHOTS?_**
<img width="797" alt="Screenshot 2021-11-12 at 07 33 38" src="https://user-images.githubusercontent.com/1590213/141410152-cc21657f-03bb-4c45-af29-23e1316c6b92.png">

