### PR TITLE
Few enhancements to the create-photo use-case

### DIFF
--- a/src/device-registry/controllers/create-photo.js
+++ b/src/device-registry/controllers/create-photo.js
@@ -45,13 +45,12 @@ const processImage = {
         const status = responseFromCreatePhoto.status
           ? responseFromCreatePhoto.status
           : HTTPStatus.INTERNAL_SERVER_ERROR;
-        const errors = responseFromCreatePhoto.errors
-          ? responseFromCreatePhoto.errors
-          : "";
         res.status(status).json({
           success: false,
           message: responseFromCreatePhoto.message,
-          errors,
+          errors: responseFromCreatePhoto.errors
+            ? responseFromCreatePhoto.errors
+            : { message: "" },
         });
       }
     } catch (error) {
@@ -97,13 +96,12 @@ const processImage = {
         const status = responseFromUpdatePhoto.status
           ? responseFromUpdatePhoto.status
           : HTTPStatus.INTERNAL_SERVER_ERROR;
-        const errors = responseFromUpdatePhoto.errors
-          ? responseFromUpdatePhoto.errors
-          : "";
         res.status(status).json({
           success: false,
           message: responseFromUpdatePhoto.message,
-          errors,
+          errors: responseFromUpdatePhoto.errors
+            ? responseFromUpdatePhoto.errors
+            : { message: "" },
         });
       }
     } catch (error) {
@@ -420,7 +418,7 @@ const processImage = {
           message: responseFromUpdatePhotoOnPlatform.message,
           errors: responseFromUpdatePhotoOnPlatform.errors
             ? responseFromUpdatePhotoOnPlatform.errors
-            : status,
+            : { message: "" },
         });
       }
     } catch (error) {

--- a/src/device-registry/models/Photo.js
+++ b/src/device-registry/models/Photo.js
@@ -88,22 +88,21 @@ photoSchema.statics = {
   async register(args) {
     try {
       logText("registering a new photo....");
-      let modifiedArgs = args;
-      let createdPhoto = await this.create({ ...modifiedArgs });
+      let modifiedArgs = Object.assign({}, args);
+      const createdPhoto = await this.create({ ...modifiedArgs });
       if (!isEmpty(createdPhoto)) {
-        const data = createdPhoto._doc;
-        logObject("data", data);
         return {
           success: true,
-          data,
+          data: createdPhoto._doc,
           message: "photo created",
           status: HTTPStatus.CREATED,
         };
-      } else {
+      } else if (isEmpty(createdPhoto)) {
         return {
           success: false,
           message: "photo not created despite successful operation",
-          status: HTTPStatus.ACCEPTED,
+          status: HTTPStatus.INTERNAL_SERVER_ERROR,
+          errors: { message: "photo not created despite successful operation" },
         };
       }
     } catch (err) {
@@ -111,11 +110,13 @@ photoSchema.statics = {
       let response = {};
       let message = "validation errors for some of the provided fields";
       let status = HTTPStatus.CONFLICT;
-      if (err.code === 11000) {
+      if (!isEmpty(err.keyPattern) && err.code === 11000) {
         Object.entries(err.keyPattern).forEach(([key, value]) => {
-          return (response[key] = "duplicate value");
+          response[key] = "duplicate value";
+          response["message"] = "duplicate value";
+          return response;
         });
-      } else {
+      } else if (!isEmpty(err.errors)) {
         Object.entries(err.errors).forEach(([key, value]) => {
           response.message = value.message;
           response[key] = value.message;
@@ -162,7 +163,7 @@ photoSchema.statics = {
       } else if (isEmpty(response)) {
         return {
           success: true,
-          message: "this photo does not exist, please crosscheck",
+          message: "No images found for this operation",
           status: HTTPStatus.OK,
           data: [],
         };
@@ -175,7 +176,9 @@ photoSchema.statics = {
       if (err.code === 11000) {
         if (!isEmpty(err.keyPattern)) {
           Object.entries(err.keyPattern).forEach(([key, value]) => {
-            return (response[key] = "duplicate value");
+            response["message"] = "duplicate value";
+            response[key] = "duplicate value";
+            return response;
           });
         } else {
           response.message = "duplicate value";
@@ -216,27 +219,25 @@ photoSchema.statics = {
       const projection = setProjection(modifiedUpdateBody);
       logObject("projection", projection);
       options["projection"] = projection;
-      let updatedPhoto = await this.findOneAndUpdate(
+      const updatedPhoto = await this.findOneAndUpdate(
         filter,
         modifiedUpdateBody,
         options
       );
       logObject("updatedPhoto", updatedPhoto);
       if (!isEmpty(updatedPhoto)) {
-        let data = updatedPhoto._doc;
-        logObject("the updated data", data);
         return {
           success: true,
           message: "successfully modified the photo",
-          data,
+          data: updatedPhoto._doc,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(updatedPhoto)) {
         return {
-          success: false,
-          message: "this photo does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
-          errors: filter,
+          success: true,
+          message: "No images found for this operation",
+          status: HTTPStatus.OK,
+          data: [],
         };
       }
     } catch (err) {
@@ -244,13 +245,17 @@ photoSchema.statics = {
       let response = {};
       let message = "validation errors for some of the provided fields";
       let status = HTTPStatus.CONFLICT;
-      if (err.code === 11000) {
+      if (!isEmpty(err.code) && err.code === 11000) {
         Object.entries(err.keyPattern).forEach(([key, value]) => {
-          return (response[key] = "duplicate value");
+          response[key] = "duplicate value";
+          response["message"] = "duplicate value";
+          return response;
         });
-      } else {
+      } else if (!isEmpty(err.errors)) {
         Object.entries(err.errors).forEach(([key, value]) => {
-          return (response[key] = value.message);
+          response[key] = value.message;
+          response["message"] = value.message;
+          return response;
         });
       }
       return {
@@ -274,22 +279,20 @@ photoSchema.statics = {
           image_url: 1,
         },
       };
-      let removedPhoto = await this.findOneAndRemove(filter, options).exec();
+      const removedPhoto = await this.findOneAndRemove(filter, options).exec();
       if (!isEmpty(removedPhoto)) {
-        let data = removedPhoto._doc;
-        logObject("the removed photo data", data);
         return {
           success: true,
           message: "successfully removed the photo",
-          data,
+          data: removedPhoto._doc,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(removedPhoto)) {
         return {
-          success: false,
-          message: "this photo does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
-          errors: filter,
+          success: true,
+          message: "No images found for this operation",
+          status: HTTPStatus.OK,
+          data: [],
         };
       }
     } catch (err) {
@@ -297,13 +300,17 @@ photoSchema.statics = {
       let response = {};
       let message = "validation errors for some of the provided fields";
       let status = HTTPStatus.CONFLICT;
-      if (err.code === 11000) {
+      if (!isEmpty(err.code) && err.code === 11000) {
         Object.entries(err.keyPattern).forEach(([key, value]) => {
-          return (response[key] = "duplicate value");
+          response[key] = "duplicate value";
+          response["message"] = "duplicate value";
+          return response;
         });
-      } else {
+      } else if (!isEmpty(err.errors)) {
         Object.entries(err.errors).forEach(([key, value]) => {
-          return (response[key] = value.message);
+          response[key] = value.message;
+          response["message"] = value.message;
+          return response;
         });
       }
       return {

--- a/src/device-registry/utils/create-photo.js
+++ b/src/device-registry/utils/create-photo.js
@@ -79,7 +79,7 @@ const createPhoto = {
   },
   extractPhotoDetails: async (request) => {
     try {
-      let responseFromListPhotos = await createPhoto.list(request);
+      const responseFromListPhotos = await createPhoto.list(request);
       logObject("responseFromListPhotos", responseFromListPhotos);
       if (responseFromListPhotos.success === true) {
         const photoDetails = responseFromListPhotos.data[0];
@@ -115,7 +115,7 @@ const createPhoto = {
       const { id } = request.query;
       let arrayOfOneImage = [];
       let device_name = "";
-      let responseFromExtractPhotoDetails = await createPhoto.extractPhotoDetails(
+      const responseFromExtractPhotoDetails = await createPhoto.extractPhotoDetails(
         request
       );
 


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] few enhancements to the responses from the static methods of Photo entity.
- [ ] Support deletion of more than one photo
- [ ] Do input validations for `device_names` during the SOFT photo creation process. User should use unique name that exists.
- [x] refactor the error messages for the `create-photo `use-case. Just to make sure they follow the agreed upon format: `{errors:{message:""}}`
- [x] correct the http error response for cases where the photo does not exist.

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [AN-296]

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [ ] bulk create photos
- [ ] bulk delete many photos
- [x] [SOFT create photo](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-df28ae74-1be7-47ab-8a24-29ae5495b22d)
- [x] [delete photo](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-a0e42427-2789-4468-a96d-a698fe8423e8)
- [x] [soft delete photo](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-6db7b83f-38cb-4072-b041-06c18645c7ba)
- [x] [view photos](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-3023d862-3b0a-4b0d-a3fb-b59917dc73e6)






[AN-296]: https://airqoteam.atlassian.net/browse/AN-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ