### PR TITLE
re-enable automatic download of csv file on browser API calls

### DIFF
--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -134,7 +134,7 @@ const createEvent = {
         if (format && format === "csv") {
           return res
             .status(status)
-            .type("text/html")
+            .type("text/csv")
             .send(responseFromListFromBigQuery.data);
         }
         return res.status(status).json({


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
re-enable automatic download of csv file on browser API calls

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [AN-129]

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- [x] [Get events V2 with `format=csv`](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-79a192b7-1e6a-45d2-8431-78f66e28392c)




[AN-129]: https://airqoteam.atlassian.net/browse/AN-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ