### PR TITLE
Fix/airqo hourly historical pipeline

### DIFF
--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -106,9 +106,11 @@ class AirQoDataUtils:
         measurements["timestamp"] = pd.to_datetime(measurements["timestamp"])
         averaged_measurements_list = []
 
-        for (device_number, site_id), device_site in measurements.groupby(["device_number", "site_id"]):
+        for (device_number, site_id), device_site in measurements.groupby(
+            ["device_number", "site_id"]
+        ):
             data = device_site.sort_index(axis=0)
-            numeric_columns = data.select_dtypes(include='number').columns
+            numeric_columns = data.select_dtypes(include="number").columns
             averages = data.resample("1H", on="timestamp")[numeric_columns].mean()
             averages["timestamp"] = averages.index
             averages["device_number"] = device_number
@@ -190,9 +192,7 @@ class AirQoDataUtils:
 
             raw_data = WeatherDataUtils.transform_raw_data(raw_data)
             aggregated_data = WeatherDataUtils.aggregate_data(raw_data)
-            aggregated_data["timestamp"] = aggregated_data["timestamp"].apply(
-                pd.to_datetime
-            )
+            aggregated_data["timestamp"] = pd.to_datetime(aggregated_data["timestamp"])
 
             for _, row in station_data.iterrows():
                 device_weather_data = aggregated_data.copy()
@@ -235,12 +235,12 @@ class AirQoDataUtils:
                 columns={col: f"device_reading_{col}_col"}, inplace=True
             )
 
-        measurements["timestamp"] = measurements["timestamp"].apply(pd.to_datetime)
+        measurements["timestamp"] = pd.to_datetime(measurements["timestamp"])
         measurements["device_number"] = measurements["device_number"].apply(
             lambda x: pd.to_numeric(x, errors="coerce", downcast="integer")
         )
 
-        weather_data["timestamp"] = weather_data["timestamp"].apply(pd.to_datetime)
+        weather_data["timestamp"] = pd.to_datetime(weather_data["timestamp"])
         weather_data["device_number"] = weather_data["device_number"].apply(
             lambda x: pd.to_numeric(x, errors="coerce", downcast="integer")
         )
@@ -260,7 +260,7 @@ class AirQoDataUtils:
 
     @staticmethod
     def restructure_airqo_mobile_data_for_bigquery(data: pd.DataFrame) -> pd.DataFrame:
-        data["timestamp"] = data["timestamp"].apply(pd.to_datetime)
+        data["timestamp"] = pd.to_datetime(data["timestamp"])
         data["tenant"] = "airqo"
         big_query_api = BigQueryApi()
         cols = big_query_api.get_columns(
@@ -469,7 +469,7 @@ class AirQoDataUtils:
     def format_data_for_bigquery(
         data: pd.DataFrame, data_type: DataType
     ) -> pd.DataFrame:
-        data.loc[:, "timestamp"] = data["timestamp"].apply(pd.to_datetime)
+        data.loc[:, "timestamp"] = pd.to_datetime(data["timestamp"])
         data.loc[:, "tenant"] = str(Tenant.AIRQO)
         big_query_api = BigQueryApi()
         if data_type == DataType.UNCLEAN_BAM_DATA:
@@ -492,19 +492,25 @@ class AirQoDataUtils:
 
     @staticmethod
     def process_raw_data_for_bigquery(data: pd.DataFrame) -> pd.DataFrame:
-        data["timestamp"] = data["timestamp"].apply(pd.to_datetime)
+        """
+        Makes neccessary conversions, adds missing columns and sets them to `None`
+        """
+        data["timestamp"] = pd.to_datetime(data["timestamp"])
         data["tenant"] = str(Tenant.AIRQO)
         big_query_api = BigQueryApi()
         cols = big_query_api.get_columns(table=big_query_api.raw_measurements_table)
-        return Utils.populate_missing_columns(data=data, cols=cols)
+        return Utils.populate_missing_columns(data=data, columns=cols)
 
     @staticmethod
     def process_aggregated_data_for_bigquery(data: pd.DataFrame) -> pd.DataFrame:
-        data["timestamp"] = data["timestamp"].apply(pd.to_datetime)
+        """
+        Makes neccessary conversions, adds missing columns and sets them to `None`
+        """
+        data["timestamp"] = pd.to_datetime(data["timestamp"])
         data["tenant"] = str(Tenant.AIRQO)
         big_query_api = BigQueryApi()
         cols = big_query_api.get_columns(table=big_query_api.hourly_measurements_table)
-        return Utils.populate_missing_columns(data=data, cols=cols)
+        return Utils.populate_missing_columns(data=data, columns=cols)
 
     @staticmethod
     def process_latest_data(
@@ -559,7 +565,7 @@ class AirQoDataUtils:
 
         restructured_data = []
 
-        data["timestamp"] = data["timestamp"].apply(pd.to_datetime)
+        data["timestamp"] = pd.to_datetime(data["timestamp"])
         data["timestamp"] = data["timestamp"].apply(date_to_str)
         airqo_api = AirQoApi()
         devices = airqo_api.get_devices(tenant=Tenant.AIRQO)
@@ -778,12 +784,12 @@ class AirQoDataUtils:
             return data
 
         data = data.copy()
-        data["timestamp"] = data["timestamp"].apply(pd.to_datetime)
-        deployment_logs["start_date_time"] = deployment_logs["start_date_time"].apply(
-            pd.to_datetime
+        data["timestamp"] = pd.to_datetime(data["timestamp"])
+        deployment_logs["start_date_time"] = pd.to_datetime(
+            deployment_logs["start_date_time"]
         )
-        deployment_logs["end_date_time"] = deployment_logs["end_date_time"].apply(
-            pd.to_datetime
+        deployment_logs["end_date_time"] = pd.to_datetime(
+            deployment_logs["end_date_time"]
         )
 
         for _, device_log in deployment_logs.iterrows():

--- a/src/workflows/dags/airqo_measurements.py
+++ b/src/workflows/dags/airqo_measurements.py
@@ -20,23 +20,20 @@ from task_docs import (
 )
 def airqo_historical_hourly_measurements():
     import pandas as pd
+    from airqo_etl_utils.airqo_utils import AirQoDataUtils
+    from airqo_etl_utils.date import DateUtils
 
     @task()
-    def extract_device_measurements(**kwargs):
-        from airqo_etl_utils.date import DateUtils
-        from airqo_etl_utils.airqo_utils import AirQoDataUtils
-
+    def extract_device_measurements(**kwargs) -> pd.DataFrame:
         start_date_time, end_date_time = DateUtils.get_dag_date_time_values(
             historical=True, days=3, **kwargs
         )
         return AirQoDataUtils.extract_aggregated_raw_data(
-            start_date_time=start_date_time,
-            end_date_time=end_date_time,
+            start_date_time=start_date_time, end_date_time=end_date_time
         )
 
     @task()
     def extract_weather_data(**kwargs):
-        from airqo_etl_utils.date import DateUtils
         from airqo_etl_utils.weather_data_utils import WeatherDataUtils
 
         start_date_time, end_date_time = DateUtils.get_dag_date_time_values(
@@ -44,42 +41,36 @@ def airqo_historical_hourly_measurements():
         )
 
         return WeatherDataUtils.extract_hourly_weather_data(
-            start_date_time=start_date_time,
-            end_date_time=end_date_time,
+            start_date_time=start_date_time, end_date_time=end_date_time
         )
 
     @task()
-    def merge_data(device_measurements: pd.DataFrame, weather_data: pd.DataFrame):
-        from airqo_etl_utils.airqo_utils import AirQoDataUtils
-
+    def merge_data(
+        device_measurements: pd.DataFrame, weather_data: pd.DataFrame
+    ) -> pd.DataFrame:
         return AirQoDataUtils.merge_aggregated_weather_data(
             airqo_data=device_measurements, weather_data=weather_data
         )
 
     @task()
-    def calibrate_data(measurements: pd.DataFrame):
-        from airqo_etl_utils.airqo_utils import AirQoDataUtils
-
+    def calibrate_data(measurements: pd.DataFrame) -> pd.DataFrame:
         return AirQoDataUtils.calibrate_data(data=measurements)
 
     @task()
-    def load(data: pd.DataFrame):
+    def load(data: pd.DataFrame) -> None:
         from airqo_etl_utils.bigquery_api import BigQueryApi
-        from airqo_etl_utils.airqo_utils import AirQoDataUtils
 
         data = AirQoDataUtils.process_aggregated_data_for_bigquery(data=data)
         big_query_api = BigQueryApi()
         big_query_api.load_data(
-            dataframe=data,
-            table=big_query_api.hourly_measurements_table,
+            dataframe=data, table=big_query_api.hourly_measurements_table
         )
 
     @task()
-    def send_hourly_measurements_to_api(airqo_data: pd.DataFrame, **kwargs):
+    def send_hourly_measurements_to_api(airqo_data: pd.DataFrame, **kwargs) -> None:
         send_to_api_param = kwargs.get("params", {}).get("send_to_api")
         if send_to_api_param:
             from airqo_etl_utils.airqo_api import AirQoApi
-            from airqo_etl_utils.airqo_utils import AirQoDataUtils
 
             data = AirQoDataUtils.process_data_for_api(
                 airqo_data, frequency=Frequency.HOURLY
@@ -91,7 +82,7 @@ def airqo_historical_hourly_measurements():
             print("The send to API parameter has been set to false")
 
     @task()
-    def send_hourly_measurements_to_message_broker(data: pd.DataFrame):
+    def send_hourly_measurements_to_message_broker(data: pd.DataFrame) -> None:
         from airqo_etl_utils.message_broker_utils import MessageBrokerUtils
         from airqo_etl_utils.data_validator import DataValidationUtils
         from airqo_etl_utils.constants import Tenant

--- a/src/workflows/dags/airqo_measurements.py
+++ b/src/workflows/dags/airqo_measurements.py
@@ -3,7 +3,10 @@ from airflow.decorators import dag, task
 from airqo_etl_utils.config import configuration
 from airqo_etl_utils.workflows_custom_utils import AirflowUtils
 from airqo_etl_utils.constants import Frequency
-from dag_docs import airqo_realtime_low_cost_measurements_doc
+from dag_docs import (
+    airqo_realtime_low_cost_measurements_doc,
+    airqo_historical_hourly_measurements_doc,
+)
 from task_docs import (
     extract_raw_airqo_data_doc,
     clean_data_raw_data_doc,
@@ -14,6 +17,7 @@ from task_docs import (
 @dag(
     "AirQo-Historical-Hourly-Measurements",
     schedule="0 0 * * *",
+    doc_md=airqo_historical_hourly_measurements_doc,
     default_args=AirflowUtils.dag_default_configs(),
     catchup=False,
     tags=["airqo", "hourly", "historical", "low cost"],

--- a/src/workflows/dags/dag_docs.py
+++ b/src/workflows/dags/dag_docs.py
@@ -6,3 +6,14 @@ Streams and calibrates measurements for AirQo low cost sensors on an hourly freq
 #### Notes
 - <a href="https://airqo.africa/" target="_blank">AirQo</a>
 """
+
+airqo_historical_hourly_measurements_doc = """
+### AirQo historical hourly recalibration ETL
+#### Purpose
+Re-calibrates measurements for AirQo sensors once a day if for any reason this did not happen.
+#### Notes
+Data sources:
+    Bigquery raw_data.device_measurements
+    Bigquery averaged_data.hourly_weather_data
+- <a href="https://airqo.africa/" target="_blank">AirQo</a>
+"""


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [ ] This should fix the `send_hourly_measurements_to_message_broker` task that was failing due to a missing `device_id` data.

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

- Jira cards
    - [] OPS-259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for the AirQo historical hourly measurements process, providing clearer guidance on functionality.
	- Introduced a new feature for daily recalibration of AirQo sensor measurements.

- **Improvements**
	- Improved type safety and readability with added type annotations in various functions.
	- Streamlined data processing logic for better performance and clarity.

- **Bug Fixes**
	- Removed redundant import statements to enhance code structure and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->