### PR TITLE
handling cases where this.getQuery might not be available

### DIFF
--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -256,7 +256,8 @@ UserSchema.pre(
     try {
       // Helper function to handle role updates
       const handleRoleUpdates = async (fieldName, idField) => {
-        const doc = await this.model.findOne(this.getQuery());
+        const query = this.getQuery ? this.getQuery() : this;
+        const doc = await this.model.findOne(query);
         if (!doc) return;
 
         let newRoles = [];

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -256,7 +256,7 @@ UserSchema.pre(
     try {
       // Helper function to handle role updates
       const handleRoleUpdates = async (fieldName, idField) => {
-        const query = this.getQuery ? this.getQuery() : this;
+        const query = this.getQuery ? this.getQuery() : { _id: this._id };
         const doc = await this.model.findOne(query);
         if (!doc) return;
 


### PR DESCRIPTION
## Description

Ensure the middleware works correctly in all environments by safely handling cases where this.getQuery might not be available

## Changes Made

- [x] Fix runtime context issues with this.getQuery

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Assign User to Role
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

The error "this.getQuery is not a function" occurs because the middleware syntax we're using isn't compatible with all MongoDB operations. We need to modify the pre-update middleware to use the correct context for accessing the query. In Mongoose, the context (this) varies depending on the operation type.

The changes ensure the middleware works correctly in all environments by safely handling cases where this.getQuery might not be available and adding proper error handling. The functionality remains the same, but it's now more robust and safer to use in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user registration and modification processes with improved validation and error handling.
	- Improved clarity in role management during updates.

- **Bug Fixes**
	- Addressed issues with password hashing consistency for new user creation and updates.
	- Improved feedback on validation errors, including unique constraints for email and username.

- **Refactor**
	- Updated method signatures for various user-related functionalities to improve clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->