### PR TITLE
just disable network creation and deletion again

### DIFF
--- a/src/auth-service/utils/create-network.js
+++ b/src/auth-service/utils/create-network.js
@@ -142,14 +142,14 @@ const createNetwork = {
   },
   create: async (request, next) => {
     try {
-      // return {
-      //   success: false,
-      //   message: "Service Temporarily Unavailable",
-      //   errors: {
-      //     message: "Service Temporarily Unavailable",
-      //   },
-      //   status: httpStatus.SERVICE_UNAVAILABLE,
-      // };
+      return {
+        success: false,
+        message: "Service Temporarily Unavailable",
+        errors: {
+          message: "Service Temporarily Unavailable",
+        },
+        status: httpStatus.SERVICE_UNAVAILABLE,
+      };
       const { body, query } = request;
       const { tenant } = query;
 
@@ -830,14 +830,14 @@ const createNetwork = {
   },
   delete: async (request, next) => {
     try {
-      // return {
-      //   success: false,
-      //   message: "Service Temporarily Unavailable",
-      //   errors: {
-      //     message: "Service Temporarily Unavailable",
-      //   },
-      //   status: httpStatus.SERVICE_UNAVAILABLE,
-      // };
+      return {
+        success: false,
+        message: "Service Temporarily Unavailable",
+        errors: {
+          message: "Service Temporarily Unavailable",
+        },
+        status: httpStatus.SERVICE_UNAVAILABLE,
+      };
       logText("the delete operation.....");
       const { query } = request;
       const { tenant } = query;


### PR DESCRIPTION
## Description

just disable network creation and deletion again

## Changes Made

- [x] just disable network creation and deletion again

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] create network
  - [x] delete network
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

## Additional Notes
just disable network creation and deletion again


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the network creation and deletion methods to ensure consistent service unavailable responses.
	- Enhanced logging for internal server errors while maintaining existing control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->