### PR TITLE
using the default tenant for the events insertion endpoint

### DIFF
--- a/src/device-registry/controllers/create-event.js
+++ b/src/device-registry/controllers/create-event.js
@@ -486,7 +486,6 @@ const createEvent = {
   addValues: async (req, res, next) => {
     try {
       logText("adding values...");
-      const { tenant } = req.query;
       const measurements = req.body;
       const errors = extractErrorsFromRequest(req);
       if (errors) {
@@ -502,7 +501,11 @@ const createEvent = {
         ? defaultTenant
         : req.query.tenant;
 
-      let result = await createEventUtil.insert(tenant, measurements, next);
+      let result = await createEventUtil.insert(
+        defaultTenant,
+        measurements,
+        next
+      );
 
       if (isEmpty(result) || res.headersSent) {
         return;


### PR DESCRIPTION
## Description

using the default tenant for the events insertion endpoint

## Changes Made

- [x] using the default tenant for the events insertion endpoint

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] add values, events
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

using the default tenant for the events insertion endpoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default tenant value of "airqo" for event creation when not specified in requests.

- **Bug Fixes**
	- Improved handling of tenant variable to ensure consistent use of default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->