### PR TITLE
hotfix to emphasize the update or addition of records

### DIFF
--- a/src/device-registry/bin/store-readings-job.js
+++ b/src/device-registry/bin/store-readings-job.js
@@ -52,9 +52,16 @@ const fetchAndStoreDataIntoReadingsModel = async () => {
             async (bail) => {
               try {
                 // logObject("document", doc);
-                const res = await ReadingModel("airqo").updateOne(doc, doc, {
-                  upsert: true,
-                });
+                const filter = { site_id: doc.site_id, time: doc.time };
+                const updateDoc = { ...doc };
+                delete updateDoc._id; // Remove the _id field
+                const res = await ReadingModel("airqo").updateOne(
+                  filter,
+                  updateDoc,
+                  {
+                    upsert: true,
+                  }
+                );
                 // logObject("res", res);
                 // logObject("Number of documents updated", res.modifiedCount);
               } catch (error) {


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] hotfix to emphasize the update or addition of records

- Idempotency: Design the function (inside the `/bin/store-readings-job job`) to be idempotent. This means that even if it's run multiple times, it won't produce different results. For example, instead of inserting records into the database, the function could update them, leaving existing records unchanged.
- We have been noticing Duplicate errors in the K8S logs yet we are using a mongoose update operation, things were not adding up!
- Additionally, we noticed some differences in the measurements for staging and production for the same site at the same time --- we think this fix could help to rectify this issue too.

**_HOW DO I TEST OUT THIS PR?_**
```
cd src/device-registry
npm install
npm run dev-mac
```



