### PR TITLE
device-registry hotfixes and metadata grooming

### DIFF
--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -379,25 +379,20 @@ airqloudSchema.statics = {
           data,
           status: HTTPStatus.OK,
         };
-      }
-
-      if (isEmpty(data)) {
+      } else if (isEmpty(data)) {
         return {
           success: true,
           message: "there are no records for this search",
-          data,
-          status: HTTPStatus.NOT_FOUND,
+          data: [],
+          status: HTTPStatus.OK,
         };
       }
     } catch (err) {
-      let errors = { message: err.message };
-      let message = "Internal Server Error";
-      let status = HTTPStatus.INTERNAL_SERVER_ERROR;
       return {
-        errors,
-        message,
+        errors: { message: err.message },
+        message: "Internal Server Error",
         success: false,
-        status,
+        status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
   },
@@ -419,40 +414,35 @@ airqloudSchema.statics = {
         modifiedUpdateBody["$addToSet"] = {};
         modifiedUpdateBody["$addToSet"]["sites"] = {};
         modifiedUpdateBody["$addToSet"]["sites"]["$each"] = update.sites;
-
         delete modifiedUpdateBody["sites"];
       }
-      let updatedAirQloud = await this.findOneAndUpdate(
+      const updatedAirQloud = await this.findOneAndUpdate(
         filter,
         modifiedUpdateBody,
         options
       ).exec();
 
       if (!isEmpty(updatedAirQloud)) {
-        let data = updatedAirQloud._doc;
         return {
           success: true,
           message: "successfully modified the airqloud",
-          data,
+          data: updatedAirQloud._doc,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(updatedAirQloud)) {
         return {
           success: false,
           message: "airqloud does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: filter,
         };
       }
     } catch (err) {
-      let errors = { message: err.message };
-      let message = "Internal Server Error";
-      let status = HTTPStatus.INTERNAL_SERVER_ERROR;
       return {
-        errors,
-        message,
+        errors: { message: err.message },
+        message: "Internal Server Error",
         success: false,
-        status,
+        status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
   },
@@ -470,36 +460,32 @@ airqloudSchema.statics = {
           metadata: 1,
         },
       };
-      let removedAirqloud = await this.findOneAndRemove(filter, options).exec();
+      const removedAirqloud = await this.findOneAndRemove(
+        filter,
+        options
+      ).exec();
 
       if (!isEmpty(removedAirqloud)) {
-        let data = removedAirqloud._doc;
         return {
           success: true,
           message: "successfully removed the airqloud",
-          data,
+          data: removedAirqloud._doc,
           status: HTTPStatus.OK,
         };
-      }
-
-      if (isEmpty(removedAirqloud)) {
+      } else if (isEmpty(removedAirqloud)) {
         return {
           success: false,
           message: "airqloud does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: filter,
         };
       }
     } catch (err) {
-      let errors = { message: err.message };
-      let message = err.message;
-      let status = HTTPStatus.INTERNAL_SERVER_ERROR;
-
       return {
         success: false,
-        message,
-        errors,
-        status,
+        message: "Internal Server Error",
+        errors: { message: err.message },
+        status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
   },

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -143,20 +143,14 @@ const deviceSchema = new mongoose.Schema(
       type: Date,
       default: monthsInfront(3),
     },
-    /**
-     *this defaults were put in place to address some challenge I am yet to remember
-     */
     deployment_date: {
       type: Date,
-      default: Date.now,
     },
     maintenance_date: {
       type: Date,
-      default: Date.now,
     },
     recall_date: {
       type: Date,
-      default: Date.now,
     },
     device_number: {
       type: Number,
@@ -445,11 +439,10 @@ deviceSchema.statics = {
 
       // logger.info(`the data produced in the model -- ${response}`);
       if (!isEmpty(response)) {
-        let data = response;
         return {
           success: true,
           message: "successfully retrieved the device details",
-          data,
+          data: response,
           status: HTTPStatus.OK,
         };
       } else {

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -143,6 +143,9 @@ const deviceSchema = new mongoose.Schema(
       type: Date,
       default: monthsInfront(3),
     },
+    /**
+     *this defaults were put in place to address some challenge I am yet to remember
+     */
     deployment_date: {
       type: Date,
       default: Date.now,
@@ -349,7 +352,6 @@ deviceSchema.statics = {
       };
     }
   },
-
   async list({ _skip = 0, _limit = 1000, filter = {} } = {}) {
     try {
       // logger.info(

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -497,18 +497,18 @@ deviceSchema.statics = {
       if (!isEmpty(updatedDevice)) {
         let data = updatedDevice._doc;
         delete data.__v;
-
         return {
           success: true,
           message: "successfully modified the device",
           data,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(updatedDevice)) {
         return {
           success: false,
-          message: "device does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          message: "Internal Server Error",
+          status: HTTPStatus.BAD_REQUEST,
+          errors: { message: "device does not exist, please crosscheck" },
         };
       }
     } catch (error) {
@@ -559,18 +559,18 @@ deviceSchema.statics = {
       ).exec();
 
       if (!isEmpty(updatedDevice)) {
-        let data = updatedDevice._doc;
         return {
           success: true,
           message: "successfully modified the device",
-          data,
+          data: updatedDevice._doc,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(updatedDevice)) {
         return {
           success: false,
-          message: "device does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          message: "Internal Server Error",
+          status: HTTPStatus.BAD_REQUEST,
+          errors: { message: "device does not exist, please crosscheck" },
         };
       }
     } catch (error) {
@@ -597,18 +597,17 @@ deviceSchema.statics = {
       let removedDevice = await this.findOneAndRemove(filter, options).exec();
 
       if (!isEmpty(removedDevice)) {
-        let data = removedDevice._doc;
         return {
           success: true,
           message: "successfully deleted device from the platform",
-          data,
+          data: removedDevice._doc,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(removedDevice)) {
         return {
           success: false,
           message: "device does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: { message: "device does not exist, please crosscheck" },
         };
       }

--- a/src/device-registry/models/Location.js
+++ b/src/device-registry/models/Location.js
@@ -227,14 +227,12 @@ locationSchema.statics = {
           data,
           status: HTTPStatus.OK,
         };
-      }
-
-      if (isEmpty(data)) {
+      } else if (isEmpty(data)) {
         return {
           success: true,
           message: "there are no records for this search",
-          data,
-          status: HTTPStatus.NOT_FOUND,
+          data: [],
+          status: HTTPStatus.OK,
         };
       }
     } catch (err) {
@@ -274,18 +272,17 @@ locationSchema.statics = {
       ).exec();
 
       if (!isEmpty(updatedLocation)) {
-        let data = updatedLocation._doc;
         return {
           success: true,
           message: "successfully modified the location",
-          data,
+          data: updatedLocation._doc,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(updatedLocation)) {
         return {
           success: false,
           message: "location does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: filter,
         };
       }
@@ -319,31 +316,26 @@ locationSchema.statics = {
       let removedLocation = await this.findOneAndRemove(filter, options).exec();
 
       if (!isEmpty(removedLocation)) {
-        let data = removedLocation._doc;
         return {
           success: true,
           message: "successfully removed the location",
-          data,
+          data: removedLocation._doc,
           status: HTTPStatus.OK,
         };
       } else if (isEmpty(removedLocation)) {
         return {
           success: false,
           message: "location does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: filter,
         };
       }
     } catch (err) {
-      let errors = { message: err.message };
-      let message = err.message;
-      let status = HTTPStatus.INTERNAL_SERVER_ERROR;
-
       return {
         success: false,
-        message,
-        errors,
-        status,
+        message: "Internal Server Error",
+        errors: { message: err.message },
+        status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }
   },

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -30,6 +30,7 @@ const siteSchema = new Schema(
     network: {
       type: String,
       trim: true,
+      required: [true, "network is required!"],
     },
     location_name: {
       type: String,
@@ -59,7 +60,7 @@ const siteSchema = new Schema(
       type: String,
       trim: true,
       unique: true,
-      required: [true, "lat_long is required is required!"],
+      required: [true, "lat_long is required!"],
     },
     description: {
       type: String,
@@ -398,6 +399,10 @@ siteSchema.statics = {
     try {
       let modifiedArgs = args;
       modifiedArgs.description = modifiedArgs.name;
+
+      if (isEmpty(modifiedArgs.network)) {
+        modifiedArgs.network = constants.DEFAULT_NETWORK;
+      }
 
       logObject("modifiedArgs", modifiedArgs);
       let createdSite = await this.create({

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -11,6 +11,7 @@ const siteSchema = new Schema(
     name: {
       type: String,
       trim: true,
+      unique: true,
       required: [true, "name is required!"],
     },
     share_links: {
@@ -26,6 +27,7 @@ const siteSchema = new Schema(
     search_name: {
       type: String,
       trim: true,
+      unique: true,
     },
     network: {
       type: String,
@@ -35,6 +37,7 @@ const siteSchema = new Schema(
     location_name: {
       type: String,
       trim: true,
+      unique: true,
     },
     generated_name: {
       type: String,
@@ -65,6 +68,7 @@ const siteSchema = new Schema(
     description: {
       type: String,
       trim: true,
+      unique: true,
     },
     site_codes: [
       {

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -652,19 +652,17 @@ siteSchema.statics = {
       ).exec();
 
       if (!isEmpty(updatedSite)) {
-        let data = updatedSite._doc;
-
         return {
           success: true,
           message: "successfully modified the site",
-          data,
+          data: updatedSite._doc,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(updatedSite)) {
         return {
           success: false,
           message: "site does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: { message: "site does not exist" },
         };
       }
@@ -689,27 +687,27 @@ siteSchema.statics = {
           district: 1,
         },
       };
-      let removedSite = await this.findOneAndRemove(filter, options).exec();
-      let data = removedSite._doc;
-      if (!isEmpty(data)) {
+      const removedSite = await this.findOneAndRemove(filter, options).exec();
+      if (!isEmpty(removedSite)) {
         return {
           success: true,
           message: "successfully removed the site",
-          data,
+          data: removedSite._doc,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(removedSite)) {
         return {
           success: false,
-          message: "site does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          message: "Internal Server Error",
+          status: HTTPStatus.BAD_REQUEST,
+          errors: { message: "site does not exist, please crosscheck" },
         };
       }
     } catch (error) {
       return {
         success: false,
-        message: "Site model server error - remove",
-        error: error.message,
+        message: "Internal Server Error",
+        errors: { message: error.message },
         status: HTTPStatus.INTERNAL_SERVER_ERROR,
       };
     }

--- a/src/device-registry/models/SiteActivity.js
+++ b/src/device-registry/models/SiteActivity.js
@@ -130,13 +130,10 @@ activitySchema.statics = {
         };
       } else if (isEmpty(response)) {
         return {
-          success: false,
+          success: true,
           message: "no activities exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
-          errors: {
-            ...filter,
-            message: "no activities exist, please crosscheck",
-          },
+          status: HTTPStatus.OK,
+          data: [],
         };
       }
     } catch (error) {
@@ -163,24 +160,23 @@ activitySchema.statics = {
           modifiedUpdateBody.tags;
         delete modifiedUpdateBody["tags"];
       }
-      let updatedActivity = await this.findOneAndUpdate(
+      const updatedActivity = await this.findOneAndUpdate(
         filter,
         modifiedUpdateBody,
         options
       );
       if (!isEmpty(updatedActivity)) {
-        let data = updatedActivity._doc;
         return {
           success: true,
           message: "successfully modified the activity",
-          data,
+          data: updatedActivity._doc,
           status: HTTPStatus.OK,
         };
       } else if (isEmpty(updatedActivity)) {
         return {
           success: false,
           message: "activity does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: filter,
         };
       }
@@ -210,18 +206,17 @@ activitySchema.statics = {
       let removedActivity = await this.findOneAndRemove(filter, options).exec();
 
       if (!isEmpty(removedActivity)) {
-        let data = removedActivity._doc;
         return {
           success: true,
           message: "successfully removed the activity",
-          data,
+          data: removedActivity._doc,
           status: HTTPStatus.OK,
         };
       } else if (isEmpty(removedActivity)) {
         return {
           success: false,
           message: "activity does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: filter,
         };
       }

--- a/src/device-registry/models/UniqueIdentifierCounter.js
+++ b/src/device-registry/models/UniqueIdentifierCounter.js
@@ -60,21 +60,25 @@ uniqueIdentifierCounterSchema.statics = {
       logObject("the filter", filter);
       logObject("the update", update);
       let options = { writeConcern: "majority" };
-      let updatedSite = await this.findOneAndUpdate(filter, update, options);
-      logObject("the data", updatedSite);
-      if (!isEmpty(updatedSite)) {
-        const data = updatedSite._doc;
+      const updatedCounter = await this.findOneAndUpdate(
+        filter,
+        update,
+        options
+      );
+      logObject("the data", updatedCounter);
+      if (!isEmpty(updatedCounter)) {
+        const data = updatedCounter._doc;
         return {
           success: true,
           message: "successfully modified the counter document",
           data,
           status: HTTPStatus.OK,
         };
-      } else {
+      } else if (isEmpty(updatedCounter)) {
         return {
           success: false,
           message: "counter does not exist, please crosscheck",
-          status: HTTPStatus.NOT_FOUND,
+          status: HTTPStatus.BAD_REQUEST,
           errors: {
             message: "can't locate the relevant counter document -- site_0",
           },

--- a/src/device-registry/routes/v1/airqlouds.js
+++ b/src/device-registry/routes/v1/airqlouds.js
@@ -693,7 +693,7 @@ router.post(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa", "unep"])
+      .isIn(["kcca", "airqo", "urban_better", "usembassy", "nasa", "unep"])
       .withMessage("the network value is not among the expected ones"),
   ]),
   airqloudController.bulkCreate

--- a/src/device-registry/routes/v1/devices.js
+++ b/src/device-registry/routes/v1/devices.js
@@ -37,7 +37,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa", "unep"])
+      .isIn(["kcca", "airqo", "urban_better", "usembassy", "nasa", "unep"])
       .withMessage("the network value is not among the expected ones"),
   ]),
   deviceController.bulkUpdate
@@ -51,7 +51,7 @@ router.post(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa", "unep"])
+      .isIn(["kcca", "airqo", "urban_better", "usembassy", "nasa", "unep"])
       .withMessage("the network value is not among the expected ones"),
   ]),
   deviceController.bulkCreate

--- a/src/device-registry/routes/v1/events.js
+++ b/src/device-registry/routes/v1/events.js
@@ -112,6 +112,12 @@ router.post(
         .withMessage("the device_number should be an integer value")
         .bail()
         .trim(),
+      body("*.network")
+        .optional()
+        .notEmpty()
+        .toLowerCase()
+        .isIn(["kcca", "airqo", "urban_better", "usembassy", "nasa", "unep"])
+        .withMessage("the network value is not among the expected ones"),
     ],
   ]),
   eventController.addValues

--- a/src/device-registry/routes/v1/sites.js
+++ b/src/device-registry/routes/v1/sites.js
@@ -39,7 +39,7 @@ router.put(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa", "unep"])
+      .isIn(["kcca", "airqo", "urban_better", "usembassy", "nasa", "unep"])
       .withMessage("the network value is not among the expected ones"),
   ]),
   siteController.bulkUpdate
@@ -56,7 +56,7 @@ router.post(
       .bail()
       .trim()
       .toLowerCase()
-      .isIn(["kcca", "airqo", "urban_better", "us_embassy", "nasa", "unep"])
+      .isIn(["kcca", "airqo", "urban_better", "usembassy", "nasa", "unep"])
       .withMessage("the network value is not among the expected ones"),
   ]),
   siteController.bulkCreate

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -278,7 +278,7 @@ const createSite = {
         $inc: { COUNT: 1 },
       };
 
-      let responseFromModifyUniqueIdentifierCounter = await getModelByTenant(
+      const responseFromModifyUniqueIdentifierCounter = await getModelByTenant(
         tenant.toLowerCase(),
         "uniqueIdentifierCounter",
         UniqueIdentifierCounterSchema
@@ -300,7 +300,7 @@ const createSite = {
             : { message: "" },
           status: responseFromModifyUniqueIdentifierCounter.status
             ? responseFromModifyUniqueIdentifierCounter.status
-            : "",
+            : HTTPStatus.BAD_REQUEST,
         };
       } else if (responseFromModifyUniqueIdentifierCounter.success === true) {
         const count = responseFromModifyUniqueIdentifierCounter.data.COUNT;
@@ -311,7 +311,7 @@ const createSite = {
           data: siteName,
           status: responseFromModifyUniqueIdentifierCounter.status
             ? responseFromModifyUniqueIdentifierCounter.status
-            : "",
+            : HTTPStatus.OK,
         };
       }
     } catch (e) {


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] remove default dates on some Date fields
- [x] ensure that if a name already exists, just inform user to choose another one.
- [x] check out more feedback notes from the PHYSICAL workshop for March 2023.
- [x] Fix any issues relating to http status codes. More details in added screenshot. This was on `staging`. Ensure that we always return the right codes.
- [x] default to "airqo" if a user does not provide the network name. Or just make the field a required one?
- [x] Also a concern about the naming of Sites. Something that makes it hard for data analysis.
- [x] Metadata Grooming: network field is not showing on some devices, this is in email and attached screenshot

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [AN-324]

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run dev-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [create site](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-430b7044-9b88-44dd-80db-0e7856c6d471)
- [x] [update site](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-f979140c-0048-4834-9e24-ba237bf2ed38)
- [x] [SOFT create device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-2341976e-cf2c-4b32-ba81-110693e47d44)
- [x] [SOFT update device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-45e2d8f1-b0a7-476c-950c-e7e9576bbda7)



**_ANY SCREENSHOTS?_**

![image](https://user-images.githubusercontent.com/1590213/226424699-15dbd38c-c74c-4904-9eb7-b1eb54b8869c.png)
![Screenshot 2023-03-21 at 10 54 53](https://user-images.githubusercontent.com/1590213/226546613-5151b586-31ad-4d98-ae3c-b9e83924a933.png)







[AN-324]: https://airqoteam.atlassian.net/browse/AN-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ