### PR TITLE
device registry deployment health checks

### DIFF
--- a/.github/workflows/deploy-apis-to-production.yml
+++ b/.github/workflows/deploy-apis-to-production.yml
@@ -292,6 +292,8 @@ jobs:
           docker push ${{ secrets.REGISTRY_URL }}/${{ secrets.PROJECT_ID }}/airqo-device-registry-api:latest
       - name: Deploy to K8S
         run: |
+          cd k8s/device-registry/
+          kubectl apply -f prod-device-registry-api.yaml
           kubectl set image deployment/airqo-device-registry-api device-reg-api=${{ secrets.REGISTRY_URL }}/${{ secrets.PROJECT_ID }}/airqo-device-registry-api:${{ needs.image-tag.outputs.build_id }} -n production
           kubectl annotate deployment/airqo-device-registry-api kubernetes.io/change-cause="Image updated to ${{ secrets.REGISTRY_URL }}/${{ secrets.PROJECT_ID }}/airqo-device-registry-api:${{ needs.image-tag.outputs.build_id }} on ${{ needs.image-tag.outputs.datetime }}" -n production
 

--- a/.github/workflows/deploy-apis-to-staging.yml
+++ b/.github/workflows/deploy-apis-to-staging.yml
@@ -329,6 +329,8 @@ jobs:
           docker push ${{ secrets.REGISTRY_URL }}/${{ secrets.PROJECT_ID }}/airqo-stage-device-registry-api:latest
       - name: Deploy to K8S
         run: |
+          cd k8s/device-registry/
+          kubectl apply -f stage-device-registry-api.yaml
           kubectl set image deployment/airqo-stage-device-registry-api sta-dev-reg-api=${{ secrets.REGISTRY_URL }}/${{ secrets.PROJECT_ID }}/airqo-stage-device-registry-api:${{ needs.image-tag.outputs.build_id }} -n staging
           kubectl annotate deployment/airqo-stage-device-registry-api kubernetes.io/change-cause="Image updated to ${{ secrets.REGISTRY_URL }}/${{ secrets.PROJECT_ID }}/airqo-stage-device-registry-api:${{ needs.image-tag.outputs.build_id }} on ${{ needs.image-tag.outputs.datetime }}" -n staging
 

--- a/k8s/device-registry/prod-device-registry-api.yaml
+++ b/k8s/device-registry/prod-device-registry-api.yaml
@@ -29,13 +29,18 @@ spec:
           ports:
             - containerPort: 3000
               name: device-reg-api
-          # readinessProbe:
-          #   httpGet:
-          #     path: /health
-          #     port: 3000
-          #   initialDelaySecond: 5
-          #   periodSeconds: 3
-          #   successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3000
+            initialDelaySecond: 5
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 3000
+            initialDelaySecond: 20
+            periodSeconds: 60
           envFrom:
             - configMapRef:
                 name: env-device-registry-production

--- a/k8s/device-registry/stage-device-registry-api.yaml
+++ b/k8s/device-registry/stage-device-registry-api.yaml
@@ -29,13 +29,18 @@ spec:
           ports:
             - containerPort: 3000
               name: sta-dev-reg-api
-          # readinessProbe:
-          #   httpGet:
-          #     path: /health
-          #     port: 3000
-          #   initialDelaySecond: 5
-          #   periodSeconds: 3
-          #   successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3000
+            initialDelaySecond: 5
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 3000
+            initialDelaySecond: 20
+            periodSeconds: 60
           envFrom:
             - configMapRef:
                 name: env-device-registry-staging

--- a/k8s/device-registry/values-dev.yaml
+++ b/k8s/device-registry/values-dev.yaml
@@ -11,6 +11,18 @@ image:
   repository: airqo-dev-device-registry-api
   tag: latest
   pullPolicy: Always
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: 3000
+    initialDelaySeconds: 5
+    periodSeconds: 30
+  livenessProbe:
+    httpGet:
+      path: /live
+      port: 3000
+    initialDelaySeconds: 20
+    periodSeconds: 60
 
 imagePullSecrets: []
 nameOverride: ""

--- a/k8s/device-registry/values-prod.yaml
+++ b/k8s/device-registry/values-prod.yaml
@@ -11,6 +11,18 @@ image:
   repository: us.gcr.io/airqo-250220/airqo-device-registry-api
   tag: latest
   pullPolicy: Always
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: 3000
+    initialDelaySeconds: 5
+    periodSeconds: 30
+  livenessProbe:
+    httpGet:
+      path: /live
+      port: 3000
+    initialDelaySeconds: 20
+    periodSeconds: 60
 
 imagePullSecrets: []
 nameOverride: ""

--- a/k8s/device-registry/values-stage.yaml
+++ b/k8s/device-registry/values-stage.yaml
@@ -11,6 +11,18 @@ image:
   repository: us.gcr.io/airqo-250220/airqo-stage-device-registry-api
   tag: latest
   pullPolicy: Always
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: 3000
+    initialDelaySeconds: 5
+    periodSeconds: 30
+  livenessProbe:
+    httpGet:
+      path: /live
+      port: 3000
+    initialDelaySeconds: 20
+    periodSeconds: 60
 
 imagePullSecrets: []
 nameOverride: ""

--- a/src/device-registry/app.js
+++ b/src/device-registry/app.js
@@ -4,8 +4,6 @@ var path = require("path");
 var log = log4js.getLogger("app");
 const health = require('@cloudnative/health-connect');
 let healthcheck = new health.HealthChecker();
-const promClient = require('prom-client')
-const register = new promClient.Registry()
 
 const dotenv = require("dotenv");
 var bodyParser = require("body-parser");
@@ -14,6 +12,7 @@ require("app-module-path").addPath(__dirname);
 var cookieParser = require("cookie-parser");
 var apiV1 = require("./routes/api-v1");
 var apiV2 = require("./routes/api-v2");
+const metrics = require("./routes/service-metrics");
 const { mongodb } = require("./config/database");
 
 mongodb;
@@ -26,15 +25,6 @@ healthcheck.registerReadinessCheck(pingcheck)
 app.use('/live', health.LivenessEndpoint(healthcheck))
 app.use('/ready', health.ReadinessEndpoint(healthcheck))
 
-// Setting default label and enabling collection of default metrics
-register.setDefaultLabels({ app: 'device-registry-api'  })
-promClient.collectDefaultMetrics({ register })
-
-app.get('/metrics', async (req, res) => {
-    res.setHeader('Content-Type', register.contentType);
-    res.send(await register.metrics());
-});
-
 app.use(log4js.connectLogger(log4js.getLogger("http"), { level: "auto" }));
 app.use(bodyParser.json());
 app.use(express.json());
@@ -44,6 +34,7 @@ app.use(express.static(path.join(__dirname, "public")));
 
 app.use("/api/v1/devices/", apiV1);
 app.use("/api/v2/devices/", apiV2);
+app.use("/metrics", metrics);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/src/device-registry/app.js
+++ b/src/device-registry/app.js
@@ -2,6 +2,8 @@ var log4js = require("log4js");
 var express = require("express");
 var path = require("path");
 var log = log4js.getLogger("app");
+const health = require('@cloudnative/health-connect');
+let healthcheck = new health.HealthChecker();
 
 const dotenv = require("dotenv");
 var bodyParser = require("body-parser");
@@ -15,6 +17,10 @@ const { mongodb } = require("./config/database");
 mongodb;
 
 var app = express();
+
+let pingCheck = new health.PingCheck('example.com')
+
+app.use('/live', health.LivenessEndpoint(healthcheck))
 
 app.use(log4js.connectLogger(log4js.getLogger("http"), { level: "auto" }));
 app.use(bodyParser.json());

--- a/src/device-registry/app.js
+++ b/src/device-registry/app.js
@@ -18,9 +18,11 @@ mongodb;
 
 var app = express();
 
-let pingCheck = new health.PingCheck('example.com')
+let pingcheck = new health.PingCheck("example.com")
+healthcheck.registerReadinessCheck(pingcheck)
 
 app.use('/live', health.LivenessEndpoint(healthcheck))
+app.use('/ready', health.ReadinessEndpoint(healthcheck))
 
 app.use(log4js.connectLogger(log4js.getLogger("http"), { level: "auto" }));
 app.use(bodyParser.json());

--- a/src/device-registry/controllers/service-metrics.js
+++ b/src/device-registry/controllers/service-metrics.js
@@ -1,0 +1,21 @@
+const promClient = require('prom-client')
+const register = new promClient.Registry()
+const { tryCatchErrors  } = require("../utils/errors");
+
+const metrics = {
+  default: async (req, res) => {
+    try{
+        // Setting default label
+        register.setDefaultLabels({ app: 'device-registry-api'  })
+        // Enabling collection of default metrics
+        promClient.collectDefaultMetrics({ register })
+
+        res.setHeader('Content-Type', register.contentType);
+        res.status(200).send(await register.metrics());
+    }catch(err){        
+      tryCatchErrors(res, err, 'Something went wrong');
+    }
+  },
+};
+
+module.exports = metrics;

--- a/src/device-registry/controllers/test/ut_create-site.js
+++ b/src/device-registry/controllers/test/ut_create-site.js
@@ -12,6 +12,7 @@ const assert = require("assert");
 const SiteModel = require("../../models/Site");
 const siteController = require("../create-site");
 const siteUtil = require("../../utils/create-site");
+const userUtil = require("../../utils/");
 
 const stubValue = {
   _id: faker.datatype.uuid(),
@@ -41,7 +42,7 @@ const stubValue = {
 
 describe("site controller", function() {
   describe("create", function() {
-    let status, json, res, siteController, siteUtil;
+    let status, json, res, siteController, siteUtil;z
     beforeEach(async () => {
       status = sinon.stub();
       json = sinon.spy();

--- a/src/device-registry/controllers/test/ut_create-site.js
+++ b/src/device-registry/controllers/test/ut_create-site.js
@@ -12,7 +12,6 @@ const assert = require("assert");
 const SiteModel = require("../../models/Site");
 const siteController = require("../create-site");
 const siteUtil = require("../../utils/create-site");
-const userUtil = require("../../utils/");
 
 const stubValue = {
   _id: faker.datatype.uuid(),
@@ -42,7 +41,7 @@ const stubValue = {
 
 describe("site controller", function() {
   describe("create", function() {
-    let status, json, res, siteController, siteUtil;z
+    let status, json, res, siteController, siteUtil;
     beforeEach(async () => {
       status = sinon.stub();
       json = sinon.spy();

--- a/src/device-registry/controllers/test/ut_service-metrics.js
+++ b/src/device-registry/controllers/test/ut_service-metrics.js
@@ -1,0 +1,13 @@
+"use-strict";
+const { expect } = require('chai');
+const request = require('supertest');
+const { describe, it } = require('mocha');
+
+const app = require('../../app');
+
+describe('device-registry default metrics',  () => {
+  it('default metrics response status is 200', async () => {
+    const response = await request(app).get('/metrics')
+    expect(response.status).to.equal(200);
+  });
+});

--- a/src/device-registry/package-lock.json
+++ b/src/device-registry/package-lock.json
@@ -57,6 +57,7 @@
                 "passport": "^0.4.0",
                 "passport-jwt": "^4.0.0",
                 "point-in-polygon": "^1.1.0",
+                "prom-client": "^14.0.1",
                 "qrcode": "^1.4.4",
                 "qs": "^6.9.4",
                 "redis": "^3.1.2",
@@ -1256,6 +1257,11 @@
             "dependencies": {
                 "file-uri-to-path": "1.0.0"
             }
+        },
+        "node_modules/bintrees": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+            "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
         },
         "node_modules/bl": {
             "version": "2.2.1",
@@ -11395,6 +11401,17 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/prom-client": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+            "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+            "dependencies": {
+                "tdigest": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/promise": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
@@ -13387,6 +13404,14 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/tdigest": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+            "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+            "dependencies": {
+                "bintrees": "1.0.1"
             }
         },
         "node_modules/teeny-request": {
@@ -15671,6 +15696,11 @@
             "requires": {
                 "file-uri-to-path": "1.0.0"
             }
+        },
+        "bintrees": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+            "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
         },
         "bl": {
             "version": "2.2.1",
@@ -23422,6 +23452,14 @@
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
+        "prom-client": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+            "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+            "requires": {
+                "tdigest": "^0.1.1"
+            }
+        },
         "promise": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
@@ -25020,6 +25058,14 @@
                         "util-deprecate": "^1.0.1"
                     }
                 }
+            }
+        },
+        "tdigest": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+            "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+            "requires": {
+                "bintrees": "1.0.1"
             }
         },
         "teeny-request": {

--- a/src/device-registry/package-lock.json
+++ b/src/device-registry/package-lock.json
@@ -8,6 +8,7 @@
             "name": "device-registry",
             "version": "0.0.0",
             "dependencies": {
+                "@cloudnative/health-connect": "^2.1.0",
                 "@google-cloud/bigquery": "^5.5.0",
                 "@google-cloud/iot": "^1.5.0",
                 "@googlemaps/google-maps-services-js": "^3.1.16",
@@ -107,6 +108,19 @@
                 "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
+            }
+        },
+        "node_modules/@cloudnative/health": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@cloudnative/health/-/health-2.1.2.tgz",
+            "integrity": "sha512-mEQdbj9dM4KMClS358MCzbqXUmj+Vw5snjDb5bXdaf1sZvVu7+3UqR4HaG4RoNkNUwe1yjfIuengdyWp9quF1A=="
+        },
+        "node_modules/@cloudnative/health-connect": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@cloudnative/health-connect/-/health-connect-2.1.0.tgz",
+            "integrity": "sha512-GieeiusY64i1Q5LdAf70n5W08MF5uom3qdVvnwIed/asBqpNPv7hlC6FGSH20lTYvyujF3wV5oBDcTa4SS/cbA==",
+            "dependencies": {
+                "@cloudnative/health": "^2.1.1"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -14726,6 +14740,19 @@
                 "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
+            }
+        },
+        "@cloudnative/health": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@cloudnative/health/-/health-2.1.2.tgz",
+            "integrity": "sha512-mEQdbj9dM4KMClS358MCzbqXUmj+Vw5snjDb5bXdaf1sZvVu7+3UqR4HaG4RoNkNUwe1yjfIuengdyWp9quF1A=="
+        },
+        "@cloudnative/health-connect": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@cloudnative/health-connect/-/health-connect-2.1.0.tgz",
+            "integrity": "sha512-GieeiusY64i1Q5LdAf70n5W08MF5uom3qdVvnwIed/asBqpNPv7hlC6FGSH20lTYvyujF3wV5oBDcTa4SS/cbA==",
+            "requires": {
+                "@cloudnative/health": "^2.1.1"
             }
         },
         "@eslint/eslintrc": {

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -12,7 +12,7 @@
         "prod-pc": "SET NODE_ENV=production&&nodemon ./bin/www",
         "stage-pc": "SET NODE_ENV=staging&&nodemon ./bin/www",
         "prettier": "prettier --single-quote --print-width 80 --trailing-comma all --write 'src/**/*.js'",
-        "test": "mocha ./**/test/ut_*.js --exit"
+        "test": "mocha ./controllers/test/ut_*.js -r dotenv/config --exit"
     },
     "dependencies": {
         "@cloudnative/health-connect": "^2.1.0",

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -15,6 +15,7 @@
         "test": "mocha ./**/test/ut_*.js --exit"
     },
     "dependencies": {
+        "@cloudnative/health-connect": "^2.1.0",
         "@google-cloud/bigquery": "^5.5.0",
         "@google-cloud/iot": "^1.5.0",
         "@googlemaps/google-maps-services-js": "^3.1.16",

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -64,6 +64,7 @@
         "passport": "^0.4.0",
         "passport-jwt": "^4.0.0",
         "point-in-polygon": "^1.1.0",
+        "prom-client": "^14.0.1",
         "qrcode": "^1.4.4",
         "qs": "^6.9.4",
         "redis": "^3.1.2",

--- a/src/device-registry/routes/service-metrics.js
+++ b/src/device-registry/routes/service-metrics.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const metricsController = require("../controllers/service-metrics");
+
+router.get('/', metricsController.default);
+
+module.exports = router;


### PR DESCRIPTION
# device registry deployment health checks and app metrics

**_WHAT DOES THIS PR DO?_**
- Adds liveness and readiness device-registry service endpoints. It adds two endpoints (/live and /ready) that k8s will check to establish the status of the service atleast every 30seconds to determine whether or not to serve the instance traffic for liveness and whether or not to restart an instance for the sake of readiness.
- It also adds app-metrics with prometheus.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
- n/a

**_WHAT IS THE LINK TO THE PR BRANCH_**
[ft-deviceRegistry-healthChecks](https://github.com/airqo-platform/AirQo-api/tree/ft-deviceRegistry-healthChecks)

**_HOW DO I TEST OUT THIS PR?_**
- For the application, follow the instructions in the [README](https://github.com/airqo-platform/AirQo-api/blob/ft-deviceRegistry-healthChecks/src/device-registry/README.md) and check out the endpoints: /live, /ready, and /metrics
- Then do a static code analysis for the deployment files

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- [Liveness](https://api.airqo.net/api/v1/live)
- [Readiness](https://api.airqo.net/api/v1/ready)
- [App metrics](https://api.airqo.net/api/v1/metrics)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
- n/a

**_ARE THERE ANY RELATED PRs?_**
- n/a