### PR TITLE
fix: resolve KafkaJS subscription error 

### DIFF
--- a/src/auth-service/bin/jobs/kafka-consumer.js
+++ b/src/auth-service/bin/jobs/kafka-consumer.js
@@ -332,8 +332,8 @@ const kafkaConsumer = async () => {
     const kafka = new Kafka({
       clientId: constants.KAFKA_CLIENT_ID,
       brokers: constants.KAFKA_BOOTSTRAP_SERVERS,
-      fetchMaxWaitMs: 500, // Set a maximum threshold for time-based batching
-      fetchMinBytes: 16384, // Set a minimum threshold for size-based batching
+      fetchMaxWaitMs: 500,
+      fetchMinBytes: 16384,
     });
 
     const consumer = kafka.consumer({
@@ -342,37 +342,40 @@ const kafkaConsumer = async () => {
 
     // Define topic-to-operation function mapping
     const topicOperations = {
-      // ["new-mobile-app-user-topic"]: operationForNewMobileAppUser,
       ["ip-address"]: operationForBlacklistedIPs,
       ["deploy-topic"]: emailsForDeployedDevices,
       ["recall-topic"]: emailsForRecalledDevices,
     };
+
     await consumer.connect();
-    // Subscribe to all topics in the mapping
+
+    // First, subscribe to all topics
     await Promise.all(
-      Object.keys(topicOperations).map(async (topic) => {
-        consumer.subscribe({ topic, fromBeginning: true });
-        await consumer.run({
-          eachMessage: async ({ topic, partition, message }) => {
-            try {
-              const operation = topicOperations[topic];
-              if (operation) {
-                const messageData = message.value.toString();
-                await operation(messageData);
-              } else {
-                logger.error(`🐛🐛 No operation defined for topic: ${topic}`);
-              }
-            } catch (error) {
-              logger.error(
-                `🐛🐛 Error processing Kafka message for topic ${topic}: ${stringify(
-                  error
-                )}`
-              );
-            }
-          },
-        });
-      })
+      Object.keys(topicOperations).map((topic) =>
+        consumer.subscribe({ topic, fromBeginning: true })
+      )
     );
+
+    // Then, start consuming messages
+    await consumer.run({
+      eachMessage: async ({ topic, partition, message }) => {
+        try {
+          const operation = topicOperations[topic];
+          if (operation) {
+            const messageData = message.value.toString();
+            await operation(messageData);
+          } else {
+            logger.error(`🐛🐛 No operation defined for topic: ${topic}`);
+          }
+        } catch (error) {
+          logger.error(
+            `🐛🐛 Error processing Kafka message for topic ${topic}: ${stringify(
+              error
+            )}`
+          );
+        }
+      },
+    });
   } catch (error) {
     logObject("📶📶 Error connecting to Kafka", error);
     logger.error(`📶📶 Error connecting to Kafka: ${stringify(error)}`);


### PR DESCRIPTION
## Description

The application was throwing a `KafkaJSNonRetriableError` with the message "Cannot subscribe to topic while consumer is running". This occurred because we were attempting to subscribe to topics after the consumer had already started running, which is not allowed by KafkaJS.

**Solution:**
Restructured the Kafka consumer initialization to properly sequence the operations:
1. Connect to Kafka
2. Subscribe to all topics
3. Start the consumer

This ensures all topic subscriptions are completed before the consumer begins processing messages.

## Changes
- ✨ Separated topic subscription logic from message consumption
- 🔧 Consolidated consumer.run() into a single call
- 🎯 Removed nested consumer initialization
- 🚀 Implemented parallel topic subscription using Promise.all
- 📝 Maintained existing message processing logic and error handling


## Testing
- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating


