### PR TITLE
Disable Device updates in staging and enhance KAFKA logging

### DIFF
--- a/src/device-registry/bin/www
+++ b/src/device-registry/bin/www
@@ -30,7 +30,7 @@ const eventSchema = Joi.object({
     "longitude": Joi.number().precision(5).optional(),
     "satellites": Joi.number().optional(),
     "hdop": Joi.number().optional(),
-    "altitude": Joi.number().optional(),
+    "altitude": Joi.number().integer().min(-Infinity).max(Infinity).optional(),
     "s1_pm2_5": Joi.number().optional(),
     "battery": Joi.number().optional(),
     "device_humidity": Joi.number().optional(),

--- a/src/device-registry/bin/www
+++ b/src/device-registry/bin/www
@@ -153,11 +153,11 @@ const run = async() => {
                             // )}`
                             //         );
                         } else if (responseFromInsertMeasurements.success === true) {
-                            logger.info(
-                                `KAFKA: successfully inserted the measurements --- ${JSON.stringify(responseFromInsertMeasurements.message ?
-                                responseFromInsertMeasurements.message :
-                                "")}`
-                            );
+                            // logger.info(
+                            //     `KAFKA: successfully inserted the measurements --- ${JSON.stringify(responseFromInsertMeasurements.message ?
+                            //     responseFromInsertMeasurements.message :
+                            //     "")}`
+                            // );
                         }
                     }
 

--- a/src/device-registry/bin/www
+++ b/src/device-registry/bin/www
@@ -30,7 +30,7 @@ const eventSchema = Joi.object({
     "longitude": Joi.number().precision(5).optional(),
     "satellites": Joi.number().optional(),
     "hdop": Joi.number().optional(),
-    "altitude": Joi.number().integer().min(-Infinity).max(Infinity).optional(),
+    "altitude": Joi.number().optional(),
     "s1_pm2_5": Joi.number().optional(),
     "battery": Joi.number().optional(),
     "device_humidity": Joi.number().optional(),
@@ -134,6 +134,12 @@ const run = async() => {
                         logger.error(
                             `KAFKA: ALL the input validation errors --- ${JSON.stringify(error.details)}`
                         );
+
+                        logger.info(
+                            `KAFKA: the VALUE for ALL the shared input validation errors --- ${JSON.stringify(value)}`
+                        );
+
+
                     } else {
                         logObject("value", value)
                         logObject("cleanedMeasurements", cleanedMeasurements)

--- a/src/device-registry/utils/create-device.js
+++ b/src/device-registry/utils/create-device.js
@@ -294,6 +294,17 @@ const createDevice = {
   update: async (request) => {
     try {
       // logger.info(`in the update util....`);
+      if (process.env.NODE_ENV !== "production") {
+        return {
+          success: false,
+          message: "Bad Request",
+          errors: {
+            message:
+              "please utilise SOFT update when operating in testing environments",
+          },
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
       let { device_number } = request.query;
       let modifiedRequest = Object.assign({}, request);
       if (isEmpty(device_number)) {


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] Disable Device updates in staging and enhance KAFKA logging whenever there are errors just to smoothen troubleshooting
- [x] Remove an informational Slack log message, just to minimise SPAMMING
- [x] Disable Device details updates in STAGING, just to prevent accidental Thingspeak updates by interns or external contributors

**_WHAT ISSUES ARE RELATED TO THIS PR?_**
<img width="1209" alt="Screenshot 2023-06-07 at 16 45 36" src="https://github.com/airqo-platform/AirQo-api/assets/1590213/4a21b05e-7259-4b04-9bb3-3c18b11b8012">


**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run stage-mac
```
**_READY ENDPOINTS?_**

- [ ] [Update device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-d4cbf3f6-6964-4af6-a5eb-0b167a0e6d37)

