### PR TITLE
create a site and attach it to a group in the same endpoint

### DIFF
--- a/src/auth-service/bin/jobs/kafka-consumer.js
+++ b/src/auth-service/bin/jobs/kafka-consumer.js
@@ -384,7 +384,7 @@ const kafkaConsumer = async () => {
       ["ip-address"]: operationForBlacklistedIPs,
       ["deploy-topic"]: emailsForDeployedDevices,
       ["recall-topic"]: emailsForRecalledDevices,
-      ["site.events"]: operationForSiteCreated,
+      ["sites-topic"]: operationForSiteCreated,
     };
 
     await consumer.connect();

--- a/src/auth-service/bin/jobs/kafka-consumer.js
+++ b/src/auth-service/bin/jobs/kafka-consumer.js
@@ -339,6 +339,22 @@ const operationForSiteCreated = async (messageData) => {
 
     if (event.groupId) {
       const { siteId, groupId, tenant } = event;
+      // Validate that IDs are proper ObjectIds before proceeding
+      if (!ObjectId.isValid(siteId) || !ObjectId.isValid(groupId)) {
+        logger.error(
+          `🛑 Invalid ObjectId format - siteId: ${siteId}, groupId: ${groupId}`
+        );
+        return;
+      }
+
+      // Check if the group exists before attempting to update
+      const groupExists = await GroupModel(tenant).findOne({ _id: groupId });
+      if (!groupExists) {
+        logger.error(
+          `🛑 Group with ID ${groupId} not found for tenant ${tenant}`
+        );
+        return;
+      }
       const filter = { _id: groupId };
       const update = { $addToSet: { grp_sites: siteId } };
       const options = { new: true };

--- a/src/auth-service/models/Group.js
+++ b/src/auth-service/models/Group.js
@@ -48,6 +48,7 @@ const GroupSchema = new Schema(
       required: [true, "grp_description is required"],
     },
     grp_manager: { type: ObjectId },
+    grp_sites: [{ type: ObjectId }],
     grp_manager_username: { type: String },
     grp_manager_firstname: { type: String },
     grp_manager_lastname: { type: String },

--- a/src/auth-service/models/Group.js
+++ b/src/auth-service/models/Group.js
@@ -48,7 +48,16 @@ const GroupSchema = new Schema(
       required: [true, "grp_description is required"],
     },
     grp_manager: { type: ObjectId },
-    grp_sites: [{ type: ObjectId }],
+    grp_sites: {
+      type: [ObjectId],
+      validate: {
+        validator: function (value) {
+          // Check for duplicates in the array
+          return Array.isArray(value) && new Set(value).size === value.length;
+        },
+        message: "Duplicate grp_sites are not allowed.",
+      },
+    },
     grp_manager_username: { type: String },
     grp_manager_firstname: { type: String },
     grp_manager_lastname: { type: String },
@@ -86,6 +95,13 @@ GroupSchema.index({ grp_title: 1 }, { unique: true });
 GroupSchema.pre(
   ["updateOne", "findOneAndUpdate", "updateMany", "update", "save"],
   async function (next) {
+    // Pre-save hook to normalize grp_sites and remove duplicates
+    if (this.grp_sites && Array.isArray(this.grp_sites)) {
+      this.grp_sites = [...new Set(this.grp_sites.map(String))].map((id) =>
+        mongoose.Types.ObjectId(id)
+      );
+    }
+
     // Determine if this is a new document or an update
     const isNew = this.isNew;
     let updates = this.getUpdate ? this.getUpdate() : this;
@@ -96,6 +112,20 @@ GroupSchema.pre(
         ...(updates || {}),
         ...(updates.$set || {}),
       };
+
+      if (actualUpdates.grp_sites) {
+        const grpSites = actualUpdates.grp_sites;
+        if (
+          Array.isArray(grpSites) &&
+          new Set(grpSites).size !== grpSites.length
+        ) {
+          return next(
+            new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+              message: "Duplicate grp_sites are not allowed.",
+            })
+          );
+        }
+      }
 
       // Profile picture validation for both new documents and updates
       if (isNew) {

--- a/src/auth-service/validators/groups.validators.js
+++ b/src/auth-service/validators/groups.validators.js
@@ -80,6 +80,29 @@ const update = [
       .withMessage("the grp_industry should not be empty if provided")
       .bail()
       .trim(),
+    body("grp_sites")
+      .optional()
+      .custom((value) => {
+        return Array.isArray(value);
+      })
+      .withMessage("grp_sites must be an array if provided")
+      .bail()
+      .custom((value) => {
+        // Check for duplicates in the array
+        if (Array.isArray(value)) {
+          return new Set(value).size === value.length;
+        }
+        return true;
+      })
+      .withMessage("Duplicate site IDs are not allowed in grp_sites"),
+    body("grp_sites.*")
+      .optional()
+      .isMongoId()
+      .withMessage("Each site ID in grp_sites must be a valid ObjectId")
+      .bail()
+      .customSanitizer((value) => {
+        return ObjectId(value);
+      }),
     body("grp_image")
       .optional()
       .notEmpty()
@@ -156,6 +179,29 @@ const create = [
         "the grp_title can only contain letters, numbers, spaces, hyphens and underscores"
       )
       .bail(),
+    body("grp_sites")
+      .optional()
+      .custom((value) => {
+        return Array.isArray(value);
+      })
+      .withMessage("grp_sites must be an array if provided")
+      .bail()
+      .custom((value) => {
+        // Check for duplicates in the array
+        if (Array.isArray(value)) {
+          return new Set(value).size === value.length;
+        }
+        return true;
+      })
+      .withMessage("Duplicate site IDs are not allowed in grp_sites"),
+    body("grp_sites.*")
+      .optional()
+      .isMongoId()
+      .withMessage("Each site ID in grp_sites must be a valid ObjectId")
+      .bail()
+      .customSanitizer((value) => {
+        return ObjectId(value);
+      }),
     body("grp_description")
       .exists()
       .withMessage("the grp_description is required")

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -592,7 +592,11 @@ const createSite = {
             messages: [
               {
                 action: "create",
-                value: JSON.stringify(createdSite),
+                value: JSON.stringify({
+                  ...createdSite,
+                  groupId: group,
+                  tenant: request.query.tenant,
+                }),
               },
             ],
           });


### PR DESCRIPTION
## Description

create a site and attach it to a group in the same endpoint

## Changes Made

- [ ] create a site and attach it to a group in the same endpoint

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Auth Service
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Create Site
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

## Additional Notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced processing for new site events, ensuring that group associations are automatically updated.
	- Expanded group records to support multiple site associations with validation against duplicates.
	- Updated site creation messages to include additional context, such as group and tenant identifiers.

- **Bug Fixes**
	- Implemented validation to prevent duplicate entries in the `grp_sites` field during updates and creations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->