### PR TITLE
Fix Database Projections Structure and Missing Definitions

### DIFF
--- a/src/device-registry/config/global/db-projections.js
+++ b/src/device-registry/config/global/db-projections.js
@@ -77,6 +77,21 @@ class ProjectionFactory {
         },
       },
 
+      kyaAnswers: {
+        inclusion: {
+          _id: 1,
+          title: 1,
+          content: 1,
+          kya_question_id: {
+            $arrayElemAt: ["$kyaquestion._id", 0],
+          },
+          kya_question_title: {
+            $arrayElemAt: ["$kyaquestion.title", 0],
+          },
+        },
+        exclusion: { nothing: 0 },
+      },
+
       kyaQuizProgress: {
         inclusion: {
           user_id: 1,
@@ -740,6 +755,69 @@ class ProjectionFactory {
           overrideExclusion: {
             // Add fields to exclude for public path if needed
           },
+        },
+      },
+
+      kyaTasks: {
+        summary: {
+          additionalExclusions: {},
+        },
+        public: {
+          overrideExclusion: {},
+        },
+      },
+
+      kyaQuiz: {
+        summary: {
+          additionalExclusions: {},
+        },
+        public: {
+          overrideExclusion: {},
+        },
+      },
+
+      kyaQuestions: {
+        summary: {
+          additionalExclusions: {},
+        },
+        public: {
+          overrideExclusion: {},
+        },
+      },
+
+      kyaAnswers: {
+        summary: {
+          additionalExclusions: {},
+        },
+        public: {
+          overrideExclusion: {},
+        },
+      },
+
+      adminLevel: {
+        summary: {
+          additionalExclusions: {},
+        },
+        public: {
+          overrideExclusion: {},
+        },
+      },
+
+      network: {
+        summary: {
+          additionalExclusions: {},
+        },
+        public: {
+          overrideExclusion: {},
+        },
+      },
+
+      siteActivities: {
+        summary: {
+          additionalExclusions: {},
+        },
+        public: {
+          overrideExclusion: {},
         },
       },
 


### PR DESCRIPTION
## Description

Addresses code review feedback by removing duplicated projections, fixing naming inconsistencies, and adding missing entity definitions.

## Changes Made

- [ ]  Removed duplicate definitions for kyaQuizProgress, kyaLessonsProgress, and kyaLessons in baseProjections
- [ ]  Removed duplicate path strategy definitions for KYA entities
- [x]  Added missing KYA_QUIZ_EXCLUSION_PROJECTION definition
- [x]  Improved camelCase to SNAKE_CASE conversion in getExclusionProjection method
- [x]  Added explicit path strategies for kyaTasks, kyaQuiz, kyaQuestions, kyaAnswers, adminLevel, network, and siteActivities
- [x]  Added missing base projection for kyaAnswers
- [ ]  Simplified cleanupDuplicateProperties method implementation
- [ ]  Fixed naming to accurately reflect function behavior

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] device registry

     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating

