### PR TITLE
temporarily disable deletion of Networks

### DIFF
--- a/src/auth-service/utils/create-network.js
+++ b/src/auth-service/utils/create-network.js
@@ -822,14 +822,14 @@ const createNetwork = {
   },
   delete: async (request, next) => {
     try {
-      // return {
-      //   success: false,
-      //   message: "Service Temporarily Unavailable",
-      //   errors: {
-      //     message: "Service Temporarily Unavailable",
-      //   },
-      //   status: httpStatus.SERVICE_UNAVAILABLE,
-      // };
+      return {
+        success: false,
+        message: "Service Temporarily Unavailable",
+        errors: {
+          message: "Service Temporarily Unavailable",
+        },
+        status: httpStatus.SERVICE_UNAVAILABLE,
+      };
       logText("the delete operation.....");
       const { query } = request;
       const { tenant } = query;


### PR DESCRIPTION
## Description

temporarily disable deletion of Networks

## Changes Made

- [x] temporarily disable deletion of Networks

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] delete Networks

## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

temporarily disable deletion of Networks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for the network deletion process by providing a clearer response when the service is temporarily unavailable. Users will now receive a structured message indicating the service status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->