### PR TITLE
fixing the recent feeds endpoint

### DIFF
--- a/src/data-mgt/node/routes/v2/feeds.js
+++ b/src/data-mgt/node/routes/v2/feeds.js
@@ -14,7 +14,7 @@ const headers = (req, res, next) => {
 };
 router.use(headers);
 
-router.get("/recent/:ch_id", transformController.getLastEntry);
+router.get("/recent/:ch_id", transformController.getLastFeed);
 router.get(
   "/transform/recent",
   oneOf([


### PR DESCRIPTION
## Description

fixing the recent feeds endpoint

## Changes Made

- [ ] fixing the recent feeds endpoint

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Data Management

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] get last entry
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

This is a fix related to the issue of a faulty offline feature via Netmanager


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint to retrieve the most recent device measurements.
	- Enhanced error handling and logging for improved tracking of issues.

- **Bug Fixes**
	- Updated routing logic for the `/recent/:ch_id` endpoint to reflect the new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->