### PR TITLE
Just logging Site details in the Alternative Flows during AirQloud refresh

### DIFF
--- a/src/device-registry/controllers/create-airqloud.js
+++ b/src/device-registry/controllers/create-airqloud.js
@@ -49,7 +49,7 @@ const createAirqloud = {
           : HTTPStatus.INTERNAL_SERVER_ERROR;
         let errors = responseFromCreateAirQloud.errors
           ? responseFromCreateAirQloud.errors
-          : "";
+          : { message: "" };
 
         return res.status(status).json({
           success: false,
@@ -71,10 +71,10 @@ const createAirqloud = {
       const hasErrors = !validationResult(req).isEmpty();
       if (hasErrors) {
         let nestedErrors = validationResult(req).errors[0].nestedErrors;
-        return badRequest(
+        return errors.badRequest(
           res,
           "bad request errors",
-          manipulateArraysUtil.convertErrorArrayToObject(nestedErrors)
+          errors.convertErrorArrayToObject(nestedErrors)
         );
       }
 
@@ -109,7 +109,7 @@ const createAirqloud = {
 
         const errors = responseFromCalculateGeographicalCenter.errors
           ? responseFromCalculateGeographicalCenter.errors
-          : "";
+          : { message: "" };
 
         return res.status(status).json({
           success: false,
@@ -159,7 +159,7 @@ const createAirqloud = {
       if (responseFromRemoveAirQloud.success === false) {
         let errors = responseFromRemoveAirQloud.errors
           ? responseFromRemoveAirQloud.errors
-          : "";
+          : { message: "" };
         let status = responseFromRemoveAirQloud.status
           ? responseFromRemoveAirQloud.status
           : HTTPStatus.INTERNAL_SERVER_ERROR;
@@ -202,7 +202,7 @@ const createAirqloud = {
           : HTTPStatus.INTERNAL_SERVER_ERROR;
         const errors = responseFromRefreshAirQloud.errors
           ? responseFromRefreshAirQloud.errors
-          : "";
+          : { message: "" };
         res.status(status).json({
           message: responseFromRefreshAirQloud.message,
           errors,
@@ -253,7 +253,7 @@ const createAirqloud = {
       if (responseFromFindSites.success === false) {
         let errors = responseFromFindSites.errors
           ? responseFromFindSites.errors
-          : "";
+          : { message: "" };
         let status = responseFromFindSites.status
           ? responseFromFindSites.status
           : httpStatus.INTERNAL_SERVER_ERROR;
@@ -307,7 +307,7 @@ const createAirqloud = {
       if (responseFromUpdateAirQloud.success === false) {
         let errors = responseFromUpdateAirQloud.errors
           ? responseFromUpdateAirQloud.errors
-          : "";
+          : { message: "" };
 
         let status = responseFromUpdateAirQloud.status
           ? responseFromUpdateAirQloud.status
@@ -359,7 +359,7 @@ const createAirqloud = {
       if (responseFromListAirQlouds.success === false) {
         let errors = responseFromListAirQlouds.errors
           ? responseFromListAirQlouds.errors
-          : "";
+          : { message: "" };
         let status = responseFromListAirQlouds.status
           ? responseFromListAirQlouds.status
           : HTTPStatus.INTERNAL_SERVER_ERROR;
@@ -412,7 +412,7 @@ const createAirqloud = {
       if (responseFromRemoveAirQloud.success === false) {
         let errors = responseFromRemoveAirQloud.errors
           ? responseFromRemoveAirQloud.errors
-          : "";
+          : { message: "" };
         let status = responseFromRemoveAirQloud.status
           ? responseFromRemoveAirQloud.status
           : HTTPStatus.INTERNAL_SERVER_ERROR;

--- a/src/device-registry/utils/create-airqloud.js
+++ b/src/device-registry/utils/create-airqloud.js
@@ -511,6 +511,11 @@ const createAirqloud = {
               if (isSiteInAirQloud === true) {
                 site_ids.push(site._id);
               } else if (isSiteInAirQloud === false) {
+                logger.info(
+                  `Site ${site._id} does not belong to this AirQloud`
+                );
+              } else {
+                logger.info(`unable to categorise this Site ${site._id} `);
               }
             } else {
               logger.error(

--- a/src/device-registry/utils/create-airqloud.js
+++ b/src/device-registry/utils/create-airqloud.js
@@ -415,8 +415,9 @@ const createAirqloud = {
           } else {
             return {
               success: false,
-              message: "unable to retrieve one respective airqloud",
-              status: httpStatus.NOT_FOUND,
+              message: `unable to find the provided airqloud: ${id}`,
+              status: responseFromListAirQloud.status,
+              errors: { message: "" },
             };
           }
         } else if (responseFromListAirQloud.success === false) {


### PR DESCRIPTION
# just logging Site details for cases where a Site does not belong to the AirQloud during AirQloud refresh operation

**_WHAT DOES THIS PR DO?_**
just logging Site details for cases where a Site does not belong to the AirQloud during AirQloud refresh operation

**_WHAT JIRA STORY/TASK IS RELATED TO THIS PR?_**
[PLAT-1081]

**_HOW DO I TEST OUT THIS PR?_**
README, staging environment

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [AirQlouds refresh](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/airqlouds#refresh-airqloud)

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

N/A

**_ARE THERE ANY RELATED PRs?_**

N/A




[PLAT-1081]: https://airqoteam.atlassian.net/browse/PLAT-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ