### PR TITLE
device registry DB >> putting back the autoIndex to true

### DIFF
--- a/src/device-registry/config/database.js
+++ b/src/device-registry/config/database.js
@@ -18,7 +18,7 @@ const options = {
   useNewUrlParser: true,
   useFindAndModify: false,
   useUnifiedTopology: true,
-  autoIndex: false,
+  autoIndex: true,
   keepAlive: true,
   keepAliveInitialDelay: 300000,
   poolSize: 20,


### PR DESCRIPTION
- [x] device registry DB >> putting back the autoIndex to true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the database configuration to enable automatic index creation and management.
  - This change ensures that necessary indexes are maintained automatically, potentially improving the performance and efficiency of data retrieval operations.
  - While no visible interface changes are introduced, these behind‐the‐scenes improvements contribute to overall system reliability and smoother operation.
  - Overall, these enhancements lay the groundwork for future performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->