### PR TITLE
only return measurements for deployed devices

### DIFF
--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -373,12 +373,15 @@ const createEvent = {
         logObject("the result for listing events", result);
         if (result.success === true) {
           const status = result.status ? result.status : HTTPStatus.OK;
+          const measurementsForDeployedDevices = result.data[0].data.filter(
+            (obj) => obj.siteDetails !== null
+          );
           res.status(status).json({
             success: true,
             isCache: result.isCache,
             message: result.message,
             meta: result.data[0].meta,
-            measurements: result.data[0].data,
+            measurements: measurementsForDeployedDevices,
           });
         } else if (result.success === false) {
           const status = result.status

--- a/src/device-registry/routes/v1/devices.js
+++ b/src/device-registry/routes/v1/devices.js
@@ -826,9 +826,6 @@ router.put(
         .optional()
         .notEmpty()
         .withMessage("long_name should not be empty IF provided")
-        .bail()
-        .matches(/^[a-zA-Z0-9_-]+$/)
-        .withMessage("long_name should only contain alphanumeric characters.")
         .trim(),
       body("mountType")
         .optional()
@@ -1365,9 +1362,6 @@ router.put(
         .optional()
         .notEmpty()
         .withMessage("long_name should not be empty IF provided")
-        .bail()
-        .matches(/^[a-zA-Z0-9]+$/)
-        .withMessage("long_name should only contain alphanumeric characters.")
         .trim(),
       body("mountType")
         .optional()


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] only return for deployed devices
- [x] enable editing of the device's `long_name`.

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run stage-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [v1 Lastest Events (external)](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-715d78b0-139e-4ee8-91ce-06f62222ad06)
- [x] [SOFT Update Device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-45e2d8f1-b0a7-476c-950c-e7e9576bbda7)
- [x] [update device](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-d4cbf3f6-6964-4af6-a5eb-0b167a0e6d37)




