### PR TITLE
updating  controller.ingressClass to be an object instead of a String

### DIFF
--- a/k8s/nginx/values.yaml
+++ b/k8s/nginx/values.yaml
@@ -208,7 +208,9 @@ controller:
   ## The Ingress Controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class.
 
   ## The Ingress Controller processes all the resources that do not have the "ingressClassName" field for all versions of kubernetes.
-  ingressClass: nginx
+  ingressClass:
+    name: nginx
+    setAsDefaultIngress: false
 
   ## New Ingresses without an ingressClassName field specified will be assigned the class specified in `controller.ingressClass`.
   setAsDefaultIngress: false


### PR DESCRIPTION
## Description

updating  controller.ingressClass to be an object instead of a String. All part of Nginx configurations.


## Changes Made

- [x] Updated the syntax f the ingressClass to an object structure
```
controller:
  ingressClass:
    name: nginx
    setAsDefaultIngress: false

```
## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating


