### PR TITLE
new endpoint for fetching airqlouds without locations

### DIFF
--- a/src/device-registry/controllers/create-airqloud.js
+++ b/src/device-registry/controllers/create-airqloud.js
@@ -567,6 +567,69 @@ const createAirqloud = {
     }
   },
 
+  listDashboard: async (req, res) => {
+    try {
+      const { query } = req;
+      let request = {};
+      logText(".....................................");
+      logText("list all airqlouds by query params provided");
+      const hasErrors = !validationResult(req).isEmpty();
+      if (hasErrors) {
+        let nestedErrors = validationResult(req).errors[0].nestedErrors;
+        try {
+          logger.error(
+            `input validation errors ${JSON.stringify(
+              errors.convertErrorArrayToObject(nestedErrors)
+            )}`
+          );
+        } catch (e) {
+          logger.error(`internal server error -- ${e.message}`);
+        }
+        return errors.badRequest(
+          res,
+          "bad request errors",
+          errors.convertErrorArrayToObject(nestedErrors)
+        );
+      }
+      request["query"] = query;
+      request["query"]["dashboard"] = "yes";
+      let responseFromListAirQlouds = await createAirQloudUtil.list(request);
+      logElement(
+        "has the response for listing airqlouds been successful?",
+        responseFromListAirQlouds.success
+      );
+      if (responseFromListAirQlouds.success === true) {
+        let status = responseFromListAirQlouds.status
+          ? responseFromListAirQlouds.status
+          : HTTPStatus.OK;
+        res.status(status).json({
+          success: true,
+          message: responseFromListAirQlouds.message,
+          airqlouds: responseFromListAirQlouds.data,
+        });
+      } else if (responseFromListAirQlouds.success === false) {
+        let errors = responseFromListAirQlouds.errors
+          ? responseFromListAirQlouds.errors
+          : { message: "" };
+        let status = responseFromListAirQlouds.status
+          ? responseFromListAirQlouds.status
+          : HTTPStatus.INTERNAL_SERVER_ERROR;
+        res.status(status).json({
+          success: false,
+          message: responseFromListAirQlouds.message,
+          errors,
+        });
+      }
+    } catch (errors) {
+      logger.error(`internal server error -- ${errors.message}`);
+      res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: errors.message },
+      });
+    }
+  },
+
   delete: async (req, res) => {
     try {
       const { query } = req;

--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -268,7 +268,7 @@ airqloudSchema.statics = {
   async list({ filter = {}, _limit = 1000, _skip = 0 } = {}) {
     try {
       logElement("the limit in the model", _limit);
-      const { summary } = filter;
+      const { summary, dashboard } = filter;
 
       let projectAll = {
         _id: 1,
@@ -300,11 +300,30 @@ airqloudSchema.statics = {
         },
       };
 
+      const projectDashboard = {
+        _id: 1,
+        name: 1,
+        long_name: 1,
+        description: 1,
+        airqloud_tags: 1,
+        admin_level: 1,
+        isCustom: 1,
+        metadata: 1,
+        center_point: 1,
+        airqloud_codes: 1,
+        sites: "$sites",
+      };
+
       let projection = projectAll;
 
       if (!isEmpty(summary)) {
         projection = projectSummary;
         delete filter.summary;
+      }
+
+      if (!isEmpty(dashboard)) {
+        projection = projectDashboard;
+        delete filter.dashboard;
       }
 
       let data = await this.aggregate()

--- a/src/device-registry/routes/v1/airqlouds.js
+++ b/src/device-registry/routes/v1/airqlouds.js
@@ -314,6 +314,62 @@ router.get(
 );
 
 router.get(
+  "/dashboard",
+  oneOf([
+    query("tenant")
+      .exists()
+      .withMessage("tenant should be provided")
+      .bail()
+      .trim()
+      .toLowerCase()
+      .isIn(constants.NETWORKS)
+      .withMessage("the tenant value is not among the expected ones"),
+  ]),
+  oneOf([
+    [
+      query("id")
+        .optional()
+        .notEmpty()
+        .trim()
+        .isMongoId()
+        .withMessage("id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
+      query("name")
+        .optional()
+        .notEmpty()
+        .withMessage("name cannot be empty")
+        .trim(),
+      query("admin_level")
+        .optional()
+        .notEmpty()
+        .withMessage(
+          "admin_level is empty, should not be if provided in request"
+        )
+        .bail()
+        .toLowerCase()
+        .isIn([
+          "village",
+          "district",
+          "parish",
+          "division",
+          "county",
+          "subcounty",
+          "country",
+          "state",
+          "province",
+        ])
+        .withMessage(
+          "admin_level values include: province, state, village, county, subcounty, village, parish, country, division and district"
+        ),
+    ],
+  ]),
+  airqloudController.listDashboard
+);
+
+router.get(
   "/sites",
   oneOf([
     query("tenant")

--- a/src/device-registry/utils/create-airqloud.js
+++ b/src/device-registry/utils/create-airqloud.js
@@ -605,29 +605,24 @@ const createAirqloud = {
       });
 
       if (responseFromListAirQloud.success === false) {
-        let errors = responseFromListAirQloud.errors
-          ? responseFromListAirQloud.errors
-          : "";
-
-        let status = responseFromListAirQloud.status
-          ? responseFromListAirQloud.status
-          : "";
         return {
           success: false,
           message: responseFromListAirQloud.message,
-          errors,
-          status,
+          errors: responseFromListAirQloud.errors
+            ? responseFromListAirQloud.errors
+            : "",
+          status: responseFromListAirQloud.status
+            ? responseFromListAirQloud.status
+            : "",
         };
       } else if (responseFromListAirQloud.success === true) {
-        let status = responseFromListAirQloud.status
-          ? responseFromListAirQloud.status
-          : "";
-        let data = responseFromListAirQloud.data;
         return {
           success: true,
           message: responseFromListAirQloud.message,
-          data,
-          status,
+          data: responseFromListAirQloud.data,
+          status: responseFromListAirQloud.status
+            ? responseFromListAirQloud.status
+            : "",
         };
       }
     } catch (err) {

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -744,6 +744,7 @@ const generateFilter = {
       name,
       admin_level,
       summary,
+      dashboard,
       airqloud_id,
       network,
       airqloud,
@@ -763,6 +764,10 @@ const generateFilter = {
 
     if (summary === "yes") {
       filter["summary"] = summary;
+    }
+
+    if (dashboard === "yes") {
+      filter["dashboard"] = dashboard;
     }
 
     if (airqloud_codes) {


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
new endpoint for fetching airqlouds without locations

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [AN-290]

**_HOW DO I TEST OUT THIS PR?_**

```
cd src/device-registry
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [list AirQlouds for dashboard](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-7b11d0e4-f4e3-479d-9b4a-af3f12b570db)





[AN-290]: https://airqoteam.atlassian.net/browse/AN-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ