### PR TITLE
Fix Deployment image Superset

### DIFF
--- a/.github/workflows/deploy-apis-to-production.yml
+++ b/.github/workflows/deploy-apis-to-production.yml
@@ -1672,7 +1672,6 @@ jobs:
         with:
           push: true
           context: src/superset
-          target: production
           tags: ${{ env.REGISTRY_URL }}/${{ env.PROJECT_ID }}/airqo-prod-superset:${{ needs.image-tag.outputs.build_id }},${{ env.REGISTRY_URL }}/${{ env.PROJECT_ID }}/airqo-prod-superset:latest
 
       - name: Apply Deployment Files


### PR DESCRIPTION
## Description

Fix Deployment image Superset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated deployment process to build the default Docker image stage for Superset, instead of targeting a specific production stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->