### PR TITLE
Update configurations to reduce the uptime calculations to 30 mins

### DIFF
--- a/k8s/device-status/prod-airqo-device-status-job.yaml
+++ b/k8s/device-status/prod-airqo-device-status-job.yaml
@@ -37,7 +37,7 @@ spec:
           schedulerName: default-scheduler
           securityContext: {}
           terminationGracePeriodSeconds: 30
-  schedule: 0 * * * *
+  schedule: */30 * * * *
   successfulJobsHistoryLimit: 3
   suspend: false
 status: {}

--- a/k8s/device-status/stage-airqo-device-status-job.yaml
+++ b/k8s/device-status/stage-airqo-device-status-job.yaml
@@ -37,7 +37,7 @@ spec:
           schedulerName: default-scheduler
           securityContext: {}
           terminationGracePeriodSeconds: 30
-  schedule: 0 * * * *
+  schedule: */30 * * * *
   successfulJobsHistoryLimit: 3
   suspend: false
 status: {}

--- a/k8s/device-uptime/prod-airqo-device-uptime-job.yaml
+++ b/k8s/device-uptime/prod-airqo-device-uptime-job.yaml
@@ -37,7 +37,7 @@ spec:
           schedulerName: default-scheduler
           securityContext: {}
           terminationGracePeriodSeconds: 30
-  schedule: 0 * * * *
+  schedule: */30 * * * *
   successfulJobsHistoryLimit: 3
   suspend: false
 status: {}

--- a/k8s/device-uptime/stage-airqo-device-uptime-job.yaml
+++ b/k8s/device-uptime/stage-airqo-device-uptime-job.yaml
@@ -37,7 +37,7 @@ spec:
           schedulerName: default-scheduler
           securityContext: {}
           terminationGracePeriodSeconds: 30
-  schedule: 0 * * * *
+  schedule: */30 * * * *
   successfulJobsHistoryLimit: 3
   suspend: false
 status: {}


### PR DESCRIPTION
# Run device uptime and device status every 30 minutes

**_WHAT DOES THIS PR DO?_**
- Schedules the device uptime and device status cron jobs to run every 30 mins

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
- [PLAT-1050](https://airqoteam.atlassian.net/browse/PLAT-1050?atlOrigin=eyJpIjoiNzAyZTYyOTJkOTE1NGJhM2JhY2NjZmNmZGRkMmI2N2IiLCJwIjoiaiJ9)

**_HOW DO I TEST OUT THIS PR?_**
- Static code analysis

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- n/a

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
N/A

**_ARE THERE ANY RELATED PRs?_**
N/A