### PR TITLE
fixing a runtime error for averages endpoints via measurements

### DIFF
--- a/src/device-registry/utils/create-event.js
+++ b/src/device-registry/utils/create-event.js
@@ -349,7 +349,7 @@ class AirQualityService {
 
       // Set cache if successful
       if (responseFromListEvents.success) {
-        await this.trySetCache(responseFromListEvents.data, params, next);
+        await this.trySetCache(responseFromListEvents.data, request, next);
 
         return {
           success: true,
@@ -406,10 +406,10 @@ class AirQualityService {
     }
   }
 
-  async tryGetCache(params, next) {
+  async tryGetCache(request, next) {
     try {
       return await Promise.race([
-        createEvent.getCache(params, next),
+        createEvent.getCache(request, next),
         this.getCacheTimeout(),
       ]);
     } catch (error) {
@@ -418,10 +418,10 @@ class AirQualityService {
     }
   }
 
-  async trySetCache(data, params, next) {
+  async trySetCache(data, request, next) {
     try {
       const result = await Promise.race([
-        createEvent.setCache(data, params, next),
+        createEvent.setCache(data, request, next),
         this.getCacheTimeout(),
       ]);
 


### PR DESCRIPTION
## Description

fixing a runtime error for averages endpoints via measurements

## Changes Made

- [ ] fixing a runtime error for averages endpoints via measurements

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] v2 Averages by Site ID
  - [ ] Averages by Site ID
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated cache management methods to use full request context instead of specific parameters
	- Improved consistency in method signatures across cache-related functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->