### PR TITLE
Functionality for refreshing all sites for a particular tenant

### DIFF
--- a/src/data-mgt/python/devices-tranformation/Readme.md
+++ b/src/data-mgt/python/devices-tranformation/Readme.md
@@ -67,6 +67,12 @@ Update sites to include the nearest Tahmo Station.
     python main.py devices_without_forecast csv
 ```
 
+## Refresh sites
+
+```bash
+    python main.py refresh_sites 
+```
+
 ## Update sites search names based on csv file
 Updates the `search_name` and `location_name` of sites. You must add to this directory a `sites.csv` file containing `search_name`, `location_name` and either `lat_long` or `id` of the sites to  be updated.
 

--- a/src/data-mgt/python/devices-tranformation/airqoApi.py
+++ b/src/data-mgt/python/devices-tranformation/airqoApi.py
@@ -88,6 +88,10 @@ class AirQoApi:
             response = self.__request("devices/sites", params, site, "put")
             print(response)
 
+    def refresh_site(self, params):
+        response = self.__request("devices/sites/refresh", params, [], "put")
+        print(response)
+
     def __request(self, endpoint, params, body=None, method=None):
 
         headers = {'Authorization': self.AIRQO_API_KEY}

--- a/src/data-mgt/python/devices-tranformation/main.py
+++ b/src/data-mgt/python/devices-tranformation/main.py
@@ -47,6 +47,9 @@ if __name__ == '__main__':
     elif action.lower().strip() == "devices_without_forecast":
         transformation.get_devices_without_forecast()
 
+    elif action.lower().strip() == "refresh_sites":
+        transformation.refresh_sites()
+
     elif action.lower().strip() == "export_sites":
         try:
             tenant = f"{strings_list[3]}"

--- a/src/data-mgt/python/devices-tranformation/transformation.py
+++ b/src/data-mgt/python/devices-tranformation/transformation.py
@@ -145,6 +145,19 @@ class Transformation:
 
         self.__print(data=updated_sites)
 
+    def refresh_sites(self):
+
+        sites = self.airqo_api.get_sites(self.tenant)
+
+        for site in sites:
+            site_dict = dict(site)
+            params = {
+                "id": site_dict.get("_id"),
+                "tenant": self.tenant
+            }
+
+            self.airqo_api.refresh_site(params=params)
+
     def get_sites_without_a_primary_device(self):
 
         sites = self.airqo_api.get_sites(tenant=self.tenant)


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
Introduces functionality for refreshing all sites for a tenant

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-1040](https://airqoteam.atlassian.net/browse/PLAT-1040)

**_HOW DO I TEST OUT THIS PR?_**
1. Setup your environment using instructions on the [readme.md file](https://github.com/airqo-platform/AirQo-api/tree/staging/src/data-mgt/python/devices-tranformation#setup-your-environment)

2. Trigger the functions 
```python
python main.py refresh_sites
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
Get sites endpoint. All sites must be refreshed after task completion



