### PR TITLE
Update acceptable device deployment statuses

### DIFF
--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -641,9 +641,10 @@ router.put(
           "undeployed",
           "decommissioned",
           "assembly",
+          "testing"
         ])
         .withMessage(
-          "the status value is not among the expected ones which include: recalled, ready, deployed, undeployed, decommissioned, assembly "
+          "the status value is not among the expected ones which include: recalled, ready, deployed, undeployed, decommissioned, assembly, testing "
         ),
       body("powerType")
         .if(body("powerType").exists())

--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -394,9 +394,10 @@ router.put(
           "undeployed",
           "decommissioned",
           "assembly",
+          "testing"
         ])
         .withMessage(
-          "the status value is not among the expected ones which include: recalled, ready, deployed, undeployed, decommissioned, assembly "
+          "the status value is not among the expected ones which include: recalled, ready, deployed, undeployed, decommissioned, assembly testing "
         ),
       body("mountType")
         .if(body("mountType").exists())


### PR DESCRIPTION
# Update acceptable device deployment statuses

**_WHAT DOES THIS PR DO?_**
- Adds testing to the list of acceptable device deployment statuses
- Closes #743 

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
- n/a

**_HOW DO I TEST OUT THIS PR?_**
- By setting 'testing' as the device deployment status ([Docs](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/create-devices))

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- [Update device](https://api.airqo.net/api/v1/devices)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
- n/a

**_ARE THERE ANY RELATED PRs?_**
- [This frontend PR](https://github.com/airqo-platform/AirQo-frontend/pull/521) depends on this PR


