### PR TITLE
New mandatory fields when creating new NETWORKS

### DIFF
--- a/src/auth-service/models/Network.js
+++ b/src/auth-service/models/Network.js
@@ -36,9 +36,18 @@ const NetworkSchema = new Schema(
       unique: true,
     },
     net_status: { type: String, default: "inactive" },
-    net_connection_string: { type: String },
-    net_connection_endpoint: { type: String },
-    net_username: { type: String },
+    net_connection_string: {
+      type: String,
+      required: [true, "net_connection_string is required"],
+    },
+    net_connection_endpoint: {
+      type: String,
+      required: [true, "net_connection_endpoint is required"],
+    },
+    net_username: {
+      type: String,
+      required: [true, "net_username is required"],
+    },
     net_password: { type: String },
     net_specific_fields: {},
     net_manager: { type: ObjectId },

--- a/src/auth-service/routes/v2/networks.js
+++ b/src/auth-service/routes/v2/networks.js
@@ -247,19 +247,25 @@ router.post(
         .withMessage("the net_password should not be empty IF provided")
         .trim(),
       body("net_username")
-        .optional()
+        .exists()
+        .withMessage("the net_username is required")
+        .bail()
         .notEmpty()
         .withMessage("the net_username should not be empty IF provided")
         .trim(),
       body("net_connection_endpoint")
-        .optional()
+        .exists()
+        .withMessage("the net_connection_endpoint is required")
+        .bail()
         .notEmpty()
         .withMessage(
           "the net_connection_endpoint should not be empty IF provided"
         )
         .trim(),
       body("net_connection_string")
-        .optional()
+        .exists()
+        .withMessage("the net_connection_string is required")
+        .bail()
         .notEmpty()
         .withMessage(
           "the net_connection_string should not be empty IF provided"


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] connection_string, connection_endpoint and username have been made mandatory when creating a new network

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/auth-service
npm install
npm run dev-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] create a Network


