### PR TITLE
Remove `margin of error` from forecast endpoint results

### DIFF
--- a/src/predict/api/helpers.py
+++ b/src/predict/api/helpers.py
@@ -232,14 +232,14 @@ def get_forecasts(
         for time, pm2_5, margin_of_error, adjusted_forecast in zip(
             site_forecasts[0]["timestamp"],
             site_forecasts[0]["pm2_5"],
-            site_forecasts[0]["margin_of_error"],
-            site_forecasts[0]["adjusted_forecast"],
+            # site_forecasts[0]["margin_of_error"],
+            # site_forecasts[0]["adjusted_forecast"],
         ):
             result = {
                 key: value
                 for key, value in zip(
-                    ["time", "pm2_5", "margin_of_error", "adjusted_forecast"],
-                    [time, pm2_5, margin_of_error, adjusted_forecast],
+                    ["time", "pm2_5"],
+                    [time, pm2_5],
                 )
             }
             results.append(result)


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
* Removes `margin of error` from endpoint results

