### PR TITLE
Suspend shifted cronjobs from the cluster

### DIFF
--- a/k8s/analytics/templates/devices-summary.yaml
+++ b/k8s/analytics/templates/devices-summary.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.jobs.devicesSummaryJob.name }}
   namespace: {{ .Values.namespace }}
 spec:
+  suspend: True
   concurrencyPolicy: Allow
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1

--- a/k8s/analytics/templates/reports.yaml
+++ b/k8s/analytics/templates/reports.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.jobs.reports.name }}
   namespace: {{ .Values.namespace }}
 spec:
+  suspend: True
   concurrencyPolicy: Allow
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1

--- a/k8s/device-status/templates/cronjob.yaml
+++ b/k8s/device-status/templates/cronjob.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.app.name }}
   namespace: {{ .Values.app.namespace }}
 spec:
+  suspend: True
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2

--- a/k8s/device-uptime/templates/cronjob-v2.yaml
+++ b/k8s/device-uptime/templates/cronjob-v2.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ .Values.app.name }}-v2"
   namespace: {{ .Values.app.namespace }}
 spec:
+  suspend: True
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2

--- a/k8s/device-uptime/templates/cronjob.yaml
+++ b/k8s/device-uptime/templates/cronjob.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.app.name }}
   namespace: {{ .Values.app.namespace }}
 spec:
+  suspend: True
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2

--- a/k8s/predict/templates/places-airquality.yaml
+++ b/k8s/predict/templates/places-airquality.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.jobs.predictPlaces.name }}
   namespace: {{ .Values.namespace }}
 spec:
+  suspend: True
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

- [ ] Suspend shifted cronjobs from the cluster


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `suspend` feature in various job and CronJob specifications, allowing users to pause job execution until explicitly resumed. This provides enhanced control over job scheduling and resource management.

- **Impact**
	- Users can now manage job execution more effectively, enabling maintenance or troubleshooting without needing to delete job configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->