### PR TITLE
Add Endpoint for Retrieving Best Air Quality Locations

### DIFF
--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -778,6 +778,58 @@ const createEvent = {
       return;
     }
   },
+  getBestAirQuality: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const request = {
+        ...req,
+        query: {
+          ...req.query,
+          tenant: isEmpty(req.query.tenant) ? "airqo" : req.query.tenant,
+        },
+      };
+
+      const result = await createEventUtil.getBestAirQuality(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      const status = result.status || httpStatus.OK;
+      if (result.success === true) {
+        res.status(status).json({
+          success: true,
+          message: result.message,
+          measurements: result.data,
+        });
+      } else {
+        const errorStatus = result.status || httpStatus.INTERNAL_SERVER_ERROR;
+        res.status(errorStatus).json({
+          success: false,
+          errors: result.errors || { message: "" },
+          message: result.message,
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+
   readingsForMap: async (req, res, next) => {
     try {
       logText("the readings for the AirQo Map...");
@@ -830,6 +882,7 @@ const createEvent = {
       return;
     }
   },
+
   recentReadings: async (req, res, next) => {
     try {
       logText("the recent readings with Filter capabilities...");

--- a/src/device-registry/controllers/test/ut_create-event.js
+++ b/src/device-registry/controllers/test/ut_create-event.js
@@ -1,39 +1,1739 @@
 require("module-alias/register");
-("use-strict");
-const createEventController = require("../create-event");
+const chai = require("chai");
+const chaiHttp = require("chai-http");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const expect = chai.expect;
+const should = chai.should();
+const chaiHttp = require("chai-http");
 
-let chai = require("chai"),
-  expect = chai.expect;
-chai.should();
+chai.use(sinonChai);
+chai.use(chaiHttp);
 
-describe("add multiple sensor values to Events collection", function() {
-  beforeEach(function() {});
-  afterEach(function() {});
-  let device = "";
-  let measurement = {};
-  it("should add multiple sensor values to Events collection", function() {});
-});
+const { createEvent } = require("@controllers/create-event");
 
-describe("add one sensor value to thingspeak", function() {
-  beforeEach(function() {});
-  afterEach(function() {});
-  let device = "";
-  let measurement = {};
-  it("should send a sensor value to thingspeak", function() {});
-});
+describe("Create Event Controller", () => {
+  describe("addValues", () => {
+    let req, res, next;
 
-describe("add multiple sensor values to thingspeak", function() {
-  beforeEach(function() {});
-  afterEach(function() {});
-  let device = "";
-  let measurement = {};
-  it("should send multiple sensor values to thingspeak", function() {});
-});
+    beforeEach(() => {
+      req = {
+        query: {},
+        body: {},
+      };
+      res = {
+        json: sinon.spy(),
+        status: sinon.stub().returns(res),
+        send: sinon.spy(),
+      };
+      next = sinon.spy();
+    });
 
-describe("add add device/channel measurements in bulk", function() {
-  beforeEach(function() {});
-  afterEach(function() {});
-  let device = "";
-  let measurement = {};
-  it("should bulk insert different device readings to thingspeak", function() {});
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should call insert method with correct parameters", async () => {
+      const measurements = {
+        /* sample measurements */
+      };
+      req.body = measurements;
+
+      await createEvent.addValues(req, res, next);
+
+      expect(createEventUtil.insert).to.have.been.calledWith(
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any
+      );
+    });
+
+    it("should handle bad request errors", async () => {
+      const errors = [{ field: "test", message: "Test error" }];
+      req.body = {};
+
+      await createEvent.addValues(req, res, next);
+
+      expect(next).to.have.been.calledWith(
+        new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+      );
+    });
+
+    it("should return OK status on successful insertion", async () => {
+      const result = { success: true, message: "success" };
+      sinon.stub(createEventUtil, "insert").resolves(result);
+
+      await createEvent.addValues(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        message: "successfully added all the events",
+      });
+    });
+
+    it("should return BAD_REQUEST status on failed insertion", async () => {
+      const result = { success: false, errors: ["error"] };
+      sinon.stub(createEventUtil, "insert").resolves(result);
+
+      await createEvent.addValues(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.BAD_REQUEST);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        message: "finished the operation with some errors",
+        errors: ["error"],
+      });
+    });
+
+    it("should handle internal server errors", async () => {
+      const error = new Error("Internal Server Error");
+      sinon.stub(createEventUtil, "insert").rejects(error);
+
+      await createEvent.addValues(req, res, next);
+
+      expect(next).to.have.been.calledWith(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: "Internal Server Error" }
+        )
+      );
+    });
+  });
+  describe("listFromBigQuery", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { format: "csv" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+        type: sinon.spy(),
+        send: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = { success: true, status: httpStatus.OK, data: [] };
+      sinon
+        .stub(createEventUtil, "getMeasurementsFromBigQuery")
+        .resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return CSV format", async () => {
+      await listFromBigQuery(req, res, next);
+
+      expect(res.type).to.have.been.calledWith("text/csv");
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.send).to.have.been.calledWith(sinon.match.array);
+    });
+
+    it("should return JSON format", async () => {
+      req.query.format = "";
+      await listFromBigQuery(req, res, next);
+
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listFromBigQuery(req, res, next);
+
+      expect(next).to.have.been.calledWith(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: "Error message" }
+        )
+      );
+    });
+  });
+
+  describe("latestFromBigQuery", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: {},
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "latestFromBigQuery").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return cached data", async () => {
+      await latestFromBigQuery(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await latestFromBigQuery(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("list", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        params: { site_id: "123", device_id: "456" },
+        query: { tenant: "custom" },
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should filter by site_id and device_id", async () => {
+      await list(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await list(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("fetchAndStoreData", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = { success: true, message: "Success message" };
+      sinon.stub(createEventUtil, "fetchAndStoreData").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should fetch and store data", async () => {
+      await fetchAndStoreData(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await fetchAndStoreData(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("getBestAirQuality", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = { success: true, message: "Success message", data: [] };
+      sinon.stub(createEventUtil, "getBestAirQuality").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return air quality measurements", async () => {
+      await getBestAirQuality(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await getBestAirQuality(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("readingsForMap", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = { success: true, message: "Success message", data: [] };
+      sinon.stub(createEventUtil, "read").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return air quality measurements", async () => {
+      await readingsForMap(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await readingsForMap(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("listEventsForAllDevices", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return cached data for devices", async () => {
+      await listEventsForAllDevices(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listEventsForAllDevices(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("listRecent", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", cohort_id: "123" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return cached data for recent events", async () => {
+      await listRecent(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors due to missing device ID", async () => {
+      await listRecent(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors due to missing site ID", async () => {
+      req.query.cohort_id = "456";
+      await listRecent(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("listHistorical", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return cached data for historical events", async () => {
+      await listHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors due to missing device ID", async () => {
+      req.query.cohort_id = "123";
+      await listHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors due to missing site ID", async () => {
+      req.query.grid_id = "789";
+      await listHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("listRunningDevices", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [{}, {}] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return running devices", async () => {
+      await listRunningDevices(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listRunningDevices(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should remove AQI-related fields from devices", async () => {
+      mockResult.data = [
+        {
+          meta: {},
+          data: [
+            {
+              aqi_color: "red",
+              aqi_category: "very poor",
+              aqi_color_name: "Red",
+            },
+          ],
+        },
+      ];
+      await listRunningDevices(req, res, next);
+
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(mockResult.data[0].data[0]).not.to.have.property("aqi_color");
+      expect(mockResult.data[0].data[0]).not.to.have.property("aqi_category");
+      expect(mockResult.data[0].data[0]).not.to.have.property("aqi_color_name");
+    });
+  });
+
+  describe("listGood", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", index: "good" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return good air quality measurements", async () => {
+      await listGood(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listGood(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("listModerate", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", index: "moderate" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return moderate air quality measurements", async () => {
+      await listModerate(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listModerate(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+  describe("listU4sg", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return U4SG air quality measurements", async () => {
+      await listU4sg(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listU4sg(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("listUnhealthy", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return unhealthy air quality measurements", async () => {
+      await listUnhealthy(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listUnhealthy(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("listVeryUnhealthy", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return very unhealthy air quality measurements", async () => {
+      await listVeryUnhealthy(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listVeryUnhealthy(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("listHazardous", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should return hazardous air quality measurements", async () => {
+      await listHazardous(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should handle errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = ["error"];
+
+      await listHazardous(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("transform", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        message: "Success message",
+        data: [{}, {}],
+      };
+      sinon.stub(createEventUtil, "transformManyEvents").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should transform events successfully", async () => {
+      await transform(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        message: mockResult.message,
+        transformedEvents: mockResult.data,
+      });
+    });
+
+    it("should handle errors during transformation", async () => {
+      mockResult.success = false;
+      mockResult.message = "Transformation error";
+      mockResult.errors = ["error"];
+
+      await transform(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        message: mockResult.message,
+        errors: mockResult.errors,
+      });
+    });
+  });
+
+  describe("create", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = { success: true, message: "Success message", errors: {} };
+      sinon.stub(createEventUtil, "create").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should create event successfully", async () => {
+      await create(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        message: mockResult.message,
+        errors: mockResult.errors,
+      });
+    });
+
+    it("should handle errors during creation", async () => {
+      mockResult.success = false;
+      mockResult.message = "Creation error";
+      mockResult.errors = ["error"];
+
+      await create(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        message: mockResult.message,
+        errors: mockResult.errors,
+      });
+    });
+  });
+
+  describe("transmitMultipleSensorValues", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", device_number: "123", chid: "456" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        message: "Success message",
+        data: [{ id: 1, value: "test" }],
+      };
+      sinon
+        .stub(createEventUtil, "transmitMultipleSensorValues")
+        .resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should transmit multiple sensor values successfully", async () => {
+      await transmitMultipleSensorValues(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        message: mockResult.message,
+        result: mockResult.data,
+      });
+    });
+
+    it("should handle errors during transmission", async () => {
+      mockResult.success = false;
+      mockResult.message = "Transmission error";
+      mockResult.errors = ["error"];
+
+      await transmitMultipleSensorValues(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        message: mockResult.message,
+        errors: mockResult.errors,
+      });
+    });
+  });
+
+  describe("bulkTransmitMultipleSensorValues", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", device_number: "123", chid: "456" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = { success: true, message: "Success message" };
+      sinon
+        .stub(createEventUtil, "bulkTransmitMultipleSensorValues")
+        .resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should bulk transmit multiple sensor values successfully", async () => {
+      await bulkTransmitMultipleSensorValues(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        message: mockResult.message,
+      });
+    });
+
+    it("should handle errors during bulk transmission", async () => {
+      mockResult.success = false;
+      mockResult.message = "Bulk transmission error";
+      mockResult.errors = ["error"];
+
+      await bulkTransmitMultipleSensorValues(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        message: mockResult.message,
+        errors: mockResult.errors,
+      });
+    });
+  });
+
+  describe("transmitValues", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        message: "Success message",
+        data: [{ id: 1, value: "test" }],
+      };
+      sinon.stub(createEventUtil, "transmitValues").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should transmit values successfully", async () => {
+      await transmitValues(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        message: mockResult.message,
+        result: mockResult.data,
+      });
+    });
+
+    it("should handle errors during transmission", async () => {
+      mockResult.success = false;
+      mockResult.message = "Transmission error";
+      mockResult.errors = ["error"];
+
+      await transmitValues(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        message: mockResult.message,
+        errors: mockResult.errors,
+      });
+    });
+  });
+  describe("deleteValuesOnPlatform", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = { success: true, message: "Success message", data: [] };
+      sinon.stub(createEventUtil, "clearEventsOnPlatform").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should delete values on platform successfully", async () => {
+      await deleteValuesOnPlatform(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        message: mockResult.message,
+        data: mockResult.data,
+      });
+    });
+
+    it("should handle errors during deletion", async () => {
+      mockResult.success = false;
+      mockResult.message = "Deletion error";
+      mockResult.error = ["error"];
+
+      await deleteValuesOnPlatform(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        message: mockResult.message,
+        errors: mockResult.error,
+      });
+    });
+  });
+
+  describe("addEvents", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        message: "Success message",
+        data: [],
+        error: null,
+      };
+      sinon.stub(createEventUtil, "addEvents").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should add events successfully", async () => {
+      await addEvents(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        message: "successfully added all the events",
+        stored_events: mockResult.data,
+        errors: mockResult.error,
+      });
+    });
+
+    it("should handle errors during addition", async () => {
+      mockResult.success = false;
+      mockResult.message = "Addition error";
+      mockResult.error = ["error"];
+
+      await addEvents(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        message: "finished the operation with some errors",
+        errors: mockResult.error,
+      });
+    });
+  });
+
+  describe("listByAirQloud", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", site_id: "123", recent: "yes" },
+        params: { airqloud_id: "abc" },
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should list events by AirQloud ID successfully", async () => {
+      await listByAirQloud(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        isCache: mockResult.isCache,
+        message: mockResult.message,
+        meta: mockResult.data[0].meta,
+        measurements: mockResult.data[0].data,
+      });
+    });
+
+    it("should handle errors when processing AirQloud IDs", async () => {
+      req = {
+        query: { tenant: "custom", airqloud_id: "invalid" },
+        params: {},
+        query: {},
+      };
+      await listByAirQloud(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        errors: {
+          message: `Unable to process measurements for the provided AirQloud IDs invalid`,
+        },
+        message: "Internal Server Error",
+      });
+    });
+  });
+
+  describe("listByAirQloudHistorical", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", airqloud_id: "abc" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should list events by AirQloud ID historically successfully", async () => {
+      await listByAirQloudHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        isCache: mockResult.isCache,
+        message: mockResult.message,
+        meta: mockResult.data[0].meta,
+        measurements: mockResult.data[0].data,
+      });
+    });
+
+    it("should handle errors when processing AirQloud IDs", async () => {
+      req = {
+        query: { tenant: "custom", airqloud_id: "invalid" },
+        params: {},
+        query: {},
+      };
+      await listByAirQloudHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        errors: {
+          message: `Unable to process measurements for the provided AirQloud IDs invalid`,
+        },
+        message: "Internal Server Error",
+      });
+    });
+  });
+
+  describe("listByGridHistorical", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", grid_id: "xyz" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should list events by Grid ID historically successfully", async () => {
+      await listByGridHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        isCache: mockResult.isCache,
+        message: mockResult.message,
+        meta: mockResult.data[0].meta,
+        measurements: mockResult.data[0].data,
+      });
+    });
+
+    it("should handle errors when processing Grid IDs", async () => {
+      req = {
+        query: { tenant: "custom", grid_id: "invalid" },
+        params: {},
+        query: {},
+      };
+      await listByGridHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        errors: {
+          message: `Unable to process measurements for the provided Grid IDs invalid`,
+        },
+        message: "Internal Server Error",
+      });
+    });
+  });
+
+  describe("listByGrid", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", grid_id: "xyz" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should list events by Grid ID successfully", async () => {
+      await listByGrid(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        isCache: mockResult.isCache,
+        message: mockResult.message,
+        meta: mockResult.data[0].meta,
+        measurements: mockResult.data[0].data,
+      });
+    });
+
+    it("should handle errors when processing Grid IDs", async () => {
+      req = {
+        query: { tenant: "custom", grid_id: "invalid" },
+        params: {},
+        query: {},
+      };
+      await listByGrid(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        errors: {
+          message: `Unable to process measurements for the provided Grid IDs invalid`,
+        },
+        message: "Internal Server Error",
+      });
+    });
+  });
+
+  describe("listByCohort", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", cohort_id: "abc" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should list events by Cohort ID successfully", async () => {
+      await listByCohort(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        isCache: mockResult.isCache,
+        message: mockResult.message,
+        meta: mockResult.data[0].meta,
+        measurements: mockResult.data[0].data,
+      });
+    });
+
+    it("should handle errors when processing Cohort IDs", async () => {
+      req = {
+        query: { tenant: "custom", cohort_id: "invalid" },
+        params: {},
+        query: {},
+      };
+      await listByCohort(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        errors: {
+          message: `Unable to process measurements for the provided Cohort IDs invalid`,
+        },
+        message: "Internal Server Error",
+      });
+    });
+  });
+
+  describe("listByCohortHistorical", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { tenant: "custom", cohort_id: "abc" },
+        params: {},
+        query: {},
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: [{ meta: {}, data: [] }],
+      };
+      sinon.stub(createEventUtil, "list").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should list events by Cohort ID historically successfully", async () => {
+      await listByCohortHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        isCache: mockResult.isCache,
+        message: mockResult.message,
+        meta: mockResult.data[0].meta,
+        measurements: mockResult.data[0].data,
+      });
+    });
+
+    it("should handle errors when processing Cohort IDs", async () => {
+      req = {
+        query: { tenant: "custom", cohort_id: "invalid" },
+        params: {},
+        query: {},
+      };
+      await listByCohortHistorical(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: false,
+        errors: {
+          message: `Unable to process measurements for the provided Cohort IDs invalid`,
+        },
+        message: "Internal Server Error",
+      });
+    });
+  });
+
+  describe("listByLatLong", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        params: { latitude: "12.3456", longitude: "-78.9012" },
+        query: { tenant: "custom", radius: "100" },
+      };
+      res = {
+        status: sinon.spy(),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        isCache: true,
+        message: "Success message",
+        data: ["site1"],
+      };
+      sinon.stub(getSitesFromLatitudeAndLongitude).resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restoreDefaultSpyCache();
+    });
+
+    it("should list events by latitude and longitude successfully", async () => {
+      await listByLatLong(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        isCache: mockResult.isCache,
+        message: mockResult.message,
+        meta: mockResult.meta,
+        measurements: mockResult.data,
+      });
+    });
+
+    it("should handle errors when getting sites from latitude and longitude", async () => {
+      const errorMockResult = {
+        success: false,
+        message: "Error fetching sites",
+      };
+      sinon.stub(getSitesFromLatitudeAndLongitude).rejects(errorMockResult);
+
+      await listByLatLong(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith(errorMockResult);
+    });
+
+    it("should handle empty result from getSitesFromLatitudeAndLongitude", async () => {
+      const emptyMockResult = { success: true, data: [] };
+      sinon.stub(getSitesFromLatitudeAndLongitude).resolves(emptyMockResult);
+
+      await listByLatLong(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        isCache: emptyMockResult.isCache,
+        message: emptyMockResult.message,
+        meta: emptyMockResult.meta,
+        measurements: [],
+      });
+    });
+  });
 });

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -298,6 +298,67 @@ ReadingsSchema.statics.recent = async function(
   }
 };
 
+ReadingsSchema.statics.getBestAirQualityLocations = async function(
+  { threshold = 10, pollutant = "pm2_5" } = {},
+  next
+) {
+  try {
+    const validPollutants = ["pm2_5", "pm10", "no2"];
+    if (!validPollutants.includes(pollutant)) {
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: `Invalid pollutant specified. Valid options are: ${validPollutants.join(
+            ", "
+          )}`,
+        })
+      );
+      return;
+    }
+
+    const matchCondition = {
+      [`${pollutant}.value`]: { $lt: threshold },
+    };
+
+    const pipeline = this.aggregate()
+      .match(matchCondition)
+      .project({
+        _id: 0,
+        site_id: 1,
+        time: 1,
+        [pollutant]: 1,
+        siteDetails: 1,
+      })
+      .allowDiskUse(true);
+
+    const data = await pipeline;
+
+    if (!isEmpty(data)) {
+      return {
+        success: true,
+        message: "Successfully retrieved locations with best air quality.",
+        data,
+        status: httpStatus.OK,
+      };
+    } else {
+      return {
+        success: true,
+        message:
+          "No locations found with air quality below the specified threshold.",
+        data: [],
+        status: httpStatus.OK,
+      };
+    }
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+    return;
+  }
+};
+
 const ReadingModel = (tenant) => {
   try {
     const readings = mongoose.model("readings");

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -299,7 +299,7 @@ ReadingsSchema.statics.recent = async function(
 };
 
 ReadingsSchema.statics.getBestAirQualityLocations = async function(
-  { threshold = 10, pollutant = "pm2_5" } = {},
+  { threshold = 10, pollutant = "pm2_5", limit = 100, skip = 0 } = {},
   next
 ) {
   try {
@@ -328,7 +328,9 @@ ReadingsSchema.statics.getBestAirQualityLocations = async function(
         [pollutant]: 1,
         siteDetails: 1,
       })
-      .allowDiskUse(true);
+      .allowDiskUse(true)
+      .skip(skip)
+      .limit(limit);
 
     const data = await pipeline;
 

--- a/src/device-registry/routes/v2/readings.js
+++ b/src/device-registry/routes/v2/readings.js
@@ -108,27 +108,28 @@ router.use(validatePagination);
 router.get("/map", eventController.readingsForMap);
 router.get(
   "/best-air-quality",
-  oneOf([
-    [
-      query("threshold")
-        .optional()
-        .notEmpty()
-        .trim()
-        .isFloat()
-        .withMessage("threshold must be a number")
-        .bail()
-        .toFloat(),
-      query("pollutant")
-        .optional()
-        .notEmpty()
-        .withMessage("the pollutant cannot be empty IF provided")
-        .bail()
-        .trim()
-        .toLowerCase()
-        .isIn(["pm2_5", "pm10", "no2"])
-        .withMessage("valid values include: pm2_5, pm10, no2"),
-    ],
-  ]),
+  [
+    query("threshold")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("the threshold cannot be empty IF provided")
+      .bail()
+      .isFloat()
+      .withMessage("threshold must be a number")
+      .bail()
+      .toFloat(),
+    query("pollutant")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("the pollutant cannot be empty IF provided")
+      .bail()
+      .toLowerCase()
+      .isIn(["pm2_5", "pm10", "no2"])
+      .withMessage("valid values include: pm2_5, pm10, no2"),
+  ],
+
   eventController.getBestAirQuality
 );
 router.get(

--- a/src/device-registry/routes/v2/readings.js
+++ b/src/device-registry/routes/v2/readings.js
@@ -107,6 +107,31 @@ router.use(validatePagination);
 
 router.get("/map", eventController.readingsForMap);
 router.get(
+  "/best-air-quality",
+  oneOf([
+    [
+      query("threshold")
+        .optional()
+        .notEmpty()
+        .trim()
+        .isFloat()
+        .withMessage("threshold must be a number")
+        .bail()
+        .toFloat(),
+      query("pollutant")
+        .optional()
+        .notEmpty()
+        .withMessage("the pollutant cannot be empty IF provided")
+        .bail()
+        .trim()
+        .toLowerCase()
+        .isIn(["pm2_5", "pm10", "no2"])
+        .withMessage("valid values include: pm2_5, pm10, no2"),
+    ],
+  ]),
+  eventController.getBestAirQuality
+);
+router.get(
   "/recent",
   [
     validateOptionalObjectId("cohort_id"),

--- a/src/device-registry/routes/v2/readings.js
+++ b/src/device-registry/routes/v2/readings.js
@@ -128,6 +128,29 @@ router.get(
       .toLowerCase()
       .isIn(["pm2_5", "pm10", "no2"])
       .withMessage("valid values include: pm2_5, pm10, no2"),
+    query("language")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("language cannot be empty if provided")
+      .isLength({ min: 2, max: 5 })
+      .withMessage("language should be a valid ISO 639-1 code"),
+    query("limit")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("limit cannot be empty if provided")
+      .isInt({ min: 1, max: 100 })
+      .withMessage("limit must be an integer between 1 and 100")
+      .toInt(),
+    query("skip")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("skip cannot be empty if provided")
+      .isInt({ min: 0 })
+      .withMessage("skip must be a non-negative integer")
+      .toInt(),
   ],
 
   eventController.getBestAirQuality

--- a/src/device-registry/routes/v2/test/ut_readings.js
+++ b/src/device-registry/routes/v2/test/ut_readings.js
@@ -1,0 +1,232 @@
+require("module-alias/register");
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const { expect } = chai;
+const proxyquire = require("proxyquire");
+const express = require("express");
+const mongoose = require("mongoose");
+
+chai.use(sinonChai);
+
+describe("Create Event Routes", () => {
+  let router, eventController, constants, NetworkModel, validationResult;
+
+  beforeEach(() => {
+    router = {
+      get: sinon.stub(),
+      use: sinon.stub(),
+    };
+    eventController = {
+      readingsForMap: sinon.stub(),
+      getBestAirQuality: sinon.stub(),
+      recentReadings: sinon.stub(),
+      fetchAndStoreData: sinon.stub(),
+    };
+    constants = {
+      NETWORKS: ["network1", "network2"],
+    };
+    NetworkModel = sinon.stub().returns({
+      distinct: sinon.stub().resolves(["Network1", "Network2"]),
+    });
+    validationResult = sinon.stub().returns({
+      isEmpty: sinon.stub().returns(true),
+      array: sinon.stub().returns([]),
+    });
+
+    const routeDefinition = proxyquire("@routes/readings", {
+      express: {
+        Router: () => router,
+      },
+      "@controllers/create-event": eventController,
+      "@config/constants": constants,
+      "@models/Network": NetworkModel,
+      "express-validator": {
+        check: sinon.stub(),
+        oneOf: sinon.stub(),
+        query: sinon.stub(),
+        body: sinon.stub(),
+        param: sinon.stub(),
+        validationResult: validationResult,
+      },
+    });
+  });
+
+  describe("Route Definitions", () => {
+    it("should define GET /map route", () => {
+      expect(router.get).to.have.been.calledWith(
+        "/map",
+        eventController.readingsForMap
+      );
+    });
+
+    it("should define GET /best-air-quality route", () => {
+      expect(router.get).to.have.been.calledWith(
+        "/best-air-quality",
+        sinon.match.any,
+        eventController.getBestAirQuality
+      );
+    });
+
+    it("should define GET /recent route", () => {
+      expect(router.get).to.have.been.calledWith(
+        "/recent",
+        sinon.match.any,
+        sinon.match.any,
+        eventController.recentReadings
+      );
+    });
+
+    it("should define GET /fetchAndStoreData route", () => {
+      expect(router.get).to.have.been.calledWith(
+        "/fetchAndStoreData",
+        eventController.fetchAndStoreData
+      );
+    });
+  });
+
+  describe("Middleware", () => {
+    it("should use headers middleware", () => {
+      expect(router.use).to.have.been.calledWith(sinon.match.func);
+    });
+
+    it("should use validatePagination middleware", () => {
+      expect(router.use).to.have.been.calledWith(sinon.match.func);
+    });
+  });
+
+  describe("Custom Validators", () => {
+    describe("isValidObjectId", () => {
+      it("should return true for valid ObjectId", () => {
+        const isValidObjectId = sinon
+          .stub(mongoose.Types.ObjectId, "isValid")
+          .returns(true);
+        expect(isValidObjectId("507f1f77bcf86cd799439011")).to.be.true;
+        isValidObjectId.restore();
+      });
+
+      it("should return false for invalid ObjectId", () => {
+        const isValidObjectId = sinon
+          .stub(mongoose.Types.ObjectId, "isValid")
+          .returns(false);
+        expect(isValidObjectId("invalid-id")).to.be.false;
+        isValidObjectId.restore();
+      });
+    });
+
+    describe("validateNetwork", () => {
+      it("should not throw error for valid network", async () => {
+        const validateNetwork = sinon.stub().resolves();
+        await expect(validateNetwork("Network1")).to.be.fulfilled;
+      });
+
+      it("should throw error for invalid network", async () => {
+        const validateNetwork = sinon
+          .stub()
+          .rejects(new Error("Invalid network"));
+        await expect(validateNetwork("InvalidNetwork")).to.be.rejected;
+      });
+    });
+  });
+
+  describe("Route Handlers", () => {
+    describe("GET /best-air-quality", () => {
+      it("should call getBestAirQuality controller method", () => {
+        const req = { query: {} };
+        const res = {};
+        const next = sinon.spy();
+
+        router.get
+          .withArgs(
+            "/best-air-quality",
+            sinon.match.any,
+            eventController.getBestAirQuality
+          )
+          .callArgWith(1, req, res, next);
+
+        expect(eventController.getBestAirQuality).to.have.been.calledWith(
+          req,
+          res,
+          next
+        );
+      });
+    });
+
+    describe("GET /recent", () => {
+      it("should call recentReadings controller method", () => {
+        const req = { query: {} };
+        const res = {};
+        const next = sinon.spy();
+
+        router.get
+          .withArgs(
+            "/recent",
+            sinon.match.any,
+            sinon.match.any,
+            eventController.recentReadings
+          )
+          .callArgWith(2, req, res, next);
+
+        expect(eventController.recentReadings).to.have.been.calledWith(
+          req,
+          res,
+          next
+        );
+      });
+
+      it("should return 400 if both cohort_id and grid_id are provided", () => {
+        const req = { query: { cohort_id: "123", grid_id: "456" } };
+        const res = {
+          status: sinon.stub().returnsThis(),
+          json: sinon.spy(),
+        };
+        const next = sinon.spy();
+
+        router.get
+          .withArgs(
+            "/recent",
+            sinon.match.any,
+            sinon.match.any,
+            eventController.recentReadings
+          )
+          .callArgWith(2, req, res, next);
+
+        expect(res.status).to.have.been.calledWith(400);
+        expect(res.json).to.have.been.calledWith({
+          success: false,
+          message: "Bad Request Error",
+          errors: {
+            message: "You cannot provide both cohort_id and grid_id",
+          },
+        });
+      });
+
+      it("should return 400 if both device_id and site_id are provided", () => {
+        const req = { query: { device_id: "123", site_id: "456" } };
+        const res = {
+          status: sinon.stub().returnsThis(),
+          json: sinon.spy(),
+        };
+        const next = sinon.spy();
+
+        router.get
+          .withArgs(
+            "/recent",
+            sinon.match.any,
+            sinon.match.any,
+            eventController.recentReadings
+          )
+          .callArgWith(2, req, res, next);
+
+        expect(res.status).to.have.been.calledWith(400);
+        expect(res.json).to.have.been.calledWith({
+          success: false,
+          message: "Bad Request Error",
+          errors: {
+            message: "You cannot provide both device_id and site_id",
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/device-registry/utils/create-event.js
+++ b/src/device-registry/utils/create-event.js
@@ -1285,7 +1285,7 @@ const createEvent = {
 
       const readingsResponse = await ReadingModel(
         tenant
-      ).getBestAirQualityLocations({ threshold, pollutant }, next);
+      ).getBestAirQualityLocations({ threshold, pollutant, limit, skip }, next);
 
       // Handle language translation for health tips if applicable
       if (


### PR DESCRIPTION
## Description

retrieve places with air quality below provided threshold.
This PR introduces a new endpoint to retrieve locations with the best air quality based on specified pollutant thresholds. The endpoint allows users to query for locations where air quality values fall below a given threshold for pollutants such as PM2.5, PM10, or NO2. This enhancement aims to provide users with actionable insights into air quality conditions across various locations.


## Changes Made

- [ ] Added a new route /best-air-quality to the Express router.
- [ ] Implemented the getBestAirQuality function in the event controller to handle requests to the new endpoint.
- [ ] Integrated validation for required parameters (threshold and pollutant).
- [ ] Implemented caching logic to optimize performance and reduce redundant calculations.
- [ ] Added translation support for health tips associated with air quality readings.
- [ ] Updated documentation to include details about the new endpoint.

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] GET` {{baseUrl}}/api/v2/devices/readings/best-air-quality.`
Query Parameters:

- `threshold` (optional): The maximum acceptable value for the specified pollutant.Default is 10.
- `pollutant `(optional): The type of pollutant to filter by (options: pm2_5, pm10, no2). Default is pm2_5.
- `language `(optional): The language for translating health tips.
-` limit `(optional): The maximum number of results to return.
- `skip` (optional): The number of results to skip for pagination.

## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint `/best-air-quality` to retrieve optimal air quality measurements.
	- Added functionality to fetch air quality locations based on specified thresholds and pollutants.
	- Enhanced the existing `/recent` endpoint with improved validation for query parameters.
	- Added a caching mechanism to improve performance for air quality data retrieval.

- **Bug Fixes**
	- Implemented error handling for invalid pollutant requests and validation errors in query parameters.

- **Documentation**
	- Updated API documentation to reflect new endpoints and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->