### PR TITLE
Fix:Second argument to $slice cant be represented as a 32-bit integer…

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -1880,8 +1880,16 @@ eventSchema.statics.list = async function(
 
     logObject("filter", filter);
 
-    const startTime = filter["values.time"]["$gte"];
-    const endTime = filter["values.time"]["$lte"];
+    // Extract startTime and endTime but convert them to ISO strings for meta object
+    const startTime =
+      filter["values.time"] && filter["values.time"]["$gte"]
+        ? filter["values.time"]["$gte"].toISOString()
+        : undefined;
+    const endTime =
+      filter["values.time"] && filter["values.time"]["$lte"]
+        ? filter["values.time"]["$lte"].toISOString()
+        : undefined;
+
     let idField;
     // const visibilityFilter = true;
 
@@ -1919,8 +1927,9 @@ eventSchema.statics.list = async function(
           1,
         ],
       },
-      startTime,
-      endTime,
+      // Convert Date objects to strings for the meta object
+      startTime: { $literal: startTime },
+      endTime: { $literal: endTime },
     };
     let siteProjection = {};
     let deviceProjection = {};
@@ -2700,6 +2709,7 @@ eventSchema.statics.list = async function(
     );
   }
 };
+
 eventSchema.statics.view = async function(filter, next) {
   try {
     const request = filter;

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -907,6 +907,20 @@ const createEvent = {
         next
       );
 
+      if (!responseFromListEvents) {
+        // Handle cases where responseFromListEvents is null or undefined
+        logger.error(`🐛🐛 responseFromListEvents is null or undefined`);
+        return next(
+          new HttpError(
+            "Internal Server Error",
+            httpStatus.INTERNAL_SERVER_ERROR,
+            {
+              message: "Error retrieving events from the database",
+            }
+          )
+        );
+      }
+
       if (
         language !== undefined &&
         !isEmpty(responseFromListEvents) &&


### PR DESCRIPTION
## Description
When fetching measurements using the measurements/historical endpoint, getting the following runtime error:
`list events --- PlanExecutor error during aggregation :: caused by :: Second argument to $slice can't be represented as a 32-bit integer: nan`

## Changes Made

- [x] Just handled the edge case inside the Events model static function for list Events where we extract startTime and endTime but convert them to ISO strings for meta object
- [x] Also added some error handling to the listEvent util function

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] list measurements (historical)
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling to gracefully manage issues during event retrieval.
	- Improved date processing to ensure consistent and validated event time displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->