### PR TITLE
addressing the issues of nested time for gps_device_timestamp

### DIFF
--- a/src/device-registry/utils/create-event.js
+++ b/src/device-registry/utils/create-event.js
@@ -168,6 +168,10 @@ const createEvent = {
         return {
           ...item,
           timestamp: item.timestamp.value,
+          gps_device_timestamp:
+            item.gps_device_timestamp && item.gps_device_timestamp.value
+              ? item.gps_device_timestamp.value
+              : "",
         };
       });
 


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
addressing the issues of nested time for gps_device_timestamp

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [PLAT-1212]

**_HOW DO I TEST OUT THIS PR?_**
```
cd device-registry
npm install
```

`npm run prod-mac` OR `npm run prod-pc`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [get measurements (v2)](https://app.gitbook.com/o/-MCogOVGQqjUharJKchL/s/-MKqyQkcfs54GYi-q96G/device-registry/events#version-2-get-events)





[PLAT-1212]: https://airqoteam.atlassian.net/browse/PLAT-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ