### PR TITLE
Updated DAG definitions with correct parameters and schedule intervals

### DIFF
--- a/src/workflows/dags/airnow.py
+++ b/src/workflows/dags/airnow.py
@@ -1,17 +1,16 @@
 from airflow.decorators import dag, task
-
+from airflow.utils.dates import days_ago
 from airqo_etl_utils.workflows_custom_utils import AirflowUtils
-
 from airqo_etl_utils.airnow_api import AirNowApi
-
 from airqo_etl_utils.constants import DataSource
 
-
+# Historical Data DAG
 @dag(
-    "Airnow-Historical-Bam-Data",
-    schedule=None,
+    dag_id="Airnow-Historical-Bam-Data",
+    schedule_interval=None,
     default_args=AirflowUtils.dag_default_configs(),
     catchup=False,
+    start_date=days_ago(1),
     tags=["bam", "airnow", "historical"],
 )
 def airnow_bam_historical_data():
@@ -20,12 +19,11 @@ def airnow_bam_historical_data():
     @task()
     def extract_bam_data(**kwargs):
         from airqo_etl_utils.date import DateUtils
+        from airqo_etl_utils.airnow_utils import AirnowDataUtils
 
         start_date_time, end_date_time = DateUtils.get_dag_date_time_values(
             historical=True, **kwargs
         )
-        from airqo_etl_utils.airnow_utils import AirnowDataUtils
-
         return AirnowDataUtils.extract_bam_data(
             start_date_time=start_date_time,
             end_date_time=end_date_time,
@@ -75,12 +73,13 @@ def airnow_bam_historical_data():
     send_to_bigquery(processed_bam_data)
     send_to_api(processed_bam_data)
 
-
+# Real-Time Data DAG
 @dag(
-    "Airnow-Realtime-Bam-Data",
-    schedule="30 * * * *",
+    dag_id="Airnow-Realtime-Bam-Data",
+    schedule_interval="30 * * * *",
     default_args=AirflowUtils.dag_default_configs(),
     catchup=False,
+    start_date=days_ago(1),
     tags=["bam", "airnow", "realtime"],
 )
 def airnow_bam_realtime_data():
@@ -133,10 +132,9 @@ def airnow_bam_realtime_data():
 
     extracted_bam_data = extract_bam_data()
     processed_bam_data = process_data(extracted_bam_data)
-    send_to_bigquery(processed_bam_data)
     send_to_message_broker(processed_bam_data)
+    send_to_bigquery(processed_bam_data)
     send_to_api(processed_bam_data)
-
 
 airnow_bam_realtime_data()
 airnow_bam_historical_data()


### PR DESCRIPTION

**_WHAT DOES THIS PR DO?_**

- [X] Correctly specified with `dag_id` and `schedule_interval` instead of schedule
- [X] start_date: Adds to ensure the DAGs start running from a specific date
