### PR TITLE
Adds Client ID rate limits when accessing AirQo API

### DIFF
--- a/src/auth-service/bin/index.js
+++ b/src/auth-service/bin/index.js
@@ -9,7 +9,7 @@ const constants = require("@config/constants");
 
 const log4jsConfiguration = require("@config/log4js");
 log4js.configure(log4jsConfiguration);
-const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- www-start-script`);
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- bin/index script`);
 
 try {
   require("fs").mkdirSync("./log");
@@ -21,7 +21,9 @@ try {
 }
 
 const main = async () => {
-  kafkaConsumer();
+  await kafkaConsumer().catch((error) => {
+    logger.error(`KAFKA: internal server error -- ${JSON.stringify(error)}`);
+  });
   createServer();
 };
 

--- a/src/auth-service/bin/kafka-consumer.js
+++ b/src/auth-service/bin/kafka-consumer.js
@@ -1,7 +1,9 @@
 const { Kafka } = require("kafkajs");
 const constants = require("@config/constants");
 const log4js = require("log4js");
-const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- Kafka Consumer`);
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- bin/kafka-consumer script`
+);
 const { logText, logObject } = require("@utils/log");
 const mailer = require("@utils/mailer");
 const emailTemplates = require("@utils/email.templates");

--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -23,7 +23,7 @@ const log4js = require("log4js");
 const debug = require("debug")("auth-service:server");
 const isEmpty = require("is-empty");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- server start script`
+  `${constants.ENVIRONMENT} -- bin/server script`
 );
 const { logText, logObject } = require("@utils/log");
 
@@ -80,67 +80,62 @@ app.use(function (req, res, next) {
 
 app.use(function (err, req, res, next) {
   if (err.status === 404) {
-    // logger.error(
-    //   `this endpoint does not exist --- ${err.message} --- path: ${
-    //     req.originalUrl ? req.originalUrl : ""
-    //   }`
-    // );
     res.status(err.status).json({
       success: false,
       message: "this endpoint does not exist",
       errors: { message: err.message },
     });
   } else if (err.status === 400) {
-    logger.error(`bad request error --- ${err.message}`);
+    logger.error(`bad request error --- ${JSON.stringify(err)}`);
     res.status(err.status).json({
       success: false,
       message: "bad request error",
       errors: { message: err.message },
     });
   } else if (err.status === 401) {
-    logger.error(`Unauthorized --- ${err.message}`);
+    logger.error(`Unauthorized --- ${JSON.stringify(err)}`);
     res.status(err.status).json({
       success: false,
       message: "Unauthorized",
       errors: { message: err.message },
     });
   } else if (err.status === 403) {
-    logger.error(`Forbidden --- ${err.message}`);
+    logger.error(`Forbidden --- ${JSON.stringify(err)}`);
     res.status(err.status).json({
       success: false,
       message: "Forbidden",
       errors: { message: err.message },
     });
   } else if (err.status === 500) {
-    logger.error(`Internal Server Error --- ${err.message}`);
+    logger.error(`Internal Server Error --- ${JSON.stringify(err)}`);
     res.status(err.status).json({
       success: false,
       message: "Internal Server Error",
       errors: { message: err.message },
     });
   } else if (err.status === 502) {
-    logger.error(`Bad Gateway --- ${err.message}`);
+    logger.error(`Bad Gateway --- ${JSON.stringify(err)}`);
     res.status(err.status).json({
       success: false,
       message: "Bad Gateway",
       errors: { message: err.message },
     });
   } else if (err.status === 503) {
-    logger.error(`Service Unavailable --- ${err.message}`);
+    logger.error(`Service Unavailable --- ${JSON.stringify(err)}`);
     res.status(err.status).json({
       success: false,
       message: "Service Unavailable",
       errors: { message: err.message },
     });
   } else if (err.status === 504) {
-    logger.error(`Gateway Timeout. --- ${err.message}`);
+    logger.error(`Gateway Timeout. --- ${JSON.stringify(err)}`);
     res.status(err.status).json({
       success: false,
       message: " Gateway Timeout.",
       errors: { message: err.message },
     });
   } else {
-    logger.error(`Internal Server Error --- ${err.message}`);
+    logger.error(`Internal Server Error --- ${JSON.stringify(err)}`);
     logObject("Internal Server Error", err);
     res.status(err.status || 500).json({
       success: false,

--- a/src/auth-service/config/constants.js
+++ b/src/auth-service/config/constants.js
@@ -186,7 +186,7 @@ const defaultConfig = {
                                     style="padding-bottom: 24px; color: #344054; font-size: 16px; font-family: Inter; font-weight: 600; line-height: 24px; word-wrap: break-word;">
                                     Dear ${name},
                                 </td>
-                            </tr>`
+                            </tr>`;
   },
   EMAIL_HEADER_TEMPLATE: () => {
     return `
@@ -299,7 +299,7 @@ const defaultConfig = {
 
     </body>
 
-</html>`
+</html>`;
   },
   NETWORKS_INCLUSION_PROJECTION: {
     _id: 1,
@@ -751,13 +751,12 @@ const defaultConfig = {
   TOKENS_INCLUSION_PROJECTION: {
     _id: 1,
     user_id: 1,
-    name: 1,
     token: 1,
-    network_id: 1,
     last_used_at: 1,
     expires: 1,
     last_ip_address: 1,
-    user: { $arrayElemAt: ["$users", 0] },
+    client: { $arrayElemAt: ["$client", 0] },
+    user: { $arrayElemAt: ["$user", 0] },
   },
 
   TOKENS_EXCLUSION_PROJECTION: (category) => {
@@ -767,7 +766,9 @@ const defaultConfig = {
       "user.verified": 0,
       "user.networks": 0,
       "user.groups": 0,
-      "user.roles": 0,
+      "user.emailConfirmed": 0,
+      "user.organization": 0,
+      "user.role": 0,
       "user.permissions": 0,
       "user.locationCount": 0,
       "user.userName": 0,
@@ -780,6 +781,14 @@ const defaultConfig = {
       "user.__v": 0,
       "user.resetPasswordExpires": 0,
       "user.resetPasswordToken": 0,
+      "user.website": 0,
+      "user.category": 0,
+      "user.jobTitle": 0,
+      "user.profilePicture": 0,
+      "user.phoneNumber": 0,
+      "user.description": 0,
+      "user.country": 0,
+      "client.__v": 0,
     };
     let projection = Object.assign({}, initialProjection);
     if (category === "summary") {

--- a/src/auth-service/controllers/create-token.js
+++ b/src/auth-service/controllers/create-token.js
@@ -24,13 +24,13 @@ const createAccessToken = {
         );
       }
 
-      let { tenant, id } = req.query;
+      let { tenant } = req.query;
       if (isEmpty(tenant)) {
         tenant = constants.DEFAULT_TENANT;
       }
 
       let request = req;
-      request["query"]["tenant"] = tenant;
+      request.query.tenant = tenant;
       const responseFromCreateAccessToken =
         await controlAccessUtil.createAccessToken(request);
 
@@ -60,6 +60,7 @@ const createAccessToken = {
         });
       }
     } catch (error) {
+      logger.error(`Internal Server Error -- ${JSON.stringify(error)}`);
       return res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message: "Internal Server Error",
@@ -117,6 +118,7 @@ const createAccessToken = {
         });
       }
     } catch (error) {
+      logger.error(`Internal Server Error -- ${JSON.stringify(error)}`);
       return res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message: "Internal Server Error",
@@ -137,7 +139,7 @@ const createAccessToken = {
           convertErrorArrayToObject(nestedErrors)
         );
       }
-      let { tenant, id } = req.query;
+      let { tenant } = req.query;
       if (isEmpty(tenant)) {
         tenant = constants.DEFAULT_TENANT;
       }
@@ -207,6 +209,7 @@ const createAccessToken = {
         });
       }
     } catch (error) {
+      logger.error(`Internal Server Error -- ${JSON.stringify(error)}`);
       return res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message: "Internal Server Error",
@@ -264,6 +267,7 @@ const createAccessToken = {
         });
       }
     } catch (error) {
+      logger.error(`Internal Server Error -- ${JSON.stringify(error)}`);
       return res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
         success: false,
         message: "Internal Server Error",

--- a/src/auth-service/middleware/rate-limit.js
+++ b/src/auth-service/middleware/rate-limit.js
@@ -1,17 +1,38 @@
-const userRateLimits = {}; // Store user rate limits here
+const { client1 } = require("@config/redis");
+const redisClient = client1;
+const httpStatus = require("http-status");
+const log4js = require("log4js");
+const logger = log4js.getLogger(`${this.ENVIRONMENT} -- middleware/rate-limit`);
 
 const rateLimitMiddleware = (getUserLimit) => {
-  return (req, res, next) => {
-    const userId = req.user.id; // Assuming you have user details available
-    const userLimit = getUserLimit(req.user); // Get user limit dynamically
+  return async (req, res, next) => {
+    const userId = req.user._id;
+    const userLimit = getUserLimit(req.user);
 
-    if (userRateLimits[userId] >= userLimit) {
-      return res.status(429).json({ message: "Rate limit exceeded" });
+    try {
+      // Fetch the current request count from Redis
+      const currentCount = await redisClient.get(userId);
+
+      if (currentCount && parseInt(currentCount) >= userLimit) {
+        return res
+          .status(httpStatus.TOO_MANY_REQUESTS)
+          .json({ message: "Rate limit exceeded" });
+      }
+
+      // Increment the request count and update Redis
+      await redisClient.incr(userId);
+      await redisClient.expire(userId, 3600); // Expire in 1 hour (adjust as needed)
+
+      next();
+    } catch (error) {
+      logger.error(
+        `Error in rate limiting middleware: -- ${JSON.stringify(error)}`
+      );
+      res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        message: "Internal Server Error",
+        error: { message: error.message },
+      });
     }
-
-    // Update request count and proceed
-    userRateLimits[userId] = (userRateLimits[userId] || 0) + 1;
-    next();
   };
 };
 

--- a/src/auth-service/middleware/rate-limit.js
+++ b/src/auth-service/middleware/rate-limit.js
@@ -1,0 +1,18 @@
+const userRateLimits = {}; // Store user rate limits here
+
+const rateLimitMiddleware = (getUserLimit) => {
+  return (req, res, next) => {
+    const userId = req.user.id; // Assuming you have user details available
+    const userLimit = getUserLimit(req.user); // Get user limit dynamically
+
+    if (userRateLimits[userId] >= userLimit) {
+      return res.status(429).json({ message: "Rate limit exceeded" });
+    }
+
+    // Update request count and proceed
+    userRateLimits[userId] = (userRateLimits[userId] || 0) + 1;
+    next();
+  };
+};
+
+module.exports = rateLimitMiddleware;

--- a/src/auth-service/middleware/rate-limit.js
+++ b/src/auth-service/middleware/rate-limit.js
@@ -1,39 +1,100 @@
 const { client1 } = require("@config/redis");
 const redisClient = client1;
 const httpStatus = require("http-status");
+const { getModelByTenant } = require("@config/database");
+const AccessTokenSchema = require("@models/AccessToken");
+const ClientSchema = require("@models/Client");
+const mongoose = require("mongoose").set("debug", true);
+const ObjectId = mongoose.Types.ObjectId;
 const log4js = require("log4js");
+const { logObject } = require("../utils/log");
+const isEmpty = require("is-empty");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- middleware/rate-limit`);
 
-const rateLimitMiddleware = (getUserLimit) => {
-  return async (req, res, next) => {
-    const userId = req.user._id;
-    const userLimit = getUserLimit(req.user);
+const AccessTokenModel = (tenant) => {
+  try {
+    let tokens = mongoose.model("access_tokens");
+    return tokens;
+  } catch (error) {
+    let tokens = getModelByTenant(tenant, "access_token", AccessTokenSchema);
+    return tokens;
+  }
+};
 
-    try {
-      // Fetch the current request count from Redis
-      const currentCount = await redisClient.get(userId);
+const ClientModel = (tenant) => {
+  try {
+    let clients = mongoose.model("clients");
+    return clients;
+  } catch (error) {
+    let clients = getModelByTenant(tenant, "client", ClientSchema);
+    return clients;
+  }
+};
 
-      if (currentCount && parseInt(currentCount) >= userLimit) {
-        return res
-          .status(httpStatus.TOO_MANY_REQUESTS)
-          .json({ message: "Rate limit exceeded" });
-      }
+const getClientLimit = (client) => {
+  return client.rateLimit || 100;
+};
 
-      // Increment the request count and update Redis
-      await redisClient.incr(userId);
-      await redisClient.expire(userId, 3600); // Expire in 1 hour (adjust as needed)
+const rateLimitMiddleware = async (req, res, next) => {
+  try {
+    let { tenant } = req.query;
 
-      next();
-    } catch (error) {
-      logger.error(
-        `Error in rate limiting middleware: -- ${JSON.stringify(error)}`
-      );
-      res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
-        message: "Internal Server Error",
-        error: { message: error.message },
-      });
+    if (!tenant) {
+      tenant = "airqo";
     }
-  };
+
+    let client;
+    if (req.params && req.params.token) {
+      const token = req.params.token;
+      const responseFromFindToken = await AccessTokenModel(tenant)
+        .find({
+          token,
+        })
+        .lean();
+
+      logObject("responseFromFindToken[0]", responseFromFindToken[0]);
+
+      if (!isEmpty(responseFromFindToken)) {
+        const { client_id } = responseFromFindToken[0];
+        if (!mongoose.Types.ObjectId.isValid(client_id)) {
+          return res
+            .status(httpStatus.BAD_REQUEST)
+            .send("Invalid client ID associated with provided token");
+        }
+        client = await ClientModel(tenant).findById(ObjectId(client_id)).lean();
+      }
+    }
+
+    logObject("client", client);
+
+    if (!client) {
+      return res.status(httpStatus.UNAUTHORIZED).send("Unauthorized");
+    }
+
+    const clientId = client._id;
+    const clientLimit = getClientLimit(client);
+
+    const currentCount = await redisClient.get(clientId);
+
+    if (currentCount && parseInt(currentCount) >= clientLimit) {
+      return res
+        .status(httpStatus.TOO_MANY_REQUESTS)
+        .send("Rate limit exceeded");
+    }
+
+    await redisClient.incr(clientId);
+    await redisClient.expire(clientId, 3600);
+
+    next();
+  } catch (error) {
+    logger.error(
+      `Error in rate limiting middleware: -- ${JSON.stringify(error)}`
+    );
+
+    return res
+      .status(httpStatus.INTERNAL_SERVER_ERROR)
+      .send(`Internal Server Error -- ${error.message}`);
+  }
 };
 
 module.exports = rateLimitMiddleware;

--- a/src/auth-service/middleware/test/ut_rate-limit.js
+++ b/src/auth-service/middleware/test/ut_rate-limit.js
@@ -1,0 +1,73 @@
+require("module-alias/register");
+const express = require("express");
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const rateLimitMiddleware = require("@middleware/rate-limit");
+const request = require("supertest");
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe("Rate Limit Middleware", () => {
+  let app;
+
+  before(() => {
+    app = express();
+
+    // Mock user object with rateLimit property
+    const mockUser = { rateLimit: 5 };
+
+    // Function to extract user limit from req.user
+    const getUserLimit = (user) => {
+      return user.rateLimit || 100;
+    };
+
+    // Apply rate limiting middleware for a specific route
+    app.get(
+      "/api/some-route",
+      rateLimitMiddleware(getUserLimit),
+      (req, res) => {
+        res.status(200).json({ message: "Success" });
+      }
+    );
+
+    // ...other route definitions
+  });
+
+  it("should allow access when user limit is not exceeded", (done) => {
+    request(app)
+      .get("/api/some-route")
+      .set("Authorization", "Bearer valid-token")
+      .set("Accept", "application/json")
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body.message).to.equal("Success");
+        done();
+      });
+  });
+
+  it("should deny access when user limit is exceeded", (done) => {
+    request(app)
+      .get("/api/some-route")
+      .set("Authorization", "Bearer valid-token")
+      .set("Accept", "application/json")
+      .end((err, res) => {
+        expect(res.status).to.equal(429);
+        expect(res.body.message).to.equal("Rate limit exceeded");
+        done();
+      });
+  });
+
+  it("should allow access for a different route", (done) => {
+    request(app)
+      .post("/api/another-route")
+      .set("Authorization", "Bearer valid-token")
+      .set("Accept", "application/json")
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body.message).to.equal("Success");
+        done();
+      });
+  });
+});

--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -6,13 +6,6 @@ const httpStatus = require("http-status");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- token-model`);
-// const saltRounds = constants.SALT_ROUNDS;
-// const bcrypt = require("bcrypt");
-
-/**
- * belongs to a user
- * a User has many access tokens
- */
 
 const toMilliseconds = (hrs, min, sec) =>
   (hrs * 60 * 60 + min * 60 + sec) * 1000;
@@ -224,13 +217,13 @@ AccessTokenSchema.statics = {
     try {
       let options = { new: true };
       let modifiedUpdate = Object.assign({}, update);
-      delete modifiedUpdate.user_id;
-      // if (modifiedUpdate.token) {
-      //   modifiedUpdate.token = bcrypt.hashSync(
-      //     modifiedUpdate.token,
-      //     saltRounds
-      //   );
-      // }
+      if (!isEmpty(modifiedUpdate.user_id)) {
+        delete modifiedUpdate.user_id;
+      }
+      if (!isEmpty(modifiedUpdate.client_id)) {
+        delete modifiedUpdate.client_id;
+      }
+
       const updatedToken = await this.findOneAndUpdate(
         filter,
         modifiedUpdate,
@@ -252,7 +245,7 @@ AccessTokenSchema.statics = {
         };
       }
     } catch (error) {
-      logger.error(`internal server error -- ${JSON.stringify(error)}`);
+      logger.error(`Internal Server Error -- ${JSON.stringify(error)}`);
       return {
         success: false,
         message: "Internal Server Error",

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -121,6 +121,9 @@ const UserSchema = new Schema(
       type: String,
       default: "airqo",
     },
+    rateLimit: {
+      type: Number,
+    },
     phoneNumber: {
       type: Number,
       validate: {
@@ -547,6 +550,7 @@ UserSchema.methods = {
         phoneNumber: this.phoneNumber,
         createdAt: this.createdAt,
         updatedAt: this.updatedAt,
+        rateLimit: this.rateLimit,
       },
       constants.JWT_SECRET
     );
@@ -591,6 +595,7 @@ UserSchema.methods = {
       role: this.role,
       verified: this.verified,
       networks: this.networks,
+      rateLimit: this.rateLimit,
     };
   },
 };

--- a/src/auth-service/package-lock.json
+++ b/src/auth-service/package-lock.json
@@ -76,7 +76,8 @@
                 "proxyquire": "^2.1.3",
                 "rewire": "^6.0.0",
                 "sinon": "^11.1.1",
-                "sinon-chai": "^3.7.0"
+                "sinon-chai": "^3.7.0",
+                "supertest": "^6.3.3"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -3423,6 +3424,22 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/dezalgo": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+            "dev": true,
+            "dependencies": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/dezalgo/node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+            "dev": true
+        },
         "node_modules/diff": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -4690,6 +4707,12 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "devOptional": true
         },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
         "node_modules/fast-text-encoding": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
@@ -5723,6 +5746,15 @@
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/hexoid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+            "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/hide-powered-by": {
@@ -8963,11 +8995,17 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+            "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+            "dependencies": {
+                "side-channel": "^1.0.4"
+            },
             "engines": {
                 "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/random-bytes": {
@@ -10203,6 +10241,119 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
+        },
+        "node_modules/supertest": {
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+            "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+            "dev": true,
+            "dependencies": {
+                "methods": "^1.1.2",
+                "superagent": "^8.0.5"
+            },
+            "engines": {
+                "node": ">=6.4.0"
+            }
+        },
+        "node_modules/supertest/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/supertest/node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/supertest/node_modules/formidable": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+            "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+            "dev": true,
+            "dependencies": {
+                "dezalgo": "^1.0.4",
+                "hexoid": "^1.0.0",
+                "once": "^1.4.0",
+                "qs": "^6.11.0"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/tunnckoCore/commissions"
+            }
+        },
+        "node_modules/supertest/node_modules/mime": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+            "dev": true,
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/supertest/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/supertest/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/supertest/node_modules/superagent": {
+            "version": "8.0.9",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
+            "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+            "dev": true,
+            "dependencies": {
+                "component-emitter": "^1.3.0",
+                "cookiejar": "^2.1.4",
+                "debug": "^4.3.4",
+                "fast-safe-stringify": "^2.1.1",
+                "form-data": "^4.0.0",
+                "formidable": "^2.1.2",
+                "methods": "^1.1.2",
+                "mime": "2.6.0",
+                "qs": "^6.11.0",
+                "semver": "^7.3.8"
+            },
+            "engines": {
+                "node": ">=6.4.0 <13 || >=14"
+            }
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -14232,6 +14383,24 @@
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
+        "dezalgo": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+            "dev": true,
+            "requires": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            },
+            "dependencies": {
+                "asap": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+                    "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+                    "dev": true
+                }
+            }
+        },
         "diff": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -15190,6 +15359,12 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "devOptional": true
         },
+        "fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
         "fast-text-encoding": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
@@ -15978,6 +16153,12 @@
                 "content-security-policy-builder": "2.1.0",
                 "dasherize": "2.0.0"
             }
+        },
+        "hexoid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+            "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+            "dev": true
         },
         "hide-powered-by": {
             "version": "1.1.0",
@@ -18505,9 +18686,12 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+            "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+            "requires": {
+                "side-channel": "^1.0.4"
+            }
         },
         "random-bytes": {
             "version": "1.0.0",
@@ -19508,6 +19692,89 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
                     "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
                     "dev": true
+                }
+            }
+        },
+        "supertest": {
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+            "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+            "dev": true,
+            "requires": {
+                "methods": "^1.1.2",
+                "superagent": "^8.0.5"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "form-data": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "formidable": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+                    "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+                    "dev": true,
+                    "requires": {
+                        "dezalgo": "^1.0.4",
+                        "hexoid": "^1.0.0",
+                        "once": "^1.4.0",
+                        "qs": "^6.11.0"
+                    }
+                },
+                "mime": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+                    "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "superagent": {
+                    "version": "8.0.9",
+                    "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
+                    "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+                    "dev": true,
+                    "requires": {
+                        "component-emitter": "^1.3.0",
+                        "cookiejar": "^2.1.4",
+                        "debug": "^4.3.4",
+                        "fast-safe-stringify": "^2.1.1",
+                        "form-data": "^4.0.0",
+                        "formidable": "^2.1.2",
+                        "methods": "^1.1.2",
+                        "mime": "2.6.0",
+                        "qs": "^6.11.0",
+                        "semver": "^7.3.8"
+                    }
                 }
             }
         },

--- a/src/auth-service/package.json
+++ b/src/auth-service/package.json
@@ -95,6 +95,7 @@
         "proxyquire": "^2.1.3",
         "rewire": "^6.0.0",
         "sinon": "^11.1.1",
-        "sinon-chai": "^3.7.0"
+        "sinon-chai": "^3.7.0",
+        "supertest": "^6.3.3"
     }
 }

--- a/src/auth-service/routes/v1/clients.js
+++ b/src/auth-service/routes/v1/clients.js
@@ -54,11 +54,17 @@ router.post(
   ]),
   oneOf([
     [
-      body("name")
+      body("user_id")
         .exists()
-        .withMessage("name is missing in your request")
+        .withMessage("the user_id is missing in the request")
         .bail()
-        .trim(),
+        .trim()
+        .isMongoId()
+        .withMessage("id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
       body("redirect_url")
         .optional()
         .notEmpty()
@@ -79,117 +85,7 @@ router.post(
 );
 
 router.patch(
-  "secret/:client_id",
-  oneOf([
-    [
-      query("tenant")
-        .optional()
-        .notEmpty()
-        .withMessage("tenant should not be empty if provided")
-        .trim()
-        .toLowerCase()
-        .bail()
-        .isIn(["kcca", "airqo"])
-        .withMessage("the tenant value is not among the expected ones"),
-    ],
-  ]),
-  oneOf([
-    [
-      param("client_id")
-        .exists()
-        .withMessage("the client_id param is missing in the request")
-        .trim(),
-    ],
-  ]),
-  oneOf([
-    [
-      body("client_id")
-        .not()
-        .exists()
-        .withMessage("the client_id should not exist in the request body"),
-      body("name")
-        .not()
-        .exists()
-        .withMessage("the name should not exist in the request body")
-        .trim(),
-      body("client_secret")
-        .exists()
-        .withMessage("client_secret should be provided")
-        .notEmpty()
-        .withMessage("the client_secret cannot be empty")
-        .trim(),
-      body("redirect_url")
-        .not()
-        .exists()
-        .withMessage("redirect_url should not exist in the request body"),
-      body("description")
-        .not()
-        .exists()
-        .withMessage("description should not exist in the request body"),
-    ],
-  ]),
-  setJWTAuth,
-  authJWT,
-  createClientController.update
-);
-
-router.patch(
-  "name/:client_id",
-  oneOf([
-    [
-      query("tenant")
-        .optional()
-        .notEmpty()
-        .withMessage("tenant should not be empty if provided")
-        .trim()
-        .toLowerCase()
-        .bail()
-        .isIn(["kcca", "airqo"])
-        .withMessage("the tenant value is not among the expected ones"),
-    ],
-  ]),
-  oneOf([
-    [
-      param("client_id")
-        .exists()
-        .withMessage("the client_id param is missing in the request")
-        .trim(),
-    ],
-  ]),
-  oneOf([
-    [
-      body("client_id")
-        .not()
-        .exists()
-        .withMessage("the client_id should not exist in the request body"),
-      body("client_secret")
-        .not()
-        .exists()
-        .withMessage("the client_secret should not exist in the request body"),
-      body("name")
-        .exists()
-        .withMessage("the name should be provided")
-        .bail()
-        .notEmpty()
-        .withMessage("name should not be empty")
-        .trim(),
-      body("redirect_url")
-        .not()
-        .exists()
-        .withMessage("redirect_url should not exist in the request body"),
-      body("description")
-        .not()
-        .exists()
-        .withMessage("description should not exist in the request body"),
-    ],
-  ]),
-  setJWTAuth,
-  authJWT,
-  createClientController.update
-);
-
-router.patch(
-  "id/:client_id",
+  "/:client_id/secret",
   oneOf([
     [
       query("tenant")
@@ -209,39 +105,21 @@ router.patch(
         .exists()
         .withMessage("the client_id param is missing in the request")
         .bail()
-        .trim(),
-    ],
-  ]),
-  oneOf([
-    [
-      body("name")
-        .not()
-        .exists()
-        .withMessage("the name should not exist in the request body"),
-      body("client_secret")
-        .not()
-        .exists()
-        .withMessage("the client_secret should not exist in the request body"),
-      body("client_id")
-        .exists()
-        .withMessage("client_id should be provided")
-        .bail()
         .notEmpty()
-        .withMessage("client_id should not be empty")
-        .trim(),
-      body("redirect_url")
-        .not()
-        .exists()
-        .withMessage("redirect_url should not exist in the request body"),
-      body("description")
-        .not()
-        .exists()
-        .withMessage("description should not exist in the request body"),
+        .withMessage("this client_id cannot be empty")
+        .bail()
+        .trim()
+        .isMongoId()
+        .withMessage("client_id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
     ],
   ]),
   setJWTAuth,
   authJWT,
-  createClientController.update
+  createClientController.updateClientSecret
 );
 
 router.put(

--- a/src/auth-service/routes/v1/tokens.js
+++ b/src/auth-service/routes/v1/tokens.js
@@ -5,6 +5,7 @@ const { check, oneOf, query, body, param } = require("express-validator");
 const { setJWTAuth, authJWT } = require("@middleware/passport");
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
+const rateLimitMiddleware = require("@middleware/rate-limit");
 
 const headers = (req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
@@ -51,38 +52,22 @@ router.post(
     ],
   ]),
   oneOf([
-    body("user_id")
+    body("client_id")
       .exists()
       .withMessage(
-        "a token requirement is missing in request, consider using the user_id"
+        "a token requirement is missing in request, consider using the client_id"
       )
       .bail()
       .notEmpty()
-      .withMessage("this user_id cannot be empty")
+      .withMessage("this client_id cannot be empty")
       .bail()
       .trim()
       .isMongoId()
-      .withMessage("user_id must be an object ID")
+      .withMessage("client_id must be an object ID")
       .bail()
       .customSanitizer((value) => {
         return ObjectId(value);
       }),
-    // body("client_id")
-    //   .exists()
-    //   .withMessage(
-    //     "a token identifier is missing in request, consider using the client_id"
-    //   )
-    //   .bail()
-    //   .notEmpty()
-    //   .withMessage("this client_id cannot be empty")
-    //   .bail()
-    //   .trim()
-    //   .isMongoId()
-    //   .withMessage("client_id must be an object ID")
-    //   .bail()
-    //   .customSanitizer((value) => {
-    //     return ObjectId(value);
-    //   }),
   ]),
   oneOf([
     [
@@ -215,6 +200,7 @@ router.get(
         .withMessage("the token must not be empty"),
     ],
   ]),
+  rateLimitMiddleware,
   createTokenController.verify
 );
 router.get(

--- a/src/auth-service/routes/v1/tokens.js
+++ b/src/auth-service/routes/v1/tokens.js
@@ -113,19 +113,6 @@ router.put(
   ]),
   oneOf([
     [
-      body("user_id")
-        .optional()
-        .trim()
-        .notEmpty()
-        .withMessage("this user ID cannot be empty if provideds")
-        .bail()
-        .trim()
-        .isMongoId()
-        .withMessage("user_id must be an object ID")
-        .bail()
-        .customSanitizer((value) => {
-          return ObjectId(value);
-        }),
       body("expires")
         .optional()
         .trim()

--- a/src/auth-service/routes/v2/clients.js
+++ b/src/auth-service/routes/v2/clients.js
@@ -54,11 +54,17 @@ router.post(
   ]),
   oneOf([
     [
-      body("name")
+      body("user_id")
         .exists()
-        .withMessage("name is missing in your request")
+        .withMessage("the user_id is missing in the request")
         .bail()
-        .trim(),
+        .trim()
+        .isMongoId()
+        .withMessage("id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
       body("redirect_url")
         .optional()
         .notEmpty()
@@ -79,117 +85,7 @@ router.post(
 );
 
 router.patch(
-  "secret/:client_id",
-  oneOf([
-    [
-      query("tenant")
-        .optional()
-        .notEmpty()
-        .withMessage("tenant should not be empty if provided")
-        .trim()
-        .toLowerCase()
-        .bail()
-        .isIn(["kcca", "airqo"])
-        .withMessage("the tenant value is not among the expected ones"),
-    ],
-  ]),
-  oneOf([
-    [
-      param("client_id")
-        .exists()
-        .withMessage("the client_id param is missing in the request")
-        .trim(),
-    ],
-  ]),
-  oneOf([
-    [
-      body("client_id")
-        .not()
-        .exists()
-        .withMessage("the client_id should not exist in the request body"),
-      body("name")
-        .not()
-        .exists()
-        .withMessage("the name should not exist in the request body")
-        .trim(),
-      body("client_secret")
-        .exists()
-        .withMessage("client_secret should be provided")
-        .notEmpty()
-        .withMessage("the client_secret cannot be empty")
-        .trim(),
-      body("redirect_url")
-        .not()
-        .exists()
-        .withMessage("redirect_url should not exist in the request body"),
-      body("description")
-        .not()
-        .exists()
-        .withMessage("description should not exist in the request body"),
-    ],
-  ]),
-  setJWTAuth,
-  authJWT,
-  createClientController.update
-);
-
-router.patch(
-  "name/:client_id",
-  oneOf([
-    [
-      query("tenant")
-        .optional()
-        .notEmpty()
-        .withMessage("tenant should not be empty if provided")
-        .trim()
-        .toLowerCase()
-        .bail()
-        .isIn(["kcca", "airqo"])
-        .withMessage("the tenant value is not among the expected ones"),
-    ],
-  ]),
-  oneOf([
-    [
-      param("client_id")
-        .exists()
-        .withMessage("the client_id param is missing in the request")
-        .trim(),
-    ],
-  ]),
-  oneOf([
-    [
-      body("client_id")
-        .not()
-        .exists()
-        .withMessage("the client_id should not exist in the request body"),
-      body("client_secret")
-        .not()
-        .exists()
-        .withMessage("the client_secret should not exist in the request body"),
-      body("name")
-        .exists()
-        .withMessage("the name should be provided")
-        .bail()
-        .notEmpty()
-        .withMessage("name should not be empty")
-        .trim(),
-      body("redirect_url")
-        .not()
-        .exists()
-        .withMessage("redirect_url should not exist in the request body"),
-      body("description")
-        .not()
-        .exists()
-        .withMessage("description should not exist in the request body"),
-    ],
-  ]),
-  setJWTAuth,
-  authJWT,
-  createClientController.update
-);
-
-router.patch(
-  "id/:client_id",
+  "/:client_id/secret",
   oneOf([
     [
       query("tenant")
@@ -209,39 +105,21 @@ router.patch(
         .exists()
         .withMessage("the client_id param is missing in the request")
         .bail()
-        .trim(),
-    ],
-  ]),
-  oneOf([
-    [
-      body("name")
-        .not()
-        .exists()
-        .withMessage("the name should not exist in the request body"),
-      body("client_secret")
-        .not()
-        .exists()
-        .withMessage("the client_secret should not exist in the request body"),
-      body("client_id")
-        .exists()
-        .withMessage("client_id should be provided")
-        .bail()
         .notEmpty()
-        .withMessage("client_id should not be empty")
-        .trim(),
-      body("redirect_url")
-        .not()
-        .exists()
-        .withMessage("redirect_url should not exist in the request body"),
-      body("description")
-        .not()
-        .exists()
-        .withMessage("description should not exist in the request body"),
+        .withMessage("this client_id cannot be empty")
+        .bail()
+        .trim()
+        .isMongoId()
+        .withMessage("client_id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
     ],
   ]),
   setJWTAuth,
   authJWT,
-  createClientController.update
+  createClientController.updateClientSecret
 );
 
 router.put(

--- a/src/auth-service/routes/v2/tokens.js
+++ b/src/auth-service/routes/v2/tokens.js
@@ -7,11 +7,6 @@ const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 const rateLimitMiddleware = require("@middleware/rate-limit");
 
-// Function to extract user limit from req.user
-const getUserLimit = (user) => {
-  return user.rateLimit || 100; // Extract user's rate limit from req.user
-};
-
 const headers = (req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
   res.header(
@@ -57,38 +52,22 @@ router.post(
     ],
   ]),
   oneOf([
-    body("user_id")
+    body("client_id")
       .exists()
       .withMessage(
-        "a token requirement is missing in request, consider using the user_id"
+        "a token requirement is missing in request, consider using the client_id"
       )
       .bail()
       .notEmpty()
-      .withMessage("this user_id cannot be empty")
+      .withMessage("this client_id cannot be empty")
       .bail()
       .trim()
       .isMongoId()
-      .withMessage("user_id must be an object ID")
+      .withMessage("client_id must be an object ID")
       .bail()
       .customSanitizer((value) => {
         return ObjectId(value);
       }),
-    // body("client_id")
-    //   .exists()
-    //   .withMessage(
-    //     "a token requirement is missing in request, consider using the client_id"
-    //   )
-    //   .bail()
-    //   .notEmpty()
-    //   .withMessage("this client_id cannot be empty")
-    //   .bail()
-    //   .trim()
-    //   .isMongoId()
-    //   .withMessage("client_id must be an object ID")
-    //   .bail()
-    //   .customSanitizer((value) => {
-    //     return ObjectId(value);
-    //   }),
   ]),
   oneOf([
     [
@@ -221,7 +200,7 @@ router.get(
         .withMessage("the token must not be empty"),
     ],
   ]),
-  rateLimitMiddleware(getUserLimit),
+  rateLimitMiddleware,
   createTokenController.verify
 );
 router.get(

--- a/src/auth-service/routes/v2/tokens.js
+++ b/src/auth-service/routes/v2/tokens.js
@@ -5,6 +5,12 @@ const { check, oneOf, query, body, param } = require("express-validator");
 const { setJWTAuth, authJWT } = require("@middleware/passport");
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
+const rateLimitMiddleware = require("@middleware/rate-limit");
+
+// Function to extract user limit from req.user
+const getUserLimit = (user) => {
+  return user.rateLimit || 100; // Extract user's rate limit from req.user
+};
 
 const headers = (req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
@@ -215,6 +221,7 @@ router.get(
         .withMessage("the token must not be empty"),
     ],
   ]),
+  rateLimitMiddleware(getUserLimit),
   createTokenController.verify
 );
 router.get(

--- a/src/auth-service/routes/v2/tokens.js
+++ b/src/auth-service/routes/v2/tokens.js
@@ -113,19 +113,6 @@ router.put(
   ]),
   oneOf([
     [
-      body("user_id")
-        .optional()
-        .trim()
-        .notEmpty()
-        .withMessage("this user ID cannot be empty if provideds")
-        .bail()
-        .trim()
-        .isMongoId()
-        .withMessage("user_id must be an object ID")
-        .bail()
-        .customSanitizer((value) => {
-          return ObjectId(value);
-        }),
       body("expires")
         .optional()
         .trim()

--- a/src/auth-service/routes/v2/users.js
+++ b/src/auth-service/routes/v2/users.js
@@ -18,13 +18,6 @@ const {
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 
-const rateLimitMiddleware = require("@middleware/rate-limit");
-
-// Function to extract user limit from req.user
-const getUserLimit = (user) => {
-  return user.rateLimit || 100; // Extract user's rate limit from req.user
-};
-
 const headers = (req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
   res.header(
@@ -336,13 +329,7 @@ router.post(
   createUserController.verifyFirebaseCustomToken
 );
 
-router.post(
-  "/verify",
-  setJWTAuth,
-  authJWT,
-  rateLimitMiddleware(getUserLimit),
-  createUserController.verify
-);
+router.post("/verify", setJWTAuth, authJWT, createUserController.verify);
 
 router.get(
   "/verify/:user_id/:token",

--- a/src/auth-service/routes/v2/users.js
+++ b/src/auth-service/routes/v2/users.js
@@ -18,6 +18,13 @@ const {
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 
+const rateLimitMiddleware = require("@middleware/rate-limit");
+
+// Function to extract user limit from req.user
+const getUserLimit = (user) => {
+  return user.rateLimit || 100; // Extract user's rate limit from req.user
+};
+
 const headers = (req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
   res.header(
@@ -329,7 +336,13 @@ router.post(
   createUserController.verifyFirebaseCustomToken
 );
 
-router.post("/verify", setJWTAuth, authJWT, createUserController.verify);
+router.post(
+  "/verify",
+  setJWTAuth,
+  authJWT,
+  rateLimitMiddleware(getUserLimit),
+  createUserController.verify
+);
 
 router.get(
   "/verify/:user_id/:token",

--- a/src/auth-service/utils/control-access.js
+++ b/src/auth-service/utils/control-access.js
@@ -415,19 +415,14 @@ const controlAccess = {
         .toUpperCase();
 
       let update = Object.assign({}, body);
-      update["token"] = token;
+      update.token = token;
 
       const responseFromUpdateToken = await AccessTokenModel(
         tenant.toLowerCase()
       ).modify({ filter, update });
-
-      if (responseFromUpdateToken.success === true) {
-        return responseFromUpdateToken;
-      } else if (responseFromUpdateToken.success === false) {
-        return responseFromUpdateToken;
-      }
+      return responseFromUpdateToken;
     } catch (error) {
-      logger.error(`internal server error -- ${error.message}`);
+      logger.error(`Internal Server Error -- ${JSON.stringify(error)}`);
       return {
         success: false,
         message: "Internal Server Error",

--- a/src/auth-service/utils/generate-filter.js
+++ b/src/auth-service/utils/generate-filter.js
@@ -376,24 +376,11 @@ const filter = {
       }
 
       if (client_id) {
-        filter["client_id"] = client_id;
+        filter["_id"] = ObjectId(client_id);
       }
 
       if (client_secret) {
         filter["client_secret"] = client_secret;
-      }
-
-      if (client_name) {
-        filter["name"] = client_name;
-      }
-
-      if (network_id) {
-        const networksArray = network_id.split(",");
-        const arrayOfNetworkObjects = networksArray.map((value) => {
-          ObjectId(value);
-        });
-        filter["networks"] = {};
-        filter["networks"]["$in"] = arrayOfNetworkObjects;
       }
 
       return filter;

--- a/src/auth-service/utils/generate-filter.js
+++ b/src/auth-service/utils/generate-filter.js
@@ -330,7 +330,7 @@ const filter = {
     try {
       const { query, params } = req;
       const { id } = query;
-      const { token, user_id, network_id, client_id } = params;
+      const { token, client_id, name } = params;
       let filter = {};
 
       if (id) {
@@ -342,16 +342,13 @@ const filter = {
       }
 
       if (client_id) {
-        filter["client_id"] = client_id;
+        filter["client_id"] = ObjectId(client_id);
       }
 
-      if (network_id) {
-        filter["network_id"] = ObjectId(network_id);
+      if (name) {
+        filter["name"] = name;
       }
 
-      if (user_id) {
-        filter[" user_id"] = ObjectId(user_id);
-      }
       return filter;
     } catch (e) {
       logger.error(`internal server error, ${JSON.stringify(e)}`);

--- a/src/auth-service/utils/test/ut_mailer.js
+++ b/src/auth-service/utils/test/ut_mailer.js
@@ -182,10 +182,15 @@ describe("mailer", () => {
       };
       sendMailStub.resolves(response);
 
-
-      const result = await mailer.inquiry(fullName, email, category, "", tenant);
-      console.log(sendMailStub.firstCall.args[0].html)
-      console.log(msgs.inquiry(fullName, email, category))
+      const result = await mailer.inquiry(
+        fullName,
+        email,
+        category,
+        "",
+        tenant
+      );
+      console.log(sendMailStub.firstCall.args[0].html);
+      console.log(msgs.inquiry(fullName, email, category));
 
       expect(result).to.deep.equal({
         success: true,
@@ -198,10 +203,12 @@ describe("mailer", () => {
         address: constants.EMAIL,
       });
       expect(sendMailStub.firstCall.args[0].to).to.equal(email);
-      expect(sendMailStub.firstCall.args[0].subject).to.equal("Welcome to AirQo");
-      expect(sendMailStub.firstCall.args[0].html).to.equal(msgs.inquiry(fullName, email, category));
-
-
+      expect(sendMailStub.firstCall.args[0].subject).to.equal(
+        "Welcome to AirQo"
+      );
+      expect(sendMailStub.firstCall.args[0].html).to.equal(
+        msgs.inquiry(fullName, email, category)
+      );
     });
 
     it("should handle email not sent scenario and return error response", async () => {
@@ -215,7 +222,13 @@ describe("mailer", () => {
         rejected: [email],
       };
       sendMailStub.resolves(response);
-      const result = await mailer.inquiry(fullName, email, category, "", tenant);
+      const result = await mailer.inquiry(
+        fullName,
+        email,
+        category,
+        "",
+        tenant
+      );
 
       // Assert the result
       expect(result).to.deep.equal({
@@ -232,7 +245,9 @@ describe("mailer", () => {
         address: constants.EMAIL,
       });
       expect(sendMailStub.firstCall.args[0].to).to.equal(email);
-      expect(sendMailStub.firstCall.args[0].subject).to.equal("Welcome to AirQo");
+      expect(sendMailStub.firstCall.args[0].subject).to.equal(
+        "Welcome to AirQo"
+      );
     });
 
     it("should handle internal server error and return error response", async () => {
@@ -243,7 +258,13 @@ describe("mailer", () => {
 
       // Stub the sendMail function to reject with an error
       sendMailStub.rejects(new Error("Mocked sendMail error"));
-      const result = await mailer.inquiry(fullName, email, category, "", tenant);
+      const result = await mailer.inquiry(
+        fullName,
+        email,
+        category,
+        "",
+        tenant
+      );
 
       // Assert the result
       expect(result).to.deep.equal({
@@ -261,8 +282,12 @@ describe("mailer", () => {
         address: constants.EMAIL,
       });
       expect(sendMailStub.firstCall.args[0].to).to.equal(email);
-      expect(sendMailStub.firstCall.args[0].subject).to.equal("Welcome to AirQo");
-      expect(sendMailStub.firstCall.args[0].html).to.equal(msgs.inquiry(fullName, email, category));
+      expect(sendMailStub.firstCall.args[0].subject).to.equal(
+        "Welcome to AirQo"
+      );
+      expect(sendMailStub.firstCall.args[0].html).to.equal(
+        msgs.inquiry(fullName, email, category)
+      );
     });
 
     // Add more tests for other categories (policy, champions, researchers, developers, general)...
@@ -362,7 +387,6 @@ describe("mailer", () => {
     const tenant = "kcca";
     const type = "confirm";
 
-
     // Set up the response from the fake transporter
     const response = {
       accepted: [],
@@ -389,7 +413,6 @@ describe("mailer", () => {
       status: 500,
       errors: { message: response },
     });
-
   });
 
   it("should handle internal server error and return error response", async () => {
@@ -748,7 +771,7 @@ describe("mailer", () => {
 
     // Add more tests for other cases...
   });
-  describe.only("signInWithEmailLink", () => {
+  describe("signInWithEmailLink", () => {
     let sendMailStub;
 
     before(() => {
@@ -797,8 +820,12 @@ describe("mailer", () => {
         address: constants.EMAIL,
       });
       expect(sendMailStub.firstCall.args[0].to).to.equal(email);
-      expect(sendMailStub.firstCall.args[0].subject).to.equal("Verify your email address!");
-      expect(sendMailStub.firstCall.args[0].html).to.equal(msgs.join_by_email(email, token));
+      expect(sendMailStub.firstCall.args[0].subject).to.equal(
+        "Verify your email address!"
+      );
+      expect(sendMailStub.firstCall.args[0].html).to.equal(
+        msgs.join_by_email(email, token)
+      );
     });
 
     it("should handle email not sent scenario and return error response", async () => {
@@ -820,7 +847,7 @@ describe("mailer", () => {
       expect(result).to.deep.equal({
         errors: { message: response },
         success: false,
-        "message": "Internal Server Error",
+        message: "Internal Server Error",
       });
 
       // Assert that the sendMail function was called with the correct parameters
@@ -830,8 +857,12 @@ describe("mailer", () => {
         address: constants.EMAIL,
       });
       expect(sendMailStub.firstCall.args[0].to).to.equal(email);
-      expect(sendMailStub.firstCall.args[0].subject).to.equal("Verify your email address!");
-      expect(sendMailStub.firstCall.args[0].html).to.equal(msgs.join_by_email(email, token));
+      expect(sendMailStub.firstCall.args[0].subject).to.equal(
+        "Verify your email address!"
+      );
+      expect(sendMailStub.firstCall.args[0].html).to.equal(
+        msgs.join_by_email(email, token)
+      );
     });
 
     it("should handle internal server error and return error response", async () => {
@@ -857,8 +888,12 @@ describe("mailer", () => {
         address: constants.EMAIL,
       });
       expect(sendMailStub.firstCall.args[0].to).to.equal(email);
-      expect(sendMailStub.firstCall.args[0].subject).to.equal("Verify your email address!");
-      expect(sendMailStub.firstCall.args[0].html).to.equal(msgs.join_by_email(email, token));
+      expect(sendMailStub.firstCall.args[0].subject).to.equal(
+        "Verify your email address!"
+      );
+      expect(sendMailStub.firstCall.args[0].html).to.equal(
+        msgs.join_by_email(email, token)
+      );
     });
   });
   describe("deleteMobileAccountEmail", () => {

--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -1,7 +1,7 @@
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 const log4js = require("log4js");
-const { isEmpty } = require("underscore");
+const isEmpty = require("is-empty");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 
 const devConfig = {


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] adding rate limit to user verification checks
- [x] ensure that we log more details for the recent server side errors
- [x] A few enhancements to the Kafka-consumer consumption
- [x] Token generation now requires client_id
- [x] Updating token details also enhanced

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/auth-service
npm install
npm run dev-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] [verify token](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-adf5f062-ac4d-4a33-a0cb-9167ca684a0b)
- [x] [update token](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-5ffcc272-8a52-4600-8862-708c41606aff)
- [x] [regenerate token](https://airqo-engineering.postman.co/workspace/internal~7a8e9fad-2d13-4d27-af27-f1f4e9a114bf/request/12513372-c29e976a-aa1f-4b2d-a8d9-ee3d7dda5e09)



