### PR TITLE
remove write and read keys from main update operation

### DIFF
--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -25,6 +25,15 @@ const noSpaces = /^\S*$/;
 
 const accessCodeGenerator = require("generate-password");
 
+function sanitizeObject(obj, invalidKeys) {
+  invalidKeys.forEach((key) => {
+    if (obj.hasOwnProperty(key)) {
+      delete obj[key];
+    }
+  });
+  return obj;
+}
+
 const deviceSchema = new mongoose.Schema(
   {
     cohorts: {
@@ -528,12 +537,10 @@ deviceSchema.statics = {
     try {
       let modifiedUpdate = Object.assign({}, update);
       modifiedUpdate["$addToSet"] = {};
-      delete modifiedUpdate.name;
-      delete modifiedUpdate.device_number;
-      delete modifiedUpdate._id;
-      delete modifiedUpdate.generation_count;
-      delete modifiedUpdate.generation_version;
-      delete modifiedUpdate.network;
+      //device_number, generation_count, generation_version, network
+      const invalidKeys = ["name", "_id", "writeKey", "readKey"];
+      modifiedUpdate = sanitizeObject(modifiedUpdate, invalidKeys);
+
       let options = { new: true, projected: modifiedUpdate, ...opts };
 
       if (!isEmpty(modifiedUpdate.access_code)) {
@@ -604,12 +611,6 @@ deviceSchema.statics = {
       logObject("the filter", filter);
       let options = { new: true };
       let modifiedUpdate = update;
-      delete modifiedUpdate.name;
-      delete modifiedUpdate.device_number;
-      delete modifiedUpdate._id;
-      delete modifiedUpdate.generation_count;
-      delete modifiedUpdate.generation_version;
-
       validKeys = ["writeKey", "readKey"];
       Object.keys(modifiedUpdate).forEach(
         (key) => validKeys.includes(key) || delete modifiedUpdate[key]


### PR DESCRIPTION
## Description

remove write and read keys from main update operation

## Changes Made

- [x] remove write and read keys from main update operation

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Update Device
  - [x] Decrypt Keys
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

This is just an effort to ensure that the user does not accidentally update unique and sensitive keys during update operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of invalid keys in device updates by consolidating the removal process, enhancing maintainability.

- **Refactor**
	- Introduced a new function to streamline the removal of specified invalid keys from device objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->