### PR TITLE
consider devices which have been off for more than 7 days

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -21,7 +21,7 @@ const logger = require("log4js").getLogger(
 const DEFAULT_LIMIT = 1000;
 const DEFAULT_SKIP = 0;
 const DEFAULT_PAGE = 1;
-const UPTIME_CHECK_THRESHOLD = 48;
+const UPTIME_CHECK_THRESHOLD = 168;
 
 const valueSchema = new Schema({
   time: {


### PR DESCRIPTION
## Description

During uptime checks, consider devices which have been off for more than 7 days


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the uptime check threshold to 168 hours, enhancing device monitoring accuracy.
  
- **Chores**
	- Adjusted internal logic for filtering devices based on their last refreshed time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->