### PR TITLE
Fix aggregate_data method to work with pandas 2.X.X

### DIFF
--- a/src/workflows/airqo_etl_utils/weather_data_utils.py
+++ b/src/workflows/airqo_etl_utils/weather_data_utils.py
@@ -196,7 +196,7 @@ class WeatherDataUtils:
             averages.reset_index(drop=True, inplace=True)
 
             summing_data = station_group.copy()[["precipitation"]]
-            sums = pd.DataFrame(summing_data.resample("H").sum(numeric_only=True))
+            sums = pd.DataFrame(summing_data.resample("H").sum())
             sums["timestamp"] = sums.index
             sums.reset_index(drop=True, inplace=True)
 

--- a/src/workflows/airqo_etl_utils/weather_data_utils.py
+++ b/src/workflows/airqo_etl_utils/weather_data_utils.py
@@ -190,7 +190,7 @@ class WeatherDataUtils:
             station_group = station_group.sort_index(axis=0)
 
             averaging_data = station_group.copy()
-            del averaging_data["precipitation"]
+            averaging_data.drop(columns=["precipitation"], inplace=True)
             numeric_cols = averaging_data.select_dtypes(include=[np.number]).columns
             averages = averaging_data.resample("H")[numeric_cols].mean()
             averages.reset_index(drop=True, inplace=True)


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

This PR fixes the `aggregate_data` method to ensure compatibility with pandas 2.0 and above. The method now correctly handles non-numeric columns by excluding them from the resampling operation, which resolves the `TypeError` encountered when trying to compute the mean of non-numeric data. It is also compatible with pandas 1.5.3 and runs error-free.

**_CHANGES MADE_**

- Select only numeric columns for averaging using `select_dtypes`.
- Simplify setting the index and sorting.
- Re-add `station_code` after resampling.

**_WHY IS THIS PR NECESSARY?_**

In pandas 2.0 and above, the `aggregate_data` method fails with a `TypeError` due to the presence of non-numeric data in the DataFrame when attempting to compute the mean. This PR addresses this issue by ensuring that only numeric columns are included in the resampling operation, allowing the method to function correctly with the latest versions of pandas. It also ensures backward compatibility with pandas 1.5.3, avoiding any errors.

**_AIRFLOW LOGS_**

The `production` and `staging` environment seem to be using pandas 1.5.3, the following warning is logged:

```
[2024-06-21, 12:25:37 UTC] {logging_mixin.py:150} 
WARNING - /home/airflow/.local/lib/python3.10/site-packages/airqo_etl_utils/weather_data_utils.py:202 
FutureWarning: The default value of numeric_only in DataFrameGroupBy.sum is deprecated. 
In a future version, numeric_only will default to False. Either specify numeric_only or select only columns which 
should be valid for the function.
```

In pandas 2.0 and above, this results in a `TypeError`:

```
TypeError: Could not convert string 'TA00032TA00032TA00032TA00032TA00032TA00032
TA00032TA00032TA00032TA00032TA00032TA00032' to numeric
```

**_HOW TO TEST._**
Run this code in a jupyter notebook. 
```python
from datetime import datetime, timedelta, timezone
from airqo_etl_utils.date import date_to_str_hours
from airqo_etl_utils.weather_data_utils import WeatherDataUtils

def extract_hourly_weather_data():
    
    hour_of_day = datetime.now(timezone.utc) - timedelta(hours=2)
    start_date_tahmo = date_to_str_hours(hour_of_day)
    end_date_tahmo = datetime.strftime(hour_of_day, "%Y-%m-%dT%H:59:59Z")

    return WeatherDataUtils.extract_hourly_data(
        start_date_time=start_date_tahmo, end_date_time=end_date_tahmo
    )

extract_hourly_weather_data()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced data processing for weather stations, including improved handling of timestamps, averaging, and summing.
  - Clearer and more efficient data resampling and column renaming for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->