### PR TITLE
Reorder API response elements to prioritize forecasts

### DIFF
--- a/src/predict/api/prediction.py
+++ b/src/predict/api/prediction.py
@@ -221,7 +221,7 @@ def get_next_24hr_forecasts():
             "success": True,
             "message": "Forecasts successfully retrieved.",
             "forecasts": result['forecasts'],
-            **result.get("aqi_ranges", {})
+            "aqi_ranges": result.get("aqi_ranges", {})
         }
         
     else:
@@ -270,7 +270,7 @@ def get_next_1_week_forecasts():
             "success": True,
             "message": "Forecasts successfully retrieved.",
             "forecasts": result['forecasts'],
-            **result.get("aqi_ranges", {})
+            "aqi_ranges": result.get("aqi_ranges", {})
         }
 
     else:
@@ -297,7 +297,7 @@ def get_all_daily_forecasts():
             "success": True,
             "message": "All daily forecasts successfully retrieved.",
             "forecasts": result['forecasts'],
-            **result.get("aqi_ranges", {})
+            "aqi_ranges": result.get("aqi_ranges", {})
         }
     else:
         response = {
@@ -322,7 +322,7 @@ def get_all_hourly_forecasts():
             "success": True,
             "message": "All hourly forecasts successfully retrieved.",
             "forecasts": result['forecasts'],
-            **result.get("aqi_ranges", {})
+            "aqi_ranges": result.get("aqi_ranges", {})
         }
     else:
         response = {

--- a/src/predict/api/prediction.py
+++ b/src/predict/api/prediction.py
@@ -81,6 +81,16 @@ AQI_RANGES = {
     }
 }
 
+def sort_and_reorder_response(response):
+    if isinstance(response, dict):
+        # Reorder keys alphabetically except 'forecasts' which should come first
+        ordered_keys = sorted([k for k in response.keys() if k != 'forecasts']) + ['forecasts']
+        return {k: response[k] for k in ordered_keys}
+    elif isinstance(response, list):
+        return [sort_and_reorder_response(item) for item in response]
+    else:
+        return response
+
 def get_aqi_category(value):
     """
     Determine the AQI category for a given value.
@@ -229,8 +239,8 @@ def get_next_24hr_forecasts():
             "message": "No forecasts are available.",
             "success": False,
         }
-    
-    return jsonify(response), 200
+    sorted_and_reordered_response = sort_and_reorder_response(response)
+    return jsonify(sorted_and_reordered_response), 200
 
 @ml_app.route(routes.route["next_1_week_forecasts"], methods=["GET"])
 @cache.cached(timeout=Config.CACHE_TIMEOUT, key_prefix=daily_forecasts_cache_key)
@@ -278,8 +288,8 @@ def get_next_1_week_forecasts():
             "message": "No forecasts are available.",
             "success": False,
         }
-    
-    return jsonify(response), 200
+    sorted_and_reordered_response = sort_and_reorder_response(response)
+    return jsonify(sorted_and_reordered_response), 200
 
 @ml_app.route(routes.route["all_1_week_forecasts"], methods=["GET"])
 @cache.cached(timeout=Config.CACHE_TIMEOUT, key_prefix=all_daily_forecasts_cache_key)
@@ -305,7 +315,8 @@ def get_all_daily_forecasts():
             "success": False,
         }
     
-    return jsonify(response), 200
+    sorted_and_reordered_response = sort_and_reorder_response(response)
+    return jsonify(sorted_and_reordered_response), 200
 
 @ml_app.route(routes.route["all_24hr_forecasts"], methods=["GET"])
 @cache.cached(timeout=Config.CACHE_TIMEOUT, key_prefix=all_hourly_forecasts_cache_key)
@@ -330,7 +341,8 @@ def get_all_hourly_forecasts():
             "success": False,
         }
     
-    return jsonify(response), 200
+    sorted_and_reordered_response = sort_and_reorder_response(response)
+    return jsonify(sorted_and_reordered_response), 200
 
 @ml_app.route(routes.route["predict_for_heatmap"], methods=["GET"])
 @cache.cached(timeout=Config.CACHE_TIMEOUT, key_prefix=heatmap_cache_key)

--- a/src/predict/api/prediction.py
+++ b/src/predict/api/prediction.py
@@ -215,15 +215,22 @@ def get_next_24hr_forecasts():
     
     if result:
         result = enhance_forecast_response(result, language)
-        response = result
+        
+        # Restructure the response to put forecasts at the top level
+        response = {
+            "success": True,
+            "message": "Forecasts successfully retrieved.",
+            "forecasts": result['forecasts'],
+            **result.get("aqi_ranges", {})
+        }
+        
     else:
         response = {
-            "message": "forecasts for this site are not available",
+            "message": "No forecasts are available.",
             "success": False,
         }
     
-    data = jsonify(response)
-    return data, 200
+    return jsonify(response), 200
 
 @ml_app.route(routes.route["next_1_week_forecasts"], methods=["GET"])
 @cache.cached(timeout=Config.CACHE_TIMEOUT, key_prefix=daily_forecasts_cache_key)
@@ -259,15 +266,20 @@ def get_next_1_week_forecasts():
     
     if result:
         result = enhance_forecast_response(result, language)
-        response = result
+        response = {
+            "success": True,
+            "message": "Forecasts successfully retrieved.",
+            "forecasts": result['forecasts'],
+            **result.get("aqi_ranges", {})
+        }
+
     else:
         response = {
-            "message": "forecasts for this site are not available",
+            "message": "No forecasts are available.",
             "success": False,
         }
     
-    data = jsonify(response)
-    return data, 200
+    return jsonify(response), 200
 
 @ml_app.route(routes.route["all_1_week_forecasts"], methods=["GET"])
 @cache.cached(timeout=Config.CACHE_TIMEOUT, key_prefix=all_daily_forecasts_cache_key)
@@ -284,13 +296,15 @@ def get_all_daily_forecasts():
         response = {
             "success": True,
             "message": "All daily forecasts successfully retrieved.",
-            "forecasts": result,
+            "forecasts": result['forecasts'],
+            **result.get("aqi_ranges", {})
         }
     else:
         response = {
             "message": "No forecasts are available.",
             "success": False,
         }
+    
     return jsonify(response), 200
 
 @ml_app.route(routes.route["all_24hr_forecasts"], methods=["GET"])
@@ -307,13 +321,15 @@ def get_all_hourly_forecasts():
         response = {
             "success": True,
             "message": "All hourly forecasts successfully retrieved.",
-            "forecasts": result,
+            "forecasts": result['forecasts'],
+            **result.get("aqi_ranges", {})
         }
     else:
         response = {
             "message": "No forecasts are available.",
             "success": False,
         }
+    
     return jsonify(response), 200
 
 @ml_app.route(routes.route["predict_for_heatmap"], methods=["GET"])


### PR DESCRIPTION
## Description

Reorder API response elements to prioritize forecasts


## Changes Made

- [ ] Restructured response format for next_24hr_forecasts route
- [ ] Updated response structure for next_1_week_forecasts route
- [ ] Modified response generation for all_daily_forecasts route
- [ ] Changed response format for all_hourly_forecasts route
- [ ] Maintained overall success and message structure
- [ ] Ensured consistent response format across all forecast-related endpoints
- [ ] Kept forecasts as the first element in the response
- [ ] Preserved aqi_ranges as a separate top-level element after forecasts

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Predict

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Hourly forecasts
  - [ ] Daily forecasts
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced response structure for forecast-related API endpoints, including success messages and AQI ranges.
- **Bug Fixes**
	- Standardized error messages for unavailable forecasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->