### PR TITLE
fixed dashbord error&refactored date hardcoding

### DIFF
--- a/src/network-uptime/.dockerignore
+++ b/src/network-uptime/.dockerignore
@@ -5,3 +5,4 @@ venv/
 venv
 env
 .env
+airqoenv/

--- a/src/network-uptime/network-dashboard.py
+++ b/src/network-uptime/network-dashboard.py
@@ -12,6 +12,8 @@ dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
 load_dotenv(dotenv_path)
 
 BASE_API_URL = os.getenv('BASE_URL')
+START_QUERY_DATE = os.getenv('START_DATE')
+END_QUERY_DATE = os.getenv('END_DATE')
 
 matplotlib.use('Agg')
 
@@ -27,11 +29,17 @@ device_name = devices_name = [data['name'] for data in devices_data]
 selected_device = st.sidebar.selectbox('Device name', device_name)
 
 
-@st.cache
+@st.cache(suppress_st_warning=True)
 def load_device_data(device):
-    api = f"{BASE_API_URL}/monitor/devices/uptime?tenant=airqo&startDate=2022-01-01T00:00:00.001Z&endDate=2022-03-25T19:00:00.001Z&device_name=' + device
+    api = f"{BASE_API_URL}/monitor/devices/uptime?tenant=airqo&startDate={START_QUERY_DATE}&endDate={END_QUERY_DATE}&device_name=" + device
     api_result = requests.get(api)
-    values = api_result.json()['data'][0]['values']
+    try:
+        values = api_result.json()['data'][0]['values']
+    except:
+        st.title('#')
+        st.title('#')
+        st.write('NO DATA AVAILABLE FOR THIS DEVICE WITHIN THE SPECIFIED DATE RANGE')
+        st.stop()
     subset = ['created_at', 'uptime', 'downtime']
     data_subset_list = []
     for element in values:


### PR DESCRIPTION
# Fix network uptime dashboard error

**_WHAT DOES THIS PR DO?_**

* Error handling for newly added devices that has no data
* Removed hard coded dates.

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**

**_HOW DO I TEST OUT THIS PR?_**
* cd to network-uptime folder
* create and activate a virtual env
*  then do from terminal `streamlit run network-dashboard.py`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?

[Fix network uptime workflow runtime error](https://github.com/airqo-platform/AirQo-api/pull/799#pullrequestreview-937571231)

**_ARE THERE ANY RELATED PRs?_**

N/A


