### PR TITLE
Optimize reducer to improve performance by avoiding the spread operator

### DIFF
--- a/src/device-registry/utils/errors.js
+++ b/src/device-registry/utils/errors.js
@@ -13,14 +13,11 @@ class HttpError extends Error {
 }
 
 const convertErrorArrayToObject = (arrays) => {
+  const initialValue = {};
   return arrays.reduce((obj, item) => {
-    let param = item.param || "message";
-    let msg = item.msg ? item.msg : "";
-    return {
-      ...obj,
-      [param]: msg,
-    };
-  }, {});
+    obj[item.param] = item.msg;
+    return obj;
+  }, initialValue);
 };
 
 const extractErrorsFromRequest = (req) => {


### PR DESCRIPTION
## Description

Optimize reducer to improve performance by avoiding the spread operator.
Using the spread operator ...obj within the .reduce method can lead to a time complexity of O(n²) because it creates a new object on each iteration. To enhance performance, consider mutating the accumulator object directly.


## Changes Made

- [x] Optimize reducer to improve performance by avoiding the spread operator.

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

