### PR TITLE
making site ID optional

### DIFF
--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -2979,9 +2979,10 @@ router.post(
         .isBoolean()
         .withMessage("is_device_primary should be Boolean"),
       body("*.site_id")
-        .exists()
+        .optional()
+        .notEmpty()
         .trim()
-        .withMessage("site_id is missing")
+        .withMessage("site_id should not be empty if provided")
         .bail()
         .isMongoId()
         .withMessage("site_id must be an object ID")

--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -2798,9 +2798,10 @@ router.post(
         .isBoolean()
         .withMessage("is_device_primary should be Boolean"),
       body("*.site_id")
-        .exists()
+        .optional()
+        .notEmpty()
         .trim()
-        .withMessage("site_id is missing")
+        .withMessage("site_id should not be empty if provided")
         .bail()
         .isMongoId()
         .withMessage("site_id must be an object ID")


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
Makes the site ID optional when querying measurements

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [PLAT-1201]

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
```
`npm run dev-mac` or `npm run dev-pc`

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
add events endpoint





[PLAT-1201]: https://airqoteam.atlassian.net/browse/PLAT-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ