### PR TITLE
Website upstream Edit

### DIFF
--- a/k8s/nginx/production/platform-vs.yaml
+++ b/k8s/nginx/production/platform-vs.yaml
@@ -65,6 +65,7 @@ spec:
     - name: website
       service: airqo-website-api-svc
       port: 8000
+      client-max-body-size: 350m
   subroutes:
     - path: /website
       action:

--- a/src/website/README.md
+++ b/src/website/README.md
@@ -1,1 +1,1 @@
-# web-db
+# web-db .


### PR DESCRIPTION
## Description

[Added client-max-body-size to website virtualserverroute upstream]

## Related Issues

- [ ] GitHub issues:
  - [ ] [Closes #123](https://github.com/your-org/your-repo/issues/123)
  - [ ] [Closes #456](https://github.com/your-org/your-repo/issues/456)
  - [ ] Any other relevant GitHub Issues...
- [ ] JIRA cards:
  - [ ] [JIRA-7890](https://your-jira-instance.atlassian.net/browse/JIRA-7890)
  - [ ] [JIRA-101112](https://your-jira-instance.atlassian.net/browse/JIRA-101112)
  - [ ] Any other relevant JIRA cards...

## Changes Made

- [ ] Brief description of change 1
- [ ] Brief description of change 2
- [ ] Brief description of change 3

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Service 1
  - [ ] Service 2
  - [ ] Other...

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Endpoint 1
  - [ ] Endpoint 2
  - [ ] Other...
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

## Additional Notes

[Add any additional notes or comments here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Increased maximum request body size to 350MB for the website route in production environment
- **Documentation**
	- Minor update to README.md comment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->