### PR TITLE
add averages data to the readings output

### DIFF
--- a/src/device-registry/bin/jobs/v2.1-store-readings-job.js
+++ b/src/device-registry/bin/jobs/v2.1-store-readings-job.js
@@ -1,0 +1,272 @@
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/v2.1-store-readings-job`
+);
+const EventModel = require("@models/Event");
+const DeviceModel = require("@models/Device");
+const SiteModel = require("@models/Site");
+const ReadingModel = require("@models/Reading");
+const { logText, logObject } = require("@utils/log");
+const stringify = require("@utils/stringify");
+const asyncRetry = require("async-retry");
+const generateFilter = require("@utils/generate-filter");
+const cron = require("node-cron");
+const moment = require("moment-timezone");
+const TIMEZONE = moment.tz.guess();
+const INACTIVE_THRESHOLD = 5 * 60 * 60 * 1000; // 5 hours in milliseconds
+
+function logDocumentDetails(doc) {
+  const deviceId = doc.device_id || "N/A";
+  const device = doc.device || "N/A";
+  const time = doc.time || "N/A";
+  const siteId = doc.site_id || "N/A";
+  const site = doc.site || "N/A";
+  logger.warn(
+    `🙀🙀 Measurement missing some key details: { time: ${time}, device_id: ${deviceId}, device: ${device}, site_id: ${siteId}, site: ${site}}`
+  );
+}
+
+function isEntityActive(entity, time) {
+  const inactiveThreshold = INACTIVE_THRESHOLD;
+
+  if (!entity || !entity.lastActive) {
+    return false;
+  }
+  const currentTime = moment()
+    .tz(TIMEZONE)
+    .toDate();
+  const measurementTime = moment(time)
+    .tz(TIMEZONE)
+    .toDate();
+  return currentTime - measurementTime < inactiveThreshold;
+}
+
+async function updateEntityStatus(Model, filter, time, entityType) {
+  try {
+    const entity = await Model.findOne(filter);
+    if (entity) {
+      const isActive = isEntityActive(entity, time);
+      const updateData = {
+        lastActive: moment(time)
+          .tz(TIMEZONE)
+          .toDate(),
+        isOnline: isActive,
+      };
+      const updateResult = await Model.updateOne(filter, updateData);
+    } else {
+      logger.warn(
+        `🙀🙀 ${entityType} not found with filter: ${stringify(filter)}`
+      );
+    }
+  } catch (error) {
+    logger.error(
+      `🐛🐛 Error updating ${entityType}'s status: ${error.message}`
+    );
+    logger.error(`🐛🐛 Stack trace: ${error.stack}`);
+  }
+}
+
+async function getAveragesForSite(siteId) {
+  try {
+    const averages = await EventModel("airqo").getAirQualityAverages(siteId);
+    if (averages && averages.success) {
+      return averages.data;
+    }
+    return null;
+  } catch (error) {
+    logger.error(
+      `🐛🐛 Error fetching averages for site ${siteId}: ${error.message}`
+    );
+    return null;
+  }
+}
+
+async function processDocument(doc) {
+  try {
+    const docTime = moment(doc.time).tz(TIMEZONE);
+    const updatePromises = [];
+
+    if (doc.site_id) {
+      updatePromises.push(
+        updateEntityStatus(
+          SiteModel("airqo"),
+          { _id: doc.site_id },
+          docTime.toDate(),
+          "Site"
+        )
+      );
+    }
+
+    if (doc.device_id) {
+      updatePromises.push(
+        updateEntityStatus(
+          DeviceModel("airqo"),
+          { _id: doc.device_id },
+          docTime.toDate(),
+          "Device"
+        )
+      );
+    }
+
+    // Wait for both updates to complete
+    await Promise.all(updatePromises);
+
+    // Get averages for site if available
+    let averages = null;
+    if (doc.site_id) {
+      averages = await getAveragesForSite(doc.site_id);
+    }
+
+    // Update Reading with averages
+    const filter = { site_id: doc.site_id, time: docTime.toDate() };
+    const updateDoc = { ...doc, time: docTime.toDate() };
+    delete updateDoc._id;
+
+    // Add averages if available
+    if (averages) {
+      updateDoc.averages = {
+        dailyAverage: averages.dailyAverage,
+        percentageDifference: averages.percentageDifference,
+        weeklyAverages: {
+          currentWeek: averages.weeklyAverages.currentWeek,
+          previousWeek: averages.weeklyAverages.previousWeek,
+        },
+      };
+    }
+    await ReadingModel("airqo").updateOne(filter, updateDoc, {
+      upsert: true,
+    });
+  } catch (error) {
+    logger.error(`🐛🐛 Error processing document: ${error.message}`);
+    throw error; // Propagate error for retry mechanism
+  }
+}
+
+const fetchAndStoreDataIntoReadingsModel = async () => {
+  try {
+    const request = {
+      query: {
+        tenant: "airqo",
+        recent: "yes",
+        metadata: "site_id",
+        active: "yes",
+        brief: "yes",
+      },
+    };
+    const filter = generateFilter.fetch(request);
+
+    let viewEventsResponse;
+    try {
+      viewEventsResponse = await EventModel("airqo").fetch(filter);
+      logText("Running the data insertion script");
+    } catch (fetchError) {
+      logger.error(`🐛🐛 Error fetching events: ${stringify(fetchError)}`);
+      return;
+    }
+
+    if (!viewEventsResponse || typeof viewEventsResponse !== "object") {
+      logger.error(
+        `🐛🐛 Unexpected response from EventModel.fetch(): ${stringify(
+          viewEventsResponse
+        )}`
+      );
+      return;
+    }
+
+    if (viewEventsResponse.success === true) {
+      if (
+        !viewEventsResponse.data ||
+        !Array.isArray(viewEventsResponse.data) ||
+        viewEventsResponse.data.length === 0
+      ) {
+        logText("No data found in the response");
+        return;
+      }
+
+      const data = viewEventsResponse.data[0].data;
+      if (!data || data.length === 0) {
+        logText("No Events found to insert into Readings");
+        logger.error(`☹️☹️ Didn't find any Events to insert into Readings`);
+        return;
+      }
+
+      // Extract unique device IDs from the fetched measurements
+      const activeDeviceIds = new Set(data.map((doc) => doc.device_id));
+
+      const batchSize = 50;
+      const batches = [];
+      for (let i = 0; i < data.length; i += batchSize) {
+        batches.push(data.slice(i, i + batchSize));
+      }
+
+      for (const batch of batches) {
+        await Promise.all(
+          batch.map(async (doc) => {
+            await asyncRetry(
+              async (bail) => {
+                try {
+                  await processDocument(doc);
+                } catch (error) {
+                  logObject("the error inside processing of batches", error);
+                  if (error.name === "MongoError" && error.code !== 11000) {
+                    logger.error(
+                      `🐛🐛 MongoError -- fetchAndStoreDataIntoReadingsModel -- ${stringify(
+                        error
+                      )}`
+                    );
+                    throw error; // Retry the operation
+                  } else if (error.code === 11000) {
+                    // Ignore duplicate key errors
+                    console.warn(
+                      `🙀🙀 Duplicate key error for document: ${stringify(doc)}`
+                    );
+                  }
+                }
+              },
+              {
+                retries: 3,
+                minTimeout: 1000,
+                factor: 2,
+              }
+            );
+          })
+        );
+      }
+
+      // Update devices that are not in the activeDeviceIds set to offline
+      const thresholdTime = moment()
+        .subtract(INACTIVE_THRESHOLD, "milliseconds")
+        .toDate();
+      await DeviceModel("airqo").updateMany(
+        {
+          _id: { $nin: Array.from(activeDeviceIds) },
+          lastActive: { $lt: thresholdTime },
+        },
+        { isOnline: false }
+      );
+
+      logText(`All data inserted successfully and offline devices updated`);
+    } else {
+      logObject(
+        `🐛🐛 Unable to retrieve Events to insert into Readings`,
+        viewEventsResponse
+      );
+      logger.error(
+        `🐛🐛 Unable to retrieve Events to insert into Readings -- ${stringify(
+          viewEventsResponse
+        )}`
+      );
+      logText(`🐛🐛 Unable to retrieve Events to insert into Readings`);
+    }
+  } catch (error) {
+    logObject("error", error);
+    logger.error(`🐛🐛 Internal Server Error ${stringify(error)}`);
+  }
+};
+
+const schedule = "30 * * * *";
+cron.schedule(schedule, fetchAndStoreDataIntoReadingsModel, {
+  scheduled: true,
+  timezone: TIMEZONE,
+});

--- a/src/device-registry/bin/jobs/v3.1-store-readings-job.js
+++ b/src/device-registry/bin/jobs/v3.1-store-readings-job.js
@@ -1,0 +1,320 @@
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/v3.1-store-readings-job`
+);
+const EventModel = require("@models/Event");
+const DeviceModel = require("@models/Device");
+const SiteModel = require("@models/Site");
+const ReadingModel = require("@models/Reading");
+const { logText, logObject } = require("@utils/log");
+const stringify = require("@utils/stringify");
+const asyncRetry = require("async-retry");
+const generateFilter = require("@utils/generate-filter");
+const cron = require("node-cron");
+const moment = require("moment-timezone");
+const TIMEZONE = moment.tz.guess();
+const INACTIVE_THRESHOLD = 5 * 60 * 60 * 1000; // 5 hours in milliseconds
+const BATCH_SIZE = 50;
+
+function logDocumentDetails(doc) {
+  const deviceId = doc.device_id || "N/A";
+  const device = doc.device || "N/A";
+  const time = doc.time || "N/A";
+  const siteId = doc.site_id || "N/A";
+  const site = doc.site || "N/A";
+  logger.warn(
+    `🙀🙀 Measurement missing some key details: { time: ${time}, device_id: ${deviceId}, device: ${device}, site_id: ${siteId}, site: ${site}}`
+  );
+}
+
+async function updateEntityStatus(Model, filter, time, entityType) {
+  try {
+    const currentTime = moment()
+      .tz(TIMEZONE)
+      .toDate();
+    const updateData = {
+      lastActive: currentTime,
+      isOnline:
+        currentTime -
+          moment(time)
+            .tz(TIMEZONE)
+            .toDate() <
+        INACTIVE_THRESHOLD,
+    };
+
+    const result = await Model.findOneAndUpdate(filter, updateData, {
+      new: true,
+      upsert: false,
+    });
+
+    if (!result) {
+      logger.warn(
+        `🙀🙀 ${entityType} not found with filter: ${stringify(filter)}`
+      );
+    }
+  } catch (error) {
+    logger.error(
+      `🐛🐛 Error updating ${entityType}'s status: ${error.message}`
+    );
+    logger.error(`🐛🐛 Stack trace: ${error.stack}`);
+  }
+}
+
+async function getAveragesForSite(siteId) {
+  try {
+    const averages = await EventModel("airqo").getAirQualityAverages(siteId);
+    if (averages && averages.success) {
+      return averages.data;
+    }
+    return null;
+  } catch (error) {
+    logger.error(
+      `🐛🐛 Error fetching averages for site ${siteId}: ${error.message}`
+    );
+    return null;
+  }
+}
+
+async function processDocument(doc) {
+  try {
+    const docTime = moment(doc.time).tz(TIMEZONE);
+    const updatePromises = [];
+
+    // Handle site updates
+    if (doc.site_id) {
+      updatePromises.push(
+        updateEntityStatus(
+          SiteModel("airqo"),
+          { _id: doc.site_id },
+          docTime.toDate(),
+          "Site"
+        )
+      );
+
+      // Fetch averages for the site
+      const averages = await getAveragesForSite(doc.site_id);
+
+      // Prepare the document for update
+      const filter = { site_id: doc.site_id, time: docTime.toDate() };
+      const { _id, ...docWithoutId } = doc;
+      const updateDoc = {
+        ...docWithoutId,
+        time: docTime.toDate(),
+      };
+
+      // Add averages if available
+      if (averages) {
+        updateDoc.averages = {
+          dailyAverage: averages.dailyAverage,
+          percentageDifference: averages.percentageDifference,
+          weeklyAverages: {
+            currentWeek: averages.weeklyAverages.currentWeek,
+            previousWeek: averages.weeklyAverages.previousWeek,
+          },
+        };
+      }
+
+      // Update Reading with the enhanced document
+      updatePromises.push(
+        ReadingModel("airqo").updateOne(filter, updateDoc, { upsert: true })
+      );
+    } else {
+      logDocumentDetails(doc);
+    }
+
+    // Handle device updates
+    if (doc.device_id) {
+      updatePromises.push(
+        updateEntityStatus(
+          DeviceModel("airqo"),
+          { _id: doc.device_id },
+          docTime.toDate(),
+          "Device"
+        )
+      );
+    } else {
+      logDocumentDetails(doc);
+    }
+
+    try {
+      await Promise.all(updatePromises);
+    } catch (error) {
+      logger.error(`🐛🐛 Error processing document updates: ${error.message}`);
+    }
+  } catch (error) {
+    logger.error(`🐛🐛 Error processing document: ${error.message}`);
+  }
+}
+
+const fetchAllData = async (
+  Model,
+  filter = {},
+  projection = {},
+  pageSize = 100,
+  isEventModel = false
+) => {
+  const allData = [];
+  let page = 0;
+  let hasMoreData = true;
+
+  while (hasMoreData) {
+    try {
+      let response;
+
+      if (isEventModel) {
+        response = await Model("airqo").fetch({
+          ...filter,
+          limit: pageSize,
+          skip: page * pageSize,
+        });
+
+        if (
+          !response.success ||
+          !response.data ||
+          response.data.length === 0 ||
+          !response.data[0].data ||
+          response.data[0].data.length === 0
+        ) {
+          hasMoreData = false;
+        } else {
+          allData.push(...response.data[0].data);
+        }
+      } else {
+        const entities = await Model("airqo")
+          .find(filter, projection)
+          .limit(pageSize)
+          .skip(page * pageSize);
+
+        if (entities.length === 0) {
+          hasMoreData = false;
+        } else {
+          allData.push(...entities);
+        }
+      }
+
+      page++;
+    } catch (error) {
+      logger.error(`🐛🐛 Error fetching data: ${error.message}`);
+      hasMoreData = false;
+    }
+  }
+
+  return allData;
+};
+
+const fetchAndStoreDataIntoReadingsModel = async () => {
+  try {
+    const request = {
+      query: {
+        tenant: "airqo",
+        recent: "yes",
+        metadata: "site_id",
+        active: "yes",
+        brief: "yes",
+      },
+    };
+    const filter = generateFilter.fetch(request);
+
+    const allEvents = await fetchAllData(EventModel, filter, {}, 100, true);
+
+    if (!allEvents || allEvents.length === 0) {
+      logText("🙀🙀 No Events found to insert into Readings");
+      logger.warn(`🙀🙀 Didn't find any Events to insert into Readings`);
+      return;
+    }
+
+    const activeDeviceIds = new Set();
+    const activeSiteIds = new Set();
+
+    // Process events in batches with enhanced document processing
+    for (let i = 0; i < allEvents.length; i += BATCH_SIZE) {
+      const batch = allEvents.slice(i, i + BATCH_SIZE);
+
+      await asyncRetry(
+        async (bail) => {
+          try {
+            await Promise.all(
+              batch.map(async (doc) => {
+                if (doc.device_id) activeDeviceIds.add(doc.device_id);
+                if (doc.site_id) activeSiteIds.add(doc.site_id);
+                await processDocument(doc);
+              })
+            );
+          } catch (error) {
+            logObject("the error inside processing of batches", error);
+            if (error.name === "MongoError" && error.code !== 11000) {
+              logger.error(
+                `🐛🐛 MongoError -- fetchAndStoreDataIntoReadingsModel -- ${stringify(
+                  error
+                )}`
+              );
+              throw error;
+            } else if (error.code === 11000) {
+              console.warn(
+                `🙀🙀 Duplicate key error for document: ${stringify(doc)}`
+              );
+            }
+          }
+        },
+        {
+          retries: 3,
+          minTimeout: 1000,
+          factor: 2,
+        }
+      );
+    }
+    // Fetch all devices and sites
+    const allDevices = await fetchAllData(
+      DeviceModel,
+      {},
+      { _id: 1, isOnline: 1, lastActive: 1 }
+    );
+    const allSites = await fetchAllData(
+      SiteModel,
+      {},
+      { _id: 1, isOnline: 1, lastActive: 1 }
+    );
+
+    // Prepare update promises for devices
+    const deviceUpdatePromises = allDevices.map((device) => {
+      if (!activeDeviceIds.has(device._id.toString())) {
+        return updateEntityStatus(
+          DeviceModel("airqo"),
+          { _id: device._id },
+          moment()
+            .tz(TIMEZONE)
+            .toDate(),
+          "Device"
+        );
+      }
+      return Promise.resolve(); // No update needed
+    });
+
+    // Prepare update promises for sites
+    const siteUpdatePromises = allSites.map((site) => {
+      if (!activeSiteIds.has(site._id.toString())) {
+        return updateEntityStatus(
+          SiteModel("airqo"),
+          { _id: site._id },
+          moment()
+            .tz(TIMEZONE)
+            .toDate(),
+          "Site"
+        );
+      }
+      return Promise.resolve(); // No update needed
+    });
+
+    // Execute all update promises concurrently
+    await Promise.all([...deviceUpdatePromises, ...siteUpdatePromises]);
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${stringify(error)}`);
+  }
+};
+
+const schedule = "30 * * * *";
+cron.schedule(schedule, fetchAndStoreDataIntoReadingsModel, {
+  scheduled: true,
+  timezone: TIMEZONE,
+});

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -24,7 +24,7 @@ const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- bin/server`);
 const { logText, logObject } = require("@utils/log");
 const stringify = require("@utils/stringify");
 require("@bin/jobs/store-signals-job");
-require("@bin/jobs/v2-store-readings-job");
+require("@bin/jobs/v2.1-store-readings-job");
 require("@bin/jobs/v2-check-network-status-job");
 require("@bin/jobs/check-unassigned-devices-job");
 require("@bin/jobs/check-active-statuses");

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -100,6 +100,20 @@ const AqiRangeSchema = new Schema(
   { _id: false }
 );
 
+const averagesSchema = new Schema(
+  {
+    dailyAverage: { type: Number },
+    percentageDifference: { type: Number },
+    weeklyAverages: {
+      currentWeek: { type: Number },
+      previousWeek: { type: Number },
+    },
+  },
+  {
+    _id: false,
+  }
+);
+
 const ReadingsSchema = new Schema(
   {
     device: String,
@@ -118,6 +132,7 @@ const ReadingsSchema = new Schema(
     aqi_color: String,
     aqi_category: String,
     aqi_color_name: String,
+    averages: { type: averagesSchema },
   },
   {
     timestamps: true,
@@ -161,6 +176,7 @@ ReadingsSchema.methods = {
       aqi_color: this.aqi_color,
       aqi_category: this.aqi_category,
       aqi_color_name: this.aqi_color_name,
+      averages: this.averages,
     };
   },
 };
@@ -307,8 +323,6 @@ ReadingsSchema.statics.recent = async function(
   try {
     let threeDaysAgo = new Date();
     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-
-    logObject("The recent filter inside Readings Model....", filter);
 
     const pipeline = this.aggregate()
       .match({


### PR DESCRIPTION
## Description

add averages data to the readings output

## Changes Made

- [x] add averages data to the readings output

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Get Readings
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

add averages data to the readings output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced scheduled jobs for processing and storing air quality readings every 30 minutes.
	- Added functionality to log missing data and update device and site statuses based on activity.
	- Implemented a new schema for averages in the readings model, enhancing data representation.
  
- **Bug Fixes**
	- Improved error handling for MongoDB operations, including duplicate key errors and logging issues during data fetching.

- **Documentation**
	- Updated import statements to reflect the new version of the readings job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->