### PR TITLE
just reverting version of express validator

### DIFF
--- a/src/device-registry/package-lock.json
+++ b/src/device-registry/package-lock.json
@@ -35,7 +35,7 @@
         "express-rate-limit": "^7.4.1",
         "express-session": "^1.17.1",
         "express-validation": "^1.0.3",
-        "express-validator": "^7.2.1",
+        "express-validator": "^6.12.0",
         "generate-password": "^1.7.0",
         "geolib": "^3.3.3",
         "google-libphonenumber": "^3.2.22",
@@ -5311,12 +5311,12 @@
       }
     },
     "node_modules/express-validator": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
-      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.15.0.tgz",
+      "integrity": "sha512-r05VYoBL3i2pswuehoFSy+uM8NBuVaY7avp5qrYjQBDzagx2Z5A77FZqPT8/gNLF3HopWkIzaTFaC4JysWXLqg==",
       "dependencies": {
         "lodash": "^4.17.21",
-        "validator": "~13.12.0"
+        "validator": "^13.9.0"
       },
       "engines": {
         "node": ">= 8.0.0"
@@ -21720,12 +21720,12 @@
       }
     },
     "express-validator": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
-      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.15.0.tgz",
+      "integrity": "sha512-r05VYoBL3i2pswuehoFSy+uM8NBuVaY7avp5qrYjQBDzagx2Z5A77FZqPT8/gNLF3HopWkIzaTFaC4JysWXLqg==",
       "requires": {
         "lodash": "^4.17.21",
-        "validator": "~13.12.0"
+        "validator": "^13.9.0"
       }
     },
     "ext": {

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -57,7 +57,7 @@
     "express-rate-limit": "^7.4.1",
     "express-session": "^1.17.1",
     "express-validation": "^1.0.3",
-    "express-validator": "^7.2.1",
+    "express-validator": "^6.12.0",
     "generate-password": "^1.7.0",
     "geolib": "^3.3.3",
     "google-libphonenumber": "^3.2.22",


### PR DESCRIPTION
- [x] just reverting version of express validator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
	- Downgraded `express-validator` package version to maintain compatibility with existing validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->