### PR TITLE
Increase Kafka message size

### DIFF
--- a/k8s/kafka/clusters/kafka-cluster.yaml
+++ b/k8s/kafka/clusters/kafka-cluster.yaml
@@ -41,6 +41,8 @@ spec:
       default.replication.factor: 3
       min.insync.replicas: 2
       inter.broker.protocol.version: "3.6"
+      message.max.bytes: 2097152
+      replica.fetch.max.bytes: 2097152
     storage:
       type: ephemeral
   zookeeper:


### PR DESCRIPTION
## Description
Increase kafka message size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration parameters for the Kafka cluster to enhance message handling capabilities.
		- `message.max.bytes` set to 2MB to control maximum message size.
		- `replica.fetch.max.bytes` set to 2MB to manage data fetching by replicas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->