### PR TITLE
feat: Include devices in the get site details API response

### DIFF
--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -519,6 +519,7 @@ siteSchema.methods = {
     return {
       _id: this._id,
       grids: this.grids,
+      devices: this.devices,
       name: this.name,
       site_category: this.site_category,
       visibility: this.visibility,

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -34,16 +34,49 @@ const createSite = {
       const { id } = req.params;
       const { tenant } = req.query;
 
-      const site = await SiteModel(tenant.toLowerCase()).findById(id);
+      const site = await SiteModel(tenant.toLowerCase())
+        .findById(id)
+        .lean(); // Use lean() for faster query
 
       if (!site) {
         throw new HttpError("site not found", httpStatus.NOT_FOUND);
       }
 
+      // Define the device projection
+      const deviceProjection = {
+        _id: 1,
+        cohorts: 1,
+        groups: 1,
+        authRequired: 1,
+        isOnline: 1,
+        device_codes: 1,
+        previous_sites: 1,
+        status: 1,
+        category: 1,
+        isActive: 1,
+        long_name: 1,
+        network: 1,
+        description: 1,
+        serial_number: 1,
+        name: 1,
+        createdAt: 1,
+        latitude: 1,
+        longitude: 1,
+        grids: 1,
+      };
+
+      // Fetch devices associated with the site, applying the projection
+      const DeviceModel = require("@models/Device"); // Import Device model here to avoid circular dependency
+      const devices = await DeviceModel(tenant.toLowerCase())
+        .find({ site_id: id }, deviceProjection)
+        .lean(); // Use lean() for faster query
+
+      const siteWithDevices = { ...site, devices };
+
       return {
         success: true,
         message: "site details fetched successfully",
-        data: site,
+        data: siteWithDevices,
         status: httpStatus.OK,
       };
     } catch (error) {


### PR DESCRIPTION
## Description

This PR enhances the get site details API endpoint to include a list of devices associated with the site, improving data accessibility and reducing the need for separate API calls.

## Changes Made

- [x] Modified the getSiteById utility function to fetch and include associated devices.
- [x] Updated the toJSON method in the SiteModel to include the devices array.
- [x] Implemented a device projection to customize the fields returned for each device.
- [x] Ensured backward compatibility with existing site details API functionality.
- [x] Used .lean() to improve query performance.
- [x] Handled potential circular dependency by importing DeviceModel within the utility function.

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] device registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] List Site Information

## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Site information now includes comprehensive device details.
	- Data retrieval has been optimized to combine site and device information more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->