### PR TITLE
update the profile pictures of Organisations which do not have

### DIFF
--- a/src/auth-service/bin/jobs/profile-picture-update-job.js
+++ b/src/auth-service/bin/jobs/profile-picture-update-job.js
@@ -1,0 +1,198 @@
+const cron = require("node-cron");
+const NetworkModel = require("@models/Network");
+const GroupModel = require("@models/Group");
+const mongoose = require("mongoose");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const { logText, logObject } = require("@utils/log");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- bin/jobs/profile-picture-update-job`
+);
+const stringify = require("@utils/stringify");
+const isEmpty = require("is-empty");
+
+// Configuration
+const BATCH_SIZE = 100;
+const DEFAULT_PROFILE_PICTURE = constants.DEFAULT_ORGANISATION_PROFILE_PICTURE;
+const MAX_CONCURRENT_OPERATIONS = 5; // Limit concurrent operations
+
+// Function to validate URL
+const isValidUrl = (url) => {
+  const urlRegex =
+    /^(http(s)?:\/\/.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/g;
+  return urlRegex.test(url);
+};
+
+// Function to validate the default profile picture
+const validateDefaultProfilePicture = () => {
+  if (!isValidUrl(DEFAULT_PROFILE_PICTURE)) {
+    logger.error(
+      `🚨 Aborting profile picture update: Invalid default profile picture URL`
+    );
+    return false;
+  }
+  return true;
+};
+
+// Generic function to process items in batches with controlled concurrency
+async function processBatch(items, processFunction) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += MAX_CONCURRENT_OPERATIONS) {
+    chunks.push(items.slice(i, i + MAX_CONCURRENT_OPERATIONS));
+  }
+
+  for (const chunk of chunks) {
+    await Promise.all(chunk.map(processFunction));
+  }
+}
+
+// Function to update a single network
+async function updateNetworkProfilePicture(network) {
+  try {
+    await NetworkModel("airqo").findByIdAndUpdate(
+      network._id,
+      {
+        $set: { net_profile_picture: DEFAULT_PROFILE_PICTURE },
+      },
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
+    logger.info(`✅ Updated profile picture for network: ${network.net_name}`);
+    return { success: true, type: "network", name: network.net_name };
+  } catch (error) {
+    logger.error(
+      `🐛 Failed to update profile picture for network ${
+        network.net_name
+      }: ${stringify(error)}`
+    );
+    return { success: false, type: "network", name: network.net_name, error };
+  }
+}
+
+// Function to update a single group
+async function updateGroupProfilePicture(group) {
+  try {
+    await GroupModel("airqo").findByIdAndUpdate(
+      group._id,
+      {
+        $set: { grp_profile_picture: DEFAULT_PROFILE_PICTURE },
+      },
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
+    logger.info(`✅ Updated profile picture for group: ${group.grp_title}`);
+    return { success: true, type: "group", name: group.grp_title };
+  } catch (error) {
+    logger.error(
+      `🐛 Failed to update profile picture for group ${
+        group.grp_title
+      }: ${stringify(error)}`
+    );
+    return { success: false, type: "group", name: group.grp_title, error };
+  }
+}
+
+// Main function to update profile pictures
+async function updateProfilePictures() {
+  // Validate default profile picture before proceeding
+  if (!validateDefaultProfilePicture()) {
+    return;
+  }
+
+  const stats = {
+    networks: { processed: 0, success: 0, error: 0 },
+    groups: { processed: 0, success: 0, error: 0 },
+  };
+
+  try {
+    const startTime = Date.now();
+    logger.info("🚀 Starting profile picture update process");
+
+    // Process both networks and groups in parallel
+    await Promise.all([
+      // Update Networks
+      (async () => {
+        let skip = 0;
+        while (true) {
+          const networks = await NetworkModel("airqo")
+            .find({
+              $or: [
+                { net_profile_picture: { $exists: false } },
+                { net_profile_picture: null },
+              ],
+            })
+            .limit(BATCH_SIZE)
+            .skip(skip)
+            .select("_id net_name net_profile_picture")
+            .lean();
+
+          if (networks.length === 0) break;
+
+          const results = await processBatch(
+            networks,
+            updateNetworkProfilePicture
+          );
+          stats.networks.processed += networks.length;
+          skip += BATCH_SIZE;
+        }
+      })(),
+
+      // Update Groups
+      (async () => {
+        let skip = 0;
+        while (true) {
+          const groups = await GroupModel("airqo")
+            .find({
+              $or: [
+                { grp_profile_picture: { $exists: false } },
+                { grp_profile_picture: null },
+              ],
+            })
+            .limit(BATCH_SIZE)
+            .skip(skip)
+            .select("_id grp_title grp_profile_picture")
+            .lean();
+
+          if (groups.length === 0) break;
+
+          const results = await processBatch(groups, updateGroupProfilePicture);
+          stats.groups.processed += groups.length;
+          skip += BATCH_SIZE;
+        }
+      })(),
+    ]);
+
+    const duration = (Date.now() - startTime) / 1000;
+    logText(`
+      📊 Profile picture update completed in ${duration} seconds
+      Networks processed: ${stats.networks.processed}
+      Groups processed: ${stats.groups.processed}
+    `);
+    logger.info(`
+      📊 Profile picture update completed in ${duration} seconds
+      Networks processed: ${stats.networks.processed}
+      Groups processed: ${stats.groups.processed}
+    `);
+  } catch (error) {
+    logObject("error", error);
+    logger.error(`🐛🐛 Error in updateProfilePictures: ${stringify(error)}`);
+  }
+}
+
+// // Schedule the job to run daily at midnight
+const schedule = "0 0 * * *";
+cron.schedule(schedule, updateProfilePictures, {
+  scheduled: true,
+  timezone: "Africa/Nairobi",
+});
+
+// Export for manual execution if needed
+module.exports = {
+  updateProfilePictures,
+  updateNetworkProfilePicture,
+  updateGroupProfilePicture,
+};

--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -25,6 +25,7 @@ require("@bin/jobs/incomplete-profile-job");
 require("@bin/jobs/preferences-log-job");
 require("@bin/jobs/preferences-update-job");
 require("@bin/jobs/update-user-activities-job");
+require("@bin/jobs/profile-picture-update-job");
 const log4js = require("log4js");
 const debug = require("debug")("auth-service:server");
 const isEmpty = require("is-empty");


### PR DESCRIPTION
## Description

update the profile pictures of Organisations which do not have. This PR just introduces a script which takes care of this automated update of Organisations (Groups and Networks) which do not have profile pictures.

## Changes Made

- [x] update the profile pictures of Organisations which do not have

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service
     
## API Documentation Updated?

- [x] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a scheduled daily job to automatically update profile pictures for networks and groups
	- Implemented batch processing for profile picture updates with concurrency management

- **Chores**
	- Integrated new profile picture update job into the server's job scheduling system
<!-- end of auto-generated comment: release notes by coderabbit.ai -->