### PR TITLE
just reducing the payload for devices summary endpoint

### DIFF
--- a/src/device-registry/config/global/db-projections.js
+++ b/src/device-registry/config/global/db-projections.js
@@ -257,9 +257,15 @@ const dbProjections = {
         "devices.mobility": 0,
         "devices.device_codes": 0,
         "devices.status": 0,
+        "devices.grids": 0,
+        "devices.cohorts": 0,
+        "devices.host_id": 0,
+        "devices.lastActive": 0,
+        "devices.isOnline": 0,
         "devices.isPrimaryInLocation": 0,
         "devices.category": 0,
         "devices.isActive": 0,
+        "devices.name": 0,
         "devices.device_number": 0,
         "devices.network": 0,
         "devices.createdAt": 0,
@@ -291,6 +297,9 @@ const dbProjections = {
         "airqlouds.weather_stations": 0,
         "airqlouds.createdAt": 0,
         "airqlouds.devices": 0,
+        "grids.admin_level": 0,
+        "grids.visibility": 0,
+        "grids.name": 0,
       });
     }
 


### PR DESCRIPTION
## Description

just reducing the payload for devices summary endpoint

## Changes Made

- [x] just reducing the payload for devices summary endpoint

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] get sites summary: `{{baseUrl}}/api/v2/devices/sites/summary`
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes
just reducing the payload for devices summary endpoint



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced exclusion projections for devices and grids, improving data specificity in summary views.
	- Added new fields to the exclusion lists for sites, devices, and grids based on context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->