### PR TITLE
Add weather stations to site details

### DIFF
--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -199,6 +199,40 @@ const siteSchema = new Schema(
       type: String,
       trim: true,
     },
+    weather_stations: [
+      {
+        code: {
+          type: String,
+          trim: true,
+          default: null,
+        },
+        name: {
+          type: String,
+          trim: true,
+          default: null,
+        },
+        country: {
+          type: String,
+          trim: true,
+          default: null,
+        },
+        longitude: {
+          type: Number,
+          trim: true,
+          default: -1,
+        },
+        latitude: {
+          type: Number,
+          trim: true,
+          default: -1,
+        },
+        timezone: {
+          type: String,
+          trim: true,
+          default: null,
+        },
+      },
+    ],
     nearest_tahmo_station: {
       id: {
         type: Number,
@@ -442,6 +476,7 @@ siteSchema.statics = {
           nearest_tahmo_station: 1,
           devices: "$devices",
           airqlouds: "$airqlouds",
+          weather_stations: 1,
         })
         .project({
           "airqlouds.location": 0,


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] Adds weather stations object to the site details.

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [PLAT-1221](https://airqoteam.atlassian.net/browse/PLAT-1221)

**_HOW DO I TEST OUT THIS PR?_**

1. Setup device registry to run locally
2. Modify any site to store weather stations by making a put request with an array of weather stations. Replace `site_id` with an existing site in your local collection.

```http
http://localhost:3000/api/v1/devices/sites?tenant=airqo&id=site_id
```

Request body
```json
{
  "weather_stations": [
    {
      "name": "Kamwokya Street",
      "code": "T123",
      "country": "UG",
      "longitude": 0.1,
      "latitude": 0.2,
      "timezone": "EAT"
    },
    {
      "name": "Lake side",
      "code": "T456",
      "country": "TZ",
      "longitude": 0.4,
      "latitude": 0.6,
      "timezone": "UTC"
    }
  ]
}
```
**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
Upate sites endpoint

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?_**
#990 

