### PR TITLE
Log percentage of users without selected_sites alongside the total count

### DIFF
--- a/src/auth-service/bin/jobs/preferences-log-job.js
+++ b/src/auth-service/bin/jobs/preferences-log-job.js
@@ -14,7 +14,7 @@ const logUserPreferences = async () => {
     const batchSize = 100;
     let skip = 0;
     let totalCountWithoutSelectedSites = 0; // To keep track of total count
-    const allUsersWithoutSelectedSites = []; // To aggregate user IDs
+    let totalUsersProcessed = 0; // To keep track of total users processed
 
     while (true) {
       const users = await UserModel("airqo")
@@ -41,29 +41,27 @@ const logUserPreferences = async () => {
       });
 
       // Collect IDs of users without selected_sites
-      const usersWithoutSelectedSites = users
-        .filter((user) => {
-          const preference = preferencesMap.get(user._id.toString());
-          return !preference || isEmpty(preference.selected_sites);
-        })
-        .map((user) => user.email);
+      const usersWithoutSelectedSites = users.filter((user) => {
+        const preference = preferencesMap.get(user._id.toString());
+        return !preference || isEmpty(preference.selected_sites);
+      });
 
       // Aggregate results
       totalCountWithoutSelectedSites += usersWithoutSelectedSites.length;
-      allUsersWithoutSelectedSites.push(...usersWithoutSelectedSites);
+      totalUsersProcessed += users.length; // Increment total processed users
 
       skip += batchSize;
     }
 
     // Log the aggregated results once after processing all users
-    if (allUsersWithoutSelectedSites.length > 0) {
-      // logger.info(
-      //   `💀💀 Users without selected_sites: ${stringify(
-      //     allUsersWithoutSelectedSites
-      //   )}`
-      // );
+    if (totalUsersProcessed > 0) {
+      const percentageWithoutSelectedSites = (
+        (totalCountWithoutSelectedSites / totalUsersProcessed) *
+        100
+      ).toFixed(2);
+
       logger.info(
-        `💔💔 Total count of users without selected_sites: ${totalCountWithoutSelectedSites}`
+        `💔💔 Total count of users without selected_sites: ${totalCountWithoutSelectedSites}, which is ${percentageWithoutSelectedSites}% of all Analytics users.`
       );
     }
   } catch (error) {


### PR DESCRIPTION
## Description

To log the percentage of users without selected_sites alongside the total count

## Changes Made

- [x] Total Users Processed: Introduced a new variable `totalUsersProcessed` to keep track of the total number of users processed.
- [x] Percentage Calculation: After processing all users, the script calculates the percentage of users without `selected_sites`
- [x] Formatted Logging: The log statement now includes both the total count and the percentage formatted to two decimal places.

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes
With these modifications, the script will now log not only the count of users without `selected_sites `but also what percentage that count represents of all processed analytics users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging of user preferences, now including a percentage of users without selected sites.

- **Bug Fixes**
	- Streamlined the data aggregation process for improved performance.

- **Documentation**
	- Updated logging messages to provide clearer context on user preferences processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->