### PR TITLE
support for bulk update of devices

### DIFF
--- a/src/device-registry/controllers/create-device.js
+++ b/src/device-registry/controllers/create-device.js
@@ -827,6 +827,7 @@ const device = {
           message: result.message,
           success: true,
           bulk_update_notes: result.data,
+          metadata: result.metadata,
         });
       } else if (result.success === false) {
         const status = result.status

--- a/src/device-registry/controllers/create-device.js
+++ b/src/device-registry/controllers/create-device.js
@@ -795,6 +795,61 @@ const device = {
       return;
     }
   },
+  updateManyDevicesOnPlatform: async (req, res, next) => {
+    try {
+      logText("the BULK update operation starts....");
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await createDeviceUtil.updateManyDevicesOnPlatform(
+        request,
+        next
+      );
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          message: result.message,
+          success: true,
+          bulk_update_notes: result.data,
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          message: result.message,
+          success: false,
+          errors: result.errors ? result.errors : { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
   deleteOnPlatform: async (req, res, next) => {
     try {
       // logger.info(`the soft delete operation starts....`);

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -690,7 +690,7 @@ deviceSchema.statics = {
           message: "No devices were updated",
           data: {
             modifiedCount: 0,
-            matchedCount: bulkUpdateResult.matchedCount,
+            matchedCount: bulkUpdateResult.n,
           },
           status: httpStatus.NOT_FOUND,
         };

--- a/src/device-registry/routes/v2/devices.js
+++ b/src/device-registry/routes/v2/devices.js
@@ -12,6 +12,7 @@ const {
   validateDecryptManyKeys,
   validateListDevices,
   validateArrayBody,
+  validateBulkUpdateDevices,
 } = require("@validators/device.validators");
 
 router.use(headers);
@@ -125,4 +126,11 @@ router.get(
   deviceController.generateQRCode
 );
 
+// New Bulk Update Devices route
+router.put(
+  "/bulk",
+  validateTenant,
+  validateBulkUpdateDevices,
+  deviceController.updateManyDevicesOnPlatform
+);
 module.exports = router;

--- a/src/device-registry/utils/create-device.js
+++ b/src/device-registry/utils/create-device.js
@@ -710,6 +710,91 @@ const createDevice = {
       );
     }
   },
+  updateManyDevicesOnPlatform: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { deviceIds, updateData } = request.body;
+
+      // Find existing devices
+      const existingDevices = await DeviceModel(tenant)
+        .find({
+          _id: { $in: deviceIds },
+        })
+        .select("_id");
+
+      // Create sets for comparison
+      const existingDeviceIds = new Set(
+        existingDevices.map((device) => device._id.toString())
+      );
+      const providedDeviceIds = new Set(deviceIds.map((id) => id.toString()));
+
+      // Identify non-existent device IDs
+      const nonExistentDeviceIds = deviceIds.filter(
+        (id) => !existingDeviceIds.has(id.toString())
+      );
+
+      // If there are non-existent devices, prepare a detailed error
+      if (nonExistentDeviceIds.length > 0) {
+        return next(
+          new HttpError("Bad Request", httpStatus.BAD_REQUEST, {
+            message: "Some provided device IDs do not exist",
+            nonExistentDeviceIds: nonExistentDeviceIds,
+            existingDeviceIds: Array.from(existingDeviceIds),
+            totalProvidedDeviceIds: deviceIds.length,
+            existingDeviceCount: existingDevices.length,
+          })
+        );
+      }
+
+      // Prepare filter
+      const filter = {
+        _id: { $in: deviceIds },
+      };
+
+      // Additional filtering from generateFilter if needed
+      const additionalFilter = generateFilter.devices(request, next);
+      Object.assign(filter, additionalFilter);
+
+      // Optimize options for bulk update
+      const opts = {
+        new: true,
+        multi: true,
+        runValidators: true,
+        context: "query",
+      };
+
+      // Perform bulk update
+      const responseFromBulkModifyDevices = await DeviceModel(
+        tenant
+      ).bulkModify(
+        {
+          filter,
+          update: updateData,
+          opts,
+        },
+        next
+      );
+
+      // Attach additional metadata to the response
+      return {
+        ...responseFromBulkModifyDevices,
+        metadata: {
+          totalDevicesUpdated: responseFromBulkModifyDevices.modifiedCount,
+          requestedDeviceIds: deviceIds,
+          existingDeviceIds: Array.from(existingDeviceIds),
+        },
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Bulk Update Error: ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
   deleteOnThingspeak: async (request, next) => {
     try {
       let device_number = parseInt(request.query.device_number, 10);

--- a/src/device-registry/utils/create-device.js
+++ b/src/device-registry/utils/create-device.js
@@ -779,7 +779,7 @@ const createDevice = {
       return {
         ...responseFromBulkModifyDevices,
         metadata: {
-          totalDevicesUpdated: responseFromBulkModifyDevices.modifiedCount,
+          totalDevicesUpdated: responseFromBulkModifyDevices.data.modifiedCount,
           requestedDeviceIds: deviceIds,
           existingDeviceIds: Array.from(existingDeviceIds),
         },

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -759,8 +759,12 @@ const validateBulkUpdateDevices = [
     .exists()
     .withMessage("updateData must be provided in the request body")
     .bail()
-    .isObject()
-    .withMessage("updateData must be an object")
+    .custom((value) => {
+      if (typeof value !== "object" || Array.isArray(value) || value === null) {
+        throw new Error("updateData must be an object");
+      }
+      return true;
+    })
     .bail()
     .custom((value) => {
       if (Object.keys(value).length === 0) {

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -720,6 +720,98 @@ const validateArrayBody = oneOf([
     .withMessage("the request body should be an array"),
 ]);
 
+const validateBulkUpdateDevices = [
+  body("deviceIds")
+    .exists()
+    .withMessage("deviceIds must be provided in the request body")
+    .bail()
+    .isArray()
+    .withMessage("deviceIds must be an array")
+    .bail()
+    .custom((value) => {
+      if (value.length === 0) {
+        throw new Error("deviceIds array cannot be empty");
+      }
+      return true;
+    })
+    .bail()
+    .custom((value) => {
+      const MAX_BULK_UPDATE_DEVICES = 30;
+      if (value.length > MAX_BULK_UPDATE_DEVICES) {
+        throw new Error(
+          `Cannot update more than ${MAX_BULK_UPDATE_DEVICES} devices in a single request`
+        );
+      }
+      return true;
+    })
+    .bail()
+    .custom((value) => {
+      const invalidIds = value.filter(
+        (id) => !mongoose.Types.ObjectId.isValid(id)
+      );
+      if (invalidIds.length > 0) {
+        throw new Error("All deviceIds must be valid MongoDB ObjectIds");
+      }
+      return true;
+    }),
+
+  body("updateData")
+    .exists()
+    .withMessage("updateData must be provided in the request body")
+    .bail()
+    .isObject()
+    .withMessage("updateData must be an object")
+    .bail()
+    .custom((value) => {
+      if (Object.keys(value).length === 0) {
+        throw new Error("updateData cannot be an empty object");
+      }
+      return true;
+    })
+    .bail()
+    .custom((value) => {
+      const allowedFields = [
+        "visibility",
+        "long_name",
+        "mountType",
+        "powerType",
+        "isActive",
+        "groups",
+        "isRetired",
+        "mobility",
+        "nextMaintenance",
+        "isPrimaryInLocation",
+        "isUsedForCollocation",
+        "owner",
+        "host_id",
+        "phoneNumber",
+        "height",
+        "elevation",
+        "writeKey",
+        "readKey",
+        "latitude",
+        "longitude",
+        "description",
+        "product_name",
+        "device_manufacturer",
+        "device_codes",
+        "category",
+      ];
+
+      const invalidFields = Object.keys(value).filter(
+        (field) => !allowedFields.includes(field)
+      );
+      if (invalidFields.length > 0) {
+        throw new Error(
+          `Invalid fields in updateData: ${invalidFields.join(", ")}`
+        );
+      }
+
+      return true;
+    }),
+  ...validateUpdateDevice,
+];
+
 module.exports = {
   validateTenant,
   validateDeviceIdentifier,
@@ -730,4 +822,5 @@ module.exports = {
   validateListDevices,
   validateDecryptKeys,
   validateDecryptManyKeys,
+  validateBulkUpdateDevices,
 };


### PR DESCRIPTION
## Description

support for bulk update of devices

## Changes Made

- [x] support for bulk update of devices

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] BULK update devices: `PUT: {{baseUrl}}/api/v2/devices/bulk`
     
## API Documentation Updated?

- [x] Yes, API documentation was updated
- [ ] No, API documentation does not need updating





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced bulk update functionality for devices, allowing multiple devices to be updated in a single request.
	- Added a new route for bulk updates at the `/bulk` endpoint.
	- Implemented a validation function for bulk update requests.

- **Bug Fixes**
	- Enhanced error handling and logging for bulk update operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->