### PR TITLE
Ft new gateway auth

### DIFF
--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -37,10 +37,18 @@ data:
       if ($request_uri ~ '(/api/v1/devices/events)|(/api/v2/devices/events)') { return 200; }
       if ($request_uri ~ '(/api/v1/meta-data/mobile-carrier)|(/api/v1/meta-data/ip-geo-coordinates)') { return 200; }
       
-      
+      set $method POST;
+      set $verification_path verify?tenant=airqo;
+
+      if ($request_uri ~* 'token=(?<token>[^&]+)') {
+        set $method GET;
+        set $verification_path tokens/$token/verify;
+      }
+
       internal;
-      proxy_method            POST;
-      proxy_pass              http://airqo-auth-api-svc.production.svc.cluster.local:3000/api/v1/users/verify?tenant=airqo;
+      resolver                kube-dns.kube-system.svc.cluster.local valid=5s;
+      proxy_method            $method;
+      proxy_pass              http://airqo-auth-api-svc.production.svc.cluster.local:3000/api/v1/users/$verification_path;
       proxy_pass_request_body off;
       proxy_set_header        Content-Length '';
       proxy_set_header        X-Original-URI $request_uri;

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -47,6 +47,7 @@ data:
       }
 
       internal;
+      resolver                kube-dns.kube-system.svc.cluster.local valid=5s;
       proxy_method            $method;
       proxy_pass              http://airqo-stage-auth-api-svc.staging.svc.cluster.local:3000/api/v1/users/$verification_path;
       proxy_pass_request_body off;

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -38,9 +38,17 @@ data:
       if ($request_uri ~ '(/api/v1/devices/events)|(/api/v2/devices/events)') { return 200; }
       if ($request_uri ~ '(/api/v1/meta-data/mobile-carrier)|(/api/v1/meta-data/ip-geo-coordinates)') { return 200; }
 
+      set $method POST;
+      set $verification_path verify?tenant=airqo;
+
+      if ($arg_token) {
+        set $method GET;
+        set $verification_path tokens/$arg_token/verify;
+      }
+
       internal;
-      proxy_method            POST;
-      proxy_pass              http://airqo-stage-auth-api-svc.staging.svc.cluster.local:3000/api/v1/users/verify?tenant=airqo;
+      proxy_method            $method;
+      proxy_pass              http://airqo-stage-auth-api-svc.staging.svc.cluster.local:3000/api/v1/users/$verification_path;
       proxy_pass_request_body off;
       proxy_set_header        Content-Length '';
       proxy_set_header        X-Original-URI $request_uri;

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -41,9 +41,9 @@ data:
       set $method POST;
       set $verification_path verify?tenant=airqo;
 
-      if ($arg_token) {
+      if ($request_uri ~* 'token=(?<token>[^&]+)') {
         set $method GET;
-        set $verification_path tokens/$arg_token/verify;
+        set $verification_path tokens/$token/verify;
       }
 
       internal;


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
- Adds support for new authentication method using access tokens to the gateway authentication

**_HOW DO I TEST OUT THIS PR?_**
- Try to access any protected endpoints using an access token
- You do not need to add the authorization header

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-ec2c7c03-6429-43b6-b000-c7469553748d

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?_**