### PR TITLE
just adding a new field for tracking online status

### DIFF
--- a/src/device-registry/bin/new-store-readings-job.js
+++ b/src/device-registry/bin/new-store-readings-job.js
@@ -14,7 +14,7 @@ const generateFilter = require("@utils/generate-filter");
 const cron = require("node-cron");
 
 function isEntityActive(entity) {
-  const inactiveThreshold = 30 * 60 * 1000; // 30 minutes in milliseconds
+  const inactiveThreshold = 180 * 60 * 1000; // 180 minutes in milliseconds
 
   if (!entity || !entity.lastActive) {
     return false;
@@ -41,7 +41,10 @@ async function updateEntityLastActive(Model, filter, time, entityType) {
         return;
       }
 
-      const updateResult = await Model.updateOne(filter, { lastActive: time });
+      const updateResult = await Model.updateOne(filter, {
+        lastActive: time,
+        isOnline: false,
+      });
       // logger.info(
       //   `Updated ${entityType} lastActive. Result: ${jsonify(updateResult)}`
       // );

--- a/src/device-registry/config/global/db-projections.js
+++ b/src/device-registry/config/global/db-projections.js
@@ -171,6 +171,7 @@ const dbProjections = {
     weather_stations: 1,
     site_category: 1,
     lastActive: 1,
+    isOnline: 1,
   },
   SITES_EXCLUSION_PROJECTION: (category) => {
     const initialProjection = {
@@ -374,6 +375,7 @@ const dbProjections = {
     cohorts: 1,
     grids: 1,
     lastActive: 1,
+    isOnline: 1,
     previous_sites: 1,
     site: { $arrayElemAt: ["$site", 0] },
     host: { $arrayElemAt: ["$host", 0] },

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -106,6 +106,11 @@ const deviceSchema = new mongoose.Schema(
       type: Date,
     },
     lastActive: { type: Date },
+    isOnline: {
+      type: Boolean,
+      trim: true,
+      default: true,
+    },
     generation_version: {
       type: Number,
     },
@@ -294,6 +299,7 @@ deviceSchema.methods = {
       isActive: this.isActive,
       writeKey: this.writeKey,
       lastActive: this.lastActive,
+      isOnline: this.isOnline,
       isRetired: this.isRetired,
       readKey: this.readKey,
       pictures: this.pictures,

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -279,6 +279,11 @@ const siteSchema = new Schema(
       trim: true,
     },
     lastActive: { type: Date },
+    isOnline: {
+      type: Boolean,
+      trim: true,
+      default: true,
+    },
     count: { type: Number },
     country: {
       type: String,
@@ -456,6 +461,7 @@ siteSchema.methods = {
       share_links: this.share_links,
       city: this.city,
       lastActive: this.lastActive,
+      isOnline: this.isOnline,
       street: this.street,
       county: this.county,
       altitude: this.altitude,


### PR DESCRIPTION
## Description

just adding a new field for tracking online status

## Changes Made

- [x] just adding a new field for tracking online status

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced an `isOnline` status for devices and sites, enhancing tracking of their operational status.
  - Increased the inactivity threshold for entities from 30 minutes to 180 minutes, allowing them to remain active longer.
  
- **Improvements**
  - Updated entity management to reflect online/offline status during last active updates.
  
These changes enhance monitoring capabilities and improve the overall management of device and site statuses within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->