### PR TITLE
3 hotfixes for creating devices

### DIFF
--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -368,7 +368,7 @@ airqloudSchema.statics = {
           "sites.createdAt": 0,
           "sites.lat_long": 0,
           "sites.weather_stations": 0,
-          "sites.airqloud_codes": 0,
+          "sites.site_codes": 0,
           "sites.network": 0,
         })
         .skip(skip ? skip : 0)

--- a/src/device-registry/models/Airqloud.js
+++ b/src/device-registry/models/Airqloud.js
@@ -181,6 +181,7 @@ airqloudSchema.pre("update", function(next) {
   if (this.isModified("_id")) {
     delete this._id;
   }
+  this.airqloud_codes = [this._id, this.name];
   return next();
 });
 
@@ -367,7 +368,7 @@ airqloudSchema.statics = {
           "sites.createdAt": 0,
           "sites.lat_long": 0,
           "sites.weather_stations": 0,
-          "sites.site_codes": 0,
+          "sites.airqloud_codes": 0,
           "sites.network": 0,
         })
         .skip(skip ? skip : 0)

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -185,16 +185,7 @@ deviceSchema.plugin(uniqueValidator, {
   message: `{VALUE} must be unique!`,
 });
 
-deviceSchema.post("save", async function(doc) {
-  doc.device_codes = [doc._id, doc.name];
-  if (doc.device_number) {
-    doc.device_codes.push(doc.device_number);
-  }
-  if (doc.alias) {
-    doc.device_codes.push(doc.alias);
-  }
-  logObject("device_codes populated successfully:", doc);
-});
+deviceSchema.post("save", async function(doc) {});
 
 deviceSchema.pre("save", function(next) {
   if (this.isModified("name")) {
@@ -204,6 +195,15 @@ deviceSchema.pre("save", function(next) {
     }
     let n = this.name;
   }
+
+  this.device_codes = [this._id, this.name];
+  if (this.device_number) {
+    this.device_codes.push(this.device_number);
+  }
+  if (this.alias) {
+    this.device_codes.push(this.alias);
+  }
+
   return next();
 });
 

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -58,7 +58,6 @@ const deviceSchema = new mongoose.Schema(
       unique: true,
       minlength: minLength,
       match: noSpaces,
-      lowercase: true,
     },
     name: {
       type: String,

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -298,19 +298,7 @@ const siteSchema = new Schema(
   }
 );
 
-siteSchema.post("save", async function(doc) {
-  doc.site_codes = [doc._id, doc.name, doc.generated_name, doc.lat_long];
-  if (doc.search_name) {
-    doc.site_codes.push(doc.search_name);
-  }
-  if (doc.location_name) {
-    doc.site_codes.push(doc.location_name);
-  }
-  if (doc.formatted_name) {
-    doc.site_codes.push(doc.formatted_name);
-  }
-  logObject("site_codes populated successfully:", doc);
-});
+siteSchema.post("save", async function(doc) {});
 
 siteSchema.pre("save", function(next) {
   if (this.isModified("latitude")) {
@@ -325,6 +313,18 @@ siteSchema.pre("save", function(next) {
   if (this.isModified("generated_name")) {
     delete this.generated_name;
   }
+
+  this.site_codes = [this._id, this.name, this.generated_name, this.lat_long];
+  if (this.search_name) {
+    this.site_codes.push(this.search_name);
+  }
+  if (this.location_name) {
+    this.site_codes.push(this.location_name);
+  }
+  if (this.formatted_name) {
+    this.site_codes.push(this.formatted_name);
+  }
+
   return next();
 });
 


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] do not manipulate the `alias` during device creation
- [x] ensure that `device_codes`, `site_codes` and `airqloud_codes` are actually updated after new ENTITY creation
- [ ] Update metadata to reflect the hotfixes

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run dev-mac

```
**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [SOFT create device](url)
- [x] [Create Site](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-430b7044-9b88-44dd-80db-0e7856c6d471)
- [x] [Create AirQloud](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-2a794f4e-04bc-4e8f-925d-e7fd9efb8cd2)


