### PR TITLE
feat: include network information in activity response

### DIFF
--- a/src/device-registry/controllers/create-activity.js
+++ b/src/device-registry/controllers/create-activity.js
@@ -34,8 +34,8 @@ function handleResponse({
   const errors = isSuccess
     ? undefined
     : result.errors !== undefined
-    ? result.errors
-    : { message: "Internal Server Error" };
+      ? result.errors
+      : { message: "Internal Server Error" };
 
   return res.status(status).json({ message, [key]: data, [errorKey]: errors });
 }
@@ -70,6 +70,7 @@ const activity = {
           message: result.message,
           createdActivity: result.data.createdActivity,
           updatedDevice: result.data.updatedDevice,
+          network: result.data.network,
         });
       } else if (result.success === false) {
         const status = result.status
@@ -122,6 +123,7 @@ const activity = {
           message: result.message,
           createdActivity: result.data.createdActivity,
           updatedDevice: result.data.updatedDevice,
+          network: result.data.network,
         });
       } else if (result.success === false) {
         const status = result.status
@@ -174,6 +176,7 @@ const activity = {
           message: result.message,
           createdActivity: result.data.createdActivity,
           updatedDevice: result.data.updatedDevice,
+          network: result.data.network,
         });
       } else if (result.success === false) {
         const status = result.status
@@ -292,6 +295,7 @@ const activity = {
           success: true,
           message: result.message,
           updated_activity: result.data,
+          network: result.data.network,
         });
       } else if (result.success === false) {
         const status = result.status
@@ -346,6 +350,7 @@ const activity = {
           success: true,
           message: result.message,
           deleted_activity: result.data,
+          network: result.data.network,
         });
       } else if (result.success === false) {
         const status = result.status
@@ -399,6 +404,7 @@ const activity = {
           success: true,
           message: result.message,
           site_activities: result.data,
+          network: result.data.network,
         });
       } else if (result.success === false) {
         const status = result.status


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
Referencing the [conversation via slack,](https://airqo.slack.com/archives/C03URQ3Q49J/p1721454368948699?thread_ts=1721453420.731309&cid=C03URQ3Q49J) this PR updates the activity controller methods to include `network details` in the response

