### PR TITLE
KAFKA errors: only timestamp and device-number as the only logged 

### DIFF
--- a/src/device-registry/bin/www
+++ b/src/device-registry/bin/www
@@ -150,17 +150,8 @@ const run = async() => {
                                 message: detail.message,
                                 key: detail.context.key,
                                 value: detail.context.value,
-                                path: detail.path,
                                 device_number: device_number ? device_number : undefined,
-                                device_id: device_id ? device_id : undefined,
                                 timestamp: timestamp ? timestamp : undefined,
-                                site_id: site_id ? site_id : undefined,
-                                battery: battery ? battery : undefined,
-                                network: network ? network : undefined,
-                                device_latitude: device_latitude ? device_latitude : undefined,
-                                device_longitude: device_longitude ? device_longitude : undefined,
-                                site_latitude: site_latitude ? site_latitude : undefined,
-                                site_longitude: site_longitude ? site_longitude : undefined,
                             };
                         });
                         logger.error(`KAFKA: Input validation formatted errors -- ${JSON.stringify(errorDetails)}`);


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
timestamp and device-number as the only logged detailed outside the error values



