### PR TITLE
Updating validation rules for get measurements v2

### DIFF
--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -3089,7 +3089,7 @@ router.get(
         .withMessage("the tenant should not be empty if provided")
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "view"])
+        .isIn(["kcca", "airqo", "view", "urbanbetter"])
         .withMessage("the tenant value is not among the expected ones"),
       query("startTime")
         .optional()
@@ -3144,7 +3144,7 @@ router.get(
         .withMessage("the tenant should not be empty if provided")
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "view"])
+        .isIn(["kcca", "airqo", "view", "urbanbetter"])
         .withMessage("the tenant value is not among the expected ones"),
       query("startTime")
         .optional()


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
Adding UrbanBetter as one of the valid tenants

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [PLAT-1203]

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run stage-mac
```

check README for OS specific commands

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [ ] [Get measurements V2](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/events#version-2-get-events)





[PLAT-1203]: https://airqoteam.atlassian.net/browse/PLAT-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ