### PR TITLE
just adding the query parameters for site and device online status

### DIFF
--- a/src/device-registry/routes/v2/devices.js
+++ b/src/device-registry/routes/v2/devices.js
@@ -418,27 +418,36 @@ router.get(
         .withMessage("last_active_before date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active_before date must be a valid datetime."),
+        .withMessage(
+          "last_active_before date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ).."
+        )
+        .bail()
+        .toDate(),
       query("last_active_after")
         .optional()
         .notEmpty()
         .withMessage("last_active_after date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active_after date must be a valid datetime."),
+        .withMessage(
+          "last_active_after date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
       query("last_active")
         .optional()
         .notEmpty()
         .withMessage("last_active date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active date must be a valid datetime."),
+        .withMessage(
+          "last_active date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
     ],
   ]),
   deviceController.list
@@ -493,6 +502,53 @@ router.get(
         .optional()
         .notEmpty()
         .trim(),
+      query("online_status")
+        .optional()
+        .notEmpty()
+        .withMessage("the online_status should not be empty if provided")
+        .bail()
+        .trim()
+        .toLowerCase()
+        .isIn(["online", "offline"])
+        .withMessage(
+          "the online_status value is not among the expected ones which include: online, offline"
+        ),
+      query("last_active_before")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active_before date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage(
+          "last_active_before date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
+      query("last_active_after")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active_after date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage(
+          "last_active_after date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
+      query("last_active")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage(
+          "last_active date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
     ],
   ]),
   deviceController.listSummary

--- a/src/device-registry/routes/v2/devices.js
+++ b/src/device-registry/routes/v2/devices.js
@@ -401,6 +401,44 @@ router.get(
         .optional()
         .notEmpty()
         .trim(),
+      query("online_status")
+        .optional()
+        .notEmpty()
+        .withMessage("the online_status should not be empty if provided")
+        .bail()
+        .trim()
+        .toLowerCase()
+        .isIn(["online", "offline"])
+        .withMessage(
+          "the online_status value is not among the expected ones which include: online, offline"
+        ),
+      query("last_active_before")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active_before date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active_before date must be a valid datetime."),
+      query("last_active_after")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active_after date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active_after date must be a valid datetime."),
+      query("last_active")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active date must be a valid datetime."),
     ],
   ]),
   deviceController.list

--- a/src/device-registry/routes/v2/sites.js
+++ b/src/device-registry/routes/v2/sites.js
@@ -113,6 +113,72 @@ router.get(
       .isIn(constants.NETWORKS)
       .withMessage("the tenant value is not among the expected ones"),
   ]),
+  oneOf([
+    [
+      query("id")
+        .optional()
+        .notEmpty()
+        .trim()
+        .isMongoId()
+        .withMessage("id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
+      query("site_id")
+        .optional()
+        .notEmpty()
+        .trim()
+        .isMongoId()
+        .withMessage("site_id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
+      query("name")
+        .optional()
+        .notEmpty()
+        .trim(),
+      query("online_status")
+        .optional()
+        .notEmpty()
+        .withMessage("the online_status should not be empty if provided")
+        .bail()
+        .trim()
+        .toLowerCase()
+        .isIn(["online", "offline"])
+        .withMessage(
+          "the online_status value is not among the expected ones which include: online, offline"
+        ),
+      query("last_active_before")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active_before date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active_before date must be a valid datetime."),
+      query("last_active_after")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active_after date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active_after date must be a valid datetime."),
+      query("last_active")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active date must be a valid datetime."),
+    ],
+  ]),
   siteController.list
 );
 router.get(
@@ -127,6 +193,72 @@ router.get(
       .toLowerCase()
       .isIn(constants.NETWORKS)
       .withMessage("the tenant value is not among the expected ones"),
+  ]),
+  oneOf([
+    [
+      query("id")
+        .optional()
+        .notEmpty()
+        .trim()
+        .isMongoId()
+        .withMessage("id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
+      query("site_id")
+        .optional()
+        .notEmpty()
+        .trim()
+        .isMongoId()
+        .withMessage("site_id must be an object ID")
+        .bail()
+        .customSanitizer((value) => {
+          return ObjectId(value);
+        }),
+      query("name")
+        .optional()
+        .notEmpty()
+        .trim(),
+      query("online_status")
+        .optional()
+        .notEmpty()
+        .withMessage("the online_status should not be empty if provided")
+        .bail()
+        .trim()
+        .toLowerCase()
+        .isIn(["online", "offline"])
+        .withMessage(
+          "the online_status value is not among the expected ones which include: online, offline"
+        ),
+      query("last_active_before")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active_before date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active_before date must be a valid datetime."),
+      query("last_active_after")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active_after date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active_after date must be a valid datetime."),
+      query("last_active")
+        .optional()
+        .notEmpty()
+        .withMessage("last_active date cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toDate()
+        .isISO8601({ strict: true, strictSeparator: true })
+        .withMessage("last_active date must be a valid datetime."),
+    ],
   ]),
   siteController.listSummary
 );

--- a/src/device-registry/routes/v2/sites.js
+++ b/src/device-registry/routes/v2/sites.js
@@ -156,27 +156,36 @@ router.get(
         .withMessage("last_active_before date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active_before date must be a valid datetime."),
+        .withMessage(
+          "last_active_before date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
       query("last_active_after")
         .optional()
         .notEmpty()
         .withMessage("last_active_after date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active_after date must be a valid datetime."),
+        .withMessage(
+          "last_active_after date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
       query("last_active")
         .optional()
         .notEmpty()
         .withMessage("last_active date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active date must be a valid datetime."),
+        .withMessage(
+          "last_active date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
     ],
   ]),
   siteController.list
@@ -237,27 +246,36 @@ router.get(
         .withMessage("last_active_before date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active_before date must be a valid datetime."),
+        .withMessage(
+          "last_active_before date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
       query("last_active_after")
         .optional()
         .notEmpty()
         .withMessage("last_active_after date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active_after date must be a valid datetime."),
+        .withMessage(
+          "last_active_after date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
       query("last_active")
         .optional()
         .notEmpty()
         .withMessage("last_active date cannot be empty IF provided")
         .bail()
         .trim()
-        .toDate()
         .isISO8601({ strict: true, strictSeparator: true })
-        .withMessage("last_active date must be a valid datetime."),
+        .withMessage(
+          "last_active date must be a valid ISO8601 datetime (YYYY-MM-DDTHH:mm:ss.sssZ)."
+        )
+        .bail()
+        .toDate(),
     ],
   ]),
   siteController.listSummary

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -903,6 +903,10 @@ const generateFilter = {
       visibility,
       deviceName,
       status,
+      online_status,
+      last_active,
+      last_active_before,
+      last_active_after,
     } = { ...req.query, ...req.params };
 
     const filter = {};
@@ -923,6 +927,32 @@ const generateFilter = {
 
     if (channel) {
       filter.device_number = parseInt(channel);
+    }
+
+    if (last_active) {
+      filter.lastActive = {};
+      const start = new Date(last_active);
+      filter["lastActive"]["$gte"] = start;
+    }
+
+    if (last_active_after) {
+      filter.last_active_after = {};
+      const start = new Date(last_active_after);
+      filter["lastActive"]["$gte"] = start;
+    }
+
+    if (last_active_before) {
+      filter.last_active_before = {};
+      const start = new Date(last_active_before);
+      filter["lastActive"]["$lte"] = start;
+    }
+
+    if (online_status) {
+      if (online_status.toLowerCase() === "online") {
+        filter["isOnline"] = true;
+      } else if (online_status.toLowerCase() === "offline") {
+        filter["isOnline"] = false;
+      }
     }
 
     if (category) {
@@ -1035,6 +1065,10 @@ const generateFilter = {
       network,
       group,
       google_place_id,
+      online_status,
+      last_active,
+      last_active_before,
+      last_active_after,
     } = { ...req.query, ...req.params, ...req.body };
     const filter = {};
     logText("we are generating the filter man!");
@@ -1076,6 +1110,32 @@ const generateFilter = {
 
     if (!isEmpty(category) && category === "public" && isEmpty(site_id)) {
       filter["visibility"] = true;
+    }
+
+    if (last_active) {
+      filter.lastActive = {};
+      const start = new Date(last_active);
+      filter["lastActive"]["$gte"] = start;
+    }
+
+    if (last_active_after) {
+      filter.last_active_after = {};
+      const start = new Date(last_active_after);
+      filter["lastActive"]["$gte"] = start;
+    }
+
+    if (last_active_before) {
+      filter.last_active_before = {};
+      const start = new Date(last_active_before);
+      filter["lastActive"]["$lte"] = start;
+    }
+
+    if (online_status) {
+      if (online_status.toLowerCase() === "online") {
+        filter["isOnline"] = true;
+      } else if (online_status.toLowerCase() === "offline") {
+        filter["isOnline"] = false;
+      }
     }
 
     if (site_codes) {

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -936,13 +936,13 @@ const generateFilter = {
     }
 
     if (last_active_after) {
-      filter.last_active_after = {};
+      filter.lastActive = {};
       const start = new Date(last_active_after);
       filter["lastActive"]["$gte"] = start;
     }
 
     if (last_active_before) {
-      filter.last_active_before = {};
+      filter.lastActive = {};
       const start = new Date(last_active_before);
       filter["lastActive"]["$lte"] = start;
     }
@@ -1119,13 +1119,13 @@ const generateFilter = {
     }
 
     if (last_active_after) {
-      filter.last_active_after = {};
+      filter.lastActive = {};
       const start = new Date(last_active_after);
       filter["lastActive"]["$gte"] = start;
     }
 
     if (last_active_before) {
-      filter.last_active_before = {};
+      filter.lastActive = {};
       const start = new Date(last_active_before);
       filter["lastActive"]["$lte"] = start;
     }


### PR DESCRIPTION
## Description

- [x] just adding the query parameters for site and device online status

## Changes Made

- [x] just adding the query parameters for site and device online status

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] device registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] get sites
  - [x] get devices
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

Just adding new query parameters to support the query for sites or devices based on the online status of the devices. the new query parameters include:
- last_active
- last_active_before
- last_active_after
- online_status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new query parameters for filtering devices by online status and last active timestamps.
	- Enhanced input validation for site listing endpoints with new optional query parameters.

- **Bug Fixes**
	- Improved validation logic for query parameters in device and site route handlers.

- **Chores**
	- Updated filter generation logic to support new query parameters for enhanced filtering capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->