### PR TITLE
Update datetime usage: change datetime.utcnow() to datetime.now(timez…

### DIFF
--- a/src/workflows/airqo_etl_utils/commons.py
+++ b/src/workflows/airqo_etl_utils/commons.py
@@ -1,5 +1,5 @@
 import math
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 import numpy as np
 import pandas as pd
@@ -127,7 +127,7 @@ def get_date_time_values(interval_in_days: int = 1, **kwargs):
         start_date_time = dag_run.conf["start_date_time"]
         end_date_time = dag_run.conf["end_date_time"]
     except KeyError:
-        end_date = datetime.utcnow()
+        end_date = datetime.now(timezone.utc)
         start_date = end_date - timedelta(days=interval_in_days)
         start_date_time = datetime.strftime(start_date, "%Y-%m-%dT00:00:00Z")
         end_date_time = datetime.strftime(end_date, "%Y-%m-%dT11:59:59Z")

--- a/src/workflows/airqo_etl_utils/date.py
+++ b/src/workflows/airqo_etl_utils/date.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 class DateUtils:
@@ -34,7 +34,7 @@ class DateUtils:
         except Exception as e:
             print("Exception in get_dag_date_time_values", repr(e))
             if hours is not None:
-                start_date_time = datetime.utcnow() - timedelta(hours=hours)
+                start_date_time = datetime.now(timezone.utc) - timedelta(hours=hours)
                 end_date_time = start_date_time + timedelta(hours=hours)
                 start_date_time = DateUtils.date_to_str(
                     start_date_time, DateUtils.hour_date_time_format
@@ -43,7 +43,7 @@ class DateUtils:
                     end_date_time, DateUtils.hour_date_time_format
                 )
             elif days is not None:
-                start_date_time = datetime.utcnow() - timedelta(days=days)
+                start_date_time = datetime.now(timezone.utc) - timedelta(days=days)
                 end_date_time = start_date_time + timedelta(days=days)
                 start_date_time = DateUtils.date_to_str(
                     start_date_time, DateUtils.day_start_date_time_format
@@ -52,8 +52,8 @@ class DateUtils:
                     end_date_time, DateUtils.day_end_date_time_format
                 )
             else:
-                start_date_time = datetime.utcnow() - timedelta(days=1)
-                end_date_time = datetime.utcnow()
+                start_date_time = datetime.now(timezone.utc) - timedelta(days=1)
+                end_date_time = datetime.now(timezone.utc)
                 start_date_time = DateUtils.date_to_str(
                     start_date_time, DateUtils.day_start_date_time_format
                 )
@@ -67,18 +67,18 @@ class DateUtils:
 
     @staticmethod
     def get_query_date_time_values(hours=1, days=0):
-        start_date_time = datetime.utcnow() - timedelta(hours=hours)
+        start_date_time = datetime.now(timezone.utc) - timedelta(hours=hours)
         end_date_time = start_date_time + timedelta(hours=hours)
 
         if days != 0:
-            start_date_time = datetime.utcnow() - timedelta(days=days)
+            start_date_time = datetime.now(timezone.utc) - timedelta(days=days)
             end_date_time = start_date_time + timedelta(days=days)
 
         return date_to_str_hours(start_date_time), date_to_str_hours(end_date_time)
 
 
 def get_utc_offset_for_hour(subject_hour: int) -> int:
-    hour = datetime.utcnow().hour
+    hour = datetime.now(timezone.utc).hour
     if hour < subject_hour:
         return abs(hour - subject_hour)
     elif hour > subject_hour:

--- a/src/workflows/airqo_etl_utils/utils.py
+++ b/src/workflows/airqo_etl_utils/utils.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 import requests
@@ -96,7 +96,7 @@ class Utils:
         from airqo_etl_utils.date import date_to_str_hours
         from datetime import datetime, timedelta
 
-        hour_of_day = datetime.utcnow() - timedelta(hours=1)
+        hour_of_day = datetime.now(timezone.utc) - timedelta(hours=1)
         start_date_time = date_to_str_hours(hour_of_day)
         end_date_time = datetime.strftime(hour_of_day, "%Y-%m-%dT%H:59:59Z")
 

--- a/src/workflows/airqo_etl_utils/weather_data_utils.py
+++ b/src/workflows/airqo_etl_utils/weather_data_utils.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -257,8 +257,8 @@ class WeatherDataUtils:
                 )
             return [
                 {
-                    "timestamp": datetime.utcfromtimestamp(
-                        result.get("dt", 0)
+                    "timestamp": datetime.fromtimestamp(
+                        result.get("dt", 0), tz=timezone.utc
                     ).strftime("%Y-%m-%d %H:%M:%S"),
                     "latitude": result.get("coord", {}).get("lat", 0),
                     "longitude": result.get("coord", {}).get("lon", 0),

--- a/src/workflows/airqo_etl_utils/workflows_custom_utils.py
+++ b/src/workflows/airqo_etl_utils/workflows_custom_utils.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import requests
 from airflow.hooks.base import BaseHook
@@ -14,7 +14,7 @@ class AirflowUtils:
     @staticmethod
     def dag_default_configs():
         return {
-            "start_date": datetime.utcnow() - timedelta(days=2),
+            "start_date": datetime.now(timezone.utc) - timedelta(days=2),
             "owner": "AirQo",
             "owner_links": {"AirQo": "https://airqo.africa"},
             "retries": 0,
@@ -132,7 +132,7 @@ class AirflowUtils:
         return dag_runs
 
     def remove_old_dag_runs(self, days: int):
-        execution_date_time = datetime.utcnow() - timedelta(days=days)
+        execution_date_time = datetime.now(timezone.utc) - timedelta(days=days)
 
         dags_response = requests.get(
             f"{self.base_url}/api/v1/dags",

--- a/src/workflows/dags/airnow.py
+++ b/src/workflows/dags/airnow.py
@@ -4,6 +4,7 @@ from airqo_etl_utils.workflows_custom_utils import AirflowUtils
 from airqo_etl_utils.airnow_api import AirNowApi
 from airqo_etl_utils.constants import DataSource
 
+
 # Historical Data DAG
 @dag(
     dag_id="Airnow-Historical-Bam-Data",
@@ -73,6 +74,7 @@ def airnow_bam_historical_data():
     send_to_bigquery(processed_bam_data)
     send_to_api(processed_bam_data)
 
+
 # Real-Time Data DAG
 @dag(
     dag_id="Airnow-Realtime-Bam-Data",
@@ -135,6 +137,7 @@ def airnow_bam_realtime_data():
     send_to_message_broker(processed_bam_data)
     send_to_bigquery(processed_bam_data)
     send_to_api(processed_bam_data)
+
 
 airnow_bam_realtime_data()
 airnow_bam_historical_data()

--- a/src/workflows/dags/airqo_bam_measurements.py
+++ b/src/workflows/dags/airqo_bam_measurements.py
@@ -17,10 +17,10 @@ from airqo_etl_utils.bigquery_api import BigQueryApi
     default_args=AirflowUtils.dag_default_configs(),
     catchup=False,
     tags=["airqo", "historical", "bam"],
-    start_date=days_ago(1),  
+    start_date=days_ago(1),
 )
 def airqo_bam_historical_measurements():
-    
+
     @task()
     def extract_bam_data(**kwargs) -> pd.DataFrame:
         start_date_time, end_date_time = DateUtils.get_dag_date_time_values(
@@ -62,6 +62,7 @@ def airqo_bam_historical_measurements():
     save_unclean_data(unclean_data)
     measurements = clean_bam_data(unclean_data)
     save_clean_bam_data(measurements)
+
 
 airqo_bam_historical_measurements_dag = airqo_bam_historical_measurements()
 

--- a/src/workflows/dags/app_notifications.py
+++ b/src/workflows/dags/app_notifications.py
@@ -162,7 +162,7 @@ def evening_notifications():
             NOTIFICATION_TEMPLATE_MAPPER,
         )
 
-        if datetime.now(timezone.utc).weekday in [5, 6]:
+        if datetime.now(timezone.utc).weekday() in [5, 6]:
             name = NOTIFICATION_TEMPLATE_MAPPER["weekend_evening"]
         else:
             name = NOTIFICATION_TEMPLATE_MAPPER["weekday_evening"]

--- a/src/workflows/dags/app_notifications.py
+++ b/src/workflows/dags/app_notifications.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from airflow.decorators import dag, task
 
@@ -117,7 +117,7 @@ def morning_notifications():
             NOTIFICATION_TEMPLATE_MAPPER,
         )
 
-        if datetime.utcnow().weekday in [5, 6]:
+        if datetime.now(timezone.utc).weekday in [5, 6]:
             template = NOTIFICATION_TEMPLATE_MAPPER["weekend_morning"]
         else:
             template = NOTIFICATION_TEMPLATE_MAPPER["weekday_morning"]
@@ -162,7 +162,7 @@ def evening_notifications():
             NOTIFICATION_TEMPLATE_MAPPER,
         )
 
-        if datetime.utcnow().weekday in [5, 6]:
+        if datetime.now(timezone.utc).weekday in [5, 6]:
             name = NOTIFICATION_TEMPLATE_MAPPER["weekend_evening"]
         else:
             name = NOTIFICATION_TEMPLATE_MAPPER["weekday_evening"]

--- a/src/workflows/dags/daily_measurements.py
+++ b/src/workflows/dags/daily_measurements.py
@@ -51,10 +51,10 @@ def realtime_daily_measurements():
     def extract():
         from airqo_etl_utils.daily_data_utils import DailyDataUtils
         from airqo_etl_utils.date import date_to_str_days
-        from datetime import datetime
+        from datetime import datetime, timezone
 
-        start_date_time = date_to_str_days(datetime.utcnow())
-        end_date_time = datetime.strftime(datetime.utcnow(), "%Y-%m-%dT23:00:00Z")
+        start_date_time = date_to_str_days(datetime.now(timezone.utc))
+        end_date_time = datetime.strftime(datetime.now(timezone.utc), "%Y-%m-%dT23:00:00Z")
 
         return DailyDataUtils.query_hourly_data(
             start_date_time=start_date_time,

--- a/src/workflows/dags/daily_measurements.py
+++ b/src/workflows/dags/daily_measurements.py
@@ -54,7 +54,9 @@ def realtime_daily_measurements():
         from datetime import datetime, timezone
 
         start_date_time = date_to_str_days(datetime.now(timezone.utc))
-        end_date_time = datetime.strftime(datetime.now(timezone.utc), "%Y-%m-%dT23:00:00Z")
+        end_date_time = datetime.strftime(
+            datetime.now(timezone.utc), "%Y-%m-%dT23:00:00Z"
+        )
 
         return DailyDataUtils.query_hourly_data(
             start_date_time=start_date_time,

--- a/src/workflows/dags/data_summary.py
+++ b/src/workflows/dags/data_summary.py
@@ -15,7 +15,7 @@ def data_summary():
 
     def extract(**kwargs):
         from airqo_etl_utils.bigquery_api import BigQueryApi
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
         from airqo_etl_utils.date import str_to_date
 
         try:
@@ -23,7 +23,7 @@ def data_summary():
             date_time = str_to_date(date_time)
         except Exception as ex:
             print(ex)
-            date_time = datetime.utcnow() - timedelta(days=2)
+            date_time = datetime.now(timezone.utc) - timedelta(days=2)
 
         bigquery_api = BigQueryApi()
         return bigquery_api.get_devices_hourly_data(day=date_time)

--- a/src/workflows/dags/kcca_measurements.py
+++ b/src/workflows/dags/kcca_measurements.py
@@ -17,9 +17,9 @@ def kcca_hourly_measurements():
     def extract():
         from airqo_etl_utils.kcca_utils import KccaUtils
         from airqo_etl_utils.date import date_to_str_hours
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
-        hour_of_day = datetime.utcnow() - timedelta(hours=1)
+        hour_of_day = datetime.now(timezone.utc) - timedelta(hours=1)
         start_date_time = date_to_str_hours(hour_of_day)
         end_date_time = datetime.strftime(hour_of_day, "%Y-%m-%dT%H:59:59Z")
 

--- a/src/workflows/dags/ml_prediction_jobs.py
+++ b/src/workflows/dags/ml_prediction_jobs.py
@@ -19,9 +19,9 @@ def make_forecasts():
     ### Hourly forecast tasks
     @task()
     def get_historical_data_for_hourly_forecasts():
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
-        start_date = datetime.utcnow() - timedelta(
+        start_date = datetime.now(timezone.utc) - timedelta(
             hours=int(configuration.HOURLY_FORECAST_PREDICTION_JOB_SCOPE)
         )
         from airqo_etl_utils.date import date_to_str
@@ -64,10 +64,10 @@ def make_forecasts():
     # Daily forecast tasks
     @task()
     def get_historical_data_for_daily_forecasts():
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
         from airqo_etl_utils.date import date_to_str
 
-        start_date = datetime.utcnow() - timedelta(
+        start_date = datetime.now(timezone.utc) - timedelta(
             days=int(configuration.DAILY_FORECAST_PREDICTION_JOB_SCOPE)
         )
         start_date = date_to_str(start_date, str_format="%Y-%m-%d")

--- a/src/workflows/dags/urban_better_measurements.py
+++ b/src/workflows/dags/urban_better_measurements.py
@@ -213,9 +213,9 @@ def realtime_measurements_etl__plume_labs():
     import pandas as pd
 
     from airqo_etl_utils.date import date_to_str_hours
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
-    hour_of_day = datetime.utcnow() - timedelta(hours=25)
+    hour_of_day = datetime.now(timezone.utc) - timedelta(hours=25)
     start_date_time = date_to_str_hours(hour_of_day)
     end_date_time = datetime.strftime(hour_of_day, "%Y-%m-%dT%H:59:59Z")
 
@@ -390,9 +390,9 @@ def realtime_measurements_etl__air_beam():
     import pandas as pd
 
     from airqo_etl_utils.date import date_to_str_hours
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
-    hour_of_day = datetime.utcnow() - timedelta(hours=1)
+    hour_of_day = datetime.now(timezone.utc) - timedelta(hours=1)
     start_time = date_to_str_hours(hour_of_day)
     end_time = datetime.strftime(hour_of_day, "%Y-%m-%dT%H:59:59Z")
 

--- a/src/workflows/dags/weather_measurements.py
+++ b/src/workflows/dags/weather_measurements.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 from airflow.decorators import dag, task
 
@@ -179,7 +179,7 @@ def weather_data_realtime():
         from airqo_etl_utils.weather_data_utils import WeatherDataUtils
         from airqo_etl_utils.date import date_to_str_hours
 
-        hour_of_day = datetime.utcnow() - timedelta(hours=1)
+        hour_of_day = datetime.now(timezone.utc) - timedelta(hours=1)
         start_date_time = date_to_str_hours(hour_of_day)
         end_date_time = datetime.strftime(hour_of_day, "%Y-%m-%dT%H:59:59Z")
 


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] Replaces all occurrences of `datetime.utcnow()` with `datetime.now(timezone.utc)` and `datetime.utcfromtimestamp()` with `datetime.fromtimestamp(timezone.utc)`:
  - This change updates deprecated methods to ensure that all datetime objects are consistently timezone-aware and set to UTC. It helps avoid potential issues with naive datetime objects.  

**_EXAMPLE_**

**Before**
```python
from datetime import datetime

# Getting the current UTC time (naive datetime object)
current_time = datetime.utcnow()

# Converting a timestamp to a naive UTC datetime object
timestamp_time = datetime.utcfromtimestamp(timestamp)
```

**After**
```python

from datetime import datetime, timezone

# Getting the current UTC time (timezone-aware datetime object)
current_time = datetime.now(timezone.utc)

# Converting a timestamp to a timezone-aware UTC datetime object
timestamp_time = datetime.fromtimestamp(timestamp, timezone.utc)
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Standardized datetime calculations to use `datetime.now(timezone.utc)` across various modules for improved time consistency and accuracy.
  - Improved timezone handling in notification templates, measurement functions, and ETL workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->