### PR TITLE
Resource optimisation: Allowing workflows to use idle cpu from high mem Node

### DIFF
--- a/k8s/workflows/values-stage.yaml
+++ b/k8s/workflows/values-stage.yaml
@@ -43,18 +43,17 @@ resources:
     limits:
       cpu: 50m
       memory: 50Mi
-nodeSelector:
-  role: high-cpu
 affinity:
   nodeAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - preference:
-          matchExpressions:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
             - key: role
               operator: In
               values:
                 - high-cpu
-        weight: 1
+                - high-mem
+
 volumeMounts:
   - name: config-volume
     mountPath: /etc/config


### PR DESCRIPTION
## Description

Allow Worklfows pods to schedule on the high-mem node which is expected to have idle CPU resources


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
  - Modified Kubernetes pod scheduling rules to enforce stricter node selection criteria
  - Updated affinity settings to require nodes with either `high-cpu` or `high-mem` labels
  - Removed previous `nodeSelector` configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->