### PR TITLE
retrieve stats for provided emails

### DIFF
--- a/src/auth-service/controllers/create-analytics.js
+++ b/src/auth-service/controllers/create-analytics.js
@@ -40,7 +40,53 @@ const analytics = {
         });
       }
     } catch (error) {
-      logger.error(`🐛🐛 Year-End Email Controller Error: ${error.message}`);
+      logger.error(`🐛🐛 Year-End Email Error: ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  fetchUserStats: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const { body, query } = req;
+      const { emails } = body;
+      const { year } = query;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+
+      const request = {
+        emails,
+        year,
+        tenant: isEmpty(req.query.tenant) ? defaultTenant : req.query.tenant,
+      };
+
+      const result = await createAnalyticsUtil.fetchUserStats(request);
+
+      if (result) {
+        res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message || "Successfully retrieved the User Stats",
+          stats: result,
+        });
+      } else {
+        res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+          success: false,
+          message: result.message || "No Stats Available for this User",
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 fetchUserStats Error: ${error.message}`);
       next(
         new HttpError(
           "Internal Server Error",

--- a/src/auth-service/routes/v2/analytics.js
+++ b/src/auth-service/routes/v2/analytics.js
@@ -14,8 +14,25 @@ router.post(
     .bail()
     .isArray()
     .withMessage("emails must be provided as an array")
-    .bail(),
+    .bail()
+    .notEmpty()
+    .withMessage("the provided emails array cannot be empty"),
   createAnalyticsController.send
+);
+
+router.post(
+  "/retrieve",
+  validateTenant(),
+  body("emails")
+    .exists()
+    .withMessage("the emails array field must be provided in the request body")
+    .bail()
+    .isArray()
+    .withMessage("emails must be provided as an array")
+    .bail()
+    .notEmpty()
+    .withMessage("the provided emails array cannot be empty"),
+  createAnalyticsController.fetchUserStats
 );
 
 module.exports = router;

--- a/src/auth-service/routes/v2/users.js
+++ b/src/auth-service/routes/v2/users.js
@@ -1131,7 +1131,7 @@ router.get(
 );
 
 router.get(
-  "/analytics",
+  "/user-stats",
   oneOf([
     query("tenant")
       .optional()


### PR DESCRIPTION
## Description

retrieve stats for provided emails

## Changes Made

- [x] Introduced a new endpoint for just retrieving user stats.

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service

## Endpoints Ready for Testing

- [x] New endpoints ready for testing:
  - [x] Retrieve User Analytics
     
## API Documentation Updated?

- [x] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `/retrieve` route for handling user statistics requests.
	- Added a `fetchUserStats` method for retrieving user statistics.
  
- **Improvements**
	- Enhanced email validation in the existing `/send` route.
	- Updated the route for retrieving user statistics from `/analytics` to `/user-stats`.

- **Bug Fixes**
	- Standardized error handling across methods for consistent responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->