### PR TITLE
adding nasa as one of the valid tenants

### DIFF
--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -57,7 +57,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -291,7 +291,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -308,7 +308,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
       query("device_number")
         .optional()
@@ -374,7 +374,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
       body("device_number")
         .optional()
@@ -592,7 +592,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -646,7 +646,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -698,7 +698,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -962,7 +962,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
       body("visibility")
         .exists()
@@ -1040,7 +1040,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1091,7 +1091,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1333,7 +1333,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1397,7 +1397,7 @@ router.delete(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1458,7 +1458,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1514,7 +1514,7 @@ router.put(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1610,7 +1610,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1674,7 +1674,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1777,7 +1777,7 @@ router.put(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1957,7 +1957,7 @@ router.delete(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2041,7 +2041,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2066,7 +2066,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2149,7 +2149,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2202,7 +2202,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   siteController.list
@@ -2218,7 +2218,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2262,7 +2262,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2306,7 +2306,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
       body("latitude")
         .exists()
@@ -2443,7 +2443,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2731,7 +2731,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2774,7 +2774,7 @@ router.delete(
     .bail()
     .trim()
     .toLowerCase()
-    .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+    .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
     .withMessage("the tenant value is not among the expected ones"),
   oneOf([
     query("id")
@@ -2804,7 +2804,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2934,7 +2934,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3107,7 +3107,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3220,7 +3220,7 @@ router.post(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage(
         "the tenant query parameter value is not among the expected ones"
       ),
@@ -3445,7 +3445,7 @@ router.post(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage(
         "the tenant query parameter value is not among the expected ones"
       ),
@@ -3676,7 +3676,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3742,7 +3742,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3857,7 +3857,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3913,7 +3913,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4043,7 +4043,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4075,7 +4075,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -4212,7 +4212,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4249,7 +4249,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4305,7 +4305,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4361,7 +4361,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4425,7 +4425,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4568,7 +4568,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4598,7 +4598,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([

--- a/src/device-registry/routes/api-v2.js
+++ b/src/device-registry/routes/api-v2.js
@@ -57,7 +57,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -291,7 +291,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -308,7 +308,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
       query("device_number")
         .optional()
@@ -357,7 +357,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
       body("device_number")
         .optional()
@@ -565,7 +565,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -617,7 +617,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -872,7 +872,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
       body("visibility")
         .exists()
@@ -940,7 +940,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -991,7 +991,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1224,7 +1224,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -1288,7 +1288,7 @@ router.delete(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1349,7 +1349,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1405,7 +1405,7 @@ router.put(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1501,7 +1501,7 @@ router.get(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1565,7 +1565,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1668,7 +1668,7 @@ router.put(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1848,7 +1848,7 @@ router.delete(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1932,7 +1932,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -1957,7 +1957,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2039,7 +2039,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -2092,7 +2092,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   siteController.list
@@ -2108,7 +2108,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2152,7 +2152,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2196,7 +2196,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
       body("latitude")
         .exists()
@@ -2333,7 +2333,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2613,7 +2613,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2656,7 +2656,7 @@ router.delete(
     .bail()
     .trim()
     .toLowerCase()
-    .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+    .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
     .withMessage("the tenant value is not among the expected ones"),
   oneOf([
     query("id")
@@ -2686,7 +2686,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -2982,7 +2982,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3208,7 +3208,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage(
           "the tenant query parameter value is not among the expected ones"
         ),
@@ -3353,7 +3353,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3421,7 +3421,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3536,7 +3536,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3592,7 +3592,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3722,7 +3722,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3754,7 +3754,7 @@ router.post(
         .bail()
         .trim()
         .toLowerCase()
-        .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+        .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
         .withMessage("the tenant value is not among the expected ones"),
     ],
   ]),
@@ -3891,7 +3891,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3928,7 +3928,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -3984,7 +3984,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4048,7 +4048,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4191,7 +4191,7 @@ router.delete(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([
@@ -4221,7 +4221,7 @@ router.get(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy"])
+      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa"])
       .withMessage("the tenant value is not among the expected ones"),
   ]),
   oneOf([


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
adding nasa as one of the valid tenants to address an ongoing runtime [input validation error](https://airqo.slack.com/archives/C03URQ3Q49J/p1663162807836169).

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [AN-163]

**_HOW DO I TEST OUT THIS PR?_**
```
cd /src/device-registry
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
[get sites , using tenant=nasa](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-d99d2b14-eab1-448a-8bc5-369c76a9579e)




[AN-163]: https://airqoteam.atlassian.net/browse/AN-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ