### PR TITLE
runtime error fix for limit input validation on best air quality endpoint

### DIFF
--- a/src/device-registry/routes/v2/readings.js
+++ b/src/device-registry/routes/v2/readings.js
@@ -75,8 +75,8 @@ router.get(
       .notEmpty()
       .withMessage("limit cannot be empty if provided")
       .bail()
-      .isInt({ min: 0 })
-      .withMessage("limit must be a non-negative integer")
+      .isInt({ min: 1, max: 2000 })
+      .withMessage("limit must be between 1 and 2000")
       .toInt(),
     query("skip")
       .optional()


### PR DESCRIPTION
## Description

Fixing the runtime for limit input validation on best air quality endpoint

## Changes Made

- [x] Fixing the runtime for limit input validation on best air quality endpoint

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] device-registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] get best air quality
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

Fixing the runtime for limit input validation on best air quality endpoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for query parameters, ensuring more accurate error handling and preventing empty values from causing issues.
	- Updated validation rules for `limit` (now accepts values between 1 and 2000) and `skip` (now requires a non-negative integer).

- **Chores**
	- Enhanced the robustness of input validation processes in the API without altering existing functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->