### PR TITLE
adding gaseous sensors to device registry

### DIFF
--- a/src/device-registry/bin/kafka-consumer.js
+++ b/src/device-registry/bin/kafka-consumer.js
@@ -55,6 +55,11 @@ const eventSchema = Joi.object({
     .optional(),
   pm2_5_calibrated_value: Joi.number().optional(),
   pm10_calibrated_value: Joi.number().optional(),
+  tvoc: Joi.number().optional(),
+  hcho: Joi.number().optional(),
+  co2: Joi.number().optional(),
+  intaketemperature: Joi.number().optional(),
+  intakehumidity: Joi.number().optional(),
 }).unknown(true);
 
 const eventsSchema = Joi.array().items(eventSchema);

--- a/src/device-registry/config/global/mappings.js
+++ b/src/device-registry/config/global/mappings.js
@@ -267,6 +267,12 @@ const mappings = {
       "battery.value": "battery",
       "satellites.value": "satellites",
       "hdop.value": "hdop",
+
+      "tvoc.value": "tvoc",
+      "hcho.value": "hcho",
+      "co2.value": "co2",
+      "intaketemperature.value": "intaketemperature",
+      "intakehumidity.value": "intakehumidity",
     },
     remove: [],
     defaults: {
@@ -390,6 +396,12 @@ const mappings = {
       "battery.value": null,
       "satellites.value": null,
       "hdop.value": null,
+
+      "tvoc.value": null,
+      "hcho.value": null,
+      "co2.value": null,
+      "intaketemperature.value": null,
+      "intakehumidity.value": null,
     },
     operate: [
       /**

--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -206,6 +206,42 @@ const valueSchema = new Schema({
       default: null,
     },
   },
+
+  tvoc: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  co2: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  hcho: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  intaketemperature: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  intakehumidity: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
   internalTemperature: {
     value: {
       type: Number,
@@ -547,6 +583,13 @@ async function fetchData(model, filter) {
     projection["externalTemperature"] = 0;
     projection["internalTemperature"] = 0;
     projection["hdop"] = 0;
+
+    projection["tvoc"] = 0;
+    projection["hcho"] = 0;
+    projection["co2"] = 0;
+    projection["intaketemperature"] = 0;
+    projection["intakehumidity"] = 0;
+
     projection["satellites"] = 0;
     projection["speed"] = 0;
     projection["altitude"] = 0;
@@ -635,6 +678,11 @@ async function fetchData(model, filter) {
       speed: 0,
       satellites: 0,
       hdop: 0,
+      intaketemperature: 0,
+      tvoc: 0,
+      hcho: 0,
+      co2: 0,
+      intakehumidity: 0,
       internalTemperature: 0,
       externalTemperature: 0,
       internalHumidity: 0,
@@ -755,6 +803,13 @@ async function fetchData(model, filter) {
         speed: { $first: "$speed" },
         satellites: { $first: "$satellites" },
         hdop: { $first: "$hdop" },
+
+        intaketemperature: { $first: "$intaketemperature" },
+        tvoc: { $first: "$tvoc" },
+        hcho: { $first: "$hcho" },
+        co2: { $first: "$co2" },
+        intakehumidity: { $first: "$intakehumidity" },
+
         internalTemperature: { $first: "$internalTemperature" },
         externalTemperature: { $first: "$externalTemperature" },
         internalHumidity: { $first: "$internalHumidity" },
@@ -1039,6 +1094,13 @@ async function fetchData(model, filter) {
         _network: "$network",
         _satellites: "$satellites",
         _hdop: "$hdop",
+
+        _tvoc: "$tvoc",
+        _hcho: "$hcho",
+        _co2: "$co2",
+        _intaketemperature: "$intaketemperature",
+        _intakehumidity: "$intakehumidity",
+
         _site_id: "$site_id",
         _device_id: "$device_id",
         _site: "$site",
@@ -1081,6 +1143,13 @@ async function fetchData(model, filter) {
         network: "$_network",
         satellites: "$_satellites",
         hdop: "$_hdop",
+
+        intaketemperature: "$_intaketemperature",
+        tvoc: "$_tvoc",
+        hcho: "$_hcho",
+        co2: "$_co2",
+        intakehumidity: "$_intakehumidity",
+
         internalTemperature: "$_internalTemperature",
         externalTemperature: "$_externalTemperature",
         internalHumidity: "$_internalHumidity",
@@ -1206,6 +1275,13 @@ async function signalData(model, filter) {
   projection["externalTemperature"] = 0;
   projection["internalTemperature"] = 0;
   projection["hdop"] = 0;
+
+  projection["tvoc"] = 0;
+  projection["hcho"] = 0;
+  projection["co2"] = 0;
+  projection["intaketemperature"] = 0;
+  projection["intakehumidity"] = 0;
+
   projection["satellites"] = 0;
   projection["speed"] = 0;
   projection["altitude"] = 0;
@@ -1337,6 +1413,13 @@ async function signalData(model, filter) {
       speed: { $first: "$speed" },
       satellites: { $first: "$satellites" },
       hdop: { $first: "$hdop" },
+
+      intaketemperature: { $first: "$intaketemperature" },
+      tvoc: { $first: "$tvoc" },
+      hcho: { $first: "$hcho" },
+      co2: { $first: "$co2" },
+      intakehumidity: { $first: "$intakehumidity" },
+
       internalTemperature: { $first: "$internalTemperature" },
       externalTemperature: { $first: "$externalTemperature" },
       internalHumidity: { $first: "$internalHumidity" },
@@ -1752,6 +1835,13 @@ eventSchema.statics.list = async function(
       projection["externalTemperature"] = 0;
       projection["internalTemperature"] = 0;
       projection["hdop"] = 0;
+
+      projection["tvoc"] = 0;
+      projection["hcho"] = 0;
+      projection["co2"] = 0;
+      projection["intaketemperature"] = 0;
+      projection["intakehumidity"] = 0;
+
       projection["satellites"] = 0;
       projection["speed"] = 0;
       projection["altitude"] = 0;
@@ -1840,6 +1930,13 @@ eventSchema.statics.list = async function(
         speed: 0,
         satellites: 0,
         hdop: 0,
+
+        intaketemperature: 0,
+        tvoc: 0,
+        hcho: 0,
+        co2: 0,
+        intakehumidity: 0,
+
         internalTemperature: 0,
         externalTemperature: 0,
         internalHumidity: 0,
@@ -1958,6 +2055,11 @@ eventSchema.statics.list = async function(
           speed: { $first: "$speed" },
           satellites: { $first: "$satellites" },
           hdop: { $first: "$hdop" },
+          intaketemperature: { $first: "$intaketemperature" },
+          tvoc: { $first: "$tvoc" },
+          hcho: { $first: "$hcho" },
+          co2: { $first: "$co2" },
+          intakehumidity: { $first: "$intakehumidity" },
           internalTemperature: { $first: "$internalTemperature" },
           externalTemperature: { $first: "$externalTemperature" },
           internalHumidity: { $first: "$internalHumidity" },
@@ -2248,6 +2350,13 @@ eventSchema.statics.list = async function(
           _network: "$network",
           _satellites: "$satellites",
           _hdop: "$hdop",
+
+          _tvoc: "$tvoc",
+          _hcho: "$hcho",
+          _co2: "$co2",
+          _intaketemperature: "$intaketemperature",
+          _intakehumidity: "$intakehumidity",
+
           _site_id: "$site_id",
           _device_id: "$device_id",
           _site: "$site",
@@ -2290,6 +2399,11 @@ eventSchema.statics.list = async function(
           network: "$_network",
           satellites: "$_satellites",
           hdop: "$_hdop",
+          intaketemperature: "$_intaketemperature",
+          tvoc: "$_tvoc",
+          hcho: "$_hcho",
+          co2: "$_co2",
+          intakehumidity: "$_intakehumidity",
           internalTemperature: "$_internalTemperature",
           externalTemperature: "$_externalTemperature",
           internalHumidity: "$_internalHumidity",


### PR DESCRIPTION
## Description

- [x] adding gaseous sensors to device registry


## Changes Made

- [x] adding gaseous sensors to device registry

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] device registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] add events
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

adding gaseous sensors to device registry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added optional properties for environmental metrics: `tvoc`, `hcho`, `co2`, `intaketemperature`, and `intakehumidity` to the event schema.
	- Introduced new mappings for these sensor values in the device registry configuration.
	- Enhanced the event model to include the new properties for better environmental data handling.

These updates improve the application's ability to monitor and manage environmental metrics effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->