### PR TITLE
[Analytics] D3 data endpoint enhancement

### DIFF
--- a/src/analytics/api/models/base/model_operations.py
+++ b/src/analytics/api/models/base/model_operations.py
@@ -75,7 +75,7 @@ class ChainableMongoOperations(BaseMongoOperations):
 
     @staticmethod
     def to_object_ids(ids):
-        return [ObjectId(ID) for ID in ids]
+        return tuple(ObjectId(ID) for ID in ids)
 
     def _update_match_stage(self, expression, raise_exc=True, **new_filters):
         """

--- a/src/analytics/api/models/events.py
+++ b/src/analytics/api/models/events.py
@@ -181,12 +181,17 @@ class EventsModel(BasePyMongoModel):
 
     @cache.memoize()
     def get_d3_chart_events(self, sites, start_date, end_date, pollutant, frequency):
+
+        diurnal_end_date = datetime.strptime(end_date, '%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=pytz.utc)
+        now = datetime.now(pytz.utc)
+        diurnal_end_date = diurnal_end_date if diurnal_end_date < now else now
+
         time_format_mapper = {
             'raw': '%Y-%m-%dT%H:%M:%S%z',
             'hourly': '%Y-%m-%dT%H:00:00%z',
             'daily': '%Y-%m-%dT00:00:00%z',
             'monthly': '%Y-%m-01T00:00:00%z',
-            'diurnal': f'{datetime.now(pytz.utc).strftime("%Y-%m-%d")}T%H:00:00%z',
+            'diurnal': f'{diurnal_end_date.strftime("%Y-%m-%d")}T%H:00:00%z',
         }
 
         return (

--- a/src/analytics/api/utils/pollutants/__init__.py
+++ b/src/analytics/api/utils/pollutants/__init__.py
@@ -1,4 +1,4 @@
-from .charts import generate_pie_chart_data
+from .charts import generate_pie_chart_data, d3_generate_pie_chart_data
 from .date import str_date_to_format_str
 from .pm_25 import (
     PM_25_CATEGORY,

--- a/src/analytics/api/utils/pollutants/charts.py
+++ b/src/analytics/api/utils/pollutants/charts.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from .pm_25 import get_pollutant_category
+from .pm_25 import get_pollutant_category, PM_COLOR_CATEGORY
 
 
 def generate_pie_chart_data(records, key, pollutant):
@@ -31,3 +31,57 @@ def generate_pie_chart_data(records, key, pollutant):
         category_count[category] = category_count[category] + 1
 
     return category_count
+
+
+def _destructure_pie_data(generated_data):
+    result = []
+    for data in generated_data:
+        destructured = []
+        name = data.pop('name')
+        for key in data.keys():
+            destructured.append({
+                'name': name,
+                'category': key,
+                'color': PM_COLOR_CATEGORY.get(key, '#808080'),
+                'value': data[key],
+            })
+        result.append(destructured)
+
+    return result
+
+
+def d3_generate_pie_chart_data(records, pollutant):
+    """
+    Function to generate pie_chart data
+    Args:
+        records (list): list of pollutant objects (dict)
+        key (str): a dict key to obtain the pollutant value from the record
+        pollutant (str): string representing the pollutant
+
+    Returns: a dict containing the category count
+    """
+
+    def default_value():
+        return {
+            'Good': 0,
+            'Moderate': 0,
+            'UHFSG': 0,
+            'Unhealthy': 0,
+            'VeryUnhealthy': 0,
+            'Hazardous': 0,
+            'Other': 0,
+            'Unknown': 0,
+        }
+
+    location_category_count = defaultdict(default_value)
+
+    for record in records:
+        value = record.get('value')
+        name = record.get('name') or record.get('generated_name')
+        category = get_pollutant_category(value, pollutant=pollutant)
+        location_category_count[name][category] = location_category_count[name][category] + 1
+        location_category_count[name][category] = location_category_count[name][category] + 1
+        location_category_count[name]['name'] = name
+
+    print(len(location_category_count.values()))
+    return _destructure_pie_data(location_category_count.values())

--- a/src/analytics/api/views/dashboard.py
+++ b/src/analytics/api/views/dashboard.py
@@ -18,6 +18,7 @@ from api.utils.coordinates import approximate_coordinates
 from api.utils.request_validators import validate_request_params, validate_request_json
 from api.utils.pollutants import (
     generate_pie_chart_data,
+    d3_generate_pie_chart_data,
     PM_COLOR_CATEGORY,
     set_pm25_category_background,
 )
@@ -164,6 +165,9 @@ class D3ChartDataResource(Resource):
 
         events_model = EventsModel(tenant)
         data = events_model.get_d3_chart_events(sites, start_date, end_date, pollutant, frequency)
+
+        if chart_type.lower() == 'pie':
+            data = d3_generate_pie_chart_data(data, pollutant)
 
         return create_response(
             "successfully retrieved d3 chart data",


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
* Enhance d3 chart data endpoint to return pie multilayer chart data

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Change directory to the analytics microservice
* Start redis (in another terminal)
* Create and/or start your `python` virtual env
* Install requirements `pip install -r requirements.txt
* Set the `.env` file. Sample [here](https://drive.google.com/file/d/1LoqE3bvWEYHv3TqTsRBs2drYEr-UqCIb/view?usp=sharing)
* Start application `flask run`
* Check the swagger docs `http://localhost:5000/api/v1/analytics/apidocs/`
* The download data endpoint `POST` `http://localhost:5000/api/v1/analytics/dashboard/chart/d3/data` should be returning sorted data.

###### Endpoint

    POST http://localhost:5000/api/v1/analytics/dashboard/chart/d3/data

###### Sample data
```
{
      "sites": ["60d058c8048305120d2d6133", "60d058c8048305120d2d6134"],
      "startDate": "2021-10-08T21:00:00.000Z",
      "endDate": "2021-12-09T21:00:00.000Z",
      "pollutant": "pm2_5",
      "chartType": "line",
      "frequency": "daily",
}
```

