### PR TITLE
reorder auth statements to fix '/' access bug

### DIFF
--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -28,11 +28,12 @@ data:
       if ($request_uri ~ '(/api/v1/users/emailLogin)|(/api/v2/users/emailLogin)') { return 200; }
       if ($request_uri ~ '(/api/v1/users/forgotPassword)|(/api/v2/users/forgotPassword)') { return 200; }
       if ($request_uri ~ '(/api/v1/users/candidates/register)|(/api/v2/users/candidates/register)') { return 200; }
-      if ($request_uri ~ '(/api/v1/users/verify)|(/api/v1/users/verify)') { return 200; }
+      if ($request_uri ~ '(/api/v1/users/verify)|(/api/v2/users/verify)') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }    
       if ($request_uri ~ '/argocd') { return 200; }    
-      if ($request_uri ~ '/api/v1') { return 200; } # API v1 endpoint requests
       if ($request_uri !~ '/api/v') { return 200; } # None API requests 
+      
+      if ($request_uri ~ '/api/v1') { return 200; } # API v1 endpoint requests
 
       set $method POST;
       set $verification_path verify?tenant=airqo;

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -29,11 +29,12 @@ data:
       if ($request_uri ~ '(/api/v1/users/emailLogin)|(/api/v2/users/emailLogin)') { return 200; }
       if ($request_uri ~ '(/api/v1/users/forgotPassword)|(/api/v2/users/forgotPassword)') { return 200; }
       if ($request_uri ~ '(/api/v1/users/candidates/register)|(/api/v2/users/candidates/register)') { return 200; }
-      if ($request_uri ~ '(/api/v1/users/verify)|(/api/v1/users/verify)') { return 200; }
+      if ($request_uri ~ '(/api/v1/users/verify)|(/api/v2/users/verify)') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }    
       if ($request_uri ~ '/grafana/api') { return 200; }    
-      if ($request_uri ~ '/api/v1') { return 200; } # API v1 endpoint requests
       if ($request_uri !~ '/api/v') { return 200; } # None API requests 
+
+      if ($request_uri ~ '/api/v1') { return 200; } # API v1 endpoint requests
 
       set $method POST;
       set $verification_path verify?tenant=airqo;


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
- Fixes the bug in which users were not able to access the platform home page without authentication
- White lists `/users/verify` on API v2 as well

**_ARE THERE ANY RELATED PRs?_**
- #1418 