### PR TITLE
adding more return fields to summary of devices

### DIFF
--- a/src/device-registry/config/global/db-projections.js
+++ b/src/device-registry/config/global/db-projections.js
@@ -502,15 +502,8 @@ const dbProjections = {
     };
     let projection = Object.assign({}, initialProjection);
     if (category === "summary") {
-      // readKey: 0,
-      // device_number: 0,
-      // isActive: 0,
-      // description: 0,
-      // network: 0,
       projection = Object.assign(initialProjection, {
         alias: 0,
-        latitude: 0,
-        longitude: 0,
         approximate_distance_in_km: 0,
         bearing_in_radians: 0,
         ISP: 0,
@@ -526,7 +519,6 @@ const dbProjections = {
         powerType: 0,
         mountType: 0,
         access_code: 0,
-        device_codes: 0,
         height: 0,
         mobility: 0,
         category: 0,


### PR DESCRIPTION
## Description

adding more return fields to summary of devices

## Changes Made

- [x] adding more return fields to summary of devices

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] device registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] get devices summary
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

## Additional Notes

adding more return fields to summary of devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined data projection for the "summary" category, reducing the amount of displayed information for enhanced clarity. 

- **Bug Fixes**
	- Removed unnecessary properties from the projection to improve performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->