### PR TITLE
patch-broken-dag-airqo-measurements

### DIFF
--- a/src/workflows/dags/airqo_measurements.py
+++ b/src/workflows/dags/airqo_measurements.py
@@ -1,7 +1,5 @@
 from airflow.decorators import dag, task
-from great_expectations_provider.operators.great_expectations import (
-    GreatExpectationsOperator,
-)
+
 from airqo_etl_utils.config import configuration
 from airqo_etl_utils.workflows_custom_utils import AirflowUtils
 from airqo_etl_utils.constants import Frequency
@@ -109,86 +107,10 @@ def airqo_historical_hourly_measurements():
         device_measurements=extracted_device_measurements,
         weather_data=extracted_weather_data,
     )
-
-    validate_schema = GreatExpectationsOperator(
-        task_id="validate_air_quality_schema",
-        expectation_suite_name="air_quality_schema_validation",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "temp_air_quality_data",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_data_quality = GreatExpectationsOperator(
-        task_id="validate_air_quality_data_quality",
-        expectation_suite_name="air_quality_data_quality",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "temp_air_quality_data",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_uniqueness_integrity = GreatExpectationsOperator(
-        task_id="validate_air_quality_uniqueness_integrity",
-        expectation_suite_name="air_quality_uniqueness_integrity",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "temp_air_quality_data",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_temporal_consistency = GreatExpectationsOperator(
-        task_id="validate_air_quality_temporal_consistency",
-        expectation_suite_name="air_quality_temporal_consistency",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "temp_air_quality_data",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_completeness = GreatExpectationsOperator(
-        task_id="validate_air_quality_completeness",
-        expectation_suite_name="air_quality_completeness",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "temp_air_quality_data",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_referential_integrity = GreatExpectationsOperator(
-        task_id="validate_air_quality_referential_integrity",
-        expectation_suite_name="air_quality_referential_integrity",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "temp_air_quality_data",
-        },
-        data_context_root_dir="gx/expectations",
-    )
     calibrated_data = calibrate_data(merged_data)
     load(calibrated_data)
     send_hourly_measurements_to_api(calibrated_data)
     send_hourly_measurements_to_message_broker(calibrated_data)
-
-    # Define Our task dependencies
-    extracted_device_measurements >> extracted_weather_data >> merged_data
-    merged_data >> validate_schema
-    validate_schema >> validate_data_quality
-    validate_data_quality >> validate_uniqueness_integrity
-    validate_uniqueness_integrity >> validate_temporal_consistency
-    validate_temporal_consistency >> validate_completeness
-    validate_completeness >> validate_referential_integrity
-    validate_referential_integrity >> calibrated_data
 
 
 @dag(
@@ -249,126 +171,13 @@ def airqo_historical_raw_measurements():
             table=big_query_api.raw_measurements_table,
         )
 
-    extracted_raw_data = extract_raw_data()
-    cleaned_data = clean_data_raw_data(extracted_raw_data)
-    device_deployment_logs = extract_device_deployment_logs()
-    mapped_site_ids_data = map_site_ids(
-        airqo_data=cleaned_data, deployment_logs=device_deployment_logs
+    raw_data = extract_raw_data()
+    clean_data = clean_data_raw_data(raw_data)
+    device_logs = extract_device_deployment_logs()
+    data_with_site_ids = map_site_ids(
+        airqo_data=clean_data, deployment_logs=device_logs
     )
-    load_data(mapped_site_ids_data)
-
-    # gx validation steps-- Raw-low cost measurements
-    validate_raw_schema = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_schema",
-        expectation_suite_name="raw_air_quality_schema",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-    validate_raw_data_quality = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_data_quality",
-        expectation_suite_name="raw_air_quality_data_quality",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_raw_uniqueness_integrity = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_uniqueness_integrity",
-        expectation_suite_name="raw_air_quality_uniqueness_integrity",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_raw_temporal_consistency = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_temporal_consistency",
-        expectation_suite_name="raw_air_quality_temporal_consistency",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_raw_uniqueness_integrity = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_uniqueness_integrity",
-        expectation_suite_name="raw_air_quality_uniqueness_integrity",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_raw_temporal_consistency = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_temporal_consistency",
-        expectation_suite_name="raw_air_quality_temporal_consistency",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_raw_completeness = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_completeness",
-        expectation_suite_name="raw_air_quality_completeness",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_raw_referential_integrity = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_referential_integrity",
-        expectation_suite_name="raw_air_quality_referential_integrity",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    validate_raw_range = GreatExpectationsOperator(
-        task_id="validate_raw_air_quality_range_validation",
-        expectation_suite_name="raw_air_quality_range_validation",
-        batch_kwargs={
-            "datasource": "{datasource_name}",
-            "dataset": "bigquery://{project_id}/{dataset_id}",
-            "table": "airqo-250220.consolidated_data_stage.hourly_device_measurements",
-        },
-        data_context_root_dir="gx/expectations",
-    )
-
-    (
-        extract_raw_data()
-        >> [
-            validate_raw_schema,
-            validate_raw_data_quality,
-            validate_raw_uniqueness_integrity,
-            validate_raw_temporal_consistency,
-            validate_raw_completeness,
-            validate_raw_referential_integrity,
-            validate_raw_range,
-        ]
-        >> clean_data_raw_data()
-    )
+    load_data(data_with_site_ids)
 
 
 @dag(


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
reverts the DAG to the previous version to address issues caused by invalid arguments passed to the `GreatExpectationsOperator`


I apologize 🤦‍♂️ for any inconvenience this may have caused to the production environment. in the future, I plan to use `Python callables`  for handling task arguments and configurations 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the processing workflow by removing redundant validation tasks for schema, data quality, uniqueness integrity, temporal consistency, completeness, referential integrity, and range validation.
  - Streamlined data processing with updated steps: data calibration, loading, and sending hourly measurements to the API and message broker.

- **Improvement**
  - Enhanced data processing efficiency by reducing the number of validation tasks and optimizing task dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->