### PR TITLE
[Analytics] D3 chart data endpoint

### DIFF
--- a/src/analytics/api/docs/dashboard/d3_chart_data_post.yml
+++ b/src/analytics/api/docs/dashboard/d3_chart_data_post.yml
@@ -1,0 +1,71 @@
+Example endpoint for fetching d3 chart data
+---
+tags: [Dashboard]
+parameters:
+  - name: tenant
+    in: query
+    type: string
+    required: true
+    default: airqo
+  - name: body
+    in: body
+    required: true
+    schema:
+      $ref: "#/definitions/CustomisedChartDataBody"
+definitions:
+  CustomisedChartDataBody:
+    type: object
+    properties:
+      sites:
+        required: true
+        type: array
+        items:
+          type: string
+        example: ["60d2b0317e9018a1a8d38c11", "60d2b5c57e9018a1a8d38c1c"]
+      startDate:
+        type: string
+        example: "2021-01-08T21:00:00.000Z"
+      endDate:
+        type: string
+        example: "2021-02-08T21:00:00.000Z"
+      frequency:
+        type: string
+        enum: [raw, hourly, daily, monthly]
+        example: daily
+  D3CustomisedChartDataResponse:
+    type: object
+    properties:
+      status:
+        type: string
+        example: success
+      message:
+        type: string
+        example: chart data successfully retrieved d3 chart data
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/D3CustomisedChartData'
+  D3CustomisedChartData:
+    type: object
+    properties:
+      time:
+        type: string
+        example: "2021-10-08T00:00:00:00+0300"
+      value:
+        type: string
+        example: 78.26
+      site_id:
+        type: string
+        example: 60d058c8048305120d2d6133
+      name:
+        type: string
+        example: "Kasharara, Rubirizi"
+      generated_name:
+        type: string
+        example: site_04
+
+responses:
+  200:
+    description: chart data successfully retrieved d3 chart data
+    schema:
+      $ref: '#/definitions/D3CustomisedChartDataResponse'

--- a/src/analytics/api/models/events.py
+++ b/src/analytics/api/models/events.py
@@ -177,6 +177,58 @@ class EventsModel(BasePyMongoModel):
                 .exec()
         )
 
+    @cache.memoize()
+    def get_d3_chart_events(self, sites, start_date, end_date, pollutant, frequency):
+        time_format_mapper = {
+            'raw': '%Y-%m-%dT%H:%M:%S%z',
+            'hourly': '%Y-%m-%dT%H:00:00:00%z',
+            'daily': '%Y-%m-%dT00:00:00:00%z',
+            'monthly': '%Y-%m-01T00:00:00:00%z'
+        }
+
+        return (
+            self
+                .project(**{"values.time": 1, "values.site_id": 1, f"values.{pollutant}": 1})
+                .date_range("values.time", start_date=start_date, end_date=end_date)
+                .match_in(**{"values.site_id": self.to_object_ids(sites)})
+                .filter_by(**{"values.frequency": "raw"})
+                .unwind("values")
+                .replace_root("values")
+                .project(
+                    _id=0,
+                    time={
+                        "$dateToString": {
+                            'format': time_format_mapper.get(frequency) or time_format_mapper.get('hourly'),
+                            'date': '$time',
+                            'timezone': 'Africa/Kampala'
+                        }
+                    },
+                    **{f"{pollutant}.value": 1},
+                    site_id={"$toString": "$site_id"},
+                )
+                .remove_outliers(pollutant)
+                .group(
+                    _id={"site_id": "$site_id", "time": "$time"},
+                    time={"$first": "$time"},
+                    site_id={"$first": "$site_id"},
+                    value={"$avg": f"${pollutant}.value"},
+                )
+                .sort(time=self.ASCENDING)
+                .project(_id=0, site_id={"$toObjectId": "$site_id"}, time=1,value=1)
+                .lookup("sites", local_field="site_id", foreign_field="_id", col_as="site")
+                .project(
+                    _id=0,
+                    time=1,
+                    value={"$round": ["$value", 2]},
+                    site_id={"$toString": "$site_id"},
+                    name="$site.name",
+                    generated_name="$site.generated_name",
+                )
+                .unwind("name")
+                .unwind("generated_name")
+                .exec()
+        )
+
     def get_events(self, sites, start_date, end_date, frequency):
         time_format_mapper = {
             'raw': '%Y-%m-%dT%H:%M:%S%z',

--- a/src/analytics/api/models/events.py
+++ b/src/analytics/api/models/events.py
@@ -181,9 +181,9 @@ class EventsModel(BasePyMongoModel):
     def get_d3_chart_events(self, sites, start_date, end_date, pollutant, frequency):
         time_format_mapper = {
             'raw': '%Y-%m-%dT%H:%M:%S%z',
-            'hourly': '%Y-%m-%dT%H:00:00:00%z',
-            'daily': '%Y-%m-%dT00:00:00:00%z',
-            'monthly': '%Y-%m-01T00:00:00:00%z'
+            'hourly': '%Y-%m-%dT%H:00:00%z',
+            'daily': '%Y-%m-%dT00:00:00%z',
+            'monthly': '%Y-%m-01T00:00:00%z'
         }
 
         return (

--- a/src/analytics/api/models/events.py
+++ b/src/analytics/api/models/events.py
@@ -1,3 +1,5 @@
+import pytz
+from datetime import datetime
 from api.models.base.base_model import BasePyMongoModel
 
 from main import cache
@@ -183,7 +185,8 @@ class EventsModel(BasePyMongoModel):
             'raw': '%Y-%m-%dT%H:%M:%S%z',
             'hourly': '%Y-%m-%dT%H:00:00%z',
             'daily': '%Y-%m-%dT00:00:00%z',
-            'monthly': '%Y-%m-01T00:00:00%z'
+            'monthly': '%Y-%m-01T00:00:00%z',
+            'diurnal': f'{datetime.now(pytz.utc).strftime("%Y-%m-%d")}T%H:00:00%z',
         }
 
         return (

--- a/src/analytics/api/utils/pre_request.py
+++ b/src/analytics/api/utils/pre_request.py
@@ -1,6 +1,7 @@
 from itertools import chain
 import re
 from flask import request, jsonify, make_response
+from config import BASE_URL
 from .messages import TENANT_REQUIRED_MSG
 
 
@@ -9,7 +10,7 @@ class PreRequest:
     This is the class that will host all static pre-request functions such as checking for tenant and authentication
     """
     TENANT_KEY = "tenant"
-    DOCS_ENDPOINTS = ['/apidocs', '/flasgger', '/apispec']
+    DOCS_ENDPOINTS = [f'{BASE_URL}/apidocs', f'{BASE_URL}/flasgger', f'{BASE_URL}/apispec']
     IGNORE_TENANT_HEADER = ['/health']
     COMBINED_IGNORE_TENANT_HEADER = f"({')|('.join(chain(DOCS_ENDPOINTS, IGNORE_TENANT_HEADER))})"
 

--- a/src/analytics/api/views/dashboard.py
+++ b/src/analytics/api/views/dashboard.py
@@ -143,6 +143,34 @@ class ChartDataResource(Resource):
         ), Status.HTTP_200_OK
 
 
+@rest_api.route('/dashboard/chart/d3/data')
+class D3ChartDataResource(Resource):
+    @swag_from('/api/docs/dashboard/customised_chart_post.yml')
+    @validate_request_json(
+        'sites|required:list', 'startDate|required:datetime',
+        'endDate|required:datetime', 'frequency|required:str',
+        'pollutant|required:str', 'chartType|required:str'
+    )
+    def post(self):
+        tenant = request.args.get('tenant')
+
+        json_data = request.get_json()
+        sites = json_data["sites"]
+        start_date = json_data["startDate"]
+        end_date = json_data["endDate"]
+        frequency = json_data["frequency"]
+        pollutant = json_data["pollutant"]
+        chart_type = json_data["chartType"]
+
+        events_model = EventsModel(tenant)
+        data = events_model.get_d3_chart_events(sites, start_date, end_date, pollutant, frequency)
+
+        return create_response(
+            "successfully retrieved d3 chart data",
+            data=data
+        ), Status.HTTP_200_OK
+
+
 @rest_api.route('/dashboard/sites')
 class MonitoringSiteResource(Resource):
 

--- a/src/analytics/api/views/dashboard.py
+++ b/src/analytics/api/views/dashboard.py
@@ -145,7 +145,7 @@ class ChartDataResource(Resource):
 
 @rest_api.route('/dashboard/chart/d3/data')
 class D3ChartDataResource(Resource):
-    @swag_from('/api/docs/dashboard/customised_chart_post.yml')
+    @swag_from('/api/docs/dashboard/d3_chart_data_post.yml')
     @validate_request_json(
         'sites|required:list', 'startDate|required:datetime',
         'endDate|required:datetime', 'frequency|required:str',

--- a/src/analytics/config.py
+++ b/src/analytics/config.py
@@ -9,6 +9,8 @@ load_dotenv(dotenv_path=env_path, verbose=True)
 
 TWO_HOURS = 7200 # seconds
 
+BASE_URL = "/api/v1/analytics"
+
 
 class Config:
     DEBUG = False
@@ -46,7 +48,8 @@ class Config:
         },
         'ui_params_text': '''{
             "operationsSorter" : (a, b) => a.get("path").localeCompare(b.get("path"))
-        }'''
+        }''',
+        "url_prefix": f"{BASE_URL}"
     }
 
 

--- a/src/analytics/main.py
+++ b/src/analytics/main.py
@@ -17,10 +17,10 @@ from api.middlewares import middleware_blueprint
 from api.middlewares.base_validator import ValidationError
 
 # Config
-from config import config
+from config import config, BASE_URL
 
 config_name = env_config('FLASK_ENV', 'production')
-rest_api = Api(prefix='/api/v1/analytics', doc=False)
+rest_api = Api(prefix=BASE_URL, doc=False)
 cache = Cache()
 
 

--- a/src/analytics/requirements.txt
+++ b/src/analytics/requirements.txt
@@ -6,6 +6,7 @@ Flask-Caching
 flasgger
 pandas
 pymongo
+pytz
 flask_pymongo
 python-decouple
 python-dotenv


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
* Add d3 chart endpoint
#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Change directory to the analytics microservice
* Start redis (in another terminal)
* Create and/or start your `python` virtual env
* Install requirements `pip install -r requirements.txt
* Set the `.env` file. Sample [here](https://drive.google.com/file/d/1LoqE3bvWEYHv3TqTsRBs2drYEr-UqCIb/view?usp=sharing)
* Start application `flask run`
* Check the swagger docs `http://localhost:5000/api/v1/analytics/apidocs/`
* The download data endpoint `POST` `http://localhost:5000/api/v1/analytics/dashboard/chart/d3/data` should be returning sorted data.

###### Endpoint

    POST http://localhost:5000/api/v1/analytics/dashboard/chart/d3/data

###### Sample data
```
{
      "sites": ["60d058c8048305120d2d6133", "60d058c8048305120d2d6134"],
      "startDate": "2021-10-08T21:00:00.000Z",
      "endDate": "2021-12-09T21:00:00.000Z",
      "pollutant": "pm2_5",
      "chartType": "line",
      "frequency": "daily",
}
```



