### PR TITLE
check if the caught error is an instance of HttpError

### DIFF
--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -786,7 +786,10 @@ UserSchema.statics = {
       }
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
-      next(
+      if (error instanceof HttpError) {
+        return next(error);
+      }
+      return next(
         new HttpError(
           "Internal Server Error",
           httpStatus.INTERNAL_SERVER_ERROR,
@@ -997,7 +1000,10 @@ UserSchema.statics = {
       }
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
-      next(
+      if (error instanceof HttpError) {
+        return next(error);
+      }
+      return next(
         new HttpError(
           "Internal Server Error",
           httpStatus.INTERNAL_SERVER_ERROR,
@@ -1039,6 +1045,9 @@ UserSchema.statics = {
       );
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      if (error instanceof HttpError) {
+        return next(error);
+      }
       return next(
         new HttpError(
           "Internal Server Error",
@@ -1078,7 +1087,10 @@ UserSchema.statics = {
     } catch (error) {
       logObject("the models error", error);
       logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
-      next(
+      if (error instanceof HttpError) {
+        return next(error);
+      }
+      return next(
         new HttpError(
           "Internal Server Error",
           httpStatus.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Description

**Error Handling in Pre-Save Hook:**
In the pre-save hook, we were correctly checking for validation errors and creating an instance of HttpError with a specific message related to the field that failed validation. However, when this error is thrown, it is being caught in the static modify function.

**Error Propagation:**
In the modify function, when an error is caught, we were creating a new HttpError instance with a generic message ("Internal Server Error") and using error.message from the caught error. This results in the original validation error message being lost or replaced by a more generic one.

**Final API Response:**
The final response shows "Internal Server Error" because that is the message set in the catch block of the modify function, instead of propagating the original validation error.

## Changes Made

- [ ] Properly manage error propagation from the User model, check if the caught error is an instance of HttpError

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Update User
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for user-related operations to provide more precise error messages and better error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->