### PR TITLE
explicitly add the NODE_ENV to the Dockerfile when running in production

### DIFF
--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "main": "./bin/www",
     "scripts": {
-        "start": "node --max-old-space-size=1024 ./bin/www",
+        "start": "NODE_ENV=production node --max-old-space-size=1024 ./bin/www",
         "stage": "NODE_ENV=staging node --max-old-space-size=1024 ./bin/www",
         "dev-mac": "NODE_ENV=development nodemon --max-old-space-size=1024 ./bin/www",
         "prod-mac": "NODE_ENV=production nodemon --max-old-space-size=1024 ./bin/www",


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [ ] explicitly add the NODE_ENV to the Dockerfile when running in production

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - []()

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run dev-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [ ] [create device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-3be73eff-b260-4c5c-933d-5f193ee89cf5)



