### PR TITLE
Update Consolidated-Data-ETL DAG Schedule to Run Twice Daily

### DIFF
--- a/src/workflows/dags/data_warehouse.py
+++ b/src/workflows/dags/data_warehouse.py
@@ -5,7 +5,7 @@ from airqo_etl_utils.workflows_custom_utils import AirflowUtils
 
 @dag(
     "Consolidated-Data-ETL",
-    schedule="0 0 * * */3",
+    schedule="0 0,12 * * *",
     default_args=AirflowUtils.dag_default_configs(),
     catchup=False,
     tags=["hourly", "consolidated data"],


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
This PR updates the schedule of the Consolidated-Data-ETL DAG to run twice daily instead of every three days. This change is made to ensure that the consolidated data, which is being used in reports, is updated at least from the previous day.

**_CONTEXT_**
The Consolidated-Data-ETL is being utilized in reports, and it's essential to have the data updated more frequently. Therefore, the schedule has been shifted to twice daily to ensure timely updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the schedule for the `Consolidated-Data-ETL` process to run twice daily at midnight and noon, ensuring more frequent data updates and fresher insights for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->