### PR TITLE
Only drop rows where the timestamp is null

### DIFF
--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -458,7 +458,7 @@ class AirQoDataUtils:
     @staticmethod
     def clean_low_cost_sensor_data(data: pd.DataFrame) -> pd.DataFrame:
         data = DataValidationUtils.remove_outliers(data)
-        data.dropna(inplace=True)
+        data.dropna(subset=["timestamp"], inplace=True)
         data["timestamp"] = pd.to_datetime(data["timestamp"])
         data.drop_duplicates(
             subset=["timestamp", "device_number"], keep="first", inplace=True


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [ ] Updates the earlier implementation where rows with NA values are dropped. This is after looking at the data and realizing that there are multiple columns that have NA values and hence might be dropping much needed rows where the timestamp is set.

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [] OPS-248

**_HOW DO I TEST OUT THIS PR?_**

- [ ] Analytics: [Link to Analytics README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/analytics#readme)
- [ ] Auth Service: [Link to Auth Service README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/auth-service#readme)
- [ ] Calibrate: [Link to Calibrate README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/calibrate#readme)
- [ ] Data Proxy: [Link to Data Proxy README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/data-proxy#readme)
- [ ] Device Monitoring: [Link to Device Monitoring README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/device-monitoring#readme)
- [ ] Device Registry: [Link to Device Registry README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/device-registry#readme)
- [ ] Device Status: [Link to Device Status README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/device-status#readme)
- [ ] Device Uptime: [Link to Device Uptime README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/device-uptime#readme)
- [ ] Exceedances: [Link to Exceedances README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/exceedances#readme)
- [ ] Firebase: [Link to Firebase README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/firebase)
- [ ] GP Model: [Link to GP Model README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/gp-model#readme)
- [ ] Incentives: [Link to Incentives README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/incentives#readme)
- [ ] Kafka Connectors: [Link to Kafka Connectors](https://github.com/airqo-platform/AirQo-api/tree/staging/src/kafka-connectors)
- [ ] Locate: [Link to Locate README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/locate#readme)
- [ ] Metadata: [Link to Metadata README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/meta-data#readme)
- [ ] Predict: [Link to Predict README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/predict#readme)
- [ ] Spatial: [Link to Spatial](https://github.com/airqo-platform/AirQo-api/tree/staging/src/spatial)
- [ ] View: [Link to View README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/view#readme)
- [ ] Workflows: [Link to Workflows README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/workflows#readme)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data cleaning to ensure only rows with missing timestamps are removed from low-cost sensor data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->