### PR TITLE
upgrade mongos backup disk size

### DIFF
--- a/infra/terraform/gcp/modules/ComputeDisk/mongos-router-0.tf
+++ b/infra/terraform/gcp/modules/ComputeDisk/mongos-router-0.tf
@@ -3,7 +3,7 @@ resource "google_compute_disk" "mongos_router_0" {
   name                      = "mongos-router-0"
   physical_block_size_bytes = 4096
   project                   = var.project_id
-  size                      = var.disk_size["small"]
+  size                      = var.disk_size["large"]
   type                      = "pd-balanced"
   zone                      = var.zone["b"]
   description               = "Disk for the mongos-router-0 instance"

--- a/infra/terraform/gcp/modules/ComputeDisk/mongos-router-0.tf
+++ b/infra/terraform/gcp/modules/ComputeDisk/mongos-router-0.tf
@@ -3,7 +3,7 @@ resource "google_compute_disk" "mongos_router_0" {
   name                      = "mongos-router-0"
   physical_block_size_bytes = 4096
   project                   = var.project_id
-  size                      = var.disk_size["large"]
+  size                      = var.disk_size["medium"]
   type                      = "pd-balanced"
   zone                      = var.zone["b"]
   description               = "Disk for the mongos-router-0 instance"

--- a/infra/terraform/gcp/modules/ComputeInstance/mongos-router-0.tf
+++ b/infra/terraform/gcp/modules/ComputeInstance/mongos-router-0.tf
@@ -39,7 +39,7 @@ resource "google_compute_instance" "mongos_router_0" {
 
   service_account {
     email  = "${var.project_number}-compute@developer.gserviceaccount.com"
-    scopes = ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/trace.append"]
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
 
   tags = ["http-server", "https-server"]


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
- [Set mongos-router-0 disk to medium size](https://github.com/airqo-platform/AirQo-api/pull/1608/commits/38ea8759dee32a20c21541d76773262041b16d67)(50GB)

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - []()
- GitHub issues
    - Closes #<enter GitHub issue number here>

**_HOW DO I TEST OUT THIS PR?_**

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

**_IS THERE ANY JENKINS CONSOLE LINK FOR CODE COVERAGE AND BUILD INFO?_**

**_ARE THERE ANY RELATED PRs?_**


