### PR TITLE
reconfiguring the nginx for staging to ensure req.body is forwarded

### DIFF
--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nginx-config
   namespace: nginx-ingress
 data:
-  proxy-body-size:  "350m"
+  proxy-body-size:  "400m"
   client-max-body-size: "350m"
   proxy-protocol: "True"
   real-ip-header: "proxy_protocol"
@@ -50,7 +50,12 @@ data:
       proxy_method            $method;
       proxy_pass              http://airqo-stage-auth-api-svc.staging.svc.cluster.local:3000/api/v2/users/$verification_path;
       proxy_pass_request_body on;
-      proxy_set_header        Content-Length '';
+      proxy_buffer_size 128k;
+      proxy_buffers 4 32k;
+      proxy_busy_buffers_size 64k;
+      proxy_temp_file_write_size 64k;
+      proxy_http_version 1.1;
+      proxy_set_header Connection '';
       proxy_set_header        X-Original-URI $request_uri;
       proxy_set_header        X-Original-Method $request_method;
       proxy_set_header        X-Client-IP $client_ip;


### PR DESCRIPTION
## Description

reconfiguring the nginx for staging to ensure req.body is forwarded

## Changes Made

- [ ] reconfiguring the nginx for staging to ensure req.body is forwarded

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

