### PR TITLE
Fx calibrate cicd

### DIFF
--- a/k8s/calibrate/prod-calibrate-api.yaml
+++ b/k8s/calibrate/prod-calibrate-api.yaml
@@ -26,13 +26,7 @@ spec:
         - name: calibrate-pickle
           image: us.gcr.io/airqo-250220/airqo-calibrate-pickle-file:latest
           imagePullPolicy: Always
-          resources:
-            requests:
-              memory: 100Mi
-              cpu: 50m
-            limits:
-              memory: 500Mi
-              cpu: 200m
+          resources: {}
           envFrom:
             - configMapRef:
                 name: prod-calibrate-api-config

--- a/k8s/calibrate/stage-calibrate-api.yaml
+++ b/k8s/calibrate/stage-calibrate-api.yaml
@@ -26,13 +26,7 @@ spec:
         - name: calibrate-pickle
           image: us.gcr.io/airqo-250220/airqo-stage-calibrate-pickle-file:latest
           imagePullPolicy: Always
-          resources:
-            requests:
-              memory: 256Mi
-              cpu: "500m"
-            limits:
-              memory: 2Gi
-              cpu: "2000m"
+          resources: {}
           envFrom:
             - configMapRef:
                 name: stage-calibrate-api-config

--- a/k8s/fault-detection/prod-fault-detection-api.yaml
+++ b/k8s/fault-detection/prod-fault-detection-api.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: prod-fault-detection
-  replicas: 2
+  replicas: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -56,7 +56,13 @@ spec:
           ports:
             - containerPort: 4001
               name: fault-detection
-          resources: {}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 250Mi
+            limits:
+              cpu: 200m
+              memory: 700Mi
           env:
             - name: LSTM_MODEL
               value: /usr/models/lstm.h5
@@ -89,3 +95,23 @@ spec:
       targetPort: 4001
       nodePort: 31013
   type: NodePort
+
+---
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2
+metadata:
+  name: prod-fault-detection-api-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: prod-fault-detection-api
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70

--- a/k8s/fault-detection/stage-fault-detection-api.yaml
+++ b/k8s/fault-detection/stage-fault-detection-api.yaml
@@ -56,7 +56,13 @@ spec:
           ports:
             - containerPort: 4001
               name: fault-detection
-          resources: {}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 250Mi
+            limits:
+              cpu: 200m
+              memory: 700Mi
           env:
             - name: LSTM_MODEL
               value: /usr/models/lstm.h5
@@ -89,3 +95,23 @@ spec:
       targetPort: 4001
       nodePort: 31013
   type: NodePort
+
+---
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2
+metadata:
+  name: stage-fault-detection-api-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: stage-fault-detection-api
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80

--- a/k8s/nginx-ingress/prod-api-ingress-resource.yaml
+++ b/k8s/nginx-ingress/prod-api-ingress-resource.yaml
@@ -56,16 +56,6 @@ metadata:
 
 spec:
   rules:
-    - host: airqalibrate.airqo.net
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: airqo-calibrate-app-svc
-                port: 
-                  number: 80
     - host: api.airqo.net
       http:
         paths:

--- a/k8s/nginx-ingress/prod-platform-ingress-resource.yaml
+++ b/k8s/nginx-ingress/prod-platform-ingress-resource.yaml
@@ -90,16 +90,6 @@ metadata:
       }
 spec:
   rules:
-    - host: airqo.net
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: airqo-website-svc
-                port: 
-                  number: 8000
     - host: airqalibrate.airqo.net
       http:
         paths:

--- a/k8s/nginx-ingress/prod-platform-ingress-resource.yaml
+++ b/k8s/nginx-ingress/prod-platform-ingress-resource.yaml
@@ -88,9 +88,18 @@ metadata:
         proxy_set_header        Content-Length "";
         proxy_set_header        X-Original-URI $request_uri;
       }
-
 spec:
   rules:
+    - host: airqo.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airqo-website-svc
+                port: 
+                  number: 8000
     - host: airqalibrate.airqo.net
       http:
         paths:


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
- Fixes the calibrate api cicd deploy to production pipeline failure
- Adds airqo.net to the production ingress
- Adds horizontal pod autoscalers for fault detection api

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

**_HOW DO I TEST OUT THIS PR?_**

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?_**


