### PR TITLE
fixing TypeError: callback is not a function

### DIFF
--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -80,14 +80,16 @@ let blacklistQueue = async.queue(async (task, callback) => {
       .then(() => {
         logObject(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
         // logger.info(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
-        callback();
+        // callback();
       });
     await kafkaProducer.disconnect();
+    callback();
   } catch (error) {
     logObject("error", error);
     // logger.error(
     //   `🐛🐛 KAFKA Producer Internal Server Error --- IP_ADDRESS: ${ip} --- ${error.message}`
     // );
+    callback();
   }
 }, 1); // Limit the number of concurrent tasks to 1
 


### PR DESCRIPTION
## Description

- [x] fixing TypeError: callback is not a function

## Changes Made

- [x] callback() Moved: The callback(); call is now outside the .then() block. It's called after kafkaProducer.disconnect() is complete (or within the catch block if there's an error).
- [x] Callback Even if Error: The callback is now also being called when an error occurs to ensure that the queue doesn't halt.
- [x] Correct Usage of callback. callback(); is now being called after the async operation has been completed, this was not being done before.

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] verify token
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced internal task processing to ensure that all background operations are conclusively completed, improving overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->