### PR TITLE
Fix Historical Data Query Error (NaN in $slice)

### DIFF
--- a/src/device-registry/controllers/event.controller.js
+++ b/src/device-registry/controllers/event.controller.js
@@ -400,6 +400,11 @@ const processCohortIds = async (cohort_ids, request) => {
         cohort_id,
       });
 
+      logObject(
+        "responseFromGetDevicesOfCohort",
+        responseFromGetDevicesOfCohort
+      );
+
       if (responseFromGetDevicesOfCohort.success === false) {
         logger.error(
           `🐛🐛 Internal Server Error --- ${JSON.stringify(
@@ -1314,12 +1319,12 @@ const createEvent = {
           });
         }
       } else {
-        res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           errors: {
             message: `Unable to process measurements for the provided measurement IDs`,
           },
-          message: "Internal Server Error",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -1405,7 +1410,7 @@ const createEvent = {
           errors: {
             message: `Unable to process measurements for the provided measurement IDs`,
           },
-          message: "Bad Request",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -1491,7 +1496,7 @@ const createEvent = {
           errors: {
             message: `Unable to process measurements for the provided measurement IDs`,
           },
-          message: "Bad Request",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -1577,7 +1582,7 @@ const createEvent = {
           errors: {
             message: `Unable to process measurements for the provided measurement IDs`,
           },
-          message: "Bad Request",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -1653,12 +1658,12 @@ const createEvent = {
           });
         }
       } else {
-        res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           errors: {
-            message: `Unable to process measurements for the provided measurement IDs`,
+            message: `Unable to process measurements - crosscheck if provided IDs exist`,
           },
-          message: "Internal Server Error",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -2463,12 +2468,12 @@ const createEvent = {
           });
         }
       } else {
-        res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           errors: {
             message: `Unable to process measurements for the provided AirQloud IDs ${airqloud_id}`,
           },
-          message: "Internal Server Error",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -2542,12 +2547,12 @@ const createEvent = {
           });
         }
       } else {
-        res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           errors: {
             message: `Unable to process measurements for the provided AirQloud IDs ${airqloud_id}`,
           },
-          message: "Internal Server Error",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -2623,12 +2628,12 @@ const createEvent = {
           });
         }
       } else {
-        res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           errors: {
             message: `Unable to process measurements for the provided Grid IDs ${grid_id}`,
           },
-          message: "Internal Server Error",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -2703,12 +2708,12 @@ const createEvent = {
           });
         }
       } else {
-        res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           errors: {
             message: `Unable to process measurements for the provided Grid IDs ${grid_id}`,
           },
-          message: "Internal Server Error",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -2784,12 +2789,12 @@ const createEvent = {
           });
         }
       } else {
-        res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           errors: {
             message: `Unable to process measurements for the provided Cohort IDs ${cohort_id}`,
           },
-          message: "Internal Server Error",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {
@@ -2865,12 +2870,12 @@ const createEvent = {
           });
         }
       } else {
-        res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+        res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           errors: {
             message: `Unable to process measurements for the provided Cohort IDs ${cohort_id}`,
           },
-          message: "Internal Server Error",
+          message: "Bad Request Error",
         });
       }
     } catch (error) {

--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -500,9 +500,17 @@ async function fetchData(model, filter) {
     brief,
     index,
     skip,
-    limit,
+    limit = DEFAULT_LIMIT,
     page,
   } = filter;
+
+  if (typeof limit !== "number" || isNaN(limit)) {
+    limit = DEFAULT_LIMIT;
+  }
+
+  if (typeof page !== "number" || isNaN(page)) {
+    page = DEFAULT_PAGE;
+  }
 
   if (page) {
     skip = parseInt((page - 1) * limit);


### PR DESCRIPTION
## Description

Resolves a runtime error ("Second argument to $slice can't be represented as a 32-bit integer: nan") that occurred when querying historical data with invalid or missing limit values.

## Changes Made

- [x] Added a default value for limit in the fetchData function to prevent NaN values in the $slice operator. This ensures a valid numerical limit is used, even if one isn't explicitly provided in the request, preventing the runtime error.
- [x] Added handling for missing or zero values in total.device within the $slice operation, preventing errors when the total count is unavailable. This makes the query more robust by using the provided limit value as a fallback if the total count cannot be determined.
- [x] Implemented a type check for the limit variable in fetchData to ensure it's a number. This adds an extra layer of validation to prevent similar errors if an invalid limit is provided in the request.

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] historical Cohort measurements
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error responses to deliver clearer, more accurate feedback when invalid inputs or non-existent identifiers are provided.
- **Refactor**
	- Enhanced input validation and default value assignments to ensure consistent and reliable system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->