### PR TITLE
Centralize AQI configuration variables for improved maintainability

### DIFF
--- a/src/device-registry/models/Event-v1.js
+++ b/src/device-registry/models/Event-v1.js
@@ -25,7 +25,6 @@ const UPTIME_CHECK_THRESHOLD = 168;
 const moment = require("moment-timezone");
 const TIMEZONE = moment.tz.guess();
 
-// Centralized AQI Range Configuration
 const AQI_RANGES = {
   good: { min: 0, max: 9.1 },
   moderate: { min: 9.101, max: 35.49 },
@@ -34,256 +33,6 @@ const AQI_RANGES = {
   very_unhealthy: { min: 125.491, max: 225.49 },
   hazardous: { min: 225.491, max: null },
 };
-
-// Centralized AQI Color Configuration
-const AQI_COLORS = {
-  good: "34C759",
-  moderate: "ECAA06",
-  u4sg: "FF851F",
-  unhealthy: "F7453C",
-  very_unhealthy: "AC5CD9",
-  hazardous: "D95BA3",
-  unknown: "Unknown",
-};
-
-// Centralized AQI Category Name Configuration
-const AQI_CATEGORIES = {
-  good: "Good",
-  moderate: "Moderate",
-  u4sg: "Unhealthy for Sensitive Groups",
-  unhealthy: "Unhealthy",
-  very_unhealthy: "Very Unhealthy",
-  hazardous: "Hazardous",
-  unknown: "Unknown",
-};
-
-// Centralized AQI Color Name Configuration
-const AQI_COLOR_NAMES = {
-  good: "Green",
-  moderate: "Yellow",
-  u4sg: "Orange",
-  unhealthy: "Red",
-  very_unhealthy: "Purple",
-  hazardous: "Maroon",
-  unknown: "Unknown",
-};
-
-// Helper function to determine AQI range based on pm2_5 value
-function getAqiRangeForValue(pm25Value) {
-  if (pm25Value >= AQI_RANGES.good.min && pm25Value <= AQI_RANGES.good.max) {
-    return "good";
-  } else if (
-    pm25Value >= AQI_RANGES.moderate.min &&
-    pm25Value <= AQI_RANGES.moderate.max
-  ) {
-    return "moderate";
-  } else if (
-    pm25Value >= AQI_RANGES.u4sg.min &&
-    pm25Value <= AQI_RANGES.u4sg.max
-  ) {
-    return "u4sg";
-  } else if (
-    pm25Value >= AQI_RANGES.unhealthy.min &&
-    pm25Value <= AQI_RANGES.unhealthy.max
-  ) {
-    return "unhealthy";
-  } else if (
-    pm25Value >= AQI_RANGES.very_unhealthy.min &&
-    pm25Value <= AQI_RANGES.very_unhealthy.max
-  ) {
-    return "very_unhealthy";
-  } else if (pm25Value >= AQI_RANGES.hazardous.min) {
-    return "hazardous";
-  }
-  return "unknown";
-}
-
-// MongoDB switch case expression for AQI color
-const getAqiColorExpression = () => ({
-  $switch: {
-    branches: [
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
-          ],
-        },
-        then: AQI_COLORS.good,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"] },
-          ],
-        },
-        then: AQI_COLORS.moderate,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
-          ],
-        },
-        then: AQI_COLORS.u4sg,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"] },
-          ],
-        },
-        then: AQI_COLORS.unhealthy,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.very_unhealthy.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.very_unhealthy.max"] },
-          ],
-        },
-        then: AQI_COLORS.very_unhealthy,
-      },
-      {
-        case: { $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"] },
-        then: AQI_COLORS.hazardous,
-      },
-    ],
-    default: AQI_COLORS.unknown,
-  },
-});
-
-// MongoDB switch case expression for AQI category
-const getAqiCategoryExpression = () => ({
-  $switch: {
-    branches: [
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
-          ],
-        },
-        then: AQI_CATEGORIES.good,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"] },
-          ],
-        },
-        then: AQI_CATEGORIES.moderate,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
-          ],
-        },
-        then: AQI_CATEGORIES.u4sg,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"] },
-          ],
-        },
-        then: AQI_CATEGORIES.unhealthy,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.very_unhealthy.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.very_unhealthy.max"] },
-          ],
-        },
-        then: AQI_CATEGORIES.very_unhealthy,
-      },
-      {
-        case: { $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"] },
-        then: AQI_CATEGORIES.hazardous,
-      },
-    ],
-    default: AQI_CATEGORIES.unknown,
-  },
-});
-
-// MongoDB switch case expression for AQI color name
-const getAqiColorNameExpression = () => ({
-  $switch: {
-    branches: [
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
-          ],
-        },
-        then: AQI_COLOR_NAMES.good,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"] },
-          ],
-        },
-        then: AQI_COLOR_NAMES.moderate,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
-          ],
-        },
-        then: AQI_COLOR_NAMES.u4sg,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"] },
-          ],
-        },
-        then: AQI_COLOR_NAMES.unhealthy,
-      },
-      {
-        case: {
-          $and: [
-            { $gte: ["$pm2_5.value", "$aqi_ranges.very_unhealthy.min"] },
-            { $lte: ["$pm2_5.value", "$aqi_ranges.very_unhealthy.max"] },
-          ],
-        },
-        then: AQI_COLOR_NAMES.very_unhealthy,
-      },
-      {
-        case: { $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"] },
-        then: AQI_COLOR_NAMES.hazardous,
-      },
-    ],
-    default: AQI_COLOR_NAMES.unknown,
-  },
-});
-
-// Function to generate the AQI addFields for MongoDB aggregation pipelines
-function generateAqiAddFields() {
-  return {
-    $addFields: {
-      device: "$device",
-      aqi_color: getAqiColorExpression(),
-      aqi_category: getAqiCategoryExpression(),
-      aqi_color_name: getAqiColorNameExpression(),
-      aqi_ranges: AQI_RANGES,
-    },
-  };
-}
 
 const valueSchema = new Schema({
   time: {
@@ -1133,7 +882,251 @@ async function fetchData(model, filter) {
       })
       .facet({
         total: [{ $count: "device" }],
-        data: [generateAqiAddFields()],
+        data: [
+          {
+            $addFields: {
+              device: "$device",
+              aqi_color: {
+                $switch: {
+                  branches: [
+                    {
+                      case: {
+                        $and: [
+                          { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                          { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                        ],
+                      },
+                      then: "00e400",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"],
+                          },
+                          {
+                            $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"],
+                          },
+                        ],
+                      },
+                      then: "ffff00",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                          { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                        ],
+                      },
+                      then: "ff7e00",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"],
+                          },
+                          {
+                            $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"],
+                          },
+                        ],
+                      },
+                      then: "ff0000",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: [
+                              "$pm2_5.value",
+                              "$aqi_ranges.very_unhealthy.min",
+                            ],
+                          },
+                          {
+                            $lte: [
+                              "$pm2_5.value",
+                              "$aqi_ranges.very_unhealthy.max",
+                            ],
+                          },
+                        ],
+                      },
+                      then: "8f3f97",
+                    },
+                    {
+                      case: {
+                        $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"],
+                      },
+                      then: "7e0023",
+                    },
+                  ],
+                  default: "Unknown",
+                },
+              },
+
+              aqi_category: {
+                $switch: {
+                  branches: [
+                    {
+                      case: {
+                        $and: [
+                          { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                          { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                        ],
+                      },
+                      then: "Good",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"],
+                          },
+                          {
+                            $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"],
+                          },
+                        ],
+                      },
+                      then: "Moderate",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                          { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                        ],
+                      },
+                      then: "Unhealthy for Sensitive Groups",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"],
+                          },
+                          {
+                            $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"],
+                          },
+                        ],
+                      },
+                      then: "Unhealthy",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: [
+                              "$pm2_5.value",
+                              "$aqi_ranges.very_unhealthy.min",
+                            ],
+                          },
+                          {
+                            $lte: [
+                              "$pm2_5.value",
+                              "$aqi_ranges.very_unhealthy.max",
+                            ],
+                          },
+                        ],
+                      },
+                      then: "Very Unhealthy",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"],
+                          },
+                        ],
+                      },
+                      then: "Hazardous",
+                    },
+                  ],
+                  default: "Unknown",
+                },
+              },
+              aqi_color_name: {
+                $switch: {
+                  branches: [
+                    {
+                      case: {
+                        $and: [
+                          { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                          { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                        ],
+                      },
+                      then: "Green",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"],
+                          },
+                          {
+                            $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"],
+                          },
+                        ],
+                      },
+                      then: "Yellow",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                          { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                        ],
+                      },
+                      then: "Orange",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"],
+                          },
+                          {
+                            $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"],
+                          },
+                        ],
+                      },
+                      then: "Red",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: [
+                              "$pm2_5.value",
+                              "$aqi_ranges.very_unhealthy.min",
+                            ],
+                          },
+                          {
+                            $lte: [
+                              "$pm2_5.value",
+                              "$aqi_ranges.very_unhealthy.max",
+                            ],
+                          },
+                        ],
+                      },
+                      then: "Purple",
+                    },
+                    {
+                      case: {
+                        $and: [
+                          {
+                            $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"],
+                          },
+                        ],
+                      },
+                      then: "Maroon",
+                    },
+                  ],
+                  default: "Unknown",
+                },
+              },
+              aqi_ranges: "$aqi_ranges",
+            },
+          },
+        ],
       })
       .project({
         meta,
@@ -1567,7 +1560,223 @@ async function signalData(model, filter) {
     })
     .facet({
       total: [{ $count: "device" }],
-      data: [generateAqiAddFields()],
+      data: [
+        {
+          $addFields: {
+            device: "$device",
+            aqi_color: {
+              $switch: {
+                branches: [
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                      ],
+                    },
+                    then: "00e400",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"] },
+                      ],
+                    },
+                    then: "ffff00",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                      ],
+                    },
+                    then: "ff7e00",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"] },
+                      ],
+                    },
+                    then: "ff0000",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        {
+                          $gte: [
+                            "$pm2_5.value",
+                            "$aqi_ranges.very_unhealthy.min",
+                          ],
+                        },
+                        {
+                          $lte: [
+                            "$pm2_5.value",
+                            "$aqi_ranges.very_unhealthy.max",
+                          ],
+                        },
+                      ],
+                    },
+                    then: "8f3f97",
+                  },
+                  {
+                    case: {
+                      $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"],
+                    },
+                    then: "7e0023",
+                  },
+                ],
+                default: "Unknown",
+              },
+            },
+
+            aqi_category: {
+              $switch: {
+                branches: [
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                      ],
+                    },
+                    then: "Good",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"] },
+                      ],
+                    },
+                    then: "Moderate",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                      ],
+                    },
+                    then: "Unhealthy for Sensitive Groups",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"] },
+                      ],
+                    },
+                    then: "Unhealthy",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        {
+                          $gte: [
+                            "$pm2_5.value",
+                            "$aqi_ranges.very_unhealthy.min",
+                          ],
+                        },
+                        {
+                          $lte: [
+                            "$pm2_5.value",
+                            "$aqi_ranges.very_unhealthy.max",
+                          ],
+                        },
+                      ],
+                    },
+                    then: "Very Unhealthy",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"] },
+                      ],
+                    },
+                    then: "Hazardous",
+                  },
+                ],
+                default: "Unknown",
+              },
+            },
+            aqi_color_name: {
+              $switch: {
+                branches: [
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                      ],
+                    },
+                    then: "Green",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"] },
+                      ],
+                    },
+                    then: "Yellow",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                      ],
+                    },
+                    then: "Orange",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"] },
+                        { $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"] },
+                      ],
+                    },
+                    then: "Red",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        {
+                          $gte: [
+                            "$pm2_5.value",
+                            "$aqi_ranges.very_unhealthy.min",
+                          ],
+                        },
+                        {
+                          $lte: [
+                            "$pm2_5.value",
+                            "$aqi_ranges.very_unhealthy.max",
+                          ],
+                        },
+                      ],
+                    },
+                    then: "Purple",
+                  },
+                  {
+                    case: {
+                      $and: [
+                        { $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"] },
+                      ],
+                    },
+                    then: "Maroon",
+                  },
+                ],
+                default: "Unknown",
+              },
+            },
+            aqi_ranges: "$aqi_ranges",
+          },
+        },
+      ],
     })
     .project({
       meta,
@@ -2032,7 +2241,292 @@ eventSchema.statics.list = async function(
         })
         .facet({
           total: [{ $count: "device" }],
-          data: [generateAqiAddFields()],
+          data: [
+            {
+              $addFields: {
+                device: "$device",
+                aqi_color: {
+                  $switch: {
+                    branches: [
+                      {
+                        case: {
+                          $and: [
+                            { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                            { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                          ],
+                        },
+                        then: "00e400",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.moderate.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.moderate.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "ffff00",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                            { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                          ],
+                        },
+                        then: "ff7e00",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.unhealthy.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.unhealthy.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "ff0000",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.very_unhealthy.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.very_unhealthy.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "8f3f97",
+                      },
+                      {
+                        case: {
+                          $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"],
+                        },
+                        then: "7e0023",
+                      },
+                    ],
+                    default: "Unknown",
+                  },
+                },
+                aqi_category: {
+                  $switch: {
+                    branches: [
+                      {
+                        case: {
+                          $and: [
+                            { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                            { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                          ],
+                        },
+                        then: "Good",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.moderate.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.moderate.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "Moderate",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                            { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                          ],
+                        },
+                        then: "Unhealthy for Sensitive Groups",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.unhealthy.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.unhealthy.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "Unhealthy",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.very_unhealthy.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.very_unhealthy.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "Very Unhealthy",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.hazardous.min",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "Hazardous",
+                      },
+                    ],
+                    default: "Unknown",
+                  },
+                },
+                aqi_color_name: {
+                  $switch: {
+                    branches: [
+                      {
+                        case: {
+                          $and: [
+                            { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
+                            { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
+                          ],
+                        },
+                        then: "Green",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.moderate.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.moderate.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "Yellow",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
+                            { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
+                          ],
+                        },
+                        then: "Orange",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.unhealthy.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.unhealthy.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "Red",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.very_unhealthy.min",
+                              ],
+                            },
+                            {
+                              $lte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.very_unhealthy.max",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "Purple",
+                      },
+                      {
+                        case: {
+                          $and: [
+                            {
+                              $gte: [
+                                "$pm2_5.value",
+                                "$aqi_ranges.hazardous.min",
+                              ],
+                            },
+                          ],
+                        },
+                        then: "Maroon",
+                      },
+                    ],
+                    default: "Unknown",
+                  },
+                },
+                aqi_ranges: "$aqi_ranges",
+              },
+            },
+          ],
         })
         .project({
           meta,

--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -156,7 +156,7 @@ const getAqiColorExpression = () => ({
   },
 });
 
-// MongoDB switch case expression for AQI category
+// Switch case expression for AQI category
 const getAqiCategoryExpression = () => ({
   $switch: {
     branches: [
@@ -214,7 +214,7 @@ const getAqiCategoryExpression = () => ({
   },
 });
 
-// MongoDB switch case expression for AQI color name
+// Switch case expression for AQI color name
 const getAqiColorNameExpression = () => ({
   $switch: {
     branches: [


### PR DESCRIPTION
## Description

This PR centralizes all AQI color, category, and name configurations at the top of the file to facilitate easier future updates and ensure consistency across the codebase.

## Changes Made

- [x]  Added centralized configuration constants for AQI colors, categories, and color names
- [x]  Created helper functions to determine AQI ranges based on PM2.5 values
- [x]  Implemented MongoDB expression generators for AQI fields in aggregation pipelines
- [x]  Created `generateAqiAddFields() `function to standardize AQI field addition
- [x]  Refactored existing aggregate pipelines to use centralized configuration
- [x]  Maintained all existing functionality while improving code maintainability

## Testing

- [x] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [x] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [x] Get Events

## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [x] No, API documentation does not need updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved consistency and maintainability of Air Quality Index (AQI) color, category, and label assignments in device data.
  - Centralized AQI-related logic, ensuring uniform AQI information across all relevant device data views.

- **New Features**
  - Device data now includes clearly labeled AQI color, category, and color name fields for easier interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->