### PR TITLE
Fix get_devices_hourly_data query

### DIFF
--- a/src/workflows/airqo_etl_utils/bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/bigquery_api.py
@@ -67,7 +67,7 @@ class BigQueryApi:
             f" WHERE DATE(`{self.hourly_measurements_table}`.timestamp) >= '{day.strftime('%Y-%m-%d')}' "
             f" AND `{self.hourly_measurements_table}`.pm2_5_raw_value IS NOT NULL "
         )
-        print(query)
+        
         job_config = bigquery.QueryJobConfig()
         job_config.use_query_cache = True
 

--- a/src/workflows/airqo_etl_utils/bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/bigquery_api.py
@@ -67,7 +67,7 @@ class BigQueryApi:
             f" WHERE DATE(`{self.hourly_measurements_table}`.timestamp) >= '{day.strftime('%Y-%m-%d')}' "
             f" AND `{self.hourly_measurements_table}`.pm2_5_raw_value IS NOT NULL "
         )
-        
+
         job_config = bigquery.QueryJobConfig()
         job_config.use_query_cache = True
 

--- a/src/workflows/airqo_etl_utils/bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/bigquery_api.py
@@ -58,16 +58,16 @@ class BigQueryApi:
         day: datetime,
     ) -> pd.DataFrame:
         query = (
-            f" SELECT {self.hourly_measurements_table}.pm2_5_calibrated_value , "
-            f" {self.hourly_measurements_table}.pm2_5_raw_value ,"
-            f" {self.hourly_measurements_table}.site_id ,"
-            f" {self.hourly_measurements_table}.device_id AS device ,"
-            f" FORMAT_DATETIME('%Y-%m-%d %H:%M:%S', {self.hourly_measurements_table}.timestamp) AS timestamp ,"
-            f" FROM {self.hourly_measurements_table} "
-            f" WHERE DATE({self.hourly_measurements_table}.timestamp) >= '{day.strftime('%Y-%m-%d')}' "
-            f" AND {self.hourly_measurements_table}.pm2_5_raw_value is not null "
+            f" SELECT `{self.hourly_measurements_table}`.pm2_5_calibrated_value , "
+            f" `{self.hourly_measurements_table}`.pm2_5_raw_value ,"
+            f" `{self.hourly_measurements_table}`.site_id ,"
+            f" `{self.hourly_measurements_table}`.device_id AS device ,"
+            f" FORMAT_DATETIME('%Y-%m-%d %H:%M:%S', `{self.hourly_measurements_table}`.timestamp) AS timestamp ,"
+            f" FROM `{self.hourly_measurements_table}` "
+            f" WHERE DATE(`{self.hourly_measurements_table}`.timestamp) >= '{day.strftime('%Y-%m-%d')}' "
+            f" AND `{self.hourly_measurements_table}`.pm2_5_raw_value IS NOT NULL "
         )
-
+        print(query)
         job_config = bigquery.QueryJobConfig()
         job_config.use_query_cache = True
 

--- a/src/workflows/airqo_etl_utils/bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/bigquery_api.py
@@ -62,7 +62,7 @@ class BigQueryApi:
             f" `{self.hourly_measurements_table}`.pm2_5_raw_value ,"
             f" `{self.hourly_measurements_table}`.site_id ,"
             f" `{self.hourly_measurements_table}`.device_id AS device ,"
-            f" FORMAT_DATETIME('%Y-%m-%d %H:%M:%S', `{self.hourly_measurements_table}`.timestamp) AS timestamp ,"
+            f" FORMAT_DATETIME('%Y-%m-%d %H:%M:%S', `{self.hourly_measurements_table}`.timestamp) AS timestamp "
             f" FROM `{self.hourly_measurements_table}` "
             f" WHERE DATE(`{self.hourly_measurements_table}`.timestamp) >= '{day.strftime('%Y-%m-%d')}' "
             f" AND `{self.hourly_measurements_table}`.pm2_5_raw_value IS NOT NULL "

--- a/src/workflows/dags/airnow.py
+++ b/src/workflows/dags/airnow.py
@@ -1,8 +1,6 @@
 from airflow.decorators import dag, task
 from airflow.utils.dates import days_ago
 from airqo_etl_utils.workflows_custom_utils import AirflowUtils
-from airqo_etl_utils.airnow_api import AirNowApi
-from airqo_etl_utils.constants import DataSource
 
 
 # Historical Data DAG

--- a/src/workflows/dags/airnow.py
+++ b/src/workflows/dags/airnow.py
@@ -4,6 +4,7 @@ from airqo_etl_utils.workflows_custom_utils import AirflowUtils
 from airqo_etl_utils.airnow_api import AirNowApi
 from airqo_etl_utils.constants import DataSource
 
+
 # Historical Data DAG
 @dag(
     dag_id="Airnow-Historical-Bam-Data",
@@ -73,6 +74,7 @@ def airnow_bam_historical_data():
     send_to_bigquery(processed_bam_data)
     send_to_api(processed_bam_data)
 
+
 # Real-Time Data DAG
 @dag(
     dag_id="Airnow-Realtime-Bam-Data",
@@ -135,6 +137,7 @@ def airnow_bam_realtime_data():
     send_to_message_broker(processed_bam_data)
     send_to_bigquery(processed_bam_data)
     send_to_api(processed_bam_data)
+
 
 airnow_bam_realtime_data()
 airnow_bam_historical_data()

--- a/src/workflows/dags/airqo_bam_measurements.py
+++ b/src/workflows/dags/airqo_bam_measurements.py
@@ -17,10 +17,10 @@ from airqo_etl_utils.bigquery_api import BigQueryApi
     default_args=AirflowUtils.dag_default_configs(),
     catchup=False,
     tags=["airqo", "historical", "bam"],
-    start_date=days_ago(1),  
+    start_date=days_ago(1),
 )
 def airqo_bam_historical_measurements():
-    
+
     @task()
     def extract_bam_data(**kwargs) -> pd.DataFrame:
         start_date_time, end_date_time = DateUtils.get_dag_date_time_values(
@@ -62,6 +62,7 @@ def airqo_bam_historical_measurements():
     save_unclean_data(unclean_data)
     measurements = clean_bam_data(unclean_data)
     save_clean_bam_data(measurements)
+
 
 airqo_bam_historical_measurements_dag = airqo_bam_historical_measurements()
 


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
This PR fixes an SQL query used to retrieve device data by adding backticks around table and column names to avoid syntax errors. This change ensures that the SQL parser correctly interprets identifiers, especially those with periods and special characters.

**_CHANGES MADE_**:

1. **Modified the SQL query**:
    - Added backticks around the table and column names in the `get_devices_hourly_data` function to prevent syntax errors.
    
    **Before**:
    ```python
    query = (
        f"SELECT {self.hourly_measurements_table}.pm2_5_calibrated_value, "
        f"{self.hourly_measurements_table}.pm2_5_raw_value, "
        f"{self.hourly_measurements_table}.site_id, "
        f"{self.hourly_measurements_table}.device_id AS device, "
        f"FORMAT_DATETIME('%Y-%m-%d %H:%M:%S', {self.hourly_measurements_table}.timestamp) AS timestamp "
        f"FROM {self.hourly_measurements_table} "
        f"WHERE DATE({self.hourly_measurements_table}.timestamp) >= '{day.strftime('%Y-%m-%d')}' "
        f"AND {self.hourly_measurements_table}.pm2_5_raw_value IS NOT NULL "
    )
    ```
    
    **After**:
   ```python
    query = (
        f"SELECT `{self.hourly_measurements_table}`.pm2_5_calibrated_value, "
        f"`{self.hourly_measurements_table}`.pm2_5_raw_value, "
        f"`{self.hourly_measurements_table}`.site_id, "
        f"`{self.hourly_measurements_table}`.device_id AS device, "
        f"FORMAT_DATETIME('%Y-%m-%d %H:%M:%S', `{self.hourly_measurements_table}`.timestamp) AS timestamp "
        f"FROM `{self.hourly_measurements_table}` "
        f"WHERE DATE(`{self.hourly_measurements_table}`.timestamp) >= '{day.strftime('%Y-%m-%d')}' "
        f"AND `{self.hourly_measurements_table}`.pm2_5_raw_value IS NOT NULL "
    )
    ```

**_WHY IS THIS NEEDED?_**

Without the backticks, the SQL query fails due to syntax errors. Adding backticks ensures that the SQL parser interprets the identifiers correctly, preventing errors and ensuring the query runs successfully.

**_ERROR MESSAGE_**
**Error**: `BadRequest: 400 Syntax error: Expected end of input but got "." at [2:40]; reason: invalidQuery, location: query, message: Syntax error: Expected end of input but got "." at [2:40]`


**_HOW DO I TEST OUT THIS PR?_**
```python
from airqo_etl_utils.bigquery_api import BigQueryApi
from datetime import datetime, timezone, timedelta

# Initialize the BigQuery API client
big_query_api = BigQueryApi()

# Define the day for the query
day = datetime.now(timezone.utc) - timedelta(days=15)

# Call the function and print the result
try:
    result = big_query_api.get_devices_hourly_data(day=day)
    print(result)
except Exception as e:
    print(f"An error occurred: {e}")

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL query syntax in `get_devices_hourly_data` function to ensure proper table reference and condition handling.

- **Style**
  - Added blank lines around function definitions in `airnow.py` for better readability.
  - Adjusted whitespace and formatting in the Airflow DAG definition for historical BAM measurements in `airqo_bam_measurements.py`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->