### PR TITLE
just fixing the get feeds endpoints for private devices

### DIFF
--- a/src/device-registry/controllers/feed.controller.js
+++ b/src/device-registry/controllers/feed.controller.js
@@ -27,7 +27,11 @@ const createFeed = {
       const channel = ch_id;
 
       try {
-        const api_key = await createFeedUtil.getAPIKey(channel);
+        const apiKeyResponse = await createFeedUtil.getAPIKey(channel);
+        if (apiKeyResponse.success !== true) {
+          return res.status(apiKeyResponse.status).json(apiKeyResponse);
+        }
+        const api_key = apiKeyResponse.data;
         const request = { channel, api_key, start, end };
         const thingspeakData = await createFeedUtil.fetchThingspeakData(
           request
@@ -75,7 +79,11 @@ const createFeed = {
       const { channel, start, end } = req.query;
 
       try {
-        const api_key = await createFeedUtil.getAPIKey(channel);
+        const apiKeyResponse = await createFeedUtil.getAPIKey(channel);
+        if (apiKeyResponse.success !== true) {
+          return res.status(apiKeyResponse.status).json(apiKeyResponse);
+        }
+        const api_key = apiKeyResponse.data;
         const request = { channel, api_key, start, end };
         const thingspeakData = await createFeedUtil.fetchThingspeakData(
           request


### PR DESCRIPTION
## Description

just fixing the get feeds endpoints for private devices

## Changes Made

- [x] just fixing the get feeds endpoints for private devices.

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Get recent feeds
  - [x] Get descriptive recent feeds
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error management for feed operations. The system now checks key retrieval outcomes and provides accurate error responses, ensuring a more stable and reliable experience when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->