### PR TITLE
[Meta Data API] Fixes a query params typo while getting greeness

### DIFF
--- a/src/meta-data/api/controllers/extract.py
+++ b/src/meta-data/api/controllers/extract.py
@@ -177,8 +177,8 @@ def get_greenness():
     input_params = {
         "latitude": request.args.get("latitude"),
         "longitude": request.args.get("longitude"),
-        "start_date": request.args.get("start_date"),
-        "end_date": request.args.get("end_date"),
+        "start_date": request.args.get("startDate"),
+        "end_date": request.args.get("endDate"),
     }
     input_data, errors = validation.validate_inputs(input_data=input_params)
 


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
Fixes a query params typo while getting greeness. start date and end date query params should be `startDate` and `endDate` respectively not `start_date` and `end_date`. As required by device registry
https://github.com/airqo-platform/AirQo-api/blob/ad6b6e096e87c55d51e694c5a6ebb84db9c92e74/src/device-registry/config/constants.js#L103

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - []()
- GitHub issues
    - Closes #<enter GitHub issue number here>

**_HOW DO I TEST OUT THIS PR?_**
Use the deploy preview. Compare it to
https://api.airqo.net/api/v1/meta-data/greenness?latitude=0.33174&longitude=32.60956&startDate=2022-09-11&endDate=2022-10-11

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?_**


