### PR TITLE
removing the name as one of Site identifiers

### DIFF
--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -41,7 +41,6 @@ const siteSchema = new Schema(
     name: {
       type: String,
       trim: true,
-      unique: true,
       required: [true, "name is required!"],
     },
     visibility: {

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -1064,7 +1064,6 @@ const generateFilter = {
       category,
       site_category,
       path,
-      name,
       site_codes,
       _id,
       network,
@@ -1076,10 +1075,6 @@ const generateFilter = {
       last_active_after,
     } = { ...req.query, ...req.params, ...req.body };
     const filter = {};
-    logText("we are generating the filter man!");
-    if (name) {
-      filter["name"] = name;
-    }
 
     if (county) {
       filter["county"] = county;


### PR DESCRIPTION
## Description

removing the name as one of Site identifiers

## Changes Made

- [x] removing the name as one of Site identifiers

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Update Site
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

removing the name as one of Site identifiers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in site registration by allowing duplicate site names.
	- Improved filter logic for site queries by removing unnecessary name parameter handling.

- **Bug Fixes**
	- Ensured validation for duplicate values in the grids array.

- **Chores**
	- Updated middleware logic for field management during save and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->