### PR TITLE
Added website route to staging  nginx virtualServers

### DIFF
--- a/k8s/nginx/staging/analytics-vs.yaml
+++ b/k8s/nginx/staging/analytics-vs.yaml
@@ -56,7 +56,10 @@ spec:
       port: 8080  
     - name: spatial
       service: airqo-stage-spatial-api-svc
-      port: 5000           
+      port: 5000     
+    - name: website
+      service: airqo-stage-website-api-svc
+      port: 8000          
   routes:
     - path: /
       action:
@@ -189,6 +192,14 @@ spec:
             add:
               - name: Content-Type
                 value: application/json  
+    - path: ~ /api\/v[1-2]\/website
+      action:
+        proxy:
+          upstream: website
+          responseHeaders:
+            add:
+              - name: Content-Type
+                value: application/json                 
 
                
 

--- a/k8s/nginx/staging/api-vs.yaml
+++ b/k8s/nginx/staging/api-vs.yaml
@@ -53,7 +53,10 @@ spec:
       port: 8080
     - name: spatial
       service: airqo-spatial-notification-api-svc
-      port: 5000      
+      port: 5000 
+    - name: website
+      service: airqo-stage-website-api-svc
+      port: 8000          
   routes:
     - path: ~ /api\/v[1-2]\/users
       action:
@@ -183,3 +186,11 @@ spec:
             add:
               - name: Content-Type
                 value: application/json                
+    - path: ~ /api\/v[1-2]\/website
+      action:
+        proxy:
+          upstream: website
+          responseHeaders:
+            add:
+              - name: Content-Type
+                value: application/json                 

--- a/k8s/nginx/staging/netmanager-vs.yaml
+++ b/k8s/nginx/staging/netmanager-vs.yaml
@@ -57,6 +57,9 @@ spec:
     - name: spatial
       service: airqo-stage-spatial-api-svc
       port: 5000           
+    - name: website
+      service: airqo-stage-website-api-svc
+      port: 8000       
   routes:
     - path: /
       action:
@@ -189,3 +192,11 @@ spec:
             add:
               - name: Content-Type
                 value: application/json 
+    - path: ~ /api\/v[1-2]\/website
+      action:
+        proxy:
+          upstream: website
+          responseHeaders:
+            add:
+              - name: Content-Type
+                value: application/json                 

--- a/k8s/nginx/staging/platform-vs.yaml
+++ b/k8s/nginx/staging/platform-vs.yaml
@@ -141,7 +141,10 @@ spec:
       port: 8080
     - name: spatial
       service: airqo-stage-spatial-api-svc
-      port: 5000      
+      port: 5000     
+    - name: website
+      service: airqo-stage-website-api-svc
+      port: 8000        
   routes:
     - path: /
       action:
@@ -286,3 +289,11 @@ spec:
             add:
               - name: Content-Type
                 value: application/json
+    - path: ~ /api\/v[1-2]\/website
+      action:
+        proxy:
+          upstream: website
+          responseHeaders:
+            add:
+              - name: Content-Type
+                value: application/json                 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes made in this PR]

## Related Issues

- [ ] GitHub issues:
  - [ ] [Closes #123](https://github.com/your-org/your-repo/issues/123)
  - [ ] [Closes #456](https://github.com/your-org/your-repo/issues/456)
  - [ ] Any other relevant GitHub Issues...
- [ ] JIRA cards:
  - [ ] [JIRA-7890](https://your-jira-instance.atlassian.net/browse/JIRA-7890)
  - [ ] [JIRA-101112](https://your-jira-instance.atlassian.net/browse/JIRA-101112)
  - [ ] Any other relevant JIRA cards...

## Changes Made

- [ ] Brief description of change 1
- [ ] Brief description of change 2
- [ ] Brief description of change 3

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Service 1
  - [ ] Service 2
  - [ ] Other...

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Endpoint 1
  - [ ] Endpoint 2
  - [ ] Other...
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

## Additional Notes

[Add any additional notes or comments here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new upstream service named `website`, allowing for routing to the `airqo-stage-website-api-svc`.
  - Added new API routes for the `website`, accessible via `/api/v[1-2]/website`, with JSON response headers.

- **Enhancements**
  - Expanded routing capabilities with new VirtualServerRoute entries for services such as `mlflow`, `grafana`, `inventory`, and `reports`. 

These changes improve the application's routing efficiency and service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->