### PR TITLE
feat: Add duplicate site fields detection job with comprehensive test coverage

### DIFF
--- a/src/device-registry/bin/jobs/check-duplicate-site-fields-job.js
+++ b/src/device-registry/bin/jobs/check-duplicate-site-fields-job.js
@@ -1,0 +1,98 @@
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/check-duplicate-site-fields-job`
+);
+const SitesModel = require("@models/Site");
+const cron = require("node-cron");
+const { logText, logObject } = require("@utils/log");
+
+// Fields to check for duplicates - easily modifiable
+const FIELDS_TO_CHECK = ["name", "search_name", "description"];
+
+// Helper function to group sites by field value
+const groupSitesByFieldValue = (sites, fieldName) => {
+  return sites.reduce((acc, site) => {
+    const fieldValue = site[fieldName];
+    if (!fieldValue) return acc;
+
+    if (!acc[fieldValue]) {
+      acc[fieldValue] = [];
+    }
+    acc[fieldValue].push(site);
+    return acc;
+  }, {});
+};
+
+// Function to find duplicates for a specific field
+const findDuplicatesForField = (groupedSites) => {
+  return Object.entries(groupedSites)
+    .filter(([_, sites]) => sites.length > 1)
+    .map(([value, sites]) => ({
+      value,
+      sites: sites.map((site) => ({
+        id: site._id,
+        generated_name: site.generated_name,
+      })),
+    }));
+};
+
+// Main function to check for duplicate field values
+const checkDuplicateSiteFields = async () => {
+  try {
+    // Get all active sites
+    const sites = await SitesModel("airqo").find({ isOnline: true });
+    logObject("Total sites checked", sites.length);
+
+    const duplicateReport = {};
+
+    // Check each field for duplicates
+    for (const field of FIELDS_TO_CHECK) {
+      const groupedSites = groupSitesByFieldValue(sites, field);
+      const duplicates = findDuplicatesForField(groupedSites);
+
+      if (duplicates.length > 0) {
+        duplicateReport[field] = duplicates;
+      }
+    }
+
+    // Log results if duplicates found
+    if (Object.keys(duplicateReport).length > 0) {
+      logText("⚠️ Duplicate site field values detected!");
+
+      for (const [field, duplicates] of Object.entries(duplicateReport)) {
+        logText(`\nField: ${field}`);
+        logger.warn(`⚠️ Duplicates found in field: ${field}`);
+
+        duplicates.forEach(({ value, sites }) => {
+          const siteNames = sites.map((site) => site.generated_name).join(", ");
+          const message = `⚠️ Value "${value}" shared by sites: ${siteNames}`;
+          logText(message);
+          logger.warn(message);
+        });
+      }
+    } else {
+      logText("✅ No duplicate Site field values found");
+      logger.info("✅ No duplicate Site field values found");
+    }
+  } catch (error) {
+    const errorMessage = `🐛 Error checking duplicate site fields: ${error.message}`;
+    logText(errorMessage);
+    logger.error(errorMessage);
+    logger.error(`Stack trace: ${error.stack}`);
+  }
+};
+
+// Initial run message
+logText("Duplicate site fields checker job is now running.....");
+// Schedule the job to run every 2 hours at minute 45
+const schedule = "45 */2 * * *";
+cron.schedule(schedule, checkDuplicateSiteFields, {
+  scheduled: true,
+});
+
+// Export for testing or manual execution
+module.exports = {
+  checkDuplicateSiteFields,
+  FIELDS_TO_CHECK,
+};

--- a/src/device-registry/bin/jobs/test/ut_check-duplicate-site-fields-job.js
+++ b/src/device-registry/bin/jobs/test/ut_check-duplicate-site-fields-job.js
@@ -1,0 +1,425 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const {
+  checkDuplicateSiteFields,
+  FIELDS_TO_CHECK,
+} = require("@bin/jobs/check-duplicate-site-fields-job");
+const SitesModel = require("@models/Site");
+const log4js = require("log4js");
+const { logText, logObject } = require("@utils/log");
+
+describe("Duplicate Site Fields Checker", () => {
+  let sandbox;
+  let loggerStub;
+  let findStub;
+  let logTextStub;
+  let logObjectStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    loggerStub = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+    };
+    sandbox.stub(log4js, "getLogger").returns(loggerStub);
+    findStub = sandbox.stub();
+    sandbox.stub(SitesModel, "airqo").returns({ find: findStub });
+    logTextStub = sandbox.stub();
+    logObjectStub = sandbox.stub();
+    sandbox.stub(require("@utils/log"), "logText").callsFake(logTextStub);
+    sandbox.stub(require("@utils/log"), "logObject").callsFake(logObjectStub);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("checkDuplicateSiteFields", () => {
+    it("should detect and report duplicate field values", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: "Duplicate Name",
+          search_name: "unique1",
+          description: "Duplicate Desc",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: "Duplicate Name",
+          search_name: "unique2",
+          description: "Duplicate Desc",
+        },
+        {
+          _id: "3",
+          generated_name: "site3",
+          name: "Unique Name",
+          search_name: "unique3",
+          description: "Unique Desc",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      expect(loggerStub.warn.called).to.be.true;
+      expect(logTextStub.calledWith("⚠️ Duplicate site field values detected!"))
+        .to.be.true;
+      expect(
+        logTextStub.calledWith(
+          'Value "Duplicate Name" shared by sites: site1, site2'
+        )
+      ).to.be.true;
+      expect(
+        logTextStub.calledWith(
+          'Value "Duplicate Desc" shared by sites: site1, site2'
+        )
+      ).to.be.true;
+    });
+
+    it("should handle multiple sets of duplicates for the same field", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: "Duplicate Name 1",
+          description: "Desc A",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: "Duplicate Name 1",
+          description: "Desc B",
+        },
+        {
+          _id: "3",
+          generated_name: "site3",
+          name: "Duplicate Name 2",
+          description: "Desc A",
+        },
+        {
+          _id: "4",
+          generated_name: "site4",
+          name: "Duplicate Name 2",
+          description: "Desc B",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      expect(
+        logTextStub.calledWith(
+          'Value "Duplicate Name 1" shared by sites: site1, site2'
+        )
+      ).to.be.true;
+      expect(
+        logTextStub.calledWith(
+          'Value "Duplicate Name 2" shared by sites: site3, site4'
+        )
+      ).to.be.true;
+    });
+
+    it("should handle case sensitivity in duplicate detection", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: "Test Name",
+          description: "Test Description",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: "test name",
+          description: "TEST DESCRIPTION",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      // Should not detect these as duplicates due to case differences
+      expect(logTextStub.calledWith("✅ No duplicate field values found")).to.be
+        .true;
+    });
+
+    it("should handle empty string values", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: "",
+          description: "",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: "",
+          description: "",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      expect(logTextStub.calledWith("⚠️ Duplicate site field values detected!"))
+        .to.be.true;
+      expect(logTextStub.calledWith('Value "" shared by sites: site1, site2'))
+        .to.be.true;
+    });
+
+    it("should handle special characters in field values", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: "Test@#$%",
+          description: "Test\nMultiline",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: "Test@#$%",
+          description: "Test\nMultiline",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      expect(
+        logTextStub.calledWith('Value "Test@#$%" shared by sites: site1, site2')
+      ).to.be.true;
+      expect(
+        logTextStub.calledWith(
+          'Value "Test\nMultiline" shared by sites: site1, site2'
+        )
+      ).to.be.true;
+    });
+
+    it("should handle very long field values", async () => {
+      const longString = "a".repeat(1000);
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: longString,
+          description: "Test",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: longString,
+          description: "Test",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      expect(loggerStub.warn.called).to.be.true;
+    });
+
+    it("should handle empty sites array", async () => {
+      findStub.resolves([]);
+
+      await checkDuplicateSiteFields();
+
+      expect(logTextStub.calledWith("✅ No duplicate field values found")).to.be
+        .true;
+      expect(logObjectStub.calledWith("Total sites checked", 0)).to.be.true;
+    });
+
+    it("should handle missing fields", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          // name field missing
+          description: "Test",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          // name field missing
+          description: "Test",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      // Should only detect duplicate in description field
+      expect(
+        logTextStub.calledWith('Value "Test" shared by sites: site1, site2')
+      ).to.be.true;
+    });
+
+    it("should handle non-string field values", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: 123,
+          description: true,
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: 123,
+          description: true,
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      expect(logTextStub.calledWith("⚠️ Duplicate site field values detected!"))
+        .to.be.true;
+    });
+
+    it("should handle database timeout errors", async () => {
+      const timeoutError = new Error("Database operation timeout");
+      timeoutError.code = "ETIMEDOUT";
+      findStub.rejects(timeoutError);
+
+      await checkDuplicateSiteFields();
+
+      expect(
+        loggerStub.error.calledWith(
+          "🐛 Error checking duplicate site fields: Database operation timeout"
+        )
+      ).to.be.true;
+    });
+  });
+
+  describe("FIELDS_TO_CHECK configuration", () => {
+    it("should contain the required fields", () => {
+      expect(FIELDS_TO_CHECK).to.include("name");
+      expect(FIELDS_TO_CHECK).to.include("search_name");
+      expect(FIELDS_TO_CHECK).to.include("description");
+    });
+
+    it("should be an array", () => {
+      expect(FIELDS_TO_CHECK).to.be.an("array");
+    });
+
+    it("should not contain duplicate fields", () => {
+      const uniqueFields = new Set(FIELDS_TO_CHECK);
+      expect(uniqueFields.size).to.equal(FIELDS_TO_CHECK.length);
+    });
+
+    it("should not contain empty strings", () => {
+      expect(FIELDS_TO_CHECK.every((field) => field.length > 0)).to.be.true;
+    });
+
+    it("should not contain whitespace-only strings", () => {
+      expect(FIELDS_TO_CHECK.every((field) => field.trim().length > 0)).to.be
+        .true;
+    });
+
+    it("should contain only string values", () => {
+      expect(FIELDS_TO_CHECK.every((field) => typeof field === "string")).to.be
+        .true;
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle sites with duplicate values across multiple fields", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: "Duplicate",
+          search_name: "Duplicate",
+          description: "Duplicate",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: "Duplicate",
+          search_name: "Duplicate",
+          description: "Duplicate",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      FIELDS_TO_CHECK.forEach((field) => {
+        expect(
+          logTextStub.calledWith(
+            'Value "Duplicate" shared by sites: site1, site2'
+          )
+        ).to.be.true;
+      });
+    });
+
+    it("should handle Unicode characters in field values", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: "Test 测试",
+          description: "Description 描述",
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: "Test 测试",
+          description: "Description 描述",
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      expect(
+        logTextStub.calledWith(
+          'Value "Test 测试" shared by sites: site1, site2'
+        )
+      ).to.be.true;
+    });
+
+    it("should handle sites with all fields being null", async () => {
+      const mockSites = [
+        {
+          _id: "1",
+          generated_name: "site1",
+          name: null,
+          search_name: null,
+          description: null,
+        },
+        {
+          _id: "2",
+          generated_name: "site2",
+          name: null,
+          search_name: null,
+          description: null,
+        },
+      ];
+
+      findStub.resolves(mockSites);
+
+      await checkDuplicateSiteFields();
+
+      // Should not detect null values as duplicates
+      expect(logTextStub.calledWith("✅ No duplicate field values found")).to.be
+        .true;
+    });
+  });
+});

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -29,7 +29,7 @@ require("@bin/jobs/v2-check-network-status-job");
 require("@bin/jobs/check-unassigned-devices-job");
 require("@bin/jobs/check-active-statuses");
 require("@bin/jobs/check-unassigned-sites-job");
-
+require("@bin/jobs/check-duplicate-site-fields-job");
 if (isEmpty(constants.SESSION_SECRET)) {
   throw new Error("SESSION_SECRET environment variable not set");
 }


### PR DESCRIPTION
## Description
feat: Add duplicate site fields detection job with comprehensive test coverage

## Changes Made

- [x] Implemented new job script to detect and report sites with duplicate field values
- [x] Added comprehensive unit tests with edge case coverage
- [x] Fields monitored: `name`, `search_name`, `description`
- [x] Configurable field list for easy maintenance
- [x] Scheduled job running every 2 hours

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a scheduled job to check for duplicate fields in site records, enhancing data integrity.
  
- **Tests**
	- Added a comprehensive suite of unit tests for the duplicate checking functionality, ensuring robustness and accuracy.

- **Chores**
	- Updated server configuration to include the new duplicate checking job, maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->