### PR TITLE
Update/calculate hourly airqualitydata using bigqdata

### DIFF
--- a/src/workflows/airqo_etl_utils/airqo_utils.py
+++ b/src/workflows/airqo_etl_utils/airqo_utils.py
@@ -842,6 +842,8 @@ class AirQoDataUtils:
         devices.drop_duplicates(
             subset=["device_id", "timestamp"], keep="first", inplace=True
         )
+
+        # TODO Might have to change approach to group by device_id depending on performance.
         for _, row in devices.iterrows():
             end_date_time = DateUtils.format_datetime_by_unit_str(
                 row.timestamp, "hours_end"

--- a/src/workflows/airqo_etl_utils/config.py
+++ b/src/workflows/airqo_etl_utils/config.py
@@ -409,6 +409,7 @@ class Config:
         },
         DataType.AVERAGED: {
             DeviceCategory.GENERAL: {
+                Frequency.RAW: BIGQUERY_HOURLY_UNCALIBRATED_EVENTS_TABLE,
                 Frequency.HOURLY: BIGQUERY_HOURLY_EVENTS_TABLE,
                 Frequency.DAILY: BIGQUERY_DAILY_EVENTS_TABLE,
             },

--- a/src/workflows/dags/airqo_measurements.py
+++ b/src/workflows/dags/airqo_measurements.py
@@ -16,6 +16,7 @@ from dag_docs import (
     airqo_gaseous_realtime_low_cost_data_doc,
     airqo_historical_raw_low_cost_measurements_doc,
     stream_old_data_doc,
+    re_calibrate_missing_calibrated_data_doc,
 )
 from task_docs import (
     extract_raw_airqo_data_doc,
@@ -24,6 +25,7 @@ from task_docs import (
     extract_raw_airqo_gaseous_data_doc,
     extract_historical_device_measurements_doc,
     extract_hourly_old_historical_data_doc,
+    extract_devices_missing_calibrated_data_doc,
 )
 from airqo_etl_utils.constants import DeviceNetwork, DeviceCategory, Frequency, DataType
 from datetime import datetime, timedelta
@@ -705,6 +707,7 @@ def airqo_bigquery_data_measurements_to_api():
     "Re_calibrate_missing_calibrated_data_doc",
     schedule="0 0 * * *",
     catchup=False,
+    doc_md=re_calibrate_missing_calibrated_data_doc,
     tags=["2025", "hourly-data", "bigquery"],
     default_args=AirflowUtils.dag_default_configs(),
 )
@@ -712,6 +715,7 @@ def calibrate_missing_measurements():
     import pandas as pd
 
     @task(
+        doc_md=extract_devices_missing_calibrated_data_doc,
         provide_context=True,
         retries=3,
         retry_delay=timedelta(minutes=5),

--- a/src/workflows/dags/dag_docs.py
+++ b/src/workflows/dags/dag_docs.py
@@ -20,7 +20,7 @@ Data Destinations:
 stream_old_data_doc = """
 ### Stream-Old-Data ETL
 #### Purpose
-Streams and old/historical measurements from biqquery to the events api. 
+Streams old/historical measurements from biqquery to the events api. 
 This flow can be updated depending on type of data to stream. 
 Ensure to manually apply start and end dates for the data required.
 #### Notes
@@ -28,6 +28,23 @@ Data sources:
 - Bigquery(prod):averaged_data.hourly_device_measurements
 Data Destinations:
 - API(devices/events):
+- <a href="https://airqo.africa/" target="_blank">AirQo</a>
+"""
+
+re_calibrate_missing_calibrated_data_doc = """
+### Calibrate-missing-calibrated-data ETL
+#### Purpose
+Re-calibrates old/historical measurements from biqquery. 
+1. This pipeline checks for missing calibrated data in the averaged data. 
+2. Checks if raw data is avalible 
+#### Notes
+Data sources:
+- Bigquery(prod):averaged_data.merged_uncalibrated_data
+- Bigquery(prod):averaged_data.hourly_device_measurements
+- Bigquery(prod):raw_data.device_measurements
+- Bigquery(prod):raw_data.weather_data
+Data Destinations:
+- - Bigquery(prod):averaged_data.hourly_device_measurements
 - <a href="https://airqo.africa/" target="_blank">AirQo</a>
 """
 

--- a/src/workflows/dags/task_docs.py
+++ b/src/workflows/dags/task_docs.py
@@ -44,3 +44,11 @@ Extracts hourly averaged data from BigQuery for a specified time window.
 #### Notes
 - <a href="https://airqo.africa/" target="_blank">AirQo</a>
 """
+extract_devices_missing_calibrated_data_doc = """
+#### Purpose
+Extracts devices that are missing calibrated data from bigquery
+
+- This is in preparation to extract, merge and re-calibrate missed air quality and weather data..
+#### Notes
+- <a href="https://airqo.africa/" target="_blank">AirQo</a>
+"""


### PR DESCRIPTION
## Description

Re-calibrate missed data
- Extracts data gaps by device from the averaged hourly data
- Uses raw air quality data + hourly weather data
- Calibrates the data by device to ensure a clean reload i.e not deleting already existing data. This case also handles null calibrated values.
- This only happens for the devices on the airqo network

## Related Issues
- [ ] JIRA cards:
  - [ ] OPS-351