### PR TITLE
Increase observed limits for data mgt Microservice

### DIFF
--- a/k8s/data-mgt/values-stage.yaml
+++ b/k8s/data-mgt/values-stage.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ''
 podAnnotations: {}
 resources:
   limits:
-    cpu: 5m
+    cpu: 50m
     memory: 200Mi
   requests:
     cpu: 1m


### PR DESCRIPTION
## Description

Increase observed limits for data mgt Microservice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Kubernetes resource configuration for staging environment
	- Increased CPU resource limit from 5m to 50m to improve application performance and resource allocation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->