### PR TITLE
Ft grafana staging access

### DIFF
--- a/k8s/grafana/datasources.yaml
+++ b/k8s/grafana/datasources.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+datasources:
+  - access: proxy
+    editable: false
+    name: prometheus
+    orgId: 1
+    type: prometheus
+    url: "http://prometheus-k8s.monitoring.svc:9090"
+    version: 1
+    isDefault: true
+  - access: proxy
+    name: prometheus-cloud
+    orgId: 1
+    type: prometheus
+    url: "https://prometheus-prod-10-prod-us-central-0.grafana.net/api/prom"
+    basicAuth: true
+    basicAuthUser: << user >>
+    secureJsonData:
+      basicAuthPassword: << password >>

--- a/k8s/grafana/grafana.ini
+++ b/k8s/grafana/grafana.ini
@@ -1,0 +1,6 @@
+[date_formats]
+default_timezone = UTC
+[server]
+domain = staging-platform.airqo.net
+root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+serve_from_sub_path = true

--- a/k8s/grafana/grafana.ini
+++ b/k8s/grafana/grafana.ini
@@ -1,6 +1,22 @@
 [date_formats]
 default_timezone = UTC
-[server]
-domain = staging-platform.airqo.net
-root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+[server] 
+root_url = https://staging-platform.airqo.net/grafana/
 serve_from_sub_path = true
+[security]
+admin_user = << admin_user >>
+admin_password = << admin_password >>
+admin_email = << admin_email >>
+[users]
+allow_sign_up = false
+[auth.github]
+enabled = true
+allow_sign_up = false
+client_id = << client_id >>
+client_secret = << client_secret >>
+scopes = user:email,read:org
+auth_url = https://github.com/login/oauth/authorize
+token_url = https://github.com/login/oauth/access_token
+api_url = https://api.github.com/user
+allowed_organizations = airqo-platform
+role_attribute_path = contains(groups[*], '@airqo-platform/devops') && 'Editor' || 'Viewer'

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -30,7 +30,6 @@ data:
       if ($request_uri ~ '(/api/v1/users/forgotPassword)|(/api/v2/users/forgotPassword)') { return 200; }
       if ($request_uri ~ '(/api/v1/users/candidates/register)|(/api/v2/users/candidates/register)') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }    
-      if ($request_uri ~ '/argocd') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # All none api requests 
 
       # Mobile app specific exemptions. To be authenticated later

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -30,6 +30,7 @@ data:
       if ($request_uri ~ '(/api/v1/users/forgotPassword)|(/api/v2/users/forgotPassword)') { return 200; }
       if ($request_uri ~ '(/api/v1/users/candidates/register)|(/api/v2/users/candidates/register)') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }    
+      if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # All none api requests 
 
       # Mobile app specific exemptions. To be authenticated later

--- a/k8s/nginx/staging/virtual-server.yaml
+++ b/k8s/nginx/staging/virtual-server.yaml
@@ -16,6 +16,23 @@ spec:
 
 ---
 apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  host: staging-platform.airqo.net
+  upstreams:
+    - name: grafana
+      service: grafana
+      port: 3000
+  subroutes:
+    - path: /grafana
+      action:
+        pass: grafana
+
+---
+apiVersion: k8s.nginx.org/v1
 kind: VirtualServer
 metadata:
   name: staging-virtual-server
@@ -74,6 +91,8 @@ spec:
         pass: platform-ui
     - path: /airflow
       route: pipeline/airflow
+    - path: /grafana
+      route: monitoring/grafana
     - path: ~ /api\/v[1-2]\/users
       action:
         proxy:


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
- Adds a staging self hosted Grafana instance(we need these alerts too just as with prod)

**_WHAT ISSUES ARE RELATED TO THIS PR?_**
 - Adds the missing staging status notifs

**_HOW DO I TEST OUT THIS PR?_**
- Go to https://staging-platform.airqo.net/grafana/
- You should be able to login with your GitHub account
- You will then be redirected to the Grafana dashboard on staging
![image](https://user-images.githubusercontent.com/41787587/216131951-3a6e6506-1488-48df-ad39-3efe67be0a4f.png)

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- https://staging-platform.airqo.net/grafana/

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**
- n/a