### PR TITLE
removing BCC for all new user registrations

### DIFF
--- a/src/auth-service/utils/mailer.js
+++ b/src/auth-service/utils/mailer.js
@@ -904,6 +904,7 @@ const mailer = {
       }
 
       const subscribedBccEmails = subscribedEmails.join(",");
+      //bcc: subscribedBccEmails,
 
       let mailOptions = {};
       mailOptions = {
@@ -914,7 +915,6 @@ const mailer = {
         to: `${email}`,
         subject: "Welcome to AirQo!",
         html: msgTemplates.afterEmailVerification(firstName, username, email),
-        bcc: subscribedBccEmails,
         attachments: attachments,
       };
 


### PR DESCRIPTION
## Description

removing BCC for all new user registrations


## Changes Made

- [x] removing BCC for all new user registrations

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] verify email endpoint
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the blind carbon copy (BCC) feature from email notifications, ensuring greater transparency in recipient visibility.
  
This change may affect how notifications are sent to multiple recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->