### PR TITLE
temporarily allow creation and deletion of networks

### DIFF
--- a/src/auth-service/utils/create-network.js
+++ b/src/auth-service/utils/create-network.js
@@ -142,14 +142,14 @@ const createNetwork = {
   },
   create: async (request, next) => {
     try {
-      return {
-        success: false,
-        message: "Service Temporarily Unavailable",
-        errors: {
-          message: "Service Temporarily Unavailable",
-        },
-        status: httpStatus.SERVICE_UNAVAILABLE,
-      };
+      // return {
+      //   success: false,
+      //   message: "Service Temporarily Unavailable",
+      //   errors: {
+      //     message: "Service Temporarily Unavailable",
+      //   },
+      //   status: httpStatus.SERVICE_UNAVAILABLE,
+      // };
       const { body, query } = request;
       const { tenant } = query;
 
@@ -830,14 +830,14 @@ const createNetwork = {
   },
   delete: async (request, next) => {
     try {
-      return {
-        success: false,
-        message: "Service Temporarily Unavailable",
-        errors: {
-          message: "Service Temporarily Unavailable",
-        },
-        status: httpStatus.SERVICE_UNAVAILABLE,
-      };
+      // return {
+      //   success: false,
+      //   message: "Service Temporarily Unavailable",
+      //   errors: {
+      //     message: "Service Temporarily Unavailable",
+      //   },
+      //   status: httpStatus.SERVICE_UNAVAILABLE,
+      // };
       logText("the delete operation.....");
       const { query } = request;
       const { tenant } = query;


### PR DESCRIPTION
## Description

temporarily allow creation and deletion of networks

## Changes Made

- [x] temporarily allow creation and deletion of networks

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Create Network
  - [x] Delete Network
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes

temporarily allow creation and deletion of networks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed premature service unavailability responses from the create and delete network methods, allowing for improved request handling.
  
- **New Features**
	- Enhanced logic in the create method for managing network names and user assignments.
	- Improved functionality in the delete method for removing network roles, permissions, and the network itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->