### PR TITLE
[Metadata] Functionality to export sites and devices as csv

### DIFF
--- a/src/data-mgt/python/devices-tranformation/Readme.md
+++ b/src/data-mgt/python/devices-tranformation/Readme.md
@@ -67,8 +67,15 @@ Update sites to include the nearest Tahmo Station.
     python main.py devices_without_forecast csv
 ```
 
-## Update sites external names based on csv file
+## Update sites search names based on csv file
 
 ```bash
-    python main.py update_site_external_names
+    python main.py update_site_search_names
+```
+
+## Export sites/devices as csv
+
+```bash
+    python main.py sites_to_csv csv
+    python main.py devices_to_csv csv
 ```

--- a/src/data-mgt/python/devices-tranformation/airqoApi.py
+++ b/src/data-mgt/python/devices-tranformation/airqoApi.py
@@ -120,8 +120,6 @@ class AirQoApi:
             handle_api_error("Invalid")
             return None
 
-        print(api_request.url)
-
         if api_request.status_code == 200 or api_request.status_code == 201:
             return api_request.json()
         else:

--- a/src/data-mgt/python/devices-tranformation/main.py
+++ b/src/data-mgt/python/devices-tranformation/main.py
@@ -41,11 +41,17 @@ if __name__ == '__main__':
     elif action.lower().strip() == "update_primary_devices":
         transformation.update_primary_devices()
 
-    elif action.lower().strip() == "update_site_external_names":
-        transformation.update_site_external_names()
+    elif action.lower().strip() == "update_site_search_names":
+        transformation.update_site_search_names()
 
     elif action.lower().strip() == "devices_without_forecast":
         transformation.get_devices_without_forecast()
+
+    elif action.lower().strip() == "sites_to_csv":
+        transformation.metadata_to_csv(component='sites')
+
+    elif action.lower().strip() == "devices_to_csv":
+        transformation.metadata_to_csv(component='devices')
 
     else:
         print("Invalid Arguments. Check the Readme.md for valid arguments")

--- a/src/data-mgt/python/devices-tranformation/transformation.py
+++ b/src/data-mgt/python/devices-tranformation/transformation.py
@@ -37,7 +37,7 @@ class Transformation:
             if name and deployed.strip().lower() == "deployed":
                 self.airqo_api.update_primary_device(tenant=tenant, name=name, primary=is_primary)
 
-    def update_site_external_names(self):
+    def update_site_search_names(self):
 
         updated_site_names = []
         sites = pd.read_csv("sites.csv")
@@ -46,7 +46,7 @@ class Transformation:
             site_dict = dict(site.to_dict())
 
             update = dict({
-                "search_name": site_dict.get("display_name"),
+                "search_name": site_dict.get("search_name"),
                 "lat_long": site_dict.get("lat_long"),
                 "tenant": self.tenant,
             })
@@ -169,6 +169,17 @@ class Transformation:
                 sites_without_primary_devices.append(site_dict)
 
         self.__print(data=sites_without_primary_devices)
+
+    def metadata_to_csv(self, component=''):
+
+        metadata = self.airqo_api.get_sites(tenant=self.tenant)\
+            if component.strip().lower() == 'sites' \
+            else self.airqo_api.get_devices(tenant=self.tenant, all_devices=True)
+
+        metadata_df = pd.DataFrame(metadata)
+        data = pd.json_normalize(metadata_df.to_dict(orient='records'))
+
+        self.__print(data=data)
 
     def get_devices_without_forecast(self):
 


### PR DESCRIPTION
# Feature

**_WHAT DOES THIS PR DO?_**

- [x] Adds functionality to export sites and devices as csv

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-913](https://airqoteam.atlassian.net/browse/PLAT-913?atlOrigin=eyJpIjoiYjZjMjVhMTMzZTc0NDdlZWI3MTI4ZDA2MjJiNzc0MWUiLCJwIjoiaiJ9)

**_WHAT IS THE LINK TO THE PR BRANCH_**
[ft-metadata-grooming](https://github.com/airqo-platform/AirQo-api/tree/ft-metadata-grooming)

**_HOW DO I TEST OUT THIS PR?_**
Follow instructions in the [Readme File](https://github.com/airqo-platform/AirQo-api/tree/ft-metadata-grooming/src/data-mgt/python/devices-tranformation#export-sitesdevices-as-csv)

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
None

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
None

**_ARE THERE ANY RELATED PRs?_**
None

