### PR TITLE
More Hotfixes for auth-service

### DIFF
--- a/src/auth-service/routes/v1/roles.js
+++ b/src/auth-service/routes/v1/roles.js
@@ -138,9 +138,8 @@ router.post(
           return ObjectId(value);
         }),
       body("network_id")
-        .optional()
-        .notEmpty()
-        .withMessage("network_id must not be empty if provided")
+        .exists()
+        .withMessage("network_id must be provided")
         .bail()
         .trim()
         .isMongoId()
@@ -200,14 +199,14 @@ router.put(
         )
         .trim(),
       body("role_name")
-        .optional()
-        .notEmpty()
-        .withMessage("the role_name should not be empty if provided")
+        .not()
+        .isEmpty()
+        .withMessage("the role_name should not be provided when updating")
         .trim(),
       body("role_code")
-        .optional()
-        .notEmpty()
-        .withMessage("the role_code should not be empty if provided")
+        .not()
+        .isEmpty()
+        .withMessage("the role_code should not be provided when updating")
         .trim(),
       body("role_permission")
         .optional()

--- a/src/auth-service/routes/v2/roles.js
+++ b/src/auth-service/routes/v2/roles.js
@@ -125,9 +125,8 @@ router.post(
           return ObjectId(value);
         }),
       body("network_id")
-        .optional()
-        .notEmpty()
-        .withMessage("network_id must not be empty if provided")
+        .exists()
+        .withMessage("network_id must be provided")
         .bail()
         .trim()
         .isMongoId()
@@ -187,14 +186,14 @@ router.put(
         )
         .trim(),
       body("role_name")
-        .optional()
-        .notEmpty()
-        .withMessage("the role_name should not be empty")
+        .not()
+        .isEmpty()
+        .withMessage("the role_name should not be provided when updating")
         .trim(),
       body("role_code")
-        .optional()
-        .notEmpty()
-        .withMessage("the role_code should not be empty if provided")
+        .not()
+        .isEmpty()
+        .withMessage("the role_code should not be provided when updating")
         .trim(),
       body("network_id")
         .optional()

--- a/src/auth-service/utils/control-access.js
+++ b/src/auth-service/utils/control-access.js
@@ -5,6 +5,7 @@ const AccessTokenSchema = require("@models/AccessToken");
 const UserSchema = require("@models/User");
 const RoleSchema = require("@models/Role");
 const DepartmentSchema = require("@models/Department");
+const NetworkSchema = require("@models/Network");
 const GroupSchema = require("@models/Group");
 const httpStatus = require("http-status");
 const mongoose = require("mongoose").set("debug", true);
@@ -21,6 +22,16 @@ const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- control-access-util`
 );
+
+const NetworkModel = (tenant) => {
+  try {
+    const networks = mongoose.model("networks");
+    return networks;
+  } catch (error) {
+    const networks = getModelByTenant(tenant, "network", NetworkSchema);
+    return networks;
+  }
+};
 
 const UserModel = (tenant) => {
   try {
@@ -779,11 +790,13 @@ const controlAccess = {
     try {
       const { query, body } = request;
       const { tenant } = query;
-      const update = body;
       const filter = generateFilter.roles(request);
       if (filter.success === false) {
         return filter;
       }
+
+      const update = Object.assign({}, body);
+
       const responseFromUpdateRole = await RoleModel(
         tenant.toLowerCase()
       ).modify({ filter, update });
@@ -802,10 +815,28 @@ const controlAccess = {
     try {
       const { query, body } = request;
       const { tenant } = query;
+
+      let newBody = Object.assign({}, body);
+      const network = await NetworkModel(tenant).findById(body.network_id);
+      if (isEmpty(network)) {
+        return {
+          success: false,
+          status: httpStatus.BAD_REQUEST,
+          message: "Bad Request Error",
+          errors: {
+            message:
+              "Provided network or organisation cannot be found, please crosscheck",
+          },
+        };
+      }
+      const organizationName = network.net_name.toUpperCase();
+      newBody.role_name = `${organizationName}_${body.role_name}`;
+      newBody.role_code = `${organizationName}_${body.role_code}`;
+
       const responseFromCreateRole = await RoleModel(
         tenant.toLowerCase()
-      ).register(body);
-      logObject("been able to create the damn role", responseFromCreateRole);
+      ).register(newBody);
+
       return responseFromCreateRole;
     } catch (error) {
       logger.error(`internal server error -- ${error.message}`);

--- a/src/auth-service/utils/mailer.js
+++ b/src/auth-service/utils/mailer.js
@@ -516,7 +516,7 @@ const mailer = {
         return {
           success: true,
           message: "email successfully sent",
-          data,
+          data: [],
           status: httpStatus.OK,
         };
       }

--- a/src/auth-service/utils/mailer.js
+++ b/src/auth-service/utils/mailer.js
@@ -512,9 +512,18 @@ const mailer = {
         bcc,
       };
 
-      let response = await transporter.sendMail(mailOptions);
+      if (email === "automated-tests@airqo.net") {
+        return {
+          success: true,
+          message: "email successfully sent",
+          data,
+          status: httpStatus.OK,
+        };
+      }
 
-      let data = response;
+      const response = await transporter.sendMail(mailOptions);
+
+      const data = response;
       if (isEmpty(data.rejected) && !isEmpty(data.accepted)) {
         return {
           success: true,


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] Do not send emails for automated tests
- [x] Ensure that each Role must have a Network ID since one user can have different roles in different Networks
- [x] Disable the update of `role_name` and` role_code`
- [x] Using the NETWORK information, add a prefix to role names for new roles being created. Just to keep names of different organisations different. Example: `KCCA_BBAALE_USER_WITH_VISIBILITY`
- [ ] Modify the logic for role assignment to consider the new naming convention

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - []()

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/auth-service
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [Send feedback](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-9dc3552b-430d-42c5-a11a-ea908dd4881e)
- [x] [Create role](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-0168bd9b-095d-449b-9a10-0ed94debcab4)
- [x] [Get role information](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-4712237c-4a4b-4244-9412-b52fa15c2058)
- [x] [Update Role](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-71aceff7-e2e0-4315-b918-e864b8491e39)


**_SCREENSHOTS?:_** 
![Screenshot 2023-04-29 at 13 23 34](https://user-images.githubusercontent.com/1590213/235297854-1239f169-b576-4167-a7dc-9bcc04f20f18.png)
