### PR TITLE
Add Endpoints to Retrieve Worst PM2.5 Readings for Devices and Sites

### DIFF
--- a/src/device-registry/routes/v2/readings.routes.js
+++ b/src/device-registry/routes/v2/readings.routes.js
@@ -24,6 +24,18 @@ router.get(
 );
 
 router.get(
+  "/worst/devices",
+  readingsValidations.worstReadingForDevices,
+  eventController.getWorstReadingForDevices
+);
+
+router.get(
+  "/worst/sites",
+  readingsValidations.worstReadingForSites,
+  eventController.getWorstReadingForSites
+);
+
+router.get(
   "/sites/:site_id/averages",
   readingsValidations.listAverages,
   pagination(),

--- a/src/device-registry/validators/readings.validators.js
+++ b/src/device-registry/validators/readings.validators.js
@@ -338,6 +338,15 @@ const commonValidations = {
         return true;
       }),
   ],
+  atLeastOneRequired: (fields, message) => [
+    query().custom((value, { req }) => {
+      const hasAtLeastOne = fields.some((field) => req.query[field]);
+      if (!hasAtLeastOne) {
+        throw new Error(message);
+      }
+      return true;
+    }),
+  ],
 };
 
 const readingsValidations = {
@@ -413,6 +422,26 @@ const readingsValidations = {
     ...commonValidations.test,
   ],
   listRecent: [...commonValidations.tenant],
+  worstReadingForDevices: [
+    ...commonValidations.atLeastOneRequired(
+      ["cohort_id", "device_id"],
+      "At least one of cohort_id or device_id is required."
+    ),
+    commonValidations.objectId("cohort_id"),
+    commonValidations.objectId("device_id"),
+    ...commonValidations.checkConflictingParams("cohort_id", "device_id"),
+    ...commonValidations.checkForEmptyArrays(["cohort_id", "device_id"]),
+  ],
+  worstReadingForSites: [
+    ...commonValidations.atLeastOneRequired(
+      ["grid_id", "site_id"],
+      "At least one of grid_id or site_id is required."
+    ),
+    commonValidations.objectId("grid_id"),
+    commonValidations.objectId("site_id"),
+    ...commonValidations.checkConflictingParams("grid_id", "site_id"),
+    ...commonValidations.checkForEmptyArrays(["grid_id", "site_id"]),
+  ],
 };
 
 module.exports = {


### PR DESCRIPTION
## Description

This pull request introduces two new endpoints to retrieve the worst PM2.5 readings within a given time frame:

*   `/worst/devices`: Retrieves the single worst PM2.5 reading from a set of devices. This endpoint can accept a `cohort_id` or `device_id` (or an array of device_ids or cohort_ids) as a query parameter to filter the results.
*   `/worst/sites`: Retrieves the single worst PM2.5 reading from a set of sites. This endpoint can accept a `grid_id` or `site_id` (or an array of site_ids or grid_ids) as a query parameter to filter the results.

These endpoints are designed to provide quick access to information about the most polluted areas or devices within the platform.

**Key Features**

*   **Flexible Input:** The endpoints can handle single `device_id` or `site_id` values, as well as arrays of `device_id`, `site_id`, `cohort_id` or `grid_id` values, providing more flexibility when filtering the results.
* **Required Query Parameters**: ensures that at least one query parameter is provided for the specified IDs (either `cohort_id` or `device_id` for `/worst/devices`, and either `grid_id` or `site_id` for `/worst/sites`.
*   **Corrected Array Handling:** Addresses the issue where an array of device Ids was not being correctly handled.
*   **Robust Data Type Validation:** Ensures all device and site IDs are strings before processing.
* **Error Handling**: ensures that if a `cohort_id` or `grid_id` is provided, but the process does not get the correct associated IDs, then an error is returned.
*   **Worst PM2.5 Selection:** Correctly identifies and returns the single worst PM2.5 reading based on the provided criteria.
*   **Time Frame:** Considers readings from the last three days.

## Changes Made

### New Routes (`readings.routes.js`)

*   Added the following routes:
    *   `GET /worst/devices`: For retrieving the worst PM2.5 reading for one or more devices or a cohort.
    *   `GET /worst/sites`: For retrieving the worst PM2.5 reading for one or more sites or a grid.

### Controller (`event.controller.js`)

*   **`getWorstReadingForDevices` (New Function):**
    *   Implements the logic for retrieving the worst PM2.5 reading for devices.
    *   Correctly handles `device_id` and `cohort_id` query parameters (single values and arrays).
     *   Ensures all device IDs are converted to strings.
*   **`getWorstReadingForSites` (New Function):**
    *   Implements the logic for retrieving the worst PM2.5 reading for sites.
    *   Correctly handles `site_id` and `grid_id` query parameters (single values and arrays).
      *   Ensures all site IDs are converted to strings.

### Utility (`event.util.js`)

*   **`getWorstReadingForDevices` (New Function):**
    *   Implements the database query logic to find the worst PM2.5 reading for devices.
*   **`getWorstReadingForSites` (New Function):**
*  Implements the database query logic to find the worst PM2.5 reading for sites.

### Validators (`readings.validators.js`)

*   **`worstReadingForDevices` (New Validation Set):**
    *   Added `...commonValidations.atLeastOneRequired(["cohort_id", "device_id"], "At least one of cohort_id or device_id is required.")` to enforce that one of the identifiers is required.
    *   Added `commonValidations.objectId("cohort_id")` and `commonValidations.objectId("device_id")` to validate that the identifiers are valid ObjectIds.
*   **`worstReadingForSites` (New Validation Set):**
    *   Added `...commonValidations.atLeastOneRequired(["grid_id", "site_id"], "At least one of grid_id or site_id is required.")` to enforce that one of the identifiers is required.
     *   Added `commonValidations.objectId("grid_id")` and `commonValidations.objectId("site_id")` to validate that the identifiers are valid ObjectIds.

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] `GET /devices/readings/worst/devices`: For retrieving the worst PM2.5 reading for one or more devices or a cohort.
  - [x] `GET /devices/readings/worst/sites`: For retrieving the worst PM2.5 reading for one or more sites or a grid.
     
## API Documentation Updated?

- [x] Yes, API documentation was updated
- [ ] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced two API endpoints that allow users to retrieve worst air quality readings for sites and devices.
  - Enhanced request validations ensure that required identifiers are provided, with clear error messages for invalid inputs.
  - Improved data aggregation logic delivers accurate recent worst PM2.5 readings, providing more reliable insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->