### PR TITLE
explicitly add the NODE_ENV to the Dockerfile when running in production

### DIFF
--- a/src/auth-service/package.json
+++ b/src/auth-service/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "main": "./bin/www",
     "scripts": {
-        "start": "./bin/www",
+        "start": "NODE_ENV=production node ./bin/www",
         "stage": "NODE_ENV=staging node ./bin/www",
         "dev-mac": "NODE_ENV=development nodemon --trace-warnings ./bin/www",
         "stage-mac": "NODE_ENV=staging nodemon ./bin/www",


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] explicitly add the NODE_ENV to the Dockerfile when running in production

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/auth-service
npm install
npm dev-mac

```



