### PR TITLE
invalidate special characters during creation of device registry entities

### DIFF
--- a/src/device-registry/validators/cohorts.validators.js
+++ b/src/device-registry/validators/cohorts.validators.js
@@ -61,13 +61,25 @@ const commonValidations = {
       .bail()
       .notEmpty()
       .withMessage("the name should not be empty")
-      .trim(),
+      .trim()
+      .bail()
+      .trim()
+      .matches(/^[a-zA-Z0-9\s\-_]+$/)
+      .withMessage(
+        "the name can only contain letters, numbers, spaces, hyphens and underscores"
+      ),
   ],
   nameOptional: [
     body("name")
       .optional()
       .notEmpty()
-      .withMessage("the name should not be empty if provided"),
+      .withMessage("the name should not be empty if provided")
+      .bail()
+      .trim()
+      .matches(/^[a-zA-Z0-9\s\-_]+$/)
+      .withMessage(
+        "the name can only contain letters, numbers, spaces, hyphens and underscores"
+      ),
   ],
   description: [
     body("description")

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -73,7 +73,14 @@ const validateDeviceIdentifier = oneOf([
     .withMessage("device name should be lower case")
     .bail()
     .matches(constants.WHITE_SPACES_REGEX, "i")
-    .withMessage("the device names do not have spaces in them"),
+    .withMessage("the device names do not have spaces in them")
+    .bail()
+    .trim()
+    .matches(/^[a-zA-Z0-9\s\-_]+$/)
+    .withMessage(
+      "the device name can only contain letters, numbers, spaces, hyphens and underscores"
+    )
+    .bail(),
 ]);
 
 const validateDeviceIdParam = [
@@ -98,7 +105,14 @@ const validateCreateDevice = [
       .bail()
       .trim()
       .notEmpty()
-      .withMessage("the name should not be empty if provided"),
+      .withMessage("the name should not be empty if provided")
+      .bail()
+      .trim()
+      .matches(/^[a-zA-Z0-9\s\-_]+$/)
+      .withMessage(
+        "the device name can only contain letters, numbers, spaces, hyphens and underscores"
+      )
+      .bail(),
     body("long_name")
       .exists()
       .withMessage(
@@ -107,7 +121,13 @@ const validateCreateDevice = [
       .bail()
       .trim()
       .notEmpty()
-      .withMessage("the long_name should not be empty if provided"),
+      .withMessage("the long_name should not be empty if provided")
+      .bail()
+      .trim()
+      .matches(/^[a-zA-Z0-9\s\-_]+$/)
+      .withMessage(
+        "the device long_name can only contain letters, numbers, spaces, hyphens and underscores"
+      ),
   ]),
   oneOf([
     [
@@ -388,7 +408,13 @@ const validateUpdateDevice = [
   body("long_name")
     .optional()
     .notEmpty()
-    .trim(),
+    .withMessage("the long_name should not be empty if provided")
+    .bail()
+    .trim()
+    .matches(/^[a-zA-Z0-9\s\-_]+$/)
+    .withMessage(
+      "the device long_name can only contain letters, numbers, spaces, hyphens and underscores"
+    ),
   body("mountType")
     .optional()
     .notEmpty()
@@ -616,7 +642,14 @@ const validateListDevices = oneOf([
     query("name")
       .optional()
       .notEmpty()
-      .trim(),
+      .trim()
+      .bail()
+      .trim()
+      .matches(/^[a-zA-Z0-9\s\-_]+$/)
+      .withMessage(
+        "the device name can only contain letters, numbers, spaces, hyphens and underscores"
+      )
+      .bail(),
     query("online_status")
       .optional()
       .notEmpty()

--- a/src/device-registry/validators/grids.validators.js
+++ b/src/device-registry/validators/grids.validators.js
@@ -97,7 +97,13 @@ const commonValidations = {
       .bail()
       .notEmpty()
       .withMessage("The name should not be empty")
-      .trim(),
+      .trim()
+      .bail()
+      .trim()
+      .matches(/^[a-zA-Z0-9\s\-_]+$/)
+      .withMessage(
+        "the name can only contain letters, numbers, spaces, hyphens and underscores"
+      ),
   ],
 
   nameQuery: [
@@ -105,7 +111,13 @@ const commonValidations = {
       .optional()
       .notEmpty()
       .withMessage("name cannot be empty")
-      .trim(),
+      .trim()
+      .bail()
+      .trim()
+      .matches(/^[a-zA-Z0-9\s\-_]+$/)
+      .withMessage(
+        "the name can only contain letters, numbers, spaces, hyphens and underscores"
+      ),
   ],
 
   adminLevel: [
@@ -571,7 +583,13 @@ const gridsValidations = {
       .optional()
       .not()
       .exists()
-      .withMessage("admin level names cannot be updated"),
+      .withMessage("admin level names cannot be updated")
+      .bail()
+      .trim()
+      .matches(/^[a-zA-Z0-9\s\-_]+$/)
+      .withMessage(
+        "the name can only contain letters, numbers, spaces, hyphens and underscores"
+      ),
     (req, res, next) => {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -185,7 +185,13 @@ const siteIdentifierChains = [
   query("name")
     .optional()
     .notEmpty()
-    .trim(),
+    .withMessage("the site name should not be empty if provided")
+    .bail()
+    .trim()
+    .matches(/^[a-zA-Z0-9\s\-_]+$/)
+    .withMessage(
+      "the site name can only contain letters, numbers, spaces, hyphens and underscores"
+    ),
 ];
 
 const validateSiteIdParam = oneOf([
@@ -283,8 +289,12 @@ const validateCreateSite = [
     .bail()
     .trim()
     .custom((value) => createSiteUtil.validateSiteName(value))
+    .withMessage("The name should be greater than 5 and less than 50 in length")
+    .bail()
+    .trim()
+    .matches(/^[a-zA-Z0-9\s\-_]+$/)
     .withMessage(
-      "The name should be greater than 5 and less than 50 in length"
+      "the site name can only contain letters, numbers, spaces, hyphens and underscores"
     ),
   body("site_tags")
     .optional()
@@ -333,8 +343,12 @@ const validateUpdateSite = [
     .bail()
     .trim()
     .custom((value) => createSiteUtil.validateSiteName(value))
+    .withMessage("The name should be greater than 5 and less than 50 in length")
+    .bail()
+    .trim()
+    .matches(/^[a-zA-Z0-9\s\-_]+$/)
     .withMessage(
-      "The name should be greater than 5 and less than 50 in length"
+      "the site name can only contain letters, numbers, spaces, hyphens and underscores"
     ),
   body("status")
     .optional()


### PR DESCRIPTION
## Description

invalidate special characters during creation of device registry entities

## Changes Made

- [x] invalidate special characters during creation of device registry entities

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Device Registry.

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] CRUD for Site
  - [x] CRUD for Device
  - [x] CRUD for Cohort
  - [x] CRUD for Grid
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced input validations across the application. User fields now only accept letters, numbers, spaces, hyphens, and underscores.
	- Clear, updated error messages guide users when inputs contain invalid characters, ensuring consistent and reliable data entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->