### PR TITLE
temporarily re-enable network deletion

### DIFF
--- a/src/auth-service/utils/create-network.js
+++ b/src/auth-service/utils/create-network.js
@@ -821,12 +821,12 @@ const createNetwork = {
   },
   delete: async (request, next) => {
     try {
-      return {
-        success: false,
-        message: "Network deletion temporarily disabled",
-        status: httpStatus.NOT_IMPLEMENTED,
-        errors: { message: "Network deletion temporarily disabled" },
-      };
+      // return {
+      //   success: false,
+      //   message: "Network deletion temporarily disabled",
+      //   status: httpStatus.NOT_IMPLEMENTED,
+      //   errors: { message: "Network deletion temporarily disabled" },
+      // };
       logText("the delete operation.....");
       const { query } = request;
       const { tenant } = query;


### PR DESCRIPTION
## Description

- [ ] [temporarily re-enable network deletion

## Related Issues

## Changes Made

- [ ]  temporarily re-enable network deletion

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Delete Network
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

## Additional Notes

temporarily re-enable network deletion
