### PR TITLE
reversing an unnecessary hotfix for getting raw events

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -611,7 +611,7 @@ eventSchema.statics = {
       projection[as] = 0;
     }
 
-    if (tenant !== "airqo" || frequency === "raw") {
+    if (tenant !== "airqo") {
       pm2_5 = "$pm2_5";
       pm10 = "$pm10";
     }


### PR DESCRIPTION
# reversing an unnecessary hotfix for getting raw events

**_WHAT DOES THIS PR DO?_**
reversing an unnecessary hotfix for getting raw events

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
https://github.com/airqo-platform/AirQo-api/tree/hotfix-create-event

**_HOW DO I TEST OUT THIS PR?_**
README, staging

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
[GET Events:](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/events#get-events)

1. `frequency=raw `and `external=no`
2.` frequency=raw` and `external=yes`

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A


