### PR TITLE
Gp model remove tenant

### DIFF
--- a/src/gp-model/config.py
+++ b/src/gp-model/config.py
@@ -16,8 +16,10 @@ class Config:
 
 
 class ProductionConfig(Config):
-    DB_NAME = os.getenv("DB_NAME_PROD")
-    MONGO_URI = os.getenv('MONGO_GCE_URI')
+    MONGO_URI_NETMANAGER = os.getenv('MONGO_GCE_URI_NETMANAGER')
+    DB_NAME_NETMANAGER = os.getenv("DB_NAME_PROD_NETMANAGER")
+    MONGO_URI_DEVICE_REGISTRY = os.getenv('MONGO_GCE_URI_DEVICE_REGISTRY')
+    DB_NAME_DEVICE_REGISTRY = os.getenv("DB_NAME_PROD_DEVICE_REGISTRY")
     VIEW_AIRQLOUD_URI = os.getenv('VIEW_AIRQLOUD_URI_PROD')
     LIST_DEVICES_URI = os.getenv('LIST_DEVICES_URI_PROD')
     EVENTS_URI = os.getenv('EVENTS_URI_PROD')
@@ -26,8 +28,10 @@ class ProductionConfig(Config):
 class DevelopmentConfig(Config):
     DEVELOPMENT = True
     DEBUG = True
-    MONGO_URI = os.getenv("MONGO_DEV_URI")
-    DB_NAME = os.getenv("DB_NAME_DEV")
+    MONGO_URI_NETMANAGER = os.getenv('MONGO_DEV_URI_NETMANAGER')
+    DB_NAME_NETMANAGER = os.getenv("DB_NAME_DEV_NETMANAGER")
+    MONGO_URI_DEVICE_REGISTRY = os.getenv('MONGO_DEV_URI_DEVICE_REGISTRY')
+    DB_NAME_DEVICE_REGISTRY = os.getenv("DB_NAME_DEV_DEVICE_REGISTRY")
     VIEW_AIRQLOUD_URI = os.getenv('VIEW_AIRQLOUD_URI_DEV')
     LIST_DEVICES_URI = os.getenv('LIST_DEVICES_URI_DEV')
     EVENTS_URI = os.getenv('EVENTS_URI_DEV')
@@ -36,8 +40,10 @@ class DevelopmentConfig(Config):
 class TestingConfig(Config):
     DEBUG = True
     TESTING = True
-    MONGO_URI = os.getenv('MONGO_GCE_URI')
-    DB_NAME = os.getenv("DB_NAME_STAGE")
+    DB_NAME_NETMANAGER = os.getenv("DB_NAME_STAGE_NETMANAGER")
+    MONGO_URI_NETMANAGER = os.getenv('MONGO_GCE_URI_NETMANAGER')
+    MONGO_URI_DEVICE_REGISTRY = os.getenv('MONGO_GCE_URI_DEVICE_REGISTRY')
+    DB_NAME_DEVICE_REGISTRY = os.getenv("DB_NAME_STAGE_DEVICE_REGISTRY")
     VIEW_AIRQLOUD_URI = os.getenv('VIEW_AIRQLOUD_URI_STAGE')
     LIST_DEVICES_URI = os.getenv('LIST_DEVICES_URI_STAGE')
     EVENTS_URI = os.getenv('EVENTS_URI_STAGE')
@@ -56,7 +62,10 @@ print("ENVIRONMENT", environment or 'staging')
 configuration = app_config.get(environment, TestingConfig)
 
 
-def connect_mongo(tenant):
-    client = MongoClient(configuration.MONGO_URI)
-    db = client[f'{configuration.DB_NAME}_{tenant.lower()}']
+def connect_mongo(tenant, db_host=configuration.MONGO_URI_NETMANAGER):
+    client = MongoClient(db_host)
+    if db_host == configuration.MONGO_URI_NETMANAGER:
+        db = client[configuration.DB_NAME_NETMANAGER]
+    else:
+        db = client[f'{configuration.DB_NAME_DEVICE_REGISTRY}_{tenant.lower()}']
     return db

--- a/src/gp-model/helpers/get_data.py
+++ b/src/gp-model/helpers/get_data.py
@@ -23,7 +23,7 @@ def get_device_details(device_id, tenant):
     name: str
         Name of the device
     """
-    db= connect_mongo(tenant)    
+    db= connect_mongo(tenant, db_host=configuration.MONGO_URI_DEVICE_REGISTRY)    
     query = {
         'channelID': device_id
     }


### PR DESCRIPTION
# Remove DB tenant parameter for gpmodel job

**_WHAT DOES THIS PR DO?_**
- Removes multitenant from gpmodel job. This is to align with the predict microservice which does not implement multitenancy

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
- N/A

**_WHAT IS THE LINK TO THE PR BRANCH_**
- https://github.com/airqo-platform/AirQo-api/tree/gp-model-remove-tenant

**_HOW DO I TEST OUT THIS PR?_**
- Get the updated `.env` from slack  and set the environment accordingly (`development`, `staging` or `production`)
- Run `python main.py`
- Observe the data added to `airqo_netmanager` or `airqo_netmanager_staging` collection NOT in `airqo_netmanager_airqo` or `airqo_netmanager_staging_airqo` as before.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- N/A

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
- N/A
-
**_ARE THERE ANY RELATED PRs?_**
- N/A


