### PR TITLE
removing BCC emails from inquiries

### DIFF
--- a/src/auth-service/utils/common/mailer.js
+++ b/src/auth-service/utils/common/mailer.js
@@ -517,7 +517,6 @@ const mailer = {
         },
         subject: `Welcome to AirQo`,
         html: msgs.inquiry(fullName, email, category),
-        bcc: subscribedBccEmails,
         attachments,
       };
 


### PR DESCRIPTION
## Description

removing BCC emails from inquiries

## Changes Made

- [ ] removing BCC emails from inquiries

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Post Inquiry
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Streamlined inquiry emails to ensure they are sent only to designated recipients, enhancing recipient privacy by removing additional, undisclosed notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->