### PR TITLE
mongoose-buffer commands until the connection is available.

### DIFF
--- a/src/auth-service/config/database.js
+++ b/src/auth-service/config/database.js
@@ -16,7 +16,7 @@ const options = {
   useUnifiedTopology: true,
   autoIndex: true,
   poolSize: 10,
-  bufferMaxEntries: 0,
+  bufferMaxEntries: 2,
   connectTimeoutMS: 1200000,
   socketTimeoutMS: 600000,
   serverSelectionTimeoutMS: 3600000,


### PR DESCRIPTION
## Description

In the our mongoose configuration, we have` bufferMaxEntries: 0`, which disables command buffering. This means that if the connection is not established, operations will fail immediately rather than waiting for the connection to be established. 

We are now setting this to a positive integer to allow Mongoose to buffer commands until the connection is available.

## Changes Made

- [x] setting `bufferMaxEntries` to a positive integer

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes
This change is inspired by a recent timeout internal error message as the micro was attempting to connnect to the DB in the STAGING environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated MongoDB connection configuration for improved operation buffering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->