### PR TITLE
Fix: Correctly handle callbacks in async queues to prevent TypeError

### DIFF
--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -80,10 +80,16 @@ let blacklistQueue = async.queue(async (task, callback) => {
       .then(() => {
         logObject(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
         // logger.info(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
-        // callback();
+        callback();
+      })
+      .catch((error) => {
+        logObject("kafka producer send error", error);
+        callback();
       });
-    await kafkaProducer.disconnect();
-    callback();
+    await kafkaProducer.disconnect().catch((error) => {
+      logObject("kafka producer disconnect error", error);
+    });
+    // callback();
   } catch (error) {
     logObject("error", error);
     // logger.error(


### PR DESCRIPTION
## Description

This commit ensures that callbacks are consistently called within async queues, resolving a TypeError: callback is not a function error and enhancing error handling.


## Changes Made

- [x] **Modified `blacklistQueue`**:
    - [x] Reinstated the `callback()` inside of the `.then()` block after the `kafkaProducer.send()`
    - [x] Added a `.catch()` block after the  `kafkaProducer.send()` promise to call `callback()` in case of errors.
    - [x] Added a `.catch()` block to handle errors on the `kafkaProducer.disconnect()` function.
    - [x] Ensured that `callback()` is called in the main `catch()` block of the `blacklistQueue` task.
- [ ] **Modified `unknownIPQueue`**:
    - [ ] Added `catch()` for errors thrown in both the `.findOneAndUpdate()` and `.create()` functions.
    - [ ] Ensured that `callback()` is called in the catch blocks.
- [ ] **Modified `ipPrefixQueue`**:
    - [ ] Added `catch()` for errors thrown in both the `.findOneAndUpdate()` and `.create()` functions.
    - [ ] Ensured that `callback()` is called in the catch blocks.
- [x] **Added better Error Logging** :
    - [x] Added better error logging to the kafka producer send and disconnect functions.
    - [x] Log all errors that were caught in the `catch()` blocks for the mongoose functions.


## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Auth Service

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] verify token
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating
