### PR TITLE
Adding site creation among activities to log and store for future reference

### DIFF
--- a/src/device-registry/models/Activity.js
+++ b/src/device-registry/models/Activity.js
@@ -31,6 +31,7 @@ const activitySchema = new Schema(
     },
     device: { type: String, trim: true },
     site_id: { type: ObjectId },
+    device_id: { type: ObjectId },
     host_id: { type: ObjectId },
     user_id: { type: ObjectId },
     date: { type: Date },

--- a/src/device-registry/models/test/ut_activity.js
+++ b/src/device-registry/models/test/ut_activity.js
@@ -3,7 +3,7 @@ const { expect } = require("chai");
 const sinon = require("sinon");
 const { describe } = require("mocha");
 const mongoose = require("mongoose");
-const activitySchema = require("@models/SiteActivity");
+const activitySchema = require("@models/Activity");
 
 describe("Activity Model Unit Tests", () => {
   let Activity;

--- a/src/device-registry/utils/create-activity.js
+++ b/src/device-registry/utils/create-activity.js
@@ -1,4 +1,4 @@
-const ActivityModel = require("@models/SiteActivity");
+const ActivityModel = require("@models/Activity");
 const { logObject } = require("./log");
 const createDeviceUtil = require("./create-device");
 const createSiteUtil = require("./create-site");

--- a/src/device-registry/utils/create-site.js
+++ b/src/device-registry/utils/create-site.js
@@ -421,9 +421,7 @@ const createSite = {
           ).register(siteActivityBody, next);
           if (responseFromRegisterActivity.success === false) {
             logger.error(
-              `Unable to Store the Site Activity for this operation ${stringify(
-                siteActivityBody
-              )} `
+              "Unable to store the site activity for this operation."
             );
           }
         } catch (error) {

--- a/src/device-registry/utils/generate-filter.js
+++ b/src/device-registry/utils/generate-filter.js
@@ -1559,8 +1559,9 @@ const generateFilter = {
     }
 
     if (activity_tags) {
+      const activityTagsArray = activity_tags.toString().split(",");
       filter["tags"] = {};
-      filter["tags"]["$in"] = activity_tags;
+      filter["tags"]["$in"] = activityTagsArray;
     }
 
     if (id) {


### PR DESCRIPTION
## Description

I am just adding site creation among activities to retrieve and know who created the Site

## Changes Made

- [x] adding site creation among activities to retrieve

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Create Site
  - [x] Get Site Activities
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

I am just adding site creation among activities to retrieve and know who created the Site


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `device_id` field in activity logging to associate activities with specific devices.
  - Enhanced site creation functionality to log detailed activity records.

- **Bug Fixes**
  - Improved error handling in various utility methods to ensure better logging and response management.

- **Refactor**
  - Updated import paths for the `ActivityModel` to streamline activity-related operations across the application.
  
- **Documentation**
  - Enhanced clarity in error messages for better debugging and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->