### PR TITLE
Removed the .customSanitizer() blocks that were forcing 5 decimal places

### DIFF
--- a/src/device-registry/routes/v2/sites.js
+++ b/src/device-registry/routes/v2/sites.js
@@ -451,10 +451,7 @@ router.post(
           return Promise.resolve("latitude validation test has passed");
         })
         .bail()
-        .customSanitizer((value) => {
-          return numeral(value).format("0.00000");
-        })
-        .isDecimal({ decimal_digits: 5 })
+        .isDecimal({ min_decimal_places: 5 })
         .withMessage("the latitude must have atleast 5 decimal places in it"),
       body("longitude")
         .exists()
@@ -473,10 +470,7 @@ router.post(
           return Promise.resolve("longitude validation test has passed");
         })
         .bail()
-        .customSanitizer((value) => {
-          return numeral(value).format("0.00000");
-        })
-        .isDecimal({ decimal_digits: 5 })
+        .isDecimal({ min_decimal_places: 5 })
         .withMessage("the longitude must have atleast 5 decimal places in it"),
       body("name")
         .exists()
@@ -542,11 +536,8 @@ router.post(
           return Promise.resolve("latitude validation test has passed");
         })
         .bail()
-        .customSanitizer((value) => {
-          return numeral(value).format("0.00");
-        })
-        .isDecimal({ decimal_digits: 2 })
-        .withMessage("the latitude must have atleast 5 decimal places in it"),
+        .isDecimal({ min_decimal_places: 2 })
+        .withMessage("the latitude must have atleast 2 decimal places in it"),
       body("longitude")
         .exists()
         .withMessage("the longitude is is missing in your request")
@@ -564,10 +555,7 @@ router.post(
           return Promise.resolve("longitude validation test has passed");
         })
         .bail()
-        .customSanitizer((value) => {
-          return numeral(value).format("0.00");
-        })
-        .isDecimal({ decimal_digits: 2 })
+        .isDecimal({ min_decimal_places: 2 })
         .withMessage("the longitude must have atleast 2 decimal places in it"),
     ],
   ]),
@@ -832,10 +820,7 @@ router.put(
           return Promise.resolve("latitude validation test has passed");
         })
         .bail()
-        .customSanitizer((value) => {
-          return numeral(value).format("0.00000");
-        })
-        .isDecimal({ decimal_digits: 5 })
+        .isDecimal({ min_decimal_places: 5 })
         .withMessage("the latitude must have atleast 5 decimal places in it"),
       body("longitude")
         .optional()
@@ -854,10 +839,7 @@ router.put(
           return Promise.resolve("longitude validation test has passed");
         })
         .bail()
-        .customSanitizer((value) => {
-          return numeral(value).format("0.00000");
-        })
-        .isDecimal({ decimal_digits: 5 })
+        .isDecimal({ min_decimal_places: 5 })
         .withMessage("the longitude must have atleast 5 decimal places in it"),
       body("description")
         .optional()
@@ -1015,11 +997,8 @@ router.get(
           return Promise.resolve("longitude validation test has passed");
         })
         .bail()
-        .customSanitizer((value) => {
-          return numeral(value).format("0.00000");
-        })
-        .isDecimal({ decimal_digits: 5 })
-        .withMessage("the longitude must have atleast 5 decimal places in it"),
+        .isDecimal({ min_decimal_places: 1 })
+        .withMessage("the longitude must have atleast 1 decimal places in it"),
       query("radius")
         .exists()
         .withMessage("the radius is missing in request")
@@ -1047,11 +1026,8 @@ router.get(
           return Promise.resolve("latitude validation test has passed");
         })
         .bail()
-        .customSanitizer((value) => {
-          return numeral(value).format("0.00000");
-        })
-        .isDecimal({ decimal_digits: 5 })
-        .withMessage("the latitude must have atleast 5 decimal places in it"),
+        .isDecimal({ min_decimal_places: 1 })
+        .withMessage("the latitude must have atleast 1 decimal places in it"),
     ],
   ]),
   siteController.findNearestSite

--- a/src/device-registry/routes/v2/sites.js
+++ b/src/device-registry/routes/v2/sites.js
@@ -445,14 +445,11 @@ router.post(
           let dp = decimalPlaces(value);
           if (dp < 5) {
             return Promise.reject(
-              "the latitude must have 5 or more characters"
+              "the latitude must have 5 or more decimal places"
             );
           }
           return Promise.resolve("latitude validation test has passed");
-        })
-        .bail()
-        .isDecimal({ min_decimal_places: 5 })
-        .withMessage("the latitude must have atleast 5 decimal places in it"),
+        }),
       body("longitude")
         .exists()
         .withMessage("the longitude is is missing in your request")
@@ -464,14 +461,11 @@ router.post(
           let dp = decimalPlaces(value);
           if (dp < 5) {
             return Promise.reject(
-              "the longitude must have 5 or more characters"
+              "the longitude must have 5 or more decimal places"
             );
           }
           return Promise.resolve("longitude validation test has passed");
-        })
-        .bail()
-        .isDecimal({ min_decimal_places: 5 })
-        .withMessage("the longitude must have atleast 5 decimal places in it"),
+        }),
       body("name")
         .exists()
         .withMessage("the name is is missing in your request")
@@ -530,14 +524,11 @@ router.post(
           let dp = decimalPlaces(value);
           if (dp < 2) {
             return Promise.reject(
-              "the latitude must have 2 or more characters"
+              "the latitude must have 2 or more decimal places"
             );
           }
           return Promise.resolve("latitude validation test has passed");
-        })
-        .bail()
-        .isDecimal({ min_decimal_places: 2 })
-        .withMessage("the latitude must have atleast 2 decimal places in it"),
+        }),
       body("longitude")
         .exists()
         .withMessage("the longitude is is missing in your request")
@@ -549,14 +540,11 @@ router.post(
           let dp = decimalPlaces(value);
           if (dp < 2) {
             return Promise.reject(
-              "the longitude must have 2 or more characters"
+              "the longitude must have 2 or more decimal places"
             );
           }
           return Promise.resolve("longitude validation test has passed");
-        })
-        .bail()
-        .isDecimal({ min_decimal_places: 2 })
-        .withMessage("the longitude must have atleast 2 decimal places in it"),
+        }),
     ],
   ]),
   siteController.generateMetadata
@@ -814,14 +802,11 @@ router.put(
           let dp = decimalPlaces(value);
           if (dp < 5) {
             return Promise.reject(
-              "the latitude must have 5 or more characters"
+              "the latitude must have 5 or more decimal places"
             );
           }
           return Promise.resolve("latitude validation test has passed");
-        })
-        .bail()
-        .isDecimal({ min_decimal_places: 5 })
-        .withMessage("the latitude must have atleast 5 decimal places in it"),
+        }),
       body("longitude")
         .optional()
         .notEmpty()
@@ -833,14 +818,11 @@ router.put(
           let dp = decimalPlaces(value);
           if (dp < 5) {
             return Promise.reject(
-              "the longitude must have 5 or more characters"
+              "the longitude must have 5 or more decimal places"
             );
           }
           return Promise.resolve("longitude validation test has passed");
-        })
-        .bail()
-        .isDecimal({ min_decimal_places: 5 })
-        .withMessage("the longitude must have atleast 5 decimal places in it"),
+        }),
       body("description")
         .optional()
         .notEmpty()
@@ -991,14 +973,11 @@ router.get(
           let dp = decimalPlaces(value);
           if (dp < 1) {
             return Promise.reject(
-              "the longitude must have 1 or more characters"
+              "the longitude must have 1 or more decimal places"
             );
           }
           return Promise.resolve("longitude validation test has passed");
-        })
-        .bail()
-        .isDecimal({ min_decimal_places: 1 })
-        .withMessage("the longitude must have atleast 1 decimal places in it"),
+        }),
       query("radius")
         .exists()
         .withMessage("the radius is missing in request")
@@ -1020,14 +999,11 @@ router.get(
           let dp = decimalPlaces(value);
           if (dp < 1) {
             return Promise.reject(
-              "the latitude must have 1 or more characters"
+              "the latitude must have 1 or more decimal places"
             );
           }
           return Promise.resolve("latitude validation test has passed");
-        })
-        .bail()
-        .isDecimal({ min_decimal_places: 1 })
-        .withMessage("the latitude must have atleast 1 decimal places in it"),
+        }),
     ],
   ]),
   siteController.findNearestSite

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -353,7 +353,7 @@ const createSite = {
         };
       }
 
-      let lat_long = createSite.generateLatLong(latitude, longitude, next);
+      let lat_long = createSite.generateLatLong(latitude, longitude);
       request["body"]["lat_long"] = lat_long;
 
       let responseFromGenerateName = await createSite.generateName(
@@ -686,7 +686,7 @@ const createSite = {
         request["body"]["name"] = availableName;
       }
 
-      let lat_long = createSite.generateLatLong(latitude, longitude, next);
+      let lat_long = createSite.generateLatLong(latitude, longitude);
       request["body"]["lat_long"] = lat_long;
 
       if (isEmpty(request["body"]["generated_name"])) {
@@ -1075,7 +1075,7 @@ const createSite = {
       );
     }
   },
-  generateLatLong: (lat, long, next) => {
+  generateLatLong: (lat, long) => {
     try {
       return `${lat}_${long}`;
     } catch (error) {


### PR DESCRIPTION
## Description

Removed the .`customSanitizer()` blocks that were forcing 5 decimal places

## Changes Made

- [x] Removed the `.customSanitizer()` blocks that were forcing 5 decimal places
- [x] Changed `decimal_digits: 5` to `min_decimal_places: 5` in the `.isDecimal()` validation to only enforce a minimum without capping the maximum

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] device-registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] create site
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

Removed the .customSanitizer() blocks that were forcing 5 decimal places


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for latitude and longitude fields across multiple routes, now requiring at least 5 decimal places for most cases and 1 decimal place for the `/nearest` route.
  
- **Bug Fixes**
	- Updated error messages to align with new validation rules for latitude and longitude inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->