### PR TITLE
Suspend Unused cron jobs on the cluster

### DIFF
--- a/k8s/analytics/templates/devices-summary.yaml
+++ b/k8s/analytics/templates/devices-summary.yaml
@@ -9,7 +9,6 @@ spec:
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   schedule: "0 4 * * *" # Every day at 4am
-  suspend: false
   jobTemplate:
     metadata:
       name: {{ .Values.jobs.devicesSummaryJob.name }}

--- a/k8s/analytics/templates/reports.yaml
+++ b/k8s/analytics/templates/reports.yaml
@@ -9,7 +9,6 @@ spec:
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   schedule: "0 0 1 */3 *" # Once every 3 months
-  suspend: false
   jobTemplate:
     metadata:
       name: {{ .Values.jobs.reports.name }}

--- a/k8s/predict/templates/places-airquality.yaml
+++ b/k8s/predict/templates/places-airquality.yaml
@@ -10,7 +10,6 @@ spec:
   failedJobsHistoryLimit: 2
   startingDeadlineSeconds: 1200
   schedule: '{{ .Values.jobs.predictPlaces.schedule }}'
-  suspend: false
   jobTemplate:
     metadata:
       name: {{ .Values.jobs.predictPlaces.name }}


### PR DESCRIPTION
## Description
Suspend Unused cron jobs on the cluster

## Changes Made

- [ ] Changed jobs to suspended

## Affected Services

- [ ] Which services were modified:
  - [ ] uptime, reports and device summary cronjobs

     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

## Additional Notes

[Add any additional notes or comments here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- CronJobs are now suspended and will not run until resumed.
	- Updated scheduling for reports to run quarterly.
- **Bug Fixes**
	- Corrected indentation for improved clarity in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->