### PR TITLE
removing the CORS restrictions on the events endpoint

### DIFF
--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -3131,7 +3131,7 @@ router.post(
 );
 router.get(
   "/events",
-  cors(corsOptionsDelegate),
+  cors(),
   oneOf([
     query("tenant")
       .exists()

--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -3061,7 +3061,7 @@ router.post(
 );
 router.get(
   "/events",
-  cors(corsOptionsDelegate),
+  cors(),
   oneOf([
     [
       query("tenant")


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
removing the CORS restrictions on the events endpoint. As a hotfix to the netmanager CORS errors when run in local ENV.


