### PR TITLE
just ensure that activity emails have the AirQo logo

### DIFF
--- a/src/auth-service/utils/common/mailer.js
+++ b/src/auth-service/utils/common/mailer.js
@@ -114,6 +114,7 @@ const createMailOptions = ({
       activityType,
     }),
     bcc: bccEmails,
+    attachments: attachments,
   };
 };
 const handleMailResponse = (data) => {


### PR DESCRIPTION
## Description

just ensure that activity emails have the AirQo logo. These activity emails are triggered by Kafka consumer immediately device activities are carried out.

## Changes Made

- [ ] just ensure that activity emails have the AirQo logo

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Auth Service


## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added image attachments to various email methods in the mailer service
	- Enhanced email communication with consistent visual branding across multiple email types

- **Improvements**
	- Standardized email configuration by including predefined image attachments in all email generation methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->