### PR TITLE
temporarily removing the validation for sites

### DIFF
--- a/src/auth-service/routes/v2/preferences.js
+++ b/src/auth-service/routes/v2/preferences.js
@@ -588,14 +588,14 @@ router.patch(
           return Array.isArray(value);
         })
         .withMessage("the selected_sites should be an array"),
-      body("selected_sites.*")
-        .optional()
-        .custom(
-          createValidateSelectedSitesField(["_id", "search_name", "name"], true)
-        )
-        .withMessage(
-          "Invalid selected_sites format. Verify required fields (latitude, longitude, search_name, name, approximate_latitude, approximate_longitude), numeric fields (latitude, longitude, approximate_latitude, approximate_longitude, search_radius if present), string fields (name, search_name), and ensure site_tags is an array of strings."
-        ),
+      // body("selected_sites.*")
+      //   .optional()
+      //   .custom(
+      //     createValidateSelectedSitesField(["_id", "search_name", "name"], true)
+      //   )
+      //   .withMessage(
+      //     "Invalid selected_sites format. Verify required fields (latitude, longitude, search_name, name, approximate_latitude, approximate_longitude), numeric fields (latitude, longitude, approximate_latitude, approximate_longitude, search_radius if present), string fields (name, search_name), and ensure site_tags is an array of strings."
+      //   ),
     ],
   ]),
   createPreferenceController.replace


### PR DESCRIPTION
## Description

temporarily removing the validation for sites

  - [x] Other...
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed validation for the `selected_sites` field in the `replace` route, allowing for more flexible input during this operation.
  
- **Chores**
	- Minor adjustments to comments and formatting for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->