### PR TITLE
few hotfixes for the create-device use case

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -53,6 +53,7 @@ const stageConfig = {
 
 const defaultConfig = {
   NETWORKS: process.env.NETWORKS.split(","),
+  DEFAULT_NETWORK: process.env.DEFAULT_NETWORK,
   DEFAULT_NEAREST_SITE_RADIUS: process.env.DEFAULT_NEAREST_SITE_RADIUS,
   SLACK_TOKEN: process.env.SLACK_TOKEN,
   KAFKA_CLIENT_ID: process.env.KAFKA_CLIENT_ID,

--- a/src/device-registry/controllers/create-device.js
+++ b/src/device-registry/controllers/create-device.js
@@ -14,6 +14,7 @@ const logger = log4js.getLogger(
 // const bulkUpdateUtil = require("../scripts/bulk-update");
 // const bulkCreateUtil = require("../scripts/bulk-create");
 const httpStatus = require("http-status");
+const isEmpty = require("is-empty");
 
 const device = {
   bulkCreate: async (req, res) => {
@@ -281,6 +282,8 @@ const device = {
   create: async (req, res) => {
     try {
       const hasErrors = !validationResult(req).isEmpty();
+      const { query, body } = req;
+      let { tenant } = query;
       if (hasErrors) {
         let nestedErrors = validationResult(req).errors[0].nestedErrors;
         try {
@@ -299,7 +302,14 @@ const device = {
         );
       }
 
-      let responseFromCreateDevice = await createDeviceUtil.create(req);
+      if (isEmpty(tenant)) {
+        tenant = "airqo";
+      }
+
+      let request = Object.assign({}, req);
+      request.query.tenant = tenant;
+
+      let responseFromCreateDevice = await createDeviceUtil.create(request);
       logger.info(
         `responseFromCreateDevice -- ${JSON.stringify(
           responseFromCreateDevice
@@ -315,9 +325,6 @@ const device = {
           created_device: responseFromCreateDevice.data,
         });
       } else if (responseFromCreateDevice.success === false) {
-        let errors = responseFromCreateDevice.errors
-          ? responseFromCreateDevice.errors
-          : "";
         let status = responseFromCreateDevice.status
           ? responseFromCreateDevice.status
           : HTTPStatus.BAD_GATEWAY;
@@ -325,7 +332,9 @@ const device = {
         return res.status(status).json({
           success: false,
           message: responseFromCreateDevice.message,
-          errors,
+          errors: responseFromCreateDevice.errors
+            ? responseFromCreateDevice.errors
+            : "",
         });
       }
     } catch (e) {
@@ -895,6 +904,8 @@ const device = {
 
   createOnPlatform: async (req, res) => {
     try {
+      const { query, body } = req;
+      let { tenant } = query;
       const hasErrors = !validationResult(req).isEmpty();
       if (hasErrors) {
         let nestedErrors = validationResult(req).errors[0].nestedErrors;
@@ -913,8 +924,10 @@ const device = {
           errors.convertErrorArrayToObject(nestedErrors)
         );
       }
-      const { tenant } = req.query;
-      const { body } = req;
+
+      if (isEmpty(tenant)) {
+        tenant = "airqo";
+      }
 
       let requestBody = {};
       requestBody["query"] = {};

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -159,6 +159,7 @@ const deviceSchema = new mongoose.Schema(
       type: Number,
       trim: true,
       unique: true,
+      required: false,
     },
     category: {
       type: String,
@@ -258,7 +259,6 @@ deviceSchema.statics = {
   async register(args) {
     try {
       let modifiedArgs = Object.assign({}, args);
-      logObject("modifiedArgs", modifiedArgs);
 
       if (isEmpty(modifiedArgs.network)) {
         modifiedArgs.network = constants.DEFAULT_NETWORK;
@@ -309,6 +309,8 @@ deviceSchema.statics = {
           };
         }
       }
+
+      logObject("modifiedArgs", modifiedArgs);
 
       let createdDevice = await this.create({
         ...modifiedArgs,

--- a/src/device-registry/routes/api-v1.js
+++ b/src/device-registry/routes/api-v1.js
@@ -429,20 +429,41 @@ router.get(
 router.post(
   "/",
   oneOf([
+    query("tenant")
+      .optional()
+      .notEmpty()
+      .withMessage("the tenant should not be empty if provided")
+      .bail()
+      .trim()
+      .toLowerCase()
+      .isIn(constants.NETWORKS)
+      .withMessage("the tenant value is not among the expected ones"),
+  ]),
+  oneOf([
+    body("name")
+      .exists()
+      .withMessage(
+        "device identification details are missing in the request, consider using the name"
+      )
+      .bail()
+      .notEmpty()
+      .withMessage("the name should not be empty if provided"),
+    body("long_name")
+      .exists()
+      .withMessage(
+        "device identification details are missing in the request, consider using the long_name"
+      )
+      .bail()
+      .notEmpty()
+      .withMessage("the long_name should not be empty if provided"),
+  ]),
+  oneOf([
     [
-      query("tenant")
-        .exists()
-        .withMessage("tenant should be provided")
-        .bail()
-        .trim()
-        .toLowerCase()
-        .isIn(constants.NETWORKS)
-        .withMessage("the tenant value is not among the expected ones"),
       body("network")
-        .exists()
-        .withMessage("network should be provided")
-        .bail()
+        .optional()
         .trim()
+        .notEmpty()
+        .withMessage("the network should not be empty if provided")
         .toLowerCase()
         .isIn(constants.NETWORKS)
         .withMessage("the network value is not among the expected ones"),
@@ -454,18 +475,6 @@ router.post(
         .trim()
         .isInt()
         .withMessage("the device_number should be an integer value"),
-      body("name")
-        .exists()
-        .withMessage("the name should be provided")
-        .bail()
-        .notEmpty()
-        .withMessage("the name should not be empty")
-        .trim(),
-      body("long_name")
-        .optional()
-        .notEmpty()
-        .withMessage("the long_name should not be empty if provided")
-        .trim(),
       body("generation_version")
         .optional()
         .notEmpty()
@@ -594,18 +603,24 @@ router.post(
       body("isRetired")
         .optional()
         .notEmpty()
+        .withMessage("the isRetired should not be empty if provided")
+        .bail()
         .trim()
         .isBoolean()
         .withMessage("isRetired must be Boolean"),
       body("mobility")
         .optional()
         .notEmpty()
+        .withMessage("the mobility should not be empty if provided")
+        .bail()
         .trim()
         .isBoolean()
         .withMessage("mobility must be Boolean"),
       body("nextMaintenance")
         .optional()
         .notEmpty()
+        .withMessage("the nextMaintenance should not be empty if provided")
+        .bail()
         .trim()
         .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
@@ -613,18 +628,24 @@ router.post(
       body("isPrimaryInLocation")
         .optional()
         .notEmpty()
+        .withMessage("the isPrimaryInLocation should not be empty if provided")
+        .bail()
         .trim()
         .isBoolean()
         .withMessage("isPrimaryInLocation must be Boolean"),
       body("isUsedForCollocation")
         .optional()
         .notEmpty()
+        .withMessage("the isUsedForCollocation should not be empty if provided")
+        .bail()
         .trim()
         .isBoolean()
         .withMessage("isUsedForCollocation must be Boolean"),
       body("owner")
         .optional()
         .notEmpty()
+        .withMessage("the owner should not be empty if provided")
+        .bail()
         .trim()
         .isMongoId()
         .withMessage("the owner must be an object ID")
@@ -635,6 +656,8 @@ router.post(
       body("host_id")
         .optional()
         .notEmpty()
+        .withMessage("the host_id should not be empty if provided")
+        .bail()
         .trim()
         .isMongoId()
         .withMessage("the host_id must be an object ID")
@@ -645,6 +668,8 @@ router.post(
       body("phoneNumber")
         .optional()
         .notEmpty()
+        .withMessage("the phoneNumber should not be empty if provided")
+        .bail()
         .trim()
         .custom((value) => {
           let parsedPhoneNumber = phoneUtil.parse(value);
@@ -656,6 +681,8 @@ router.post(
       body("height")
         .optional()
         .notEmpty()
+        .withMessage("the height should not be empty if provided")
+        .bail()
         .trim()
         .isFloat({ gt: 0, lt: 100 })
         .withMessage("height must be a number between 0 and 100")
@@ -664,6 +691,8 @@ router.post(
       body("elevation")
         .optional()
         .notEmpty()
+        .withMessage("the elevation should not be empty if provided")
+        .bail()
         .trim()
         .isFloat()
         .withMessage("elevation must be a float")
@@ -672,10 +701,14 @@ router.post(
       body("writeKey")
         .optional()
         .notEmpty()
+        .withMessage("the writeKey should not be empty if provided")
+        .bail()
         .trim(),
       body("readKey")
         .optional()
         .notEmpty()
+        .withMessage("the readKey should not be empty if provided")
+        .bail()
         .trim(),
     ],
   ]),
@@ -1010,18 +1043,40 @@ router.get(
 router.post(
   "/soft",
   oneOf([
+    query("tenant")
+      .optional()
+      .notEmpty()
+      .withMessage("the tenant should not be empty if provided")
+      .bail()
+      .trim()
+      .toLowerCase()
+      .isIn(constants.NETWORKS)
+      .withMessage("the tenant value is not among the expected ones"),
+  ]),
+  oneOf([
+    body("name")
+      .exists()
+      .withMessage(
+        "device identification details are missing in the request, consider using the name"
+      )
+      .bail()
+      .notEmpty()
+      .withMessage("the name should not be empty if provided"),
+    body("long_name")
+      .exists()
+      .withMessage(
+        "device identification details are missing in the request, consider using the long_name"
+      )
+      .bail()
+      .notEmpty()
+      .withMessage("the long_name should not be empty if provided"),
+  ]),
+  oneOf([
     [
-      query("tenant")
-        .exists()
-        .withMessage("tenant should be provided")
-        .bail()
-        .trim()
-        .toLowerCase()
-        .isIn(constants.NETWORKS)
-        .withMessage("the tenant value is not among the expected ones"),
       body("network")
-        .exists()
-        .withMessage("network should be provided")
+        .optional()
+        .notEmpty()
+        .withMessage("network should not be empty if provided")
         .bail()
         .trim()
         .toLowerCase()
@@ -1043,19 +1098,6 @@ router.post(
         .trim()
         .isInt()
         .withMessage("the device_number should be an integer value"),
-      body("long_name")
-        .optional()
-        .notEmpty()
-        .withMessage("the long_name should not be empty if provided")
-        .bail()
-        .trim(),
-      body("name")
-        .exists()
-        .withMessage("the name should be provided")
-        .bail()
-        .notEmpty()
-        .withMessage("the name should not be empty")
-        .trim(),
       body("generation_version")
         .optional()
         .notEmpty()

--- a/src/device-registry/utils/create-device.js
+++ b/src/device-registry/utils/create-device.js
@@ -749,12 +749,15 @@ const createDevice = {
       const baseURL = constants.CREATE_THING_URL;
       const { body } = request;
       const { category } = body;
-      const data = body;
+      let data = body;
+      if (isEmpty(data.long_name) && !isEmpty(data.name)) {
+        data.long_name = data.name;
+      }
       const map = constants.DEVICE_THINGSPEAK_MAPPINGS;
       let context = {};
       if (category === "bam") {
         context = constants.BAM_THINGSPEAK_FIELD_DESCRIPTIONS;
-      } else if (category === "lowcost") {
+      } else {
         context = constants.THINGSPEAK_FIELD_DESCRIPTIONS;
       }
 
@@ -777,35 +780,54 @@ const createDevice = {
           message: responseFromTransformRequestBody.message,
         };
       }
-      const response = await axios.post(baseURL, transformedBody);
+      return await axios
+        .post(baseURL, transformedBody)
+        .then((response) => {
+          let writeKey = response.data.api_keys[0].write_flag
+            ? response.data.api_keys[0].api_key
+            : "";
+          let readKey = !response.data.api_keys[1].write_flag
+            ? response.data.api_keys[1].api_key
+            : "";
 
-      if (isEmpty(response)) {
-        return {
-          success: false,
-          message: "unable to create the device on thingspeak",
-        };
-      }
+          let newChannel = {
+            device_number: `${response.data.id}`,
+            writeKey: writeKey,
+            readKey: readKey,
+          };
 
-      let writeKey = response.data.api_keys[0].write_flag
-        ? response.data.api_keys[0].api_key
-        : "";
-      let readKey = !response.data.api_keys[1].write_flag
-        ? response.data.api_keys[1].api_key
-        : "";
-
-      let newChannel = {
-        device_number: `${response.data.id}`,
-        writeKey: writeKey,
-        readKey: readKey,
-      };
-
-      return {
-        success: true,
-        message: "successfully created the device on thingspeak",
-        data: newChannel,
-      };
+          return {
+            success: true,
+            message: "successfully created the device on thingspeak",
+            data: newChannel,
+          };
+        })
+        .catch((error) => {
+          if (error.response) {
+            return {
+              success: false,
+              status: error.response.status
+                ? error.response.status
+                : parseInt(error.response.data.status),
+              errors: {
+                message: error.response.statusText
+                  ? error.response.statusText
+                  : error.response.data.error,
+              },
+            };
+          } else {
+            return {
+              success: false,
+              message: "Bad Gateway Error",
+              status: HTTPStatus.BAD_GATEWAY,
+              errors: {
+                message:
+                  "unable to create the device on thingspeak, crosscheck why",
+              },
+            };
+          }
+        });
     } catch (error) {
-      logger.error(`internal server error -- ${error.message}`);
       return {
         success: false,
         message: "Internal Server Error",


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

With a focus on the `device creation` use case.....

- [x] make the error responses more descriptive
- [x] EITHER `long_name` OR `name` are the ONLY required fields during device creation. All other fields are optional
- [x] device_number is no longer required but it must be unique for every device

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [AN-284]

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run stage

```
**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [create device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-3be73eff-b260-4c5c-933d-5f193ee89cf5)
- [x] [soft create device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-2341976e-cf2c-4b32-ba81-110693e47d44)




[AN-284]: https://airqoteam.atlassian.net/browse/AN-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ