### PR TITLE
just disable network creation temporarily

### DIFF
--- a/src/auth-service/utils/create-network.js
+++ b/src/auth-service/utils/create-network.js
@@ -142,6 +142,14 @@ const createNetwork = {
   },
   create: async (request, next) => {
     try {
+      return {
+        success: false,
+        message: "Service Temporarily Unavailable",
+        errors: {
+          message: "Service Temporarily Unavailable",
+        },
+        status: httpStatus.SERVICE_UNAVAILABLE,
+      };
       const { body, query } = request;
       const { tenant } = query;
 


### PR DESCRIPTION
## Description

just disable network creation temporarily

## Changes Made

- [x] just disable network creation temporarily

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Create Network
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

just disable network creation temporarily


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for network creation and deletion processes, providing immediate feedback when the service is unavailable.

- **Bug Fixes**
	- Improved response structure for service unavailability, ensuring users receive clear communication regarding network operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->