### PR TITLE
Export sites and devices

### DIFF
--- a/src/data-mgt/python/devices-tranformation/Readme.md
+++ b/src/data-mgt/python/devices-tranformation/Readme.md
@@ -75,6 +75,6 @@ Update sites to include the nearest Tahmo Station.
 
 ## Export sites/devices to csv or json
 ```bash
-    python main.py export_sites csv tenant
-    python main.py export_devices csv tenant
+    python main.py export_sites csv
+    python main.py export_devices json airqo
 ```

--- a/src/data-mgt/python/devices-tranformation/Readme.md
+++ b/src/data-mgt/python/devices-tranformation/Readme.md
@@ -73,9 +73,8 @@ Update sites to include the nearest Tahmo Station.
     python main.py update_site_search_names
 ```
 
-## Export sites/devices as csv
-
+## Export sites/devices to csv or json
 ```bash
-    python main.py sites_to_csv csv
-    python main.py devices_to_csv csv
+    python main.py export_sites csv tenant
+    python main.py export_devices csv tenant
 ```

--- a/src/data-mgt/python/devices-tranformation/main.py
+++ b/src/data-mgt/python/devices-tranformation/main.py
@@ -47,11 +47,19 @@ if __name__ == '__main__':
     elif action.lower().strip() == "devices_without_forecast":
         transformation.get_devices_without_forecast()
 
-    elif action.lower().strip() == "sites_to_csv":
-        transformation.metadata_to_csv(component='sites')
+    elif action.lower().strip() == "export_sites":
+        try:
+            tenant = f"{strings_list[3]}"
+        except IndexError:
+            tenant = None
+        transformation.metadata_to_csv(component='sites', tenant=tenant)
 
-    elif action.lower().strip() == "devices_to_csv":
-        transformation.metadata_to_csv(component='devices')
+    elif action.lower().strip() == "export_devices":
+        try:
+            tenant = f"{strings_list[3]}"
+        except IndexError:
+            tenant = None
+        transformation.metadata_to_csv(component='devices', tenant=tenant)
 
     else:
         print("Invalid Arguments. Check the Readme.md for valid arguments")

--- a/src/data-mgt/python/devices-tranformation/transformation.py
+++ b/src/data-mgt/python/devices-tranformation/transformation.py
@@ -170,11 +170,21 @@ class Transformation:
 
         self.__print(data=sites_without_primary_devices)
 
-    def metadata_to_csv(self, component=''):
+    def metadata_to_csv(self, component='', tenant=None):
 
-        metadata = self.airqo_api.get_sites(tenant=self.tenant)\
-            if component.strip().lower() == 'sites' \
-            else self.airqo_api.get_devices(tenant=self.tenant, all_devices=True)
+        if tenant is None:
+            metadata = []
+            for tenant in ['airqo', 'kcca']:
+                tenant_metadata = self.airqo_api.get_sites(tenant=tenant) \
+                    if component.strip().lower() == 'sites' \
+                    else self.airqo_api.get_devices(tenant=tenant, all_devices=True)
+                tenant_metadata_df = pd.DataFrame(tenant_metadata)
+                tenant_metadata_df['tenant'] = tenant
+                metadata.extend(tenant_metadata_df.to_dict(orient='records'))
+        else:
+            metadata = self.airqo_api.get_sites(tenant=tenant)\
+                if component.strip().lower() == 'sites' \
+                else self.airqo_api.get_devices(tenant=tenant, all_devices=True)
 
         metadata_df = pd.DataFrame(metadata)
         data = pd.json_normalize(metadata_df.to_dict(orient='records'))


### PR DESCRIPTION
Added functionality to export all sites and devices irrespective of tenant

# Feature

**_WHAT DOES THIS PR DO?_**
- [ ] Adds functionality to export all sites and devices as `csv` or `json`, irrespective of tenant

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
None. functionality is required to import sites/devices into BigQuery

**_WHAT IS THE LINK TO THE PR BRANCH_**
[sites-utility-functions](https://github.com/airqo-platform/AirQo-api/tree/sites-utility-functions)

**_HOW DO I TEST OUT THIS PR?_**

1. Setup your environment. [Link to setup instructions](https://github.com/airqo-platform/AirQo-api/tree/sites-utility-functions/src/data-mgt/python/devices-tranformation#setup-your-environment)
2. Run any of the commands in [Export sites/devices to csv or json](https://github.com/airqo-platform/AirQo-api/tree/sites-utility-functions/src/data-mgt/python/devices-tranformation#export-sitesdevices-to-csv-or-json). A `json` or `csv` file containing sites or devices should be created

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
None

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
None

**_ARE THERE ANY RELATED PRs?_**
None