### PR TITLE
Fix missing Latitude and Longitude meta-data in extract_raw_data()

### DIFF
--- a/src/workflows/airqo_etl_utils/airqo_api.py
+++ b/src/workflows/airqo_etl_utils/airqo_api.py
@@ -104,7 +104,7 @@ class AirQoApi:
         tenant: Tenant = Tenant.ALL,
         device_category: DeviceCategory = DeviceCategory.NONE,
     ) -> list:
-        params = {"tenant": str(Tenant.AIRQO)}
+        params = {"tenant": str(Tenant.AIRQO), "active": "yes"}
         if tenant != Tenant.ALL:
             params["network"] = str(tenant)
 
@@ -131,7 +131,6 @@ class AirQoApi:
             }
             for device in response.get("devices", [])
         ]
-        # TODO: For cases where lat & lon, look into checking bigquery metadata
 
         if device_category != DeviceCategory.NONE:
             devices = [

--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -373,7 +373,7 @@ class AirQoDataUtils:
                         )
                     )
 
-                meta_data = data.attrs.get("meta_data", {})
+                meta_data = data.attrs.pop("meta_data", {})
 
                 data["device_number"] = device.get("device_number", None)
                 data["device_id"] = device.get("device_id", None)

--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -302,18 +302,34 @@ class AirQoDataUtils:
             tenant=Tenant.AIRQO, device_category=device_category
         )
 
-        devices = [x for x in devices if x["device_number"] in device_numbers] if device_numbers else devices
+        devices = (
+            [x for x in devices if x["device_number"] in device_numbers]
+            if device_numbers
+            else devices
+        )
 
         if device_category == DeviceCategory.BAM:
             field_8_cols = list(configuration.AIRQO_BAM_CONFIG.values())
             other_fields_cols = []
         else:
             field_8_cols = list(configuration.AIRQO_LOW_COST_CONFIG.values())
-            other_fields_cols = ["s1_pm2_5", "s1_pm10", "s2_pm2_5", "s2_pm10", "battery"]
+            other_fields_cols = [
+                "s1_pm2_5",
+                "s1_pm10",
+                "s2_pm2_5",
+                "s2_pm10",
+                "battery",
+            ]
 
         data_columns = [
-            "device_number", "device_id", "site_id", "latitude", "longitude", "timestamp",
-            *field_8_cols, *other_fields_cols
+            "device_number",
+            "device_id",
+            "site_id",
+            "latitude",
+            "longitude",
+            "timestamp",
+            *field_8_cols,
+            *other_fields_cols,
         ]
         data_columns = list(set(data_columns))
 
@@ -342,7 +358,9 @@ class AirQoDataUtils:
                     read_key=read_key,
                 )
 
-                if data.empty: print(f"{device_number} does not have data between {start} and {end}"); continue
+                if data.empty:
+                    print(f"Device does not have data between {start} and {end}")
+                    continue
 
                 if "field8" not in data.columns.to_list():
                     data = DataValidationUtils.fill_missing_columns(

--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -378,7 +378,6 @@ class AirQoDataUtils:
                 data["device_number"] = device.get("device_number", None)
                 data["device_id"] = device.get("device_id", None)
                 data["site_id"] = device.get("site_id", None)
-                
 
                 if device_category == DeviceCategory.LOW_COST:
                     data["latitude"] = device.get("latitude", None)

--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -282,14 +282,18 @@ class AirQoDataUtils:
         remove_outliers: bool = True,
     ) -> pd.DataFrame:
         """
-        Returns a dataframe of AiQo sensors measurements.
+        Extracts sensor measurements from AirQo devices recorded between specified date and time ranges.
 
-        :param start_date_time: start date time
-        :param end_date_time: end date time
-        :param device_category: BAM or low cost sensors
-        :param device_numbers: list of device numbers whose data you want to extract. Defaults to all AirQo devices
-        :param remove_outliers: Removes outliers if set to true.
-        :return: a dataframe of measurements recorded between start date time and end date time
+        Retrieves sensor data from Thingspeak API for devices belonging to the specified device category (BAM or low-cost sensors).
+        Optionally filters data by specific device numbers and removes outliers if requested.
+
+        Parameters:
+        - start_date_time (str): Start date and time (ISO 8601 format) for data extraction.
+        - end_date_time (str): End date and time (ISO 8601 format) for data extraction.
+        - device_category (DeviceCategory): Category of devices to extract data from (BAM or low-cost sensors).
+        - device_numbers (list, optional): List of device numbers whose data to extract. Defaults to None (all devices).
+        - remove_outliers (bool, optional): If True, removes outliers from the extracted data. Defaults to True.
+
         """
 
         airqo_api = AirQoApi()
@@ -298,31 +302,19 @@ class AirQoDataUtils:
             tenant=Tenant.AIRQO, device_category=device_category
         )
 
-        if device_numbers:
-            devices = [x for x in devices if x["device_number"] in device_numbers]
+        devices = [x for x in devices if x["device_number"] in device_numbers] if device_numbers else devices
+
         if device_category == DeviceCategory.BAM:
+            field_8_cols = list(configuration.AIRQO_BAM_CONFIG.values())
             other_fields_cols = []
-            field_8_cols = [x for x in configuration.AIRQO_BAM_CONFIG.values()]
         else:
-            field_8_cols = [x for x in configuration.AIRQO_LOW_COST_CONFIG.values()]
-            other_fields_cols = [
-                "s1_pm2_5",
-                "s1_pm10",
-                "s2_pm2_5",
-                "s2_pm10",
-                "battery",
-            ]
+            field_8_cols = list(configuration.AIRQO_LOW_COST_CONFIG.values())
+            other_fields_cols = ["s1_pm2_5", "s1_pm10", "s2_pm2_5", "s2_pm10", "battery"]
 
         data_columns = [
-            "device_number",
-            "device_id",
-            "site_id",
-            "latitude",
-            "longitude",
-            "timestamp",
+            "device_number", "device_id", "site_id", "latitude", "longitude", "timestamp",
+            *field_8_cols, *other_fields_cols
         ]
-        data_columns.extend(field_8_cols)
-        data_columns.extend(other_fields_cols)
         data_columns = list(set(data_columns))
 
         read_keys = airqo_api.get_thingspeak_read_keys(devices=devices)
@@ -334,7 +326,6 @@ class AirQoDataUtils:
             data_source=DataSource.THINGSPEAK,
         )
 
-        # TODO: Need to review this entire data querying process. some metadata for some devices seems to be missing after the operation. Intend to look into in different pull request.
         for device in devices:
             device_number = device.get("device_number", None)
             read_key = read_keys.get(device_number, None)
@@ -351,13 +342,7 @@ class AirQoDataUtils:
                     read_key=read_key,
                 )
 
-                if data.empty:
-                    print(
-                        f"{device_number} does not have data between {start} and {end}"
-                    )
-                    continue
-
-                meta_data = data.attrs.pop("meta_data", {})
+                if data.empty: print(f"{device_number} does not have data between {start} and {end}"); continue
 
                 if "field8" not in data.columns.to_list():
                     data = DataValidationUtils.fill_missing_columns(
@@ -370,13 +355,11 @@ class AirQoDataUtils:
                         )
                     )
 
-                data["device_number"] = device_number
-                data["device_id"] = device.get("device_id")
-                data["site_id"] = device.get("site_id")
-
-                if device_category == DeviceCategory.BAM:
-                    data["latitude"] = meta_data.get("latitude", None)
-                    data["longitude"] = meta_data.get("longitude", None)
+                data["device_number"] = device.get("device_number", None)
+                data["device_id"] = device.get("device_id", None)
+                data["site_id"] = device.get("site_id", None)
+                data["latitude"] = device.get("latitude", None)
+                data["longitude"] = device.get("longitude", None)
 
                 if device_category == DeviceCategory.LOW_COST:
                     data.rename(

--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -373,13 +373,16 @@ class AirQoDataUtils:
                         )
                     )
 
+                meta_data = data.attrs.get("meta_data", {})
+
                 data["device_number"] = device.get("device_number", None)
                 data["device_id"] = device.get("device_id", None)
                 data["site_id"] = device.get("site_id", None)
-                data["latitude"] = device.get("latitude", None)
-                data["longitude"] = device.get("longitude", None)
+                
 
                 if device_category == DeviceCategory.LOW_COST:
+                    data["latitude"] = device.get("latitude", None)
+                    data["longitude"] = device.get("longitude", None)
                     data.rename(
                         columns={
                             "field1": "s1_pm2_5",
@@ -391,6 +394,9 @@ class AirQoDataUtils:
                         },
                         inplace=True,
                     )
+                else:
+                    data["latitude"] = meta_data.get("latitude", None)
+                    data["longitude"] = meta_data.get("longitude", None)
 
                 devices_data = pd.concat(
                     [devices_data, data[data_columns]], ignore_index=True


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
 - This PR ensures that the `extract_devices_data` method includes latitude and longitude metadata for all device categories (BAM and low-cost sensors). The changes address the issue of missing latitude and longitude in the final output.

**_JIRA CARDS_**
OPS-231 OPS-234

**_CHANGES MADE_**
  - Included latitude and longitude metadata for both BAM and low-cost devices.
  - Simplified device filtering logic.

**_HOW DO I TEST OUT THIS PR?_**
```python 
from datetime import datetime, timedelta, timezone
from airqo_etl_utils.utils import Utils
from airqo_etl_utils.date import date_to_str_hours
from airqo_etl_utils.airqo_utils import AirQoDataUtils
from airqo_etl_utils.constants import DeviceCategory
import pandas as pd 


hour_of_day = datetime.now(timezone.utc) - timedelta(hours=2)
start_date = date_to_str_hours(hour_of_day)
end_date = datetime.strftime(hour_of_day, "%Y-%m-%dT%H:59:59Z")

def extract_raw_data() -> pd.DataFrame:
    
    return AirQoDataUtils.extract_devices_data(
        start_date_time=start_date,
        end_date_time=end_date,
        device_category=DeviceCategory.LOW_COST,
    )

extract_raw_data()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced sensor data extraction for AirQo devices, including refined parameter descriptions, improved data handling, and optimized logic.

- **Bug Fixes**
  - Added missing type annotations and adjusted logic for better device filtering and data extraction.

- **New Features**
  - Introduced a new parameter to the `get_devices` function to filter for active devices only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->