### PR TITLE
edge cases for device name during device creation process

### DIFF
--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -259,6 +259,25 @@ deviceSchema.statics = {
       logObject("the args", args);
       logger.info("in the register static fn of the Device model...");
       let modifiedArgs = args;
+
+      if (
+        isEmpty(modifiedArgs.name) &&
+        !isEmpty(args.generation_version) &&
+        !isEmpty(args.generation_count)
+      ) {
+        modifiedArgs.name = `aq_g${args.generation_version}_${args.generation_count}`;
+      } else {
+        try {
+          let nameWithoutWhiteSpaces = modifiedArgs.name.replace(/\s/g, "");
+          let shortenedName = nameWithoutWhiteSpaces.substring(0, 15);
+          modifiedArgs.name = shortenedName.trim().toLowerCase();
+        } catch (error) {
+          logger.error(
+            `internal server error -- sanitiseName-- ${error.message}`
+          );
+        }
+      }
+
       let createdDevice = await this.create({
         ...modifiedArgs,
       });


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
**Context:**
We recently reduced the number of required fields whenever one creates a device. Because of this, a number of changes were done to the system and on that note, some of those changes are continuously reviewed to ensure that no error was made in the process of change.


In case `generation_number` and `generation_count` are provided, just use them to generate the name.
Otherwise, just use the provided name during device creation.

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [AN-227]

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run dev-mac

```
**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [create device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-3be73eff-b260-4c5c-933d-5f193ee89cf5)
- [x] [soft create device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-2341976e-cf2c-4b32-ba81-110693e47d44)






[AN-227]: https://airqoteam.atlassian.net/browse/AN-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ