### PR TITLE
Update fix/clean up

### DIFF
--- a/src/workflows/airqo_etl_utils/airnow_utils.py
+++ b/src/workflows/airqo_etl_utils/airnow_utils.py
@@ -161,7 +161,7 @@ class AirnowDataUtils:
                         "timestamp": row["UTC"],
                         "network": row["network"],
                         "site_id": device_details.get("site_id"),
-                        "device_id": device_details.get("device_id"),
+                        "device_id": device_details.get("name"),
                         "mongo_id": device_details.get("_id"),
                         "device_number": device_details.get("device_number"),
                         "frequency": str(Frequency.HOURLY),

--- a/src/workflows/airqo_etl_utils/airnow_utils.py
+++ b/src/workflows/airqo_etl_utils/airnow_utils.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from .airnow_api import AirNowApi
 from .airqo_api import AirQoApi
-from .constants import DataSource, DeviceCategory, Frequency
+from .constants import DataSource, DeviceCategory, Frequency, DeviceNetwork
 from .data_validator import DataValidationUtils
 from .date import str_to_date, date_to_str
 from .utils import Utils
@@ -68,7 +68,9 @@ class AirnowDataUtils:
         Raises:
             ValueError: If no devices are found for the BAM network or if no data is returned for the specified date range.
         """
-        devices = AirQoApi().get_devices_by_network(DeviceCategory.BAM)
+        devices = AirQoApi().get_devices_by_network(
+            device_network=DeviceNetwork.METONE, device_category=DeviceCategory.BAM
+        )
         bam_data = pd.DataFrame()
 
         if not devices:
@@ -119,7 +121,12 @@ class AirnowDataUtils:
         """
         air_now_data = []
 
-        devices = AirQoApi().get_devices(device_category=DeviceCategory.BAM)
+        devices = AirQoApi().get_devices_by_network(
+            device_network=DeviceNetwork.METONE, device_category=DeviceCategory.BAM
+        )
+
+        # Initialize pollutant values (note: pm10 and no2 are not always present)
+        pollutant_value = {"pm2_5": None, "pm10": None, "no2": None}
 
         # Precompute device mapping for faster lookup
         device_mapping = {}
@@ -129,16 +136,14 @@ class AirnowDataUtils:
 
         for _, row in data.iterrows():
             try:
-                device_id = str(row["FullAQSCode"])
+                # Temp external device id
+                device_id_ = str(row["FullAQSCode"])
 
                 # Lookup device details based on FullAQSCode
-                device_details = device_mapping.get(device_id)
+                device_details = device_mapping.get(device_id_)
                 if not device_details:
-                    logger.exception(f"Device with ID {device_id} not found")
+                    logger.exception(f"Device with ID {device_id_} not found")
                     continue
-
-                # Initialize pollutant values (note: pm10 and no2 are not always present)
-                pollutant_value = {"pm2_5": None, "pm10": None, "no2": None}
 
                 # Get the corresponding pollutant value for the current parameter
                 parameter_col_name = AirnowDataUtils.parameter_column_name(
@@ -148,7 +153,7 @@ class AirnowDataUtils:
                     pollutant_value[parameter_col_name] = row["Value"]
 
                 if row["network"] != device_details.get("network"):
-                    logger.exception(f"Network mismatch for device ID {device_id}")
+                    logger.exception(f"Network mismatch for device ID {device_id_}")
                     continue
 
                 air_now_data.append(
@@ -157,7 +162,7 @@ class AirnowDataUtils:
                         "network": row["network"],
                         "site_id": device_details.get("site_id"),
                         "device_id": device_details.get("device_id"),
-                        "mongo_id": device_details.get("mongo_id"),
+                        "mongo_id": device_details.get("_id"),
                         "device_number": device_details.get("device_number"),
                         "frequency": str(Frequency.HOURLY),
                         "latitude": row["Latitude"],

--- a/src/workflows/airqo_etl_utils/constants.py
+++ b/src/workflows/airqo_etl_utils/constants.py
@@ -47,6 +47,32 @@ class DeviceCategory(Enum):
         return DeviceCategory.LOW_COST
 
 
+class DeviceNetwork(Enum):
+    """
+    METONE -> Us embassy
+    AIRQO -> Airqo
+    URBANBETTER -> Urban Better
+    IQAIR -> Iqair
+    """
+
+    METONE = 1
+    AIRQO = 2
+    URBANBETTER = 3
+    IQAIR = 4
+
+    def __str__(self):
+        if self == self.METONE:
+            return "metone"
+        elif self == self.AIRQO:
+            return "airqo"
+        elif self == self.URBANBETTER:
+            return "airbeam"
+        elif self == self.IQAIR:
+            return "iqair"
+        else:
+            raise LookupError("Invalid network supplied")
+
+
 class Frequency(Enum):
     """
     RAW -> Raw current data returned from devices

--- a/src/workflows/airqo_etl_utils/data_validator.py
+++ b/src/workflows/airqo_etl_utils/data_validator.py
@@ -274,6 +274,8 @@ class DataValidationUtils:
         cols = bigquery_api.get_columns(bigquery_api.hourly_measurements_table)
         cols.append("battery")
         data = DataValidationUtils.fill_missing_columns(data, cols=cols)
+
+        # TODO Use DataValidation.format_data_types() to convert cleanup multipe columns.
         data["device_number"] = (
             data["device_number"]
             .fillna("")

--- a/src/workflows/dags/airqo_bam_measurements.py
+++ b/src/workflows/dags/airqo_bam_measurements.py
@@ -6,11 +6,11 @@ from airqo_etl_utils.workflows_custom_utils import AirflowUtils
 from airflow.utils.dates import days_ago
 import pandas as pd
 from airqo_etl_utils.airqo_utils import AirQoDataUtils
-from airqo_etl_utils.constants import DeviceCategory, DataType
 from airqo_etl_utils.date import DateUtils
 from airqo_etl_utils.bigquery_api import BigQueryApi
 from datetime import timedelta
 from airflow.exceptions import AirflowFailException
+from airqo_etl_utils.constants import Frequency, DeviceNetwork, DeviceCategory, DataType
 
 
 @dag(
@@ -22,8 +22,6 @@ from airflow.exceptions import AirflowFailException
     start_date=days_ago(1),
 )
 def airqo_bam_historical_measurements():
-    from airqo_etl_utils.constants import Frequency
-
     @task(provide_context=True, retries=3, retry_delay=timedelta(minutes=5))
     def extract_bam_data(**kwargs) -> pd.DataFrame:
         start_date_time, end_date_time = DateUtils.get_dag_date_time_values(
@@ -33,6 +31,7 @@ def airqo_bam_historical_measurements():
             start_date_time=start_date_time,
             end_date_time=end_date_time,
             device_category=DeviceCategory.BAM,
+            device_network=DeviceNetwork.AIRQO,
             resolution=Frequency.HISTORICAL,
         )
 
@@ -80,13 +79,11 @@ airqo_bam_historical_measurements_dag = airqo_bam_historical_measurements()
 )
 def airqo_bam_realtime_measurements():
     import pandas as pd
-    from airqo_etl_utils.constants import Frequency
 
     @task(provide_context=True, retries=3, retry_delay=timedelta(minutes=5))
     def extract_bam_data(**kwargs):
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
         from airqo_etl_utils.date import DateUtils
-        from airqo_etl_utils.constants import DeviceCategory
 
         start_date_time, end_date_time = DateUtils.get_query_date_time_values(**kwargs)
 
@@ -94,13 +91,13 @@ def airqo_bam_realtime_measurements():
             start_date_time=start_date_time,
             end_date_time=end_date_time,
             device_category=DeviceCategory.BAM,
+            device_network=DeviceNetwork.AIRQO,
             resolution=Frequency.RAW,
         )
 
     @task(retries=3, retry_delay=timedelta(minutes=5))
     def save_unclean_data(data: pd.DataFrame):
         from airqo_etl_utils.bigquery_api import BigQueryApi
-        from airqo_etl_utils.constants import DataType
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
 
         data = AirQoDataUtils.format_data_for_bigquery(
@@ -121,7 +118,6 @@ def airqo_bam_realtime_measurements():
     @task(retries=3, retry_delay=timedelta(minutes=5))
     def save_clean_bam_data(data: pd.DataFrame):
         from airqo_etl_utils.bigquery_api import BigQueryApi
-        from airqo_etl_utils.constants import DataType
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
 
         data = AirQoDataUtils.format_data_for_bigquery(
@@ -137,9 +133,7 @@ def airqo_bam_realtime_measurements():
     def update_latest_data_topic(data: pd.DataFrame, **kwargs):
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
         from airqo_etl_utils.message_broker_utils import MessageBrokerUtils
-        from airqo_etl_utils.constants import DeviceCategory
         from airqo_etl_utils.data_validator import DataValidationUtils
-        from airqo_etl_utils.constants import Tenant
         from datetime import datetime
 
         now = datetime.now()

--- a/src/workflows/dags/airqo_measurements.py
+++ b/src/workflows/dags/airqo_measurements.py
@@ -2,7 +2,6 @@ from airflow.decorators import dag, task
 
 from airqo_etl_utils.config import configuration
 from airqo_etl_utils.workflows_custom_utils import AirflowUtils
-from airqo_etl_utils.constants import Frequency
 from airflow.exceptions import AirflowFailException
 from dag_docs import (
     airqo_realtime_low_cost_measurements_doc,
@@ -16,6 +15,7 @@ from task_docs import (
     send_raw_measurements_to_bigquery_doc,
     extract_raw_airqo_gaseous_data_doc,
 )
+from airqo_etl_utils.constants import DeviceNetwork, DeviceCategory, Frequency
 from datetime import timedelta
 import logging
 
@@ -102,7 +102,6 @@ def airqo_historical_hourly_measurements():
     ) -> None:
         from airqo_etl_utils.message_broker_utils import MessageBrokerUtils
         from airqo_etl_utils.data_validator import DataValidationUtils
-        from airqo_etl_utils.constants import Tenant
         from datetime import datetime
 
         now = datetime.now()
@@ -151,7 +150,6 @@ def airqo_historical_raw_measurements():
     def extract_raw_data(**kwargs):
         from airqo_etl_utils.date import DateUtils
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
-        from airqo_etl_utils.constants import DeviceCategory
 
         start_date_time, end_date_time = DateUtils.get_dag_date_time_values(
             historical=True, days=2, **kwargs
@@ -166,7 +164,6 @@ def airqo_historical_raw_measurements():
     @task()
     def clean_data_raw_data(data: pd.DataFrame):
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
-        from airqo_etl_utils.constants import DeviceCategory
 
         return AirQoDataUtils.clean_low_cost_sensor_data(
             data=data, device_category=DeviceCategory.LOW_COST
@@ -217,7 +214,6 @@ def airqo_historical_raw_measurements():
 )
 def airqo_cleanup_measurements():
     import pandas as pd
-    from airqo_etl_utils.constants import Frequency
 
     @task(provide_context=True)
     def extract_raw_data(**kwargs) -> pd.DataFrame:
@@ -307,7 +303,6 @@ def airqo_realtime_measurements():
     )
     def extract_raw_data(**kwargs) -> pd.DataFrame:
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
-        from airqo_etl_utils.constants import DeviceCategory
 
         execution_date = kwargs["dag_run"].execution_date
         hour_of_day = execution_date - timedelta(hours=1)
@@ -326,7 +321,6 @@ def airqo_realtime_measurements():
     def clean_data_raw_data(data: pd.DataFrame) -> pd.DataFrame:
         # TODO Future possibility of adding gx data quality checks here to measure data quality
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
-        from airqo_etl_utils.constants import DeviceCategory
 
         return AirQoDataUtils.clean_low_cost_sensor_data(
             data=data, device_category=DeviceCategory.LOW_COST
@@ -394,7 +388,6 @@ def airqo_realtime_measurements():
     def send_hourly_measurements_to_message_broker(data: pd.DataFrame, **kwargs):
         from airqo_etl_utils.message_broker_utils import MessageBrokerUtils
         from airqo_etl_utils.data_validator import DataValidationUtils
-        from airqo_etl_utils.constants import Tenant
         from datetime import datetime
 
         now = datetime.now()
@@ -441,7 +434,6 @@ def airqo_realtime_measurements():
     def update_latest_data_topic(data: pd.DataFrame, **kwargs):
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
         from airqo_etl_utils.message_broker_utils import MessageBrokerUtils
-        from airqo_etl_utils.constants import DeviceCategory, Tenant
         from airqo_etl_utils.data_validator import DataValidationUtils
         from datetime import datetime
 
@@ -503,7 +495,6 @@ def airqo_raw_data_measurements():
     )
     def extract_raw_data(**kwargs):
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
-        from airqo_etl_utils.constants import DeviceCategory
         from airqo_etl_utils.date import date_to_str_hours
         from datetime import datetime, timedelta
 
@@ -524,7 +515,6 @@ def airqo_raw_data_measurements():
     )
     def clean_data_raw_data(data: pd.DataFrame):
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
-        from airqo_etl_utils.constants import DeviceCategory
 
         return AirQoDataUtils.clean_low_cost_sensor_data(
             data=data, device_category=DeviceCategory.LOW_COST
@@ -567,7 +557,6 @@ def airqo_gaseous_realtime_measurements():
     )
     def extract_raw_data(**kwargs) -> pd.DataFrame:
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
-        from airqo_etl_utils.constants import DeviceCategory
         from airqo_etl_utils.date import date_to_str_hours
         from datetime import datetime, timedelta
 
@@ -580,6 +569,7 @@ def airqo_gaseous_realtime_measurements():
             start_date_time=start_date_time,
             end_date_time=end_date_time,
             device_category=DeviceCategory.LOW_COST_GAS,
+            device_network=DeviceNetwork.AIRQO,
             remove_outliers=False,
         )
 
@@ -588,7 +578,6 @@ def airqo_gaseous_realtime_measurements():
     )
     def clean_data_raw_data(data: pd.DataFrame):
         from airqo_etl_utils.airqo_utils import AirQoDataUtils
-        from airqo_etl_utils.constants import DeviceCategory
 
         return AirQoDataUtils.clean_low_cost_sensor_data(
             data=data, device_category=DeviceCategory.LOW_COST_GAS


### PR DESCRIPTION
## Description

This PR allows to pick specific network devices and cleans up the field naming to match the fields returned by get_devices_by_network.

## Related Issues
- [ ] JIRA cards:
  - [ ] OPS-327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `DeviceNetwork` constant to categorize devices by network type
	- Enhanced device data retrieval with network-specific filtering

- **Refactor**
	- Renamed `Tenant` to `DeviceNetwork` across multiple utility files
	- Updated method signatures to include network-specific parameters
	- Improved code clarity and consistency in device data handling

- **Chores**
	- Updated import statements and constant usage in DAG files
	- Removed deprecated import references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->