### PR TITLE
Hotfix for the events v2 to cater for mobile data

### DIFF
--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -73,7 +73,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -307,7 +307,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -324,7 +324,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       query("device_number")
         .optional()
@@ -390,7 +390,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       body("device_number")
         .optional()
@@ -608,7 +608,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -660,7 +660,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -924,7 +924,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       body("visibility")
         .exists()
@@ -1002,7 +1002,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1053,7 +1053,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1295,7 +1295,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1359,7 +1359,7 @@ router.delete(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1420,7 +1420,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1476,7 +1476,7 @@ router.put(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1572,7 +1572,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1636,7 +1636,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1739,7 +1739,7 @@ router.put(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1919,7 +1919,7 @@ router.delete(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2003,7 +2003,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2028,7 +2028,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2111,7 +2111,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2164,7 +2164,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   siteController.list
@@ -2180,7 +2180,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2224,7 +2224,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2268,7 +2268,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       body("latitude")
         .exists()
@@ -2405,7 +2405,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2693,7 +2693,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2736,7 +2736,7 @@ router.delete(
     .bail()
     .trim()
     .toLowerCase()
-    .isIn(["kcca", "airqo", "urbanbetter"])
+    .isIn(["kcca", "airqo", "urban_better"])
     .withMessage("the tenant value is not among the expected ones"),
   oneOf([
     query("id")
@@ -2766,7 +2766,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2896,7 +2896,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3068,7 +3068,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3181,7 +3181,7 @@ router.post(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage(
         "the tenant query parameter value is not among the expected ones"
       ),
@@ -3406,7 +3406,7 @@ router.post(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage(
         "the tenant query parameter value is not among the expected ones"
       ),
@@ -3637,7 +3637,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3703,7 +3703,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3818,7 +3818,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3874,7 +3874,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4004,7 +4004,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4036,7 +4036,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -4173,7 +4173,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4210,7 +4210,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4266,7 +4266,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4322,7 +4322,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4386,7 +4386,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4529,7 +4529,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4559,7 +4559,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([

--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -73,7 +73,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -307,7 +307,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -324,7 +324,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       query("device_number")
         .optional()
@@ -373,7 +373,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       body("device_number")
         .optional()
@@ -581,7 +581,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -633,7 +633,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -888,7 +888,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       body("visibility")
         .exists()
@@ -956,7 +956,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1007,7 +1007,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1240,7 +1240,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1304,7 +1304,7 @@ router.delete(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1365,7 +1365,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1421,7 +1421,7 @@ router.put(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1517,7 +1517,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1581,7 +1581,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1684,7 +1684,7 @@ router.put(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1864,7 +1864,7 @@ router.delete(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1948,7 +1948,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1973,7 +1973,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2055,7 +2055,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2108,7 +2108,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   siteController.list
@@ -2124,7 +2124,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2168,7 +2168,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2212,7 +2212,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       body("latitude")
         .exists()
@@ -2349,7 +2349,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2629,7 +2629,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2672,7 +2672,7 @@ router.delete(
     .bail()
     .trim()
     .toLowerCase()
-    .isIn(["kcca", "airqo", "urbanbetter"])
+    .isIn(["kcca", "airqo", "urban_better"])
     .withMessage("the tenant value is not among the expected ones"),
   oneOf([
     query("id")
@@ -2702,7 +2702,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2997,7 +2997,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3089,7 +3089,7 @@ router.get(
         .withMessage("the tenant should not be empty if provided")
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "view", "urbanbetter"])
+        .isIn(["kcca", "airqo", "view", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       query("startTime")
         .optional()
@@ -3157,7 +3157,7 @@ router.get(
         .withMessage("the tenant should not be empty if provided")
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "view", "urbanbetter"])
+        .isIn(["kcca", "airqo", "view", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
       query("startTime")
         .optional()
@@ -3223,7 +3223,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage(
           "the tenant query parameter value is not among the expected ones"
         ),
@@ -3368,7 +3368,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3436,7 +3436,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3551,7 +3551,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3607,7 +3607,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3737,7 +3737,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3769,7 +3769,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urbanbetter"])
+        .isIn(["kcca", "airqo", "urban_better"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3906,7 +3906,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3943,7 +3943,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3999,7 +3999,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4063,7 +4063,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4206,7 +4206,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4236,7 +4236,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urbanbetter"])
+      .isIn(["kcca", "airqo", "urban_better"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
Hotfix for the events v2 to cater for mobile data (Urban Better)

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [PLAT-1212]

**_HOW DO I TEST OUT THIS PR?_**
cd website
npm install

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [get measurements (v2)](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/events#version-2-get-events)




[PLAT-1212]: https://airqoteam.atlassian.net/browse/PLAT-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ