### PR TITLE
Increase Resources for Workflows to fix Sigkill for some DAGs

### DIFF
--- a/k8s/workflows/values-prod.yaml
+++ b/k8s/workflows/values-prod.yaml
@@ -16,10 +16,10 @@ podAnnotations: {}
 resources:
   limits:
     cpu: 2000m
-    memory: 6000Mi
+    memory: 6500Mi
   requests:
     cpu: 700m
-    memory: 4500Mi
+    memory: 4000Mi
 volumeMounts:
   - name: config-volume
     mountPath: /etc/config

--- a/k8s/workflows/values-prod.yaml
+++ b/k8s/workflows/values-prod.yaml
@@ -18,7 +18,7 @@ resources:
     cpu: 2000m
     memory: 6000Mi
   requests:
-    cpu: 1000m
+    cpu: 700m
     memory: 4500Mi
 volumeMounts:
   - name: config-volume

--- a/k8s/workflows/values-prod.yaml
+++ b/k8s/workflows/values-prod.yaml
@@ -15,11 +15,11 @@ fullnameOverride: ''
 podAnnotations: {}
 resources:
   limits:
-    cpu: 1500m
-    memory: 4500Mi
+    cpu: 2000m
+    memory: 6000Mi
   requests:
-    cpu: 500m
-    memory: 3000Mi
+    cpu: 1000m
+    memory: 4500Mi
 volumeMounts:
   - name: config-volume
     mountPath: /etc/config

--- a/k8s/workflows/values-stage.yaml
+++ b/k8s/workflows/values-stage.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 1500m
     memory: 4500Mi
   requests:
-    cpu: 400m
-    memory: 2000Mi
+    cpu: 150m
+    memory: 1400Mi
 volumeMounts:
   - name: config-volume
     mountPath: /etc/config

--- a/k8s/workflows/values-stage.yaml
+++ b/k8s/workflows/values-stage.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 1500m
     memory: 4500Mi
   requests:
-    cpu: 150m
-    memory: 1400Mi
+    cpu: 400m
+    memory: 2000Mi
 volumeMounts:
   - name: config-volume
     mountPath: /etc/config


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- Increase Resources for Workflows to fix Sigkill for some DAGs

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- AirQo Historical measurements DAG failing to work.
- A couple of DAGs failing occasionally.

**_HOW DO I TEST OUT THIS PR?_**

- [ ] Workflows: [Link to Workflows README](https://github.com/airqo-platform/AirQo-api/tree/staging/src/workflows#readme)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Increased resource allocation for production and staging environments to enhance performance.
		- CPU limits raised from 1500m to 2000m in production and from 150m to 400m in staging.
		- Memory limits increased from 4500Mi to 6000Mi in production and from 1400Mi to 2000Mi in staging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->