### PR TITLE
Type Error Fix & Unit test for AirQo-Historical-Hourly-Measurements (extract_aggregated_raw_data)

### DIFF
--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -104,7 +104,6 @@ class AirQoDataUtils:
 
         measurements = measurements.dropna(subset=["timestamp"])
         measurements["timestamp"] = pd.to_datetime(measurements["timestamp"])
-        devices_groups = measurements.groupby("device_number")
         averaged_measurements_list = []
 
         for (device_number, site_id), device_site in measurements.groupby(["device_number", "site_id"]):

--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -103,24 +103,24 @@ class AirQoDataUtils:
             return pd.DataFrame([])
 
         measurements = measurements.dropna(subset=["timestamp"])
-        measurements["timestamp"] = measurements["timestamp"].apply(pd.to_datetime)
-        averaged_measurements = pd.DataFrame()
+        measurements["timestamp"] = pd.to_datetime(measurements["timestamp"])
         devices_groups = measurements.groupby("device_number")
+        averaged_measurements_list = []
 
-        for _, device_group in devices_groups:
-            device_number = device_group.iloc[0]["device_number"]
+        for device_number, device_group in devices_groups:
             device_site_groups = device_group.groupby("site_id")
 
-            for _, device_site in device_site_groups:
-                site_id = device_site.iloc[0]["site_id"]
+            for site_id, device_site in device_site_groups:
                 data = device_site.sort_index(axis=0)
-                averages = pd.DataFrame(data.resample("1H", on="timestamp").mean())
+                numeric_columns = data.select_dtypes(include='number').columns
+                averages = data.resample("1H", on="timestamp")[numeric_columns].mean()
+
                 averages["timestamp"] = averages.index
                 averages["device_number"] = device_number
                 averages["site_id"] = site_id
-                averaged_measurements = averaged_measurements.append(
-                    averages, ignore_index=True
-                )
+                averaged_measurements_list.append(averages)
+                
+        averaged_measurements = pd.concat(averaged_measurements_list, ignore_index=True)
 
         return averaged_measurements
 

--- a/src/workflows/airqo_etl_utils/tests/test_airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/tests/test_airqo_utils.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime
 
 import pandas as pd
+import numpy as np
 import pymongo as pm
 import pytest
 
@@ -9,7 +10,6 @@ import airqo_etl_utils.tests.conftest as ct
 from airqo_etl_utils.airqo_utils import AirQoDataUtils
 from airqo_etl_utils.config import configuration
 from airqo_etl_utils.date import date_to_str
-from airqo_etl_utils.tests.conftest import FaultDetectionFixtures
 
 
 class TestAirQoDataUtils(unittest.TestCase):
@@ -54,6 +54,61 @@ class TestAirQoDataUtils(unittest.TestCase):
         self.assertEqual(data.iloc[0]["site_id"], "01")
         self.assertEqual(data.iloc[0]["device_number"], 2)
         self.assertEqual(date_to_str(data.iloc[0]["timestamp"]), "2022-01-01T10:00:00Z")
+
+    def test_extract_aggregated_raw_data(self):
+
+        expected_data = {
+            'device_number': [930426, 930426, 930426, 930426, 930426, 930426],
+            'latitude': [0.36545, 0.36545, 0.36545, 0.36545, 0.36545, 0.36545],
+            'longitude': [32.64675, 32.64675, 32.64675, 32.64675, 32.64675, 32.64675],
+            'pm2_5': [92.92818181818183, 87.155, 85.07763157894736, 86.9524, 78.91153846153846, 76.75399999999999],
+            's1_pm2_5': [95.87681818181818, 89.86695652173913, 87.45578947368422, 89.01360000000001, 81.49, 80.02000000000001],
+            's2_pm2_5': [89.97954545454546, 84.44304347826088, 82.69947368421053, 84.89119999999998, 76.33307692307692, 73.488],
+            'pm10': [100.07227272727273, 94.0882608695652, 91.97763157894737, 95.05799999999999, 89.10865384615384, 85.256],
+            's1_pm10': [105.55363636363636, 99.2895652173913, 96.8221052631579, 99.984, 94.99538461538462, 90.313],
+            's2_pm10': [94.5909090909091, 88.88695652173914, 87.13315789473684, 90.132, 83.22192307692308, 80.199],
+            'no2': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'pm1': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            's1_pm1': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            's2_pm1': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'pressure': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            's1_pressure': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            's2_pressure': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'temperature': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'humidity': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'voc': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            's1_voc': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            's2_voc': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'wind_speed': [0.10909090909090909, 0.02, 0.13789473684210526, 0.1275, 0.030000000000000002, 0.03],
+            'altitude': [1190.081818181818, 1202.3, 1193.3736842105263, 1188.825, 1180.2, 1180.2],
+            'satellites': [10.0, 10.0, 10.0, 10.0, 10.0, 10.0],
+            'hdop': [111.18181818181819, 87.0, 146.78947368421052, 140.75, 89.0, 89.0],
+            'device_temperature': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'device_humidity': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'battery': [3.9490909090909097, 3.9495652173913043, 3.9489473684210528, 3.95, 3.9496153846153845, 3.9490000000000003],
+            'co': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'nh3': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            'timestamp': [pd.Timestamp('2024-07-10 00:00:00+0000', tz='UTC'),
+                        pd.Timestamp('2024-07-10 01:00:00+0000', tz='UTC'),
+                        pd.Timestamp('2024-07-10 02:00:00+0000', tz='UTC'),
+                        pd.Timestamp('2024-07-10 03:00:00+0000', tz='UTC'),
+                        pd.Timestamp('2024-07-10 04:00:00+0000', tz='UTC'),
+                        pd.Timestamp('2024-07-10 05:00:00+0000', tz='UTC')],
+            'site_id': ['60d058c8048305120d2d616d', '60d058c8048305120d2d616d', '60d058c8048305120d2d616d',
+                        '60d058c8048305120d2d616d', '60d058c8048305120d2d616d', '60d058c8048305120d2d616d']
+        }
+        expected_df = pd.DataFrame(expected_data)
+
+        start_date_time = '2024-07-10T00:00:00Z'
+        end_date_time = '2024-07-11T11:59:59Z'
+
+        result = AirQoDataUtils.extract_aggregated_raw_data(start_date_time, end_date_time)
+
+        result_filtered = result[result['device_number'] == 930426]
+
+        result_subset = result_filtered.head(6).reset_index(drop=True)
+
+        pd.testing.assert_frame_equal(result_subset, expected_df)
 
 
 class TestFaultDetector(ct.FaultDetectionFixtures):


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [x] Fixes the type error in the `extract_aggregated_raw_data` task (Ensure that only numeric columns are aggregated)
- [x] Adds a Unit Test for the task.

**_HOW TO TEST_**
```python
import unittest
from airqo_etl_utils.tests.test_airqo_utils import TestAirQoDataUtils

test_loader = unittest.TestLoader()
test_names = test_loader.getTestCaseNames(TestAirQoDataUtils)

suite = unittest.TestSuite()
suite.addTest(TestAirQoDataUtils('test_extract_aggregated_raw_data'))

runner = unittest.TextTestRunner()
runner.run(suite)
```
**_TEST SUCCESS_**
```
----------------------------------------------------------------------
Ran 1 test in 82.382s

OK
<unittest.runner.TextTestResult run=1 errors=0 failures=0>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of data aggregation by updating the method for calculating hourly averages.

- **Tests**
  - Added new test to validate the extraction of aggregated raw data, ensuring reliability and performance within specified date ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->