### PR TITLE
View microservice build fix

### DIFF
--- a/src/view/Dockerfile
+++ b/src/view/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 COPY .mvn/ .mvn
 COPY mvnw pom.xml ./
+RUN ./mvnw dependency:go-offline
 COPY src ./src
 
 FROM base as test

--- a/src/view/pom.xml
+++ b/src/view/pom.xml
@@ -104,11 +104,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] Removes a test dependency that was causing failure of the workflow. Failing workflow is [here](https://github.com/airqo-platform/AirQo-api/actions/runs/1999004373)
- [x] Adds dependency cache during image building