### PR TITLE
Add airqalibrate subdomain

### DIFF
--- a/k8s/nginx-ingress/prod-api-ingress-resource.yaml
+++ b/k8s/nginx-ingress/prod-api-ingress-resource.yaml
@@ -56,6 +56,16 @@ metadata:
 
 spec:
   rules:
+    - host: airqalibrate.airqo.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airqo-calibrate-app-svc
+                port: 
+                  number: 80
     - host: api.airqo.net
       http:
         paths:

--- a/k8s/nginx-ingress/prod-platform-ingress-resource.yaml
+++ b/k8s/nginx-ingress/prod-platform-ingress-resource.yaml
@@ -91,6 +91,16 @@ metadata:
 
 spec:
   rules:
+    - host: airqalibrate.airqo.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airqo-calibrate-app-svc
+                port: 
+                  number: 80
     - host: platform.airqo.net
       http:
         paths:

--- a/k8s/nginx-ingress/stage-platform-ingress-resource.yaml
+++ b/k8s/nginx-ingress/stage-platform-ingress-resource.yaml
@@ -8,7 +8,37 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
-  rules:
+  rules:    
+    - host: staging.airqo.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airqo-stage-website-svc
+                port: 
+                  number: 8000
+    - host: staging.airqo.africa
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airqo-stage-website-svc
+                port: 
+                  number: 8000
+    - host: staging-airqalibrate.airqo.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airqo-stage-calibrate-app-svc
+                port: 
+                  number: 80
     - host: staging-platform.airqo.net
       http:
         paths:
@@ -194,4 +224,3 @@ spec:
                 name: airqo-stage-network-uptime-api-svc
                 port: 
                   number: 8501
-


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
Configures https://airqalibrate.airqo.net/ and https://staging-airqalibrate.airqo.net/ subdomains

- Jira cards
    - [PLAT-1156](https://airqoteam.atlassian.net/browse/PLAT-1156)

**_HOW DO I TEST OUT THIS PR?_**
You should be able to securely access the calibrate app via https://airqalibrate.airqo.net/ and https://staging-airqalibrate.airqo.net/



