### PR TITLE
App Forecast Insights

### DIFF
--- a/src/airflow/airqo_etl_utils/airqo_api.py
+++ b/src/airflow/airqo_etl_utils/airqo_api.py
@@ -178,13 +178,15 @@ class AirQoApi:
         end_time: str,
         frequency: str,
         site_id=None,
+        forecast=False,
+        empty=False,
     ) -> list:
         params = {
             "startDateTime": start_time,
             "endDateTime": end_time,
             "frequency": frequency,
-            "empty": False,
-            "forecast": False,
+            "empty": empty,
+            "forecast": forecast,
         }
         if site_id:
             params["siteId"] = site_id

--- a/src/airflow/airqo_etl_utils/airqo_api.py
+++ b/src/airflow/airqo_etl_utils/airqo_api.py
@@ -180,14 +180,21 @@ class AirQoApi:
         site_id=None,
         forecast=False,
         empty=False,
+        all_data=False,
     ) -> list:
-        params = {
-            "startDateTime": start_time,
-            "endDateTime": end_time,
-            "frequency": frequency,
-            "empty": empty,
-            "forecast": forecast,
-        }
+        if all_data:
+            params = {
+                "startDateTime": start_time,
+                "endDateTime": end_time,
+            }
+        else:
+            params = {
+                "startDateTime": start_time,
+                "endDateTime": end_time,
+                "frequency": frequency,
+                "empty": empty,
+                "forecast": forecast,
+            }
         if site_id:
             params["siteId"] = site_id
 

--- a/src/airflow/airqo_etl_utils/app_insights_utils.py
+++ b/src/airflow/airqo_etl_utils/app_insights_utils.py
@@ -108,7 +108,7 @@ def save_insights_data(insights_data: list = None, action: str = "insert"):
     if insights_data is None:
         insights_data = []
 
-    print("saving insights .... ")
+    print(f"saving {len(insights_data)} insights .... ")
 
     data = {
         "data": insights_data,
@@ -266,7 +266,7 @@ def transform_old_forecast(start_date_time: str, end_date_time: str) -> list:
 
 
 def query_insights_data(
-    freq: str, start_date_time: str, end_date_time: str, forecast=False
+    freq: str, start_date_time: str, end_date_time: str, forecast=False, all_data=False
 ) -> list:
     airqo_api = AirQoApi()
     insights = []
@@ -287,7 +287,11 @@ def query_insights_data(
 
         try:
             api_results = airqo_api.get_app_insights(
-                start_time=start, frequency=freq, end_time=end, forecast=forecast
+                start_time=start,
+                frequency=freq,
+                end_time=end,
+                forecast=forecast,
+                all_data=all_data,
             )
             insights.extend(api_results)
 
@@ -321,7 +325,10 @@ def create_insights_data_from_bigquery(
 def create_insights_data(data: list) -> list:
     print("creating insights .... ")
 
-    insights_data = pd.DataFrame(data)
+    if not data:
+        return []
+
+    insights_data = pd.DataFrame(data, columns=insights_columns)
 
     insights_data["frequency"] = insights_data["frequency"].apply(
         lambda x: str(x).upper()

--- a/src/airflow/docker-compose.yaml
+++ b/src/airflow/docker-compose.yaml
@@ -10,6 +10,10 @@ x-db-common-data: &db-common-data
     AIRFLOW_UI_USER: airflow
     AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://postgres:postgres@db:5432/postgres
 
+x-message-borker-common-data: &message-broker-common-data
+  env_file:
+    - .env
+
 x-common-data: &common-data
 #  platform: linux/amd64
   restart: on-failure
@@ -59,6 +63,7 @@ services:
       - "9093:9092"
 
   message-broker-setup:
+    <<: *message-broker-common-data
     container_name: message-broker-setup
     build:
       context: .

--- a/src/airflow/main.py
+++ b/src/airflow/main.py
@@ -179,7 +179,19 @@ def insights_forecast():
     from airqo_etl_utils.app_insights_utils import (
         create_insights_data,
         get_forecast_data,
+        transform_old_forecast,
     )
+
+    from airqo_etl_utils.date import date_to_str, first_day_of_week, first_day_of_month
+
+    now = datetime.now()
+    start_date_time = date_to_str(first_day_of_week(first_day_of_month(date_time=now)))
+    end_date_time = date_to_str(now)
+
+    old_forecast = transform_old_forecast(
+        start_date_time=start_date_time, end_date_time=end_date_time
+    )
+    pd.DataFrame(old_forecast).to_csv(path_or_buf="old_forecast_data.csv", index=False)
 
     forecast_data = get_forecast_data("airqo")
     pd.DataFrame(forecast_data).to_csv(path_or_buf="forecast_data.csv", index=False)

--- a/src/airflow/message-broker-setup.sh
+++ b/src/airflow/message-broker-setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-kafka/bin/kafka-topics.sh --create --topic app-insights-measurements-topic --partitions 1 --bootstrap-server message-broker:9092
-kafka/bin/kafka-topics.sh --create --topic hourly-measurements-topic --partitions 1 --bootstrap-server message-broker:9092
+kafka/bin/kafka-topics.sh --create --topic "$INSIGHTS_MEASUREMENTS_TOPIC" --partitions 1 --bootstrap-server message-broker:9092
+kafka/bin/kafka-topics.sh --create --topic "$HOURLY_MEASUREMENTS_TOPIC" --partitions 1 --bootstrap-server message-broker:9092

--- a/src/view/src/main/java/airqo/models/Insight.java
+++ b/src/view/src/main/java/airqo/models/Insight.java
@@ -59,8 +59,9 @@ public class Insight implements Serializable {
 	@JsonIgnore
 	private Date endDateTime;
 
-	public void setId() {
+	public Insight setId() {
 		this.id = new InsightId(time, frequency, siteId).toString();
+		return this;
 	}
 
 	@Override

--- a/src/view/src/main/java/airqo/repository/InsightRepository.java
+++ b/src/view/src/main/java/airqo/repository/InsightRepository.java
@@ -11,6 +11,6 @@ public interface InsightRepository extends BaseRepository<Insight> {
 
 	void deleteAllByTimeBefore(Date time);
 
-	List<Insight> findAllByTimeBefore(Date time);
+	List<Insight> findAllByTimeBeforeAndForecast(Date time, Boolean forecast);
 
 }

--- a/src/view/src/main/java/airqo/services/MeasurementService.java
+++ b/src/view/src/main/java/airqo/services/MeasurementService.java
@@ -18,7 +18,7 @@ public interface MeasurementService {
 
 	Page<Measurement> apiGetMeasurements(Predicate predicate, Pageable pageable);
 
-	List<Insight> getInsightsBefore(Date beforeTime);
+	List<Insight> getForecastInsightsBefore(Date beforeTime);
 
 	void saveInsights(List<Insight> insights);
 

--- a/src/view/src/main/java/airqo/services/MeasurementServiceImpl.java
+++ b/src/view/src/main/java/airqo/services/MeasurementServiceImpl.java
@@ -60,8 +60,8 @@ public class MeasurementServiceImpl implements MeasurementService {
 	}
 
 	@Override
-	public List<Insight> getInsightsBefore(Date beforeTime) {
-		return insightRepository.findAllByTimeBefore(beforeTime);
+	public List<Insight> getForecastInsightsBefore(Date beforeTime) {
+		return insightRepository.findAllByTimeBeforeAndForecast(beforeTime, true);
 	}
 
 	@Override

--- a/src/view/src/main/java/airqo/tasks/InsightsTasks.java
+++ b/src/view/src/main/java/airqo/tasks/InsightsTasks.java
@@ -28,24 +28,27 @@ public class InsightsTasks {
 
 	@Scheduled(cron = "@hourly")
 	public void forecastInsightsTasks() {
-		List<Insight> oldInsights = measurementService.getInsightsBefore(new Date());
-		List<Insight> insights = new ArrayList<>();
 		log.info("Deleting forecast Insights");
+		List<Insight> oldInsights = measurementService.getForecastInsightsBefore(new Date());
+		List<Insight> insights = new ArrayList<>();
+
 		for (Insight insight : oldInsights) {
 			insight.setForecast(false);
 			insights.add(insight);
 		}
 		measurementService.saveInsights(insights);
+		log.info("Deleted forecast Insights");
 	}
 
 	@Scheduled(cron = "@monthly")
 	public void oldInsightsTasks() {
-		log.info("Running old Insights");
+		log.info("Deleting old Insights");
 		Calendar cal = Calendar.getInstance();
 		cal.setTime(new Date());
 		cal.add(Calendar.DAY_OF_MONTH, -50);
 		Date dateTime = cal.getTime();
 		measurementService.deleteInsightsBefore(dateTime);
+		log.info("Deleted old Insights");
 	}
 
 }


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] Creates an ETL pipeline for app insights (Forecast)
- [x] Deletes old insights forecast data.
- [x] Modifies the view api message broker connection, replacing for loops with streams.
- [x] Adds a tasks on the view message broker to delete outdated insights

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[MOB-41](https://airqoteam.atlassian.net/browse/MOB-41)

**_HOW DO I TEST OUT THIS PR?_**
Follow instructions in the [Readme file ](https://github.com/airqo-platform/AirQo-api/tree/app-forecast-etl/src/airflow#running-using-docker)on how to run the app.

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
App Insights endpoint with the `forecast` query parameter set to `true` 

**EndPoint**: https://platform.airqo.net/api/v1/view/measurements/app/insights?forecast=true
**Documentation**: https://platform.airqo.net/api/v1/view/docs/index.html#App-Insights