### PR TITLE
Update fix/pipeline task retries

### DIFF
--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -1058,7 +1058,7 @@ class AirQoDataUtils:
                 except json.JSONDecodeError as e:
                     logger.exception(f"Error decoding JSON: {e}")
                     continue
-                if not key or not value.get("_id"):
+                if not key or not value.get("_id") or not value.get("device_id"):
                     logger.warning(
                         f"Skipping message with key: {key}, missing 'device_id'."
                     )

--- a/src/workflows/airqo_etl_utils/data_validator.py
+++ b/src/workflows/airqo_etl_utils/data_validator.py
@@ -170,13 +170,10 @@ class DataValidationUtils:
             data.rename(columns={"device_id": "device_name"}, inplace=True)
 
             devices = AirQoDataUtils.get_devices(group_id=caller)
-            devices = devices[
-                ["tenant", "device_id", "site_id", "latitude", "longitude"]
-            ]
+            devices = devices[["tenant", "_id", "site_id", "latitude", "longitude"]]
             devices.rename(
                 columns={
-                    "device_id": "device_name",
-                    "mongo_id": "device_id",
+                    "_id": "device_id",
                     "latitude": "device_latitude",
                     "longitude": "device_longitude",
                 },
@@ -295,7 +292,7 @@ class DataValidationUtils:
         devices.rename(
             columns={
                 "device_id": "device_name",
-                "mongo_id": "device_id",
+                "_id": "device_id",
                 "latitude": "device_latitude",
                 "longitude": "device_longitude",
             },

--- a/src/workflows/airqo_etl_utils/date.py
+++ b/src/workflows/airqo_etl_utils/date.py
@@ -50,8 +50,8 @@ class DateUtils:
         delta_kwargs = {unit: value}
         dag_run = kwargs.get("dag_run", None)
         is_manual_run = dag_run.external_trigger if dag_run else False
-        logger.info("KWARGS:", kwargs)
-        print("IS MANUAL RUN:", is_manual_run)
+        logger.info(f"KWARGS:, {kwargs}")
+        logger.info(f"IS MANUAL RUN: {is_manual_run}")
 
         if historical and is_manual_run:
             start_date_time = kwargs.get("params", {}).get("start_date_time")

--- a/src/workflows/airqo_etl_utils/date.py
+++ b/src/workflows/airqo_etl_utils/date.py
@@ -1,6 +1,10 @@
 from datetime import datetime, timedelta, timezone
 from typing import Tuple
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class DateUtils:
     day_start_date_time_format = "%Y-%m-%dT00:00:00Z"
@@ -46,7 +50,7 @@ class DateUtils:
         delta_kwargs = {unit: value}
         dag_run = kwargs.get("dag_run", None)
         is_manual_run = dag_run.external_trigger if dag_run else False
-        print("KWARGS:", kwargs)
+        logger.info("KWARGS:", kwargs)
         print("IS MANUAL RUN:", is_manual_run)
 
         if historical and is_manual_run:
@@ -62,7 +66,8 @@ class DateUtils:
                     print("Exception in get_dag_date_time_values", repr(e))
 
         if exception_occurred or not is_manual_run:
-            start_date_time = datetime.now(timezone.utc) - timedelta(**delta_kwargs)
+            execution_date = kwargs["dag_run"].execution_date
+            start_date_time = execution_date - timedelta(**delta_kwargs)
             end_date_time = (
                 start_date_time + timedelta(**delta_kwargs)
                 if hours or days

--- a/src/workflows/airqo_etl_utils/workflows_custom_utils.py
+++ b/src/workflows/airqo_etl_utils/workflows_custom_utils.py
@@ -17,7 +17,6 @@ class AirflowUtils:
             "start_date": datetime.now(timezone.utc) - timedelta(days=2),
             "owner": "AirQo",
             "owner_links": {"AirQo": "https://airqo.africa"},
-            "retries": 0,
             "on_failure_callback": AirflowUtils.dag_failure_notification,
         }
 

--- a/src/workflows/dags/airqo_kafka_workflows.py
+++ b/src/workflows/dags/airqo_kafka_workflows.py
@@ -4,33 +4,40 @@ from airqo_etl_utils.config import configuration
 from airqo_etl_utils.workflows_custom_utils import AirflowUtils
 
 from dag_docs import extract_store_devices_data_in_kafka
+from datetime import timedelta
+from typing import List, Dict, Any
 
 
 @dag(
     "AirQo-devices-to-kafka-pipeline",
     schedule="0 0 * * *",
     doc_md=extract_store_devices_data_in_kafka,
-    default_args=AirflowUtils.dag_default_configs(),
     catchup=False,
     tags=["devices", "kafka"],
+    default_args=AirflowUtils.dag_default_configs(),
 )
 def airqo_devices_data():
     import pandas as pd
     from airqo_etl_utils.airqo_utils import AirQoApi
 
-    @task()
-    def extract_devices(**kwargs) -> pd.DataFrame:
+    @task(retries=3, retry_delay=timedelta(minutes=5))
+    def extract_devices() -> pd.DataFrame:
         airqo_api = AirQoApi()
         return airqo_api.get_devices()
 
     @task()
-    def send_device_data_to_broker(devices: pd.DataFrame, **kwargs) -> None:
-        from airqo_etl_utils.message_broker_utils import MessageBrokerUtils
+    def transform_devices(devices: List[Dict[str, Any]], **kwargs) -> pd.DataFrame:
         from airqo_etl_utils.data_validator import DataValidationUtils
 
         devices = DataValidationUtils.transform_devices(
             devices=devices, taskinstance=kwargs["ti"]
         )
+        return devices
+
+    @task(retries=3, retry_delay=timedelta(minutes=5))
+    def send_device_data_to_broker(devices: pd.DataFrame) -> None:
+        from airqo_etl_utils.message_broker_utils import MessageBrokerUtils
+
         if not devices.empty:
             broker = MessageBrokerUtils()
             broker.publish_to_topic(
@@ -39,8 +46,9 @@ def airqo_devices_data():
                 column_key="device_name",
             )
 
-    extracted_device = extract_devices()
-    send_device_data_to_broker(extracted_device)
+    extracted_devices = extract_devices()
+    transformed_devices = transform_devices(extracted_devices)
+    send_device_data_to_broker(transformed_devices)
 
 
 airqo_devices_data()


### PR DESCRIPTION
## Description
This PR makes tasks idempotent by making sure that they always run with the start_date_time that they had been scheduled for. This fixes/removes the use of datetime.datetime.now().

This will reduce data gaps due to running with wrong start_date_time when rerunning pipelines.

## Related Issues

- [ ] JIRA cards:
  - [ ] OPS-251



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced data validation for device records, ensuring both `_id` and `device_id` are present.
	- Added a new `transform_devices` task in the Airflow DAG for improved data processing.
- **Improvements**
	- Introduced retry logic and better error handling across multiple tasks in the Airflow DAGs.
	- Updated logging practices for better traceability in data processing.
	- Updated default arguments in DAGs for uniformity and consistency.
- **Bug Fixes**
	- Corrected notification messages for task success and failure in the Airflow workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->