### PR TITLE
Update schedule for forecast training job

### DIFF
--- a/k8s/predict/values-prod.yaml
+++ b/k8s/predict/values-prod.yaml
@@ -33,7 +33,7 @@ jobs:
   train:
     name: airqo-train-job
     configmap: env-train-job-production
-    schedule: 0 1 1 * *
+    schedule: 0 1 * * 1
     suspend: false
     resources:
       limits:

--- a/k8s/predict/values-stage.yaml
+++ b/k8s/predict/values-stage.yaml
@@ -33,7 +33,7 @@ jobs:
   train:
     name: stage-airqo-train-job
     configmap: env-train-job-staging
-    schedule: 0 1 1 * *
+    schedule: 0 1 * * 1
     suspend: true
     resources:
       limits:


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
* Updates the training schedule for the `predict-train` (forecast) job


**_WHAT ISSUES ARE RELATED TO THIS PR?_**
* Hourly forecasts are currently failing in production because the training job hasn't been run. 