### PR TITLE
 Exclude organisations without corresponding network_role.network or group_role.group fields

### DIFF
--- a/src/auth-service/utils/generate-filter.js
+++ b/src/auth-service/utils/generate-filter.js
@@ -33,7 +33,17 @@ const filter = {
         user_id,
       } = { ...req.body, ...req.query, ...req.params };
 
-      let filter = {};
+      let filter = {
+        $or: [
+          {
+            "network_roles.network": { $exists: true, $ne: null },
+          },
+          {
+            "group_roles.group": { $exists: true, $ne: null },
+          },
+        ],
+      };
+
       if (email) {
         filter["email"] = email;
       }


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [ ]  While listing users, exclude network_role or group_role objects without corresponding `network_role.network` or `group_role.group` fields

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/auth-service
npm install
npm run dev-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [ ] list Users



