### PR TITLE
Return empty array for Groups and Networks based on availability

### DIFF
--- a/src/auth-service/config/constants.js
+++ b/src/auth-service/config/constants.js
@@ -586,10 +586,22 @@ const defaultConfig = {
     description: 1,
     profilePicture: 1,
     phoneNumber: 1,
-    lol: { $ifNull: [{ $arrayElemAt: ["$lol", 0] }, null] },
-    networks: "$networks",
+    networks: {
+      $cond: {
+        if: { $eq: ["$network_role", []] }, // Check if network_role is empty
+        then: [], // Represent "networks" as an empty array for users with empty network_role
+        else: "$networks", // Include the "networks" field for users with non-empty network_role
+      },
+    },
     clients: "$clients",
-    groups: "$groups",
+    groups: {
+      $cond: {
+        if: { $eq: ["$group_role", []] }, // Check if group_role is empty
+        then: [], // Represent "groups" as an empty array  for users with empty group_role
+        else: "$groups", // Include the "groups" field for users with non-empty group_role
+      },
+    },
+    clients: "$clients",
     permissions: "$permissions",
     createdAt: {
       $dateToString: {

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -481,7 +481,8 @@ UserSchema.statics = {
           description: { $first: "$description" },
           profilePicture: { $first: "$profilePicture" },
           phoneNumber: { $first: "$phoneNumber" },
-          lol: { $first: "$lol" },
+          group_role: { $first: "$group_role" },
+          network_role: { $first: "$network_role" },
           clients: { $first: "$clients" },
           groups: {
             $addToSet: {

--- a/src/auth-service/utils/generate-filter.js
+++ b/src/auth-service/utils/generate-filter.js
@@ -33,16 +33,7 @@ const filter = {
         user_id,
       } = { ...req.body, ...req.query, ...req.params };
 
-      let filter = {
-        $or: [
-          {
-            "network_roles.network": { $exists: true, $ne: null },
-          },
-          {
-            "group_roles.group": { $exists: true, $ne: null },
-          },
-        ],
-      };
+      let filter = {};
 
       if (email) {
         filter["email"] = email;


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
Represent Networks and Groups as an empty array for users who do not have any of them

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/auth-service
npm install
npm run dev-mac
```

**_WHICH ENDPOINTS SHOULD BE READY FOR TESTING?:_** 

- [x] list users
- [x] list user information




