### PR TITLE
adding new query parameters for v2 endpoint

### DIFF
--- a/src/device-registry/utils/create-event.js
+++ b/src/device-registry/utils/create-event.js
@@ -96,6 +96,7 @@ const createEvent = {
       ${site_id ? `AND site_id=${site_id}` : ""}
       ${airqloud_id ? `AND airqloud_id=${airqloud_id}` : ""}
       ${airqloud_name ? `AND airqloud_name=${airqloud_name}` : ""}
+      ${device_lat_long ? `AND device_lat_long=${device_lat_long}` : ""}
       ${
         tenant
           ? `AND \`${constants.DATAWAREHOUSE_METADATA}.sites\`.tenant="${tenant}"`

--- a/src/device-registry/utils/create-event.js
+++ b/src/device-registry/utils/create-event.js
@@ -36,6 +36,12 @@ const createEvent = {
       const {
         frequency,
         device,
+        device_name,
+        device_id,
+        device_lat_long,
+        site_id,
+        airqloud_id,
+        airqloud_name,
         device_number,
         startTime,
         endTime,
@@ -85,6 +91,11 @@ const createEvent = {
       ${site ? `AND site_id="${site}"` : ""}
       ${device ? `AND device="${device}"` : ""}
       ${device_number ? `AND device_number=${device_number}` : ""}
+      ${device_name ? `AND device_name=${device_name}` : ""}
+      ${device_id ? `AND device_id=${device_id}` : ""}
+      ${site_id ? `AND site_id=${site_id}` : ""}
+      ${airqloud_id ? `AND airqloud_id=${airqloud_id}` : ""}
+      ${airqloud_name ? `AND airqloud_name=${airqloud_name}` : ""}
       ${
         tenant
           ? `AND \`${constants.DATAWAREHOUSE_METADATA}.sites\`.tenant="${tenant}"`


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
adding new query parameters for v2 endpoint. These are:

-  device_name,
-   device_id,
-    device_lat_long,
-    site_id,
-    airqloud_id,
-    airqloud_name,

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [PLAT-1208]


**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
```

check README for OS specific run commands

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [get measurements V2](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/events#version-2-get-events)






[PLAT-1208]: https://airqoteam.atlassian.net/browse/PLAT-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ