### PR TITLE
enhancements to User Update Emails

### DIFF
--- a/src/auth-service/utils/create-user.js
+++ b/src/auth-service/utils/create-user.js
@@ -879,7 +879,23 @@ const join = {
           filter,
           update,
         });
-        return responseFromModifyUser;
+
+        if (responseFromModifyUser.success === true) {
+          const { email, firstName, lastName } = userDetails;
+          const responseFromSendEmail = await mailer.updateForgottenPassword(
+            email,
+            firstName,
+            lastName
+          );
+
+          if (responseFromSendEmail.success === true) {
+            return responseFromModifyUser;
+          } else if (responseFromSendEmail.success === false) {
+            return responseFromSendEmail;
+          }
+        } else if (responseFromModifyUser.success === false) {
+          return responseFromModifyUser;
+        }
       } else if (responseFromCheckTokenValidity.success === false) {
         return responseFromCheckTokenValidity;
       }
@@ -968,7 +984,23 @@ const join = {
         filter,
         update,
       });
-      return responseFromUpdateUser;
+
+      if (responseFromUpdateUser.success === true) {
+        const { email, firstName, lastName } = user[0];
+        const responseFromSendEmail = await mailer.updateKnownPassword(
+          email,
+          firstName,
+          lastName
+        );
+
+        if (responseFromSendEmail.success === true) {
+          return responseFromUpdateUser;
+        } else if (responseFromSendEmail.success === false) {
+          return responseFromSendEmail;
+        }
+      } else if (responseFromUpdateUser.success === false) {
+        return responseFromUpdateUser;
+      }
     } catch (e) {
       logObject("the error when updating known password", e);
       logger.error(`Internal Server Error ${e.message}`);

--- a/src/auth-service/utils/email.msgs.js
+++ b/src/auth-service/utils/email.msgs.js
@@ -127,15 +127,33 @@ module.exports = {
   },
   user_updated: (firstName, lastName, updatedData) => {
     const updatedFields = Object.keys(updatedData)
-      .map((field) => `• ${field}: ${updatedData[field]}`)
+      .map((field) => `• ${field}`)
       .join("\n");
 
     return (
       `Dear ${firstName} ${lastName},\n\n` +
-      "Your AirQo Analytics account details have been updated:\n\n" +
+      "Your AirQo Analytics account details have been updated.\n\n" +
+      "The following fields have been updated:\n" +
       `${updatedFields}\n\n` +
-      "If this activity sounds suspicious to you, please reach out to your organisation's administrator.\n\n" +
+      "If this activity sounds suspicious to you, please reach out to your organization's administrator.\n\n" +
       `Follow this link to access the platform right now: ${constants.LOGIN_PAGE}\n`
+    );
+  },
+
+  forgotten_password_updated: (firstName, lastName) => {
+    return (
+      `Dear ${firstName} ${lastName},\n\n` +
+      "Your AirQo Analytics account password has been successfully reset.\n\n" +
+      "If you did not initiate this password reset, please reach out to your organization's administrator immediately.\n\n" +
+      `Follow this link to access the platform: ${constants.LOGIN_PAGE}\n`
+    );
+  },
+  known_password_updated: (firstName, lastName) => {
+    return (
+      `Dear ${firstName} ${lastName},\n\n` +
+      "Your AirQo Analytics account password has been successfully updated.\n\n" +
+      "If you did not initiate this password change, please reach out to your organization's administrator immediately.\n\n" +
+      `Follow this link to access the platform: ${constants.LOGIN_PAGE}\n`
     );
   },
   join_by_email: (email, token) => {

--- a/src/auth-service/utils/mailer.js
+++ b/src/auth-service/utils/mailer.js
@@ -518,7 +518,84 @@ const mailer = {
       };
     }
   },
+  updateForgottenPassword: async (email, firstName, lastName) => {
+    try {
+      const mailOptions = {
+        from: {
+          name: constants.EMAIL_NAME,
+          address: constants.EMAIL,
+        },
+        to: `${email}`,
+        subject: "AirQo Analytics Password Reset Successful",
+        text: `${msgs.forgotten_password_updated(firstName, lastName)}`,
+      };
+      let response = transporter.sendMail(mailOptions);
+      let data = await response;
 
+      if (isEmpty(data.rejected) && !isEmpty(data.accepted)) {
+        return {
+          success: true,
+          message: "email successfully sent",
+          data,
+          status: httpStatus.OK,
+        };
+      } else {
+        return {
+          success: false,
+          message: "Internal Server Error",
+          errors: { message: data },
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: "Internal Server Error",
+        error: error.message,
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+  updateKnownPassword: async (email, firstName, lastName) => {
+    try {
+      const mailOptions = {
+        from: {
+          name: constants.EMAIL_NAME,
+          address: constants.EMAIL,
+        },
+        to: `${email}`,
+        subject: "AirQo Analytics Password Update Successful",
+        text: `${msgs.known_password_updated(firstName, lastName)}`,
+      };
+      let response = transporter.sendMail(mailOptions);
+      let data = await response;
+
+      if (isEmpty(data.rejected) && !isEmpty(data.accepted)) {
+        return {
+          success: true,
+          message: "email successfully sent",
+          data,
+          status: httpStatus.OK,
+        };
+      } else {
+        return {
+          success: false,
+          message: "Internal Server Error",
+          errors: { message: data },
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: "Internal Server Error",
+        error: error.message,
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
   newMobileAppUser: async ({ email, message, subject } = {}) => {
     try {
       logObject("the values to send to email function", {


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] only send the updated field but not the value when sending update emails. 
- [x] Also, send update emails for password reset and etc

**_HOW DO I TEST OUT THIS PR?_**
```
cd  src/auth-service
npm install
npm run prod-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 
- [update forgotten password](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-5f2cdfe3-7381-47e9-ab6b-65bf7306e0d2)
- [update known password](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-ef9d01b3-dc44-4c4b-8898-3460023ef4c2)
- [update user details](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-f2581c1d-7182-4f2c-84d8-cc116873e23a)



