### PR TITLE
Updating site search names

### DIFF
--- a/src/data-mgt/python/devices-tranformation/Readme.md
+++ b/src/data-mgt/python/devices-tranformation/Readme.md
@@ -10,7 +10,7 @@ Contains Utils for manipulating devices' data
     pip install -r requirements.txt
 ```
 
-Obtain and add the `.env` to this directory.
+Add the `.env` to this directory. [link to env file](https://docs.google.com/document/d/12SFbaC9aECzQJDtGp4ECkLpMqVAnmQQ22QyqE2d9L94/edit?usp=sharing)
 
 In scenarios where the output is  **csv** or **json**, a file named `output.json` or `output.csv` is generated with the
 data.

--- a/src/data-mgt/python/devices-tranformation/Readme.md
+++ b/src/data-mgt/python/devices-tranformation/Readme.md
@@ -66,3 +66,9 @@ Update sites to include the nearest Tahmo Station.
 ```bash
     python main.py devices_without_forecast csv
 ```
+
+## Update sites external names based on csv file
+
+```bash
+    python main.py update_site_external_names
+```

--- a/src/data-mgt/python/devices-tranformation/airqoApi.py
+++ b/src/data-mgt/python/devices-tranformation/airqoApi.py
@@ -77,7 +77,13 @@ class AirQoApi:
     def update_sites(self, updated_sites):
         for i in updated_sites:
             site = dict(i)
-            params = {"tenant": site.pop("tenant"), "id": site.pop("_id")}
+
+            params = {"tenant": site.pop("tenant")}
+
+            if "_id" in site.keys():
+                params["id"] = site.pop("_id")
+            if "lat_long" in site.keys():
+                params["lat_long"] = site.pop("lat_long")
 
             response = self.__request("devices/sites", params, site, "put")
             print(response)

--- a/src/data-mgt/python/devices-tranformation/main.py
+++ b/src/data-mgt/python/devices-tranformation/main.py
@@ -41,6 +41,9 @@ if __name__ == '__main__':
     elif action.lower().strip() == "update_primary_devices":
         transformation.update_primary_devices()
 
+    elif action.lower().strip() == "update_site_external_names":
+        transformation.update_site_external_names()
+
     elif action.lower().strip() == "devices_without_forecast":
         transformation.get_devices_without_forecast()
 

--- a/src/data-mgt/python/devices-tranformation/transformation.py
+++ b/src/data-mgt/python/devices-tranformation/transformation.py
@@ -37,6 +37,23 @@ class Transformation:
             if name and deployed.strip().lower() == "deployed":
                 self.airqo_api.update_primary_device(tenant=tenant, name=name, primary=is_primary)
 
+    def update_site_external_names(self):
+
+        updated_site_names = []
+        sites = pd.read_csv("sites.csv")
+        for _, site in sites.iterrows():
+
+            site_dict = dict(site.to_dict())
+
+            update = dict({
+                "search_name": site_dict.get("display_name"),
+                "lat_long": site_dict.get("lat_long"),
+                "tenant": self.tenant,
+            })
+            updated_site_names.append(update)
+
+        self.airqo_api.update_sites(updated_site_names)
+
     def map_devices_to_tahmo_station(self):
 
         devices = self.airqo_api.get_devices(self.tenant)
@@ -111,9 +128,7 @@ class Transformation:
                     update = dict({
                         "nearest_tahmo_station": station_data,
                         "_id": site_dict.get("_id"),
-                        "name": site_dict.get("name"),
-                        "latitude": latitude,
-                        "longitude": longitude,
+                        "tenant": self.tenant,
                     })
 
                     updated_sites.append(update)


### PR DESCRIPTION
# Feature

**_WHAT DOES THIS PR DO?_**
Adds functionality for updating sites search names

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
None

**_WHAT IS THE LINK TO THE PR BRANCH_**
[site-display-names](https://github.com/airqo-platform/AirQo-api/tree/site-display-names)

**_HOW DO I TEST OUT THIS PR?_**

- Add a sample csv to the directory [link to sample](https://docs.google.com/spreadsheets/d/1wyh4kxE8e2yUtKRR09ihb_R-wEKRDuJOOMZ0JXPRXlY/edit#gid=1152899809) and name it `sites.csv`
- Follow instructions on the [Readme file](https://github.com/airqo-platform/AirQo-api/tree/site-display-names/src/data-mgt/python/devices-tranformation#update-sites-external-names-based-on-csv-file)

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
[Get Sites endpoint](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/create-sites)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
None

**_ARE THERE ANY RELATED PRs?_**
None

