### PR TITLE
Refactor Event Utils to Use Centralized Measurement Registry

### DIFF
--- a/src/device-registry/config/global/mappings-v1.js
+++ b/src/device-registry/config/global/mappings-v1.js
@@ -1,0 +1,599 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Types.ObjectId;
+const log4js = require("log4js");
+const isEmpty = require("is-empty");
+const { logObject, logText } = require("@utils/shared");
+const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
+const envs = require("./envs");
+
+function generateDateFormatWithoutHrs(ISODate) {
+  try {
+    let date = new Date(ISODate);
+    let year = date.getFullYear();
+    let month = date.getMonth() + 1;
+    let day = date.getUTCDate();
+
+    if (day < 10) {
+      day = "0" + day;
+    }
+    if (month < 10) {
+      month = "0" + month;
+    }
+    return `${year}-${month}-${day}`;
+  } catch (e) {
+    logger.error(`internal server error -- ${e.message}`);
+  }
+}
+
+const mappings = {
+  AQI_INDEX: {
+    good: { min: 0, max: 9.1 },
+    moderate: { min: 9.101, max: 35.49 },
+    u4sg: { min: 35.491, max: 55.49 },
+    unhealthy: { min: 55.491, max: 125.49 },
+    very_unhealthy: { min: 125.491, max: 225.49 },
+    hazardous: { min: 225.491, max: null },
+  },
+  PREDEFINED_FILTER_VALUES: {
+    NETWORKS: ["metone", "usembassy"],
+    COMBINATIONS: {
+      NETWORK_PAIRS: [
+        ["metone", "usembassy", "us_embassy", "us-embassy"],
+        ["kcca", "clarity"],
+        ["urbanbetter", "airbeam", "urban_better"],
+      ],
+      GROUP_PAIRS: [
+        ["us-embassy", "usembassy", "us_embassy"],
+        ["kcca", "kampala"],
+        ["urbanbetter", "urban_better", "urban-better"],
+      ],
+      STATUS_PAIRS: [
+        ["active", "enabled", "running"],
+        ["inactive", "disabled"],
+        ["inactive", "disabled", "stopped", "halted"],
+        ["pending", "processing"][("pending", "processing", "initializing")],
+      ],
+      LOCATION_ALIASES: [
+        ["kampala", "kla", "kamp"],
+        ["entebbe", "ebb", "entb"],
+        ["jinja", "jja"],
+      ],
+    },
+  },
+  GET_ROAD_METADATA_PATHS: {
+    altitude: "altitude",
+    greenness: "greenness",
+    aspect: "aspect",
+    landform_270: "landform-270",
+    landform_90: "landform-90",
+    bearing_to_kampala_center: "bearing",
+    distance_to_kampala_center: "distance/kampala",
+    bearing_to_capital_city_center: "bearing",
+    distance_to_capital_city_center: "distance/capital",
+    distance_to_nearest_road: "distance/road",
+    distance_to_nearest_residential_road: "distance/residential/road",
+    distance_to_nearest_tertiary_road: "distance/tertiary/road",
+    distance_to_nearest_primary_road: "distance/primary/road",
+    distance_to_nearest_secondary_road: "distance/secondary/road",
+    distance_to_nearest_unclassified_road: "distance/unclassified/road",
+    weather_stations: "nearest-weather-stations",
+  },
+  BAM_THINGSPEAK_FIELD_DESCRIPTIONS: {
+    field1: "Date and time ",
+    field2: "ConcRt(ug/m3)",
+    field3: "ConcHR(ug/m3)",
+    field4: "ConcS(ug/m3)",
+    field5: "Flow(LPM)",
+    field6: "DeviceStatus",
+    field7: "Logger Battery",
+    field8: "CompleteBAM dataset Comma Separated Data",
+    created_at: "created_at",
+  },
+  THINGSPEAK_FIELD_DESCRIPTIONS: {
+    field1: "Sensor1 PM2.5_CF_1_ug/m3",
+    field2: "Sensor1 PM10_CF_1_ug/m3",
+    field3: "Sensor2 PM2.5_CF_1_ug/m3",
+    field4: "Sensor2 PM10_CF_1_ug/m3",
+    field5: "Latitude",
+    field6: "Longitude",
+    field7: "Battery Voltage",
+    field8: "ExtraData",
+  },
+  THINGSPEAK_GAS_FIELD_DESCRIPTIONS: {
+    field1: "PM2.5",
+    field2: "TVOC",
+    field3: "HCHO",
+    field4: "CO2",
+    field5: "Intake Temperature",
+    field6: "Intake Humidity",
+    field7: "Battery Voltage",
+    field8: "ExtraData",
+  },
+  DEVICE_THINGSPEAK_MAPPINGS: {
+    item: {
+      name: "long_name",
+      description: "description",
+      elevation: "elevation",
+      tags: "tags",
+      latitude: "latitude",
+      longitude: "longitude",
+      public_flag: "visibility",
+    },
+    remove: [],
+    defaults: {
+      missingData: true,
+    },
+    operate: [
+      {
+        run: "Date.parse",
+        on: "",
+      },
+    ],
+    each: function(item, index, collection, context) {
+      item.field1 = context.field1;
+      item.field2 = context.field2;
+      item.field3 = context.field3;
+      item.field4 = context.field4;
+      item.field5 = context.field5;
+      item.field6 = context.field6;
+      item.field7 = context.field7;
+      item.field8 = context.field8;
+      return item;
+    },
+  },
+  DEVICE_MAPPINGS: {},
+  SITE_MAPPINGS: {},
+  PHOTO_MAPPINGS: {},
+  DATA_PROVIDER_MAPPINGS: (network) => {
+    switch (network) {
+      case "airqo":
+        return "AirQo";
+        break;
+      case "usembassy":
+        return "US Embassy";
+        break;
+      default:
+        return "AirQo";
+    }
+  },
+  EVENT_MAPPINGS: {
+    item: {
+      time: "timestamp",
+      day: "timestamp",
+      frequency: "frequency",
+      device: "device_name",
+      device_number: "device_number",
+      site: "site",
+      site_id: "site_id",
+      device_id: "device_id",
+      tenant: "tenant",
+      network: "network",
+      is_test_data: "is_test_data",
+      is_device_primary: "is_device_primary",
+
+      "pm2_5.value": "pm2_5_raw_value",
+      "pm2_5.calibratedValue": "pm2_5_calibrated_value",
+      "pm2_5.uncertaintyValue": "pm2_5_uncertainty_value",
+      "pm2_5.standardDeviationValue": "pm2_5_standard_deviation_value",
+
+      "average_pm2_5.value": "pm2_5_raw_value",
+      "average_pm2_5.calibratedValue": "pm2_5_calibrated_value",
+      "average_pm2_5.uncertaintyValue": "pm2_5_uncertainty_value",
+      "average_pm2_5.standardDeviationValue": "pm2_5_standard_deviation_value",
+
+      "average_pm10.value": "pm10_raw_value",
+      "average_pm10.calibratedValue": "pm10_calibrated_value",
+      "average_pm10.uncertaintyValue": "pm10_uncertainty_value",
+      "average_pm10.standardDeviationValue": "pm10_standard_deviation_value",
+
+      "s1_pm2_5.value": "s1_pm2_5",
+      "s1_pm2_5.calibratedValue": "s1_pm2_5_calibrated_value",
+      "s1_pm2_5.uncertaintyValue": "s1_pm2_5_uncertainty_value",
+      "s1_pm2_5.standardDeviationValue": "s1_pm2_5_standard_deviation_value",
+
+      "s2_pm2_5.value": "s2_pm2_5",
+      "s2_pm2_5.calibratedValue": "s2_pm2_5_calibrated_value",
+      "s2_pm2_5.uncertaintyValue": "s2_pm2_5_uncertainty_value",
+      "s2_pm2_5.standardDeviationValue": "s2_pm2_5_standard_deviation_value",
+
+      "pm10.value": "pm10_raw_value",
+      "pm10.calibratedValue": "pm10_calibrated_value",
+      "pm10.uncertaintyValue": "pm10_uncertainty_value",
+      "pm10.standardDeviationValue": "pm10_standard_deviation_value",
+
+      "s1_pm10.value": "s1_pm10",
+      "s1_pm10.calibrated_value": "s1_pm10_calibrated_value",
+      "s1_pm10.uncertainty_value": "s1_pm10_uncertainty_value",
+      "s1_pm10.standard_deviation_value": "s1_pm10_standard_deviation_value",
+
+      "s2_pm10.value": "s2_pm10",
+      "s2_pm10.calibratedValue": "s2_pm10_calibrated_value",
+      "s2_pm10.uncertaintyValue": "s2_pm10_uncertainty_value",
+      "s2_pm10.standardDeviationValue": "s2_pm10_standard_deviation_value",
+
+      "pm1.value": "pm1_raw_value",
+      "pm1.calibratedValue": "pm1_calibrated_value",
+      "pm1.uncertaintyValue": "pm1_uncertainty_value",
+      "pm1.standardDeviationValue": "pm1_standard_deviation_value",
+
+      "s1_pm1.value": "s1_pm1",
+      "s1_pm1.calibratedValue": "s1_pm1_calibrated_value",
+      "s1_pm1.uncertaintyValue": "s1_pm1_uncertainty_value",
+      "s1_pm1.standardDeviationValue": "s1_pm1_standard_deviation_value",
+
+      "s2_pm1.value": "s2_pm1",
+      "s2_pm1.calibratedValue": "s2_pm1_calibrated_value",
+      "s2_pm1.uncertaintyValue": "s2_pm1_uncertainty_value",
+      "s2_pm1.standardDeviationValue": "s2_pm1_standard_deviation_value",
+
+      "latitude.value": "latitude",
+      "longitude.value": "longitude",
+
+      "no2.value": "no2_raw_value",
+      "no2.calibratedValue": "no2_calibrated_value",
+      "no2.uncertaintyValue": "no2_uncertainty_value",
+      "no2.standardDeviationValue": "no2_standard_deviation_value",
+
+      "pm1.value": "pm1_raw_value",
+      "pm1.calibratedValue": "pm1_calibrated_value",
+      "pm1.uncertaintyValue": "pm1_uncertainty_value",
+      "pm1.standardDeviationValue": "pm1_standard_deviation_value",
+
+      "s1_pm1.value": "s1_pm1",
+      "s1_pm1.calibratedValue": "s1_pm1_calibrated_value",
+      "s1_pm1.uncertaintyValue": "s1_pm1_uncertainty_value",
+      "s1_pm1.standardDeviationValue": "s1_pm1_standard_deviation_value",
+
+      "rtc_adc.value": "rtc_adc",
+      "rtc_adc.calibratedValue": "rtc_adc_calibrated_value",
+      "rtc_adc.uncertaintyValue": "rtc_adc_uncertainty_value",
+      "rtc_adc.standardDeviationValue": "rtc_adc_standard_deviation_value",
+
+      "rtc_v.value": "rtc_v",
+      "rtc_v.calibratedValue": "rtc_v_calibrated_value",
+      "rtc_v.uncertaintyValue": "rtc_v_uncertainty_value",
+      "rtc_v.standardDeviationValue": "rtc_v_standard_deviation_value",
+
+      "rtc.value": "rtc",
+      "rtc.calibratedValue": "rtc_calibrated_value",
+      "rtc.uncertaintyValue": "rtc_uncertainty_value",
+      "rtc.standardDeviationValue": "rtc_standard_deviation_value",
+
+      "stc_adc.value": "stc_adc",
+      "stc_adc.calibratedValue": "stc_adc_calibrated_value",
+      "stc_adc.uncertaintyValue": "stc_adc_uncertainty_value",
+      "stc_adc.standardDeviationValue": "stc_adc_standard_deviation_value",
+
+      "stc_v.value": "stc_v",
+      "stc_v.calibratedValue": "stc_v_calibrated_value",
+      "stc_v.uncertaintyValue": "stc_v_uncertainty_value",
+      "stc_v.standardDeviationValue": "stc_v_standard_deviation_value",
+
+      "stc.value": "stc",
+      "stc.calibratedValue": "stc_calibrated_value",
+      "stc.uncertaintyValue": "stc_uncertainty_value",
+      "stc.standardDeviationValue": "stc_standard_deviation_value",
+
+      "s2_pm1.value": "s2_pm1",
+      "s2_pm1.calibratedValue": "s2_pm1_calibrated_value",
+      "s2_pm1.uncertaintyValue": "s2_pm1_uncertainty_value",
+      "s2_pm1.standardDeviationValue": "s2_pm1_standard_deviation_value",
+
+      "internalTemperature.value": "device_temperature",
+      "externalTemperature.value": "temperature",
+
+      "internalHumidity.value": "device_humidity",
+      "externalHumidity.value": "humidity",
+
+      "externalPressure.value": "external_pressure",
+      "internalPressure.value": "internal_pressure",
+
+      "speed.value": "wind_speed",
+      "altitude.value": "altitude",
+      "battery.value": "battery",
+      "satellites.value": "satellites",
+      "hdop.value": "hdop",
+
+      "tvoc.value": "tvoc",
+      "hcho.value": "hcho",
+      "co2.value": "co2",
+      "intaketemperature.value": "intaketemperature",
+      "intakehumidity.value": "intakehumidity",
+    },
+    remove: [],
+    defaults: {
+      time: null,
+      tenant: "airqo",
+      network: "airqo",
+      device: null,
+      device_id: null,
+      site_id: null,
+      day: null,
+      frequency: "hourly",
+      site: null,
+      device_number: null,
+      is_test_data: null,
+      is_device_primary: null,
+
+      "pm10.value": null,
+      "pm10.calibratedValue": null,
+      "pm10.uncertaintyValue": null,
+      "pm10.standardDeviationValue": null,
+
+      "average_pm2_5.value": null,
+      "average_pm2_5.calibratedValue": null,
+      "average_pm2_5.uncertaintyValue": null,
+      "average_pm2_5.standardDeviationValue": null,
+
+      "average_pm10.value": null,
+      "average_pm10.calibratedValue": null,
+      "average_pm10.uncertaintyValue": null,
+      "average_pm10.standardDeviationValue": null,
+
+      "s1_pm10.value": null,
+      "s1_pm10.calibratedValue": null,
+      "s1_pm10.uncertaintyValue": null,
+      "s1_pm10.standardDeviationValue": null,
+
+      "s2_pm10.value": null,
+      "s2_pm10.calibratedValue": null,
+      "s2_pm10.uncertaintyValue": null,
+      "s2_pm10.standardDeviationValue": null,
+
+      "pm2_5.value": null,
+      "pm2_5.calibratedValue": null,
+      "pm2_5.uncertaintyValue": null,
+      "pm2_5.standardDeviationValue": null,
+
+      "s1_pm2_5.value": null,
+      "s1_pm2_5.calibratedValue": null,
+      "s1_pm2_5.uncertaintyValue": null,
+      "s1_pm2_5.standardDeviationValue": null,
+
+      "s2_pm2_5.value": null,
+      "s2_pm2_5.calibratedValue": null,
+      "s2_pm2_5.uncertaintyValue": null,
+      "s2_pm2_5.standardDeviationValue": null,
+
+      "latitude.value": null,
+      "longitude.value": null,
+
+      "no2.value": null,
+      "no2.calibratedValue": null,
+      "no2.uncertaintyValue": null,
+      "no2.standardDeviationValue": null,
+
+      "pm1.value": null,
+      "pm1.calibratedValue": null,
+      "pm1.uncertaintyValue": null,
+      "pm1.standardDeviationValue": null,
+
+      "s1_pm1.value": null,
+      "s1_pm1.calibratedValue": null,
+      "s1_pm1.uncertaintyValue": null,
+      "s1_pm1.standardDeviationValue": null,
+
+      "s2_pm1.value": null,
+      "s2_pm1.calibratedValue": null,
+      "s2_pm1.uncertaintyValue": null,
+      "s2_pm1.standardDeviationValue": null,
+
+      "internalTemperature.value": null,
+      "externalTemperature.value": null,
+
+      "internalHumidity.value": null,
+      "externalHumidity.value": null,
+
+      "externalPressure.value": null,
+      "internalPressure.value": null,
+
+      "rtc_adc.value": null,
+      "rtc_adc.calibratedValue": null,
+      "rtc_adc.uncertaintyValue": null,
+      "rtc_adc.standardDeviationValue": null,
+
+      "rtc_v.value": null,
+      "rtc_v.calibratedValue": null,
+      "rtc_v.uncertaintyValue": null,
+      "rtc_v.standardDeviationValue": null,
+
+      "rtc.value": null,
+      "rtc.calibratedValue": null,
+      "rtc.uncertaintyValue": null,
+      "rtc.standardDeviationValue": null,
+
+      "stc_adc.value": null,
+      "stc_adc.calibratedValue": null,
+      "stc_adc.uncertaintyValue": null,
+      "stc_adc.standardDeviationValue": null,
+
+      "stc_v.value": null,
+      "stc_v.calibratedValue": null,
+      "stc_v.uncertaintyValue": null,
+      "stc_v.standardDeviationValue": null,
+
+      "stc.value": null,
+      "stc.calibratedValue": null,
+      "stc.uncertaintyValue": null,
+      "stc.standardDeviationValue": null,
+
+      "speed.value": null,
+      "altitude.value": null,
+      "battery.value": null,
+      "satellites.value": null,
+      "hdop.value": null,
+
+      "tvoc.value": null,
+      "hcho.value": null,
+      "co2.value": null,
+      "intaketemperature.value": null,
+      "intakehumidity.value": null,
+    },
+    operate: [
+      /**
+       * do some sanitisation from here for:
+       * Site ID
+       * device ID
+       * device_number
+       * and other numbers, all from here
+       */
+      {
+        run: function(time) {
+          const day = generateDateFormatWithoutHrs(time);
+          return day;
+        },
+        on: "day",
+      },
+      {
+        run: function(time) {
+          const cleanedTime = new Date(time);
+          return cleanedTime;
+        },
+        on: "time",
+      },
+
+      {
+        run: function(device_number) {
+          if (!isEmpty(device_number)) {
+            return parseInt(device_number);
+          }
+          return device_number;
+        },
+        on: "device_number",
+      },
+    ],
+    each: function(item, index, collection, context) {
+      item.filter = {};
+      item.update = {};
+      item.options = {};
+      item["filter"]["device"] = item.device;
+      item["filter"]["device_id"] = item.device_id;
+      item["filter"]["site_id"] = item.site_id;
+      item["filter"]["nValues"] = { $lt: parseInt(envs.N_VALUES || 500) };
+      item["filter"]["day"] = item.day;
+      item["filter"]["$or"] = [
+        { "values.time": { $ne: item.time } },
+        { "values.device": { $ne: item.device } },
+        {
+          "values.frequency": {
+            $ne: item.frequency,
+          },
+        },
+        {
+          "values.device_id": {
+            $ne: item.device_id,
+          },
+        },
+        { "values.site_id": { $ne: item.site_id } },
+        {
+          day: {
+            $ne: item.day,
+          },
+        },
+      ];
+      item["update"]["$min"] = {
+        first: item.time,
+      };
+      item["update"]["$max"] = {
+        last: item.time,
+      };
+      item["update"]["$inc"] = { nValues: 1 };
+      item["options"]["upsert"] = true;
+      return item;
+    },
+  },
+  BAM_FIELDS_AND_DESCRIPTIONS: {
+    field1: "Date and time",
+    field2: "ConcRt(ug/m3)",
+    field3: "ConcHR(ug/m3)",
+    field4: "ConcS(ug/m3)",
+    field5: "Flow(LPM)",
+    field6: "DeviceStatus",
+    field7: "Logger Battery",
+    field8: "CompleteBAM dataset Comma Separated Data",
+    created_at: "created_at",
+  },
+
+  BAM_FIELDS_AND_LABELS: {
+    field1: "date",
+    field2: "real_time_concetration",
+    field3: "hourly_concetration",
+    field4: "short_time_concetration",
+    field5: "litres_per_minute",
+    field6: "device_status",
+    field7: "battery_voltage",
+    field8: "other_data",
+    created_at: "created_at",
+  },
+
+  BAM_POSITIONS_AND_LABELS: {
+    0: "timestamp",
+    1: "real_time_concentration",
+    2: "hourly_concetration",
+    3: "short_time_concetration",
+    4: "air_flow",
+    5: "wind_speed",
+    6: "wind_direction",
+    7: "temperature",
+    8: "humidity",
+    9: "barometric_pressure",
+    10: "filter_temperature",
+    11: "filter_humidity",
+    12: "status",
+  },
+
+  FIELDS_AND_LABELS: {
+    field1: "pm2_5",
+    field2: "pm10",
+    field3: "s2_pm2_5",
+    field4: "s2_pm10",
+    field5: "latitude",
+    field6: "longitude",
+    field7: "battery",
+    field8: "other_data",
+    created_at: "created_at",
+  },
+
+  POSITIONS_AND_LABELS: {
+    0: "latitude",
+    1: "longitude",
+    2: "altitude",
+    3: "speed",
+    4: "satellites",
+    5: "hdop",
+    6: "internalTemperature",
+    7: "internalHumidity",
+    8: "externalTemperature",
+    9: "ExternalHumidity",
+    10: "ExternalPressure",
+    11: "ExternalAltitude",
+    12: "DeviceType",
+  },
+  THINGSPEAK_GAS_FIELD_DESCRIPTIONS: {
+    field1: "pm2_5",
+    field2: "TVOC",
+    field3: "HCHO",
+    field4: "CO2",
+    field5: "IntakeTemperature",
+    field6: "IntakeHumidity",
+    field7: "BatteryVoltage",
+    field8: "other_data",
+    created_at: "created_at",
+  },
+  GAS_POSITIONS_AND_LABELS: {
+    0: "latitude",
+    1: "longitude",
+    2: "altitude",
+    3: "speed",
+    4: "satellites",
+    5: "hdop",
+    6: "internalTemperature",
+    7: "internalHumidity",
+    8: "externalTemperature",
+    9: "ExternalHumidity",
+    10: "ExternalPressure",
+    11: "ExternalAltitude",
+    12: "DeviceType",
+  },
+};
+module.exports = mappings;

--- a/src/device-registry/config/global/mappings.js
+++ b/src/device-registry/config/global/mappings.js
@@ -6,6 +6,14 @@ const { logObject, logText } = require("@utils/shared");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 const envs = require("./envs");
 
+// Import the measurement registry
+const {
+  MEASUREMENT_REGISTRY,
+  generateEventMappings,
+  generateEventDefaults,
+  getThingSpeakFieldMappings,
+} = require("@utils/measurement-registry");
+
 function generateDateFormatWithoutHrs(ISODate) {
   try {
     let date = new Date(ISODate);
@@ -24,6 +32,43 @@ function generateDateFormatWithoutHrs(ISODate) {
     logger.error(`internal server error -- ${e.message}`);
   }
 }
+
+// Use the registry functions for field mappings
+const FIELDS_AND_LABELS = getThingSpeakFieldMappings("standard");
+const BAM_FIELDS_AND_LABELS = getThingSpeakFieldMappings("bam");
+const THINGSPEAK_GAS_FIELD_DESCRIPTIONS = getThingSpeakFieldMappings("gas");
+
+// Use the measurement registry for EVENT_MAPPINGS
+const EVENT_MAPPINGS = {
+  item: {
+    time: "timestamp",
+    day: "timestamp",
+    frequency: "frequency",
+    device: "device_name",
+    device_number: "device_number",
+    site: "site",
+    site_id: "site_id",
+    device_id: "device_id",
+    tenant: "tenant",
+    network: "network",
+    is_test_data: "is_test_data",
+    is_device_primary: "is_device_primary",
+
+    // Include all mappings from the registry
+    ...generateEventMappings(),
+  },
+  remove: [],
+  defaults: {
+    // Include default values from the registry
+    ...generateEventDefaults(),
+  },
+  operate: [
+    // Same operate functions as before
+  ],
+  each: function(item, index, collection, context) {
+    // Same function as before
+  },
+};
 
 const mappings = {
   AQI_INDEX: {
@@ -99,16 +144,7 @@ const mappings = {
     field7: "Battery Voltage",
     field8: "ExtraData",
   },
-  THINGSPEAK_GAS_FIELD_DESCRIPTIONS: {
-    field1: "PM2.5",
-    field2: "TVOC",
-    field3: "HCHO",
-    field4: "CO2",
-    field5: "Intake Temperature",
-    field6: "Intake Humidity",
-    field7: "Battery Voltage",
-    field8: "ExtraData",
-  },
+  THINGSPEAK_GAS_FIELD_DESCRIPTIONS: getThingSpeakFieldMappings("gas"),
   DEVICE_THINGSPEAK_MAPPINGS: {
     item: {
       name: "long_name",
@@ -156,6 +192,8 @@ const mappings = {
         return "AirQo";
     }
   },
+
+  // Use the measurement registry to generate the mappings
   EVENT_MAPPINGS: {
     item: {
       time: "timestamp",
@@ -171,263 +209,13 @@ const mappings = {
       is_test_data: "is_test_data",
       is_device_primary: "is_device_primary",
 
-      "pm2_5.value": "pm2_5_raw_value",
-      "pm2_5.calibratedValue": "pm2_5_calibrated_value",
-      "pm2_5.uncertaintyValue": "pm2_5_uncertainty_value",
-      "pm2_5.standardDeviationValue": "pm2_5_standard_deviation_value",
-
-      "average_pm2_5.value": "pm2_5_raw_value",
-      "average_pm2_5.calibratedValue": "pm2_5_calibrated_value",
-      "average_pm2_5.uncertaintyValue": "pm2_5_uncertainty_value",
-      "average_pm2_5.standardDeviationValue": "pm2_5_standard_deviation_value",
-
-      "average_pm10.value": "pm10_raw_value",
-      "average_pm10.calibratedValue": "pm10_calibrated_value",
-      "average_pm10.uncertaintyValue": "pm10_uncertainty_value",
-      "average_pm10.standardDeviationValue": "pm10_standard_deviation_value",
-
-      "s1_pm2_5.value": "s1_pm2_5",
-      "s1_pm2_5.calibratedValue": "s1_pm2_5_calibrated_value",
-      "s1_pm2_5.uncertaintyValue": "s1_pm2_5_uncertainty_value",
-      "s1_pm2_5.standardDeviationValue": "s1_pm2_5_standard_deviation_value",
-
-      "s2_pm2_5.value": "s2_pm2_5",
-      "s2_pm2_5.calibratedValue": "s2_pm2_5_calibrated_value",
-      "s2_pm2_5.uncertaintyValue": "s2_pm2_5_uncertainty_value",
-      "s2_pm2_5.standardDeviationValue": "s2_pm2_5_standard_deviation_value",
-
-      "pm10.value": "pm10_raw_value",
-      "pm10.calibratedValue": "pm10_calibrated_value",
-      "pm10.uncertaintyValue": "pm10_uncertainty_value",
-      "pm10.standardDeviationValue": "pm10_standard_deviation_value",
-
-      "s1_pm10.value": "s1_pm10",
-      "s1_pm10.calibrated_value": "s1_pm10_calibrated_value",
-      "s1_pm10.uncertainty_value": "s1_pm10_uncertainty_value",
-      "s1_pm10.standard_deviation_value": "s1_pm10_standard_deviation_value",
-
-      "s2_pm10.value": "s2_pm10",
-      "s2_pm10.calibratedValue": "s2_pm10_calibrated_value",
-      "s2_pm10.uncertaintyValue": "s2_pm10_uncertainty_value",
-      "s2_pm10.standardDeviationValue": "s2_pm10_standard_deviation_value",
-
-      "pm1.value": "pm1_raw_value",
-      "pm1.calibratedValue": "pm1_calibrated_value",
-      "pm1.uncertaintyValue": "pm1_uncertainty_value",
-      "pm1.standardDeviationValue": "pm1_standard_deviation_value",
-
-      "s1_pm1.value": "s1_pm1",
-      "s1_pm1.calibratedValue": "s1_pm1_calibrated_value",
-      "s1_pm1.uncertaintyValue": "s1_pm1_uncertainty_value",
-      "s1_pm1.standardDeviationValue": "s1_pm1_standard_deviation_value",
-
-      "s2_pm1.value": "s2_pm1",
-      "s2_pm1.calibratedValue": "s2_pm1_calibrated_value",
-      "s2_pm1.uncertaintyValue": "s2_pm1_uncertainty_value",
-      "s2_pm1.standardDeviationValue": "s2_pm1_standard_deviation_value",
-
-      "latitude.value": "latitude",
-      "longitude.value": "longitude",
-
-      "no2.value": "no2_raw_value",
-      "no2.calibratedValue": "no2_calibrated_value",
-      "no2.uncertaintyValue": "no2_uncertainty_value",
-      "no2.standardDeviationValue": "no2_standard_deviation_value",
-
-      "pm1.value": "pm1_raw_value",
-      "pm1.calibratedValue": "pm1_calibrated_value",
-      "pm1.uncertaintyValue": "pm1_uncertainty_value",
-      "pm1.standardDeviationValue": "pm1_standard_deviation_value",
-
-      "s1_pm1.value": "s1_pm1",
-      "s1_pm1.calibratedValue": "s1_pm1_calibrated_value",
-      "s1_pm1.uncertaintyValue": "s1_pm1_uncertainty_value",
-      "s1_pm1.standardDeviationValue": "s1_pm1_standard_deviation_value",
-
-      "rtc_adc.value": "rtc_adc",
-      "rtc_adc.calibratedValue": "rtc_adc_calibrated_value",
-      "rtc_adc.uncertaintyValue": "rtc_adc_uncertainty_value",
-      "rtc_adc.standardDeviationValue": "rtc_adc_standard_deviation_value",
-
-      "rtc_v.value": "rtc_v",
-      "rtc_v.calibratedValue": "rtc_v_calibrated_value",
-      "rtc_v.uncertaintyValue": "rtc_v_uncertainty_value",
-      "rtc_v.standardDeviationValue": "rtc_v_standard_deviation_value",
-
-      "rtc.value": "rtc",
-      "rtc.calibratedValue": "rtc_calibrated_value",
-      "rtc.uncertaintyValue": "rtc_uncertainty_value",
-      "rtc.standardDeviationValue": "rtc_standard_deviation_value",
-
-      "stc_adc.value": "stc_adc",
-      "stc_adc.calibratedValue": "stc_adc_calibrated_value",
-      "stc_adc.uncertaintyValue": "stc_adc_uncertainty_value",
-      "stc_adc.standardDeviationValue": "stc_adc_standard_deviation_value",
-
-      "stc_v.value": "stc_v",
-      "stc_v.calibratedValue": "stc_v_calibrated_value",
-      "stc_v.uncertaintyValue": "stc_v_uncertainty_value",
-      "stc_v.standardDeviationValue": "stc_v_standard_deviation_value",
-
-      "stc.value": "stc",
-      "stc.calibratedValue": "stc_calibrated_value",
-      "stc.uncertaintyValue": "stc_uncertainty_value",
-      "stc.standardDeviationValue": "stc_standard_deviation_value",
-
-      "s2_pm1.value": "s2_pm1",
-      "s2_pm1.calibratedValue": "s2_pm1_calibrated_value",
-      "s2_pm1.uncertaintyValue": "s2_pm1_uncertainty_value",
-      "s2_pm1.standardDeviationValue": "s2_pm1_standard_deviation_value",
-
-      "internalTemperature.value": "device_temperature",
-      "externalTemperature.value": "temperature",
-
-      "internalHumidity.value": "device_humidity",
-      "externalHumidity.value": "humidity",
-
-      "externalPressure.value": "external_pressure",
-      "internalPressure.value": "internal_pressure",
-
-      "speed.value": "wind_speed",
-      "altitude.value": "altitude",
-      "battery.value": "battery",
-      "satellites.value": "satellites",
-      "hdop.value": "hdop",
-
-      "tvoc.value": "tvoc",
-      "hcho.value": "hcho",
-      "co2.value": "co2",
-      "intaketemperature.value": "intaketemperature",
-      "intakehumidity.value": "intakehumidity",
+      // Include all mappings from the registry
+      ...generateEventMappings(),
     },
     remove: [],
     defaults: {
-      time: null,
-      tenant: "airqo",
-      network: "airqo",
-      device: null,
-      device_id: null,
-      site_id: null,
-      day: null,
-      frequency: "hourly",
-      site: null,
-      device_number: null,
-      is_test_data: null,
-      is_device_primary: null,
-
-      "pm10.value": null,
-      "pm10.calibratedValue": null,
-      "pm10.uncertaintyValue": null,
-      "pm10.standardDeviationValue": null,
-
-      "average_pm2_5.value": null,
-      "average_pm2_5.calibratedValue": null,
-      "average_pm2_5.uncertaintyValue": null,
-      "average_pm2_5.standardDeviationValue": null,
-
-      "average_pm10.value": null,
-      "average_pm10.calibratedValue": null,
-      "average_pm10.uncertaintyValue": null,
-      "average_pm10.standardDeviationValue": null,
-
-      "s1_pm10.value": null,
-      "s1_pm10.calibratedValue": null,
-      "s1_pm10.uncertaintyValue": null,
-      "s1_pm10.standardDeviationValue": null,
-
-      "s2_pm10.value": null,
-      "s2_pm10.calibratedValue": null,
-      "s2_pm10.uncertaintyValue": null,
-      "s2_pm10.standardDeviationValue": null,
-
-      "pm2_5.value": null,
-      "pm2_5.calibratedValue": null,
-      "pm2_5.uncertaintyValue": null,
-      "pm2_5.standardDeviationValue": null,
-
-      "s1_pm2_5.value": null,
-      "s1_pm2_5.calibratedValue": null,
-      "s1_pm2_5.uncertaintyValue": null,
-      "s1_pm2_5.standardDeviationValue": null,
-
-      "s2_pm2_5.value": null,
-      "s2_pm2_5.calibratedValue": null,
-      "s2_pm2_5.uncertaintyValue": null,
-      "s2_pm2_5.standardDeviationValue": null,
-
-      "latitude.value": null,
-      "longitude.value": null,
-
-      "no2.value": null,
-      "no2.calibratedValue": null,
-      "no2.uncertaintyValue": null,
-      "no2.standardDeviationValue": null,
-
-      "pm1.value": null,
-      "pm1.calibratedValue": null,
-      "pm1.uncertaintyValue": null,
-      "pm1.standardDeviationValue": null,
-
-      "s1_pm1.value": null,
-      "s1_pm1.calibratedValue": null,
-      "s1_pm1.uncertaintyValue": null,
-      "s1_pm1.standardDeviationValue": null,
-
-      "s2_pm1.value": null,
-      "s2_pm1.calibratedValue": null,
-      "s2_pm1.uncertaintyValue": null,
-      "s2_pm1.standardDeviationValue": null,
-
-      "internalTemperature.value": null,
-      "externalTemperature.value": null,
-
-      "internalHumidity.value": null,
-      "externalHumidity.value": null,
-
-      "externalPressure.value": null,
-      "internalPressure.value": null,
-
-      "rtc_adc.value": null,
-      "rtc_adc.calibratedValue": null,
-      "rtc_adc.uncertaintyValue": null,
-      "rtc_adc.standardDeviationValue": null,
-
-      "rtc_v.value": null,
-      "rtc_v.calibratedValue": null,
-      "rtc_v.uncertaintyValue": null,
-      "rtc_v.standardDeviationValue": null,
-
-      "rtc.value": null,
-      "rtc.calibratedValue": null,
-      "rtc.uncertaintyValue": null,
-      "rtc.standardDeviationValue": null,
-
-      "stc_adc.value": null,
-      "stc_adc.calibratedValue": null,
-      "stc_adc.uncertaintyValue": null,
-      "stc_adc.standardDeviationValue": null,
-
-      "stc_v.value": null,
-      "stc_v.calibratedValue": null,
-      "stc_v.uncertaintyValue": null,
-      "stc_v.standardDeviationValue": null,
-
-      "stc.value": null,
-      "stc.calibratedValue": null,
-      "stc.uncertaintyValue": null,
-      "stc.standardDeviationValue": null,
-
-      "speed.value": null,
-      "altitude.value": null,
-      "battery.value": null,
-      "satellites.value": null,
-      "hdop.value": null,
-
-      "tvoc.value": null,
-      "hcho.value": null,
-      "co2.value": null,
-      "intaketemperature.value": null,
-      "intakehumidity.value": null,
+      // Include default values from the registry
+      ...generateEventDefaults(),
     },
     operate: [
       /**
@@ -513,19 +301,7 @@ const mappings = {
     field8: "CompleteBAM dataset Comma Separated Data",
     created_at: "created_at",
   },
-
-  BAM_FIELDS_AND_LABELS: {
-    field1: "date",
-    field2: "real_time_concetration",
-    field3: "hourly_concetration",
-    field4: "short_time_concetration",
-    field5: "litres_per_minute",
-    field6: "device_status",
-    field7: "battery_voltage",
-    field8: "other_data",
-    created_at: "created_at",
-  },
-
+  BAM_FIELDS_AND_LABELS: getThingSpeakFieldMappings("bam"),
   BAM_POSITIONS_AND_LABELS: {
     0: "timestamp",
     1: "real_time_concentration",
@@ -541,19 +317,7 @@ const mappings = {
     11: "filter_humidity",
     12: "status",
   },
-
-  FIELDS_AND_LABELS: {
-    field1: "pm2_5",
-    field2: "pm10",
-    field3: "s2_pm2_5",
-    field4: "s2_pm10",
-    field5: "latitude",
-    field6: "longitude",
-    field7: "battery",
-    field8: "other_data",
-    created_at: "created_at",
-  },
-
+  FIELDS_AND_LABELS: getThingSpeakFieldMappings("standard"),
   POSITIONS_AND_LABELS: {
     0: "latitude",
     1: "longitude",
@@ -569,17 +333,7 @@ const mappings = {
     11: "ExternalAltitude",
     12: "DeviceType",
   },
-  THINGSPEAK_GAS_FIELD_DESCRIPTIONS: {
-    field1: "pm2_5",
-    field2: "TVOC",
-    field3: "HCHO",
-    field4: "CO2",
-    field5: "IntakeTemperature",
-    field6: "IntakeHumidity",
-    field7: "BatteryVoltage",
-    field8: "other_data",
-    created_at: "created_at",
-  },
+  THINGSPEAK_GAS_FIELD_DESCRIPTIONS: getThingSpeakFieldMappings("gas"),
   GAS_POSITIONS_AND_LABELS: {
     0: "latitude",
     1: "longitude",

--- a/src/device-registry/docs/NEW_MEASUREMENT_TYPE_GUIDE.md
+++ b/src/device-registry/docs/NEW_MEASUREMENT_TYPE_GUIDE.md
@@ -1,0 +1,51 @@
+### How to Add a New Measurement Type:
+
+When you need to add a new pollutant or sensor type to the system, you now only need to make changes in one place. Here's an example of how to add a new pollutant called "O3" (ozone):
+
+1. Open `measurement-registry.js`
+2. Add a new entry to the `MEASUREMENT_REGISTRY` object:
+
+```javascript
+o3: {
+  name: "O3",
+  description: "Ozone",
+  schema: {
+    value: { type: Number, default: null },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  mappings: {
+    value: "o3_raw_value",
+    calibratedValue: "o3_calibrated_value",
+    uncertaintyValue: "o3_uncertainty_value",
+    standardDeviationValue: "o3_standard_deviation_value",
+  },
+  isPollutant: true,
+  includeInAggregation: true,
+  unit: "ppb",
+  category: "gas",
+},
+```
+
+That's it! The rest of your code will automatically use this new measurement type because:
+
+1. The schema will be generated automatically from the registry
+2. Mappings for transformations will include the new pollutant
+3. Default values will be handled correctly
+4. All utilities will recognize it as a valid pollutant
+5. It will be included in aggregation pipelines where appropriate
+
+### Additional Benefits:
+
+1. **Improved Readability**: The code is now more self-documenting because the structure of measurements is clearly defined in one place
+2. **Better Maintenance**: When requirements change, you only need to update one file
+3. **Easier Testing**: You can test measurement handling with known registry inputs
+4. **Reduced Errors**: Consistent handling of measurement types across your codebase
+
+### Future Enhancements:
+
+1. **Validation Rules**: Add measurement-specific validation rules to the registry
+2. **Conversion Functions**: Include unit conversion functions in the registry
+3. **Documentation Generation**: Auto-generate API documentation from the registry
+4. **Visualization Preferences**: Add visualization settings for each measurement type

--- a/src/device-registry/models/Event-v2.js
+++ b/src/device-registry/models/Event-v2.js
@@ -15,14 +15,6 @@ const isEmpty = require("is-empty");
 const httpStatus = require("http-status");
 const { getModelByTenant } = require("@config/database");
 
-// Import the measurement registry
-const {
-  generateValueSchema,
-  getMeasurementsByCategory,
-  MEASUREMENT_REGISTRY,
-  getProjectionFields,
-} = require("@utils/measurement-registry");
-
 const logger = require("log4js").getLogger(
   `${constants.ENVIRONMENT} -- event-model`
 );
@@ -179,7 +171,6 @@ function generateAqiAddFields() {
   };
 }
 
-// Generate value schema using the measurement registry
 const valueSchema = new Schema({
   time: {
     type: Date,
@@ -228,8 +219,268 @@ const valueSchema = new Schema({
     type: ObjectId,
   },
   /**** */
-  // Use the measurement registry to generate the schema
-  ...generateValueSchema(),
+  pm1: {
+    value: {
+      type: Number,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  s1_pm1: {
+    value: {
+      type: Number,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  s2_pm1: {
+    value: {
+      type: Number,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  pm2_5: {
+    value: {
+      type: Number,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  s1_pm2_5: {
+    value: {
+      type: Number,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  s2_pm2_5: {
+    value: {
+      type: Number,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  pm10: {
+    value: {
+      type: Number,
+      trim: true,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  s1_pm10: {
+    value: {
+      type: Number,
+      trim: true,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  s2_pm10: {
+    value: {
+      type: Number,
+      trim: true,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  no2: {
+    value: {
+      type: Number,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  battery: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  location: {
+    latitude: {
+      value: {
+        type: Number,
+        default: null,
+      },
+    },
+    longitude: {
+      value: {
+        type: Number,
+        default: null,
+      },
+    },
+  },
+  altitude: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  speed: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  satellites: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  hdop: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  tvoc: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  co2: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  hcho: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  intaketemperature: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  intakehumidity: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  internalTemperature: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  internalHumidity: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  externalTemperature: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  externalHumidity: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  average_pm2_5: {
+    value: {
+      type: Number,
+      trim: true,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  average_pm10: {
+    value: {
+      type: Number,
+      trim: true,
+      default: null,
+    },
+    calibratedValue: { type: Number, default: null },
+    uncertaintyValue: { type: Number, default: null },
+    standardDeviationValue: { type: Number, default: null },
+  },
+  externalPressure: {
+    value: { type: Number, default: null },
+  },
+  externalAltitude: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  rtc_adc: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  rtc_v: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  rtc: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  stc_adc: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  stc_v: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
+  stc: {
+    value: {
+      type: Number,
+      default: null,
+    },
+  },
 });
 
 const eventSchema = new Schema(
@@ -357,9 +608,7 @@ eventSchema.methods = {
     };
   },
 };
-
-// Add this function near the top of your file with the other helper functions
-function elementAtIndexName(metadata, recent) {
+const elementAtIndexName = (metadata, recent) => {
   if (metadata === "site" || metadata === "site_id") {
     if (!recent || recent === "yes") {
       return { $first: { $arrayElemAt: ["$siteDetails", 0] } };
@@ -377,77 +626,7 @@ function elementAtIndexName(metadata, recent) {
       return { $arrayElemAt: ["$deviceDetails", 0] };
     }
   }
-}
-
-// Function to create projection object for external/brief view
-function createSimplifiedProjection(external, brief, running, tenant) {
-  const projection = { _id: 0 };
-
-  // Start with an empty exclusion list
-  const excludeList = [];
-
-  if (external === "yes" || brief === "yes") {
-    // Add calibration and device categories to the exclusion list
-    excludeList.push(...getMeasurementsByCategory("calibration"));
-    excludeList.push(...getMeasurementsByCategory("device"));
-
-    // Add additional specific exclusions
-    excludeList.push(
-      "site_image",
-      "location",
-      "network",
-      "average_pm10",
-      "average_pm2_5",
-      "device_number",
-      "pm2_5.uncertaintyValue",
-      "pm2_5.calibratedValue",
-      "pm2_5.standardDeviationValue",
-      "pm10.uncertaintyValue",
-      "pm10.calibratedValue",
-      "pm10.standardDeviationValue",
-      "no2.uncertaintyValue",
-      "no2.standardDeviationValue",
-      "no2.calibratedValue",
-      "site"
-    );
-  }
-
-  if (running === "yes") {
-    excludeList.push(
-      "pm2_5.uncertaintyValue",
-      "pm2_5.standardDeviationValue",
-      "pm2_5.calibratedValue",
-      "site_image",
-      "is_reading_primary",
-      "deviceDetails",
-      "aqi_color",
-      "aqi_category",
-      "aqi_color_name",
-      "pm2_5",
-      "average_pm10",
-      "average_pm2_5",
-      "pm10",
-      "frequency",
-      "network",
-      "location",
-      "site",
-      "site_id",
-      "health_tips",
-      "siteDetails"
-    );
-
-    // Exclude all measurement categories for running view
-    excludeList.push(...Object.keys(MEASUREMENT_REGISTRY));
-  }
-
-  // Apply exclusions
-  excludeList.forEach((key) => {
-    projection[key] = 0;
-  });
-
-  return projection;
-}
-
+};
 async function fetchData(model, filter) {
   let {
     metadata,
@@ -479,6 +658,7 @@ async function fetchData(model, filter) {
   const startTime = filter["values.time"]["$gte"];
   const endTime = filter["values.time"]["$lte"];
   let idField;
+  // const visibilityFilter = true;
 
   let search = filter;
   let groupId = "$device";
@@ -492,8 +672,9 @@ async function fetchData(model, filter) {
   let s1_pm2_5 = "$pm2_5";
   let s1_pm10 = "$pm10";
   let elementAtIndex0 = elementAtIndexName(metadata, recent);
-  let projection = createSimplifiedProjection(external, brief, running, tenant);
-
+  let projection = {
+    _id: 0,
+  };
   let meta = {
     total: { $arrayElemAt: ["$total.device", 0] },
     skip: { $literal: skip },
@@ -532,6 +713,580 @@ async function fetchData(model, filter) {
   delete search["index"];
   delete search["limit"];
   delete search["skip"];
+
+  /**
+   * The Alternative Flows present in this Events entity:
+   * 1. Based on tenant, which PM values should we showcase?
+   * 2. Which metadata should we show? Sites or Devices? etc....
+   * 3. Should we show recent or historical measurements?
+   */
+  if (tenant !== "airqo") {
+    pm2_5 = "$pm2_5";
+    pm10 = "$pm10";
+  }
+
+  if (external === "yes" || brief === "yes") {
+    projection["s2_pm10"] = 0;
+    projection["s1_pm10"] = 0;
+    projection["s2_pm2_5"] = 0;
+    projection["s1_pm2_5"] = 0;
+    projection["rtc_adc"] = 0;
+    projection["rtc_v"] = 0;
+    projection["rtc"] = 0;
+    projection["stc_adc"] = 0;
+    projection["stc_v"] = 0;
+    projection["stc"] = 0;
+    projection["pm1"] = 0;
+    projection["externalHumidity"] = 0;
+    projection["externalAltitude"] = 0;
+    projection["internalHumidity"] = 0;
+    projection["externalTemperature"] = 0;
+    projection["internalTemperature"] = 0;
+    projection["hdop"] = 0;
+
+    projection["tvoc"] = 0;
+    projection["hcho"] = 0;
+    projection["co2"] = 0;
+    projection["intaketemperature"] = 0;
+    projection["intakehumidity"] = 0;
+
+    projection["satellites"] = 0;
+    projection["speed"] = 0;
+    projection["altitude"] = 0;
+    projection["site_image"] = 0;
+    projection["location"] = 0;
+    projection["network"] = 0;
+    projection["battery"] = 0;
+    projection["average_pm10"] = 0;
+    projection["average_pm2_5"] = 0;
+    projection["device_number"] = 0;
+    projection["pm2_5.uncertaintyValue"] = 0;
+    projection["pm2_5.calibratedValue"] = 0;
+    projection["pm2_5.standardDeviationValue"] = 0;
+    projection["pm10.uncertaintyValue"] = 0;
+    projection["pm10.calibratedValue"] = 0;
+    projection["pm10.standardDeviationValue"] = 0;
+    projection["no2.uncertaintyValue"] = 0;
+    projection["no2.standardDeviationValue"] = 0;
+    projection["no2.calibratedValue"] = 0;
+    projection["site"] = 0;
+    projection[as] = 0;
+  }
+
+  if (!metadata || metadata === "device" || metadata === "device_id") {
+    idField = "$device";
+    groupId = "$" + metadata ? metadata : groupId;
+    localField = metadata ? metadata : localField;
+    if (metadata === "device_id") {
+      foreignField = "_id";
+    }
+    if (metadata === "device" || !metadata) {
+      foreignField = "name";
+    }
+
+    from = "devices";
+    _as = "_deviceDetails";
+    as = "deviceDetails";
+    elementAtIndex0 = elementAtIndexName(metadata, recent);
+    deviceProjection = constants.EVENTS_METADATA_PROJECTION("device", as);
+    Object.assign(projection, deviceProjection);
+  }
+
+  if (metadata === "site_id" || metadata === "site") {
+    idField = "$site_id";
+    groupId = "$" + metadata;
+    localField = metadata;
+    if (metadata === "site") {
+      foreignField = "generated_name";
+    }
+    if (metadata === "site_id") {
+      foreignField = "_id";
+    }
+    from = "sites";
+    _as = "_siteDetails";
+    as = "siteDetails";
+    elementAtIndex0 = elementAtIndexName(metadata, recent);
+
+    if (brief === "yes") {
+      siteProjection = constants.EVENTS_METADATA_PROJECTION("brief_site", as);
+    } else {
+      siteProjection = constants.EVENTS_METADATA_PROJECTION("site", as);
+    }
+    Object.assign(projection, siteProjection);
+  }
+
+  if (running === "yes") {
+    delete projection["pm2_5.uncertaintyValue"];
+    delete projection["pm2_5.standardDeviationValue"];
+    delete projection["pm2_5.calibratedValue"];
+
+    Object.assign(projection, {
+      site_image: 0,
+      is_reading_primary: 0,
+      deviceDetails: 0,
+      aqi_color: 0,
+      aqi_category: 0,
+      aqi_color_name: 0,
+      pm2_5: 0,
+      average_pm10: 0,
+      average_pm2_5: 0,
+      pm10: 0,
+      frequency: 0,
+      network: 0,
+      location: 0,
+      altitude: 0,
+      speed: 0,
+      satellites: 0,
+      hdop: 0,
+      intaketemperature: 0,
+      tvoc: 0,
+      hcho: 0,
+      co2: 0,
+      intakehumidity: 0,
+      internalTemperature: 0,
+      externalTemperature: 0,
+      internalHumidity: 0,
+      externalHumidity: 0,
+      externalAltitude: 0,
+      pm1: 0,
+      no2: 0,
+      site: 0,
+      site_id: 0,
+      health_tips: 0,
+      s1_pm2_5: 0,
+      s2_pm2_5: 0,
+      s1_pm10: 0,
+      s2_pm10: 0,
+      battery: 0,
+      rtc_adc: 0,
+      rtc_v: 0,
+      rtc: 0,
+      stc_adc: 0,
+      stc_v: 0,
+      stc: 0,
+      siteDetails: 0,
+    });
+  }
+
+  if (!isEmpty(index)) {
+    sort = { "pm2_5.value": 1 };
+  }
+
+  logObject("the query for this request", search);
+
+  if (!recent || recent === "yes") {
+    const data = await model
+      .aggregate()
+      .unwind("values")
+      .match(search)
+      .replaceRoot("values")
+      .lookup({
+        from: "photos",
+        localField: "site_id",
+        foreignField: "site_id",
+        as: "site_images",
+      })
+      .lookup({
+        from: "devices",
+        localField: "device_id",
+        foreignField: "_id",
+        as: "device_details",
+      })
+      .lookup({
+        from: "cohorts",
+        localField: "device_details.cohorts",
+        foreignField: "_id",
+        as: "cohort_details",
+      })
+      .match({
+        "cohort_details.visibility": { $ne: false },
+      })
+      // .match({ "device_details.visibility": visibilityFilter })
+      .lookup({
+        from,
+        localField,
+        foreignField,
+        as,
+      })
+      .lookup({
+        from: "healthtips",
+        let: { pollutantValue: { $toInt: "$pm2_5.value" } },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  {
+                    $lte: ["$aqi_category.min", "$$pollutantValue"],
+                  },
+                  {
+                    $gte: ["$aqi_category.max", "$$pollutantValue"],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        as: "healthTips",
+      })
+      .sort(sort)
+      .group({
+        _id: idField,
+        device: { $first: "$device" },
+        device_id: { $first: "$device_id" },
+        site_image: {
+          $first: { $arrayElemAt: ["$site_images.image_url", 0] },
+        },
+        is_reading_primary: {
+          $first: {
+            $arrayElemAt: ["$device_details.isPrimaryInLocation", 0],
+          },
+        },
+        device_number: { $first: "$device_number" },
+        health_tips: { $first: "$healthTips" },
+        site: { $first: "$site" },
+        site_id: { $first: "$site_id" },
+        time: { $first: "$time" },
+        average_pm2_5: { $first: "$average_pm2_5" },
+        pm2_5: { $first: pm2_5 },
+        s1_pm2_5: { $first: s1_pm2_5 },
+        s2_pm2_5: { $first: "$s2_pm2_5" },
+        average_pm10: { $first: "$average_pm10" },
+        pm10: { $first: pm10 },
+        s1_pm10: { $first: s1_pm10 },
+        s2_pm10: { $first: "$s2_pm10" },
+        frequency: { $first: "$frequency" },
+        battery: { $first: "$battery" },
+        network: { $first: "$network" },
+        location: { $first: "$location" },
+        altitude: { $first: "$altitude" },
+        speed: { $first: "$speed" },
+        satellites: { $first: "$satellites" },
+        hdop: { $first: "$hdop" },
+
+        intaketemperature: { $first: "$intaketemperature" },
+        tvoc: { $first: "$tvoc" },
+        hcho: { $first: "$hcho" },
+        co2: { $first: "$co2" },
+        intakehumidity: { $first: "$intakehumidity" },
+
+        internalTemperature: { $first: "$internalTemperature" },
+        externalTemperature: { $first: "$externalTemperature" },
+        internalHumidity: { $first: "$internalHumidity" },
+        externalHumidity: { $first: "$externalHumidity" },
+        externalAltitude: { $first: "$externalAltitude" },
+        pm1: { $first: "$pm1" },
+        no2: { $first: "$no2" },
+        rtc_adc: { $first: "$rtc_adc" },
+        rtc_v: { $first: "$rtc_v" },
+        rtc: { $first: "$rtc" },
+        stc_adc: { $first: "$stc_adc" },
+        stc_v: { $first: "$stc_v" },
+        stc: { $first: "$stc" },
+        [as]: elementAtIndex0,
+      })
+      .addFields({
+        timeDifferenceHours: {
+          $divide: [
+            { $subtract: [new Date(), "$time"] },
+            1000 * 60 * 60, // milliseconds to hours
+          ],
+        },
+      })
+      .project({
+        "health_tips.aqi_category": 0,
+        "health_tips.value": 0,
+        "health_tips.createdAt": 0,
+        "health_tips.updatedAt": 0,
+        "health_tips.__v": 0,
+      })
+      .project({
+        "site_image.createdAt": 0,
+        "site_image.updatedAt": 0,
+        "site_image.metadata": 0,
+        "site_image.__v": 0,
+        "site_image.device_name": 0,
+        "site_image.device_id": 0,
+        "site_image._id": 0,
+        "site_image.tags": 0,
+        "site_image.image_code": 0,
+        "site_image.site_id": 0,
+        "site_image.airqloud_id": 0,
+      })
+      .project(projection)
+      .addFields({
+        aqi_ranges: AQI_RANGES,
+      })
+      .facet({
+        total: [{ $count: "device" }],
+        data: [generateAqiAddFields()],
+      })
+      .project({
+        meta,
+        data: {
+          $slice: [
+            "$data",
+            skip,
+            {
+              $ifNull: [limit, { $arrayElemAt: ["$total.device", 0] }],
+            },
+          ],
+        },
+      })
+      .allowDiskUse(true);
+
+    return data;
+  }
+
+  if (recent === "no") {
+    let data = await model
+      .aggregate()
+      .unwind("values")
+      .match(search)
+      .replaceRoot("values")
+      .lookup({
+        from,
+        localField,
+        foreignField,
+        as,
+      })
+      .sort(sort)
+      .addFields({
+        timeDifferenceHours: {
+          $divide: [
+            { $subtract: [new Date(), "$time"] },
+            1000 * 60 * 60, // milliseconds to hours
+          ],
+        },
+      })
+      .project({
+        _device: "$device",
+        _time: "$time",
+        _average_pm2_5: "$average_pm2_5",
+        _pm2_5: pm2_5,
+        _s1_pm2_5: s1_pm2_5,
+        _s2_pm2_5: "$s2_pm2_5",
+        _average_pm10: "$average_pm10",
+        _pm10: pm10,
+        _s1_pm10: s1_pm10,
+        _s2_pm10: "$s2_pm10",
+        _frequency: "$frequency",
+        _battery: "$battery",
+        _location: "$location",
+        _altitude: "$altitude",
+        _speed: "$speed",
+        _network: "$network",
+        _satellites: "$satellites",
+        _hdop: "$hdop",
+
+        _tvoc: "$tvoc",
+        _hcho: "$hcho",
+        _co2: "$co2",
+        _intaketemperature: "$intaketemperature",
+        _intakehumidity: "$intakehumidity",
+
+        _site_id: "$site_id",
+        _device_id: "$device_id",
+        _site: "$site",
+        _device_number: "$device_number",
+        _internalTemperature: "$internalTemperature",
+        _externalTemperature: "$externalTemperature",
+        _internalHumidity: "$internalHumidity",
+        _externalHumidity: "$externalHumidity",
+        _externalAltitude: "$externalAltitude",
+        _pm1: "$pm1",
+        _no2: "$no2",
+        _rtc_adc: "$rtc_adc",
+        _rtc_v: "$rtc_v",
+        _rtc: "$rtc",
+        _stc_adc: "$stc_adc",
+        _stc_v: "$stc_v",
+        _stc: "$stc",
+        [_as]: elementAtIndex0,
+      })
+      .project({
+        device: "$_device",
+        device_id: "$_device_id",
+        device_number: "$_device_number",
+        site: "$_site",
+        site_id: "$_site_id",
+        time: "$_time",
+        average_pm2_5: "$_average_pm2_5",
+        pm2_5: "$_pm2_5",
+        s1_pm2_5: "$_s1_pm2_5",
+        s2_pm2_5: "$_s2_pm2_5",
+        average_pm10: "$_average_pm10",
+        pm10: "$_pm10",
+        s1_pm10: "$_s1_pm10",
+        s2_pm10: "$_s2_pm10",
+        frequency: "$_frequency",
+        battery: "$_battery",
+        location: "$_location",
+        altitude: "$_altitude",
+        speed: "$_speed",
+        network: "$_network",
+        satellites: "$_satellites",
+        hdop: "$_hdop",
+
+        intaketemperature: "$_intaketemperature",
+        tvoc: "$_tvoc",
+        hcho: "$_hcho",
+        co2: "$_co2",
+        intakehumidity: "$_intakehumidity",
+
+        internalTemperature: "$_internalTemperature",
+        externalTemperature: "$_externalTemperature",
+        internalHumidity: "$_internalHumidity",
+        externalHumidity: "$_externalHumidity",
+        externalAltitude: "$_externalAltitude",
+        pm1: "$_pm1",
+        no2: "$_no2",
+        rtc_adc: "$_rtc_adc",
+        rtc_v: "$_rtc_v",
+        rtc: "$_rtc",
+        stc_adc: "$_stc_adc",
+        stc_v: "$_stc_v",
+        stc: "$_stc",
+        [as]: "$" + _as,
+      })
+      .project(projection)
+      .facet({
+        total: [{ $count: "device" }],
+        data: [
+          {
+            $addFields: { device: "$device" },
+          },
+        ],
+      })
+      .project({
+        meta,
+        data: {
+          $slice: [
+            "$data",
+            skip,
+            {
+              $ifNull: [limit, { $arrayElemAt: ["$total.device", 0] }],
+            },
+          ],
+        },
+      })
+      .allowDiskUse(true);
+
+    return data;
+  }
+}
+async function signalData(model, filter) {
+  let { skip, limit, page } = filter;
+  const recent = "yes";
+  const metadata = "site_id";
+
+  if (page) {
+    skip = parseInt((page - 1) * limit);
+  }
+
+  const startTime = filter["values.time"]["$gte"];
+  const endTime = filter["values.time"]["$lte"];
+  let idField;
+  // const visibilityFilter = true;
+
+  let search = filter;
+  let groupId = "$device";
+  let localField = "device";
+  let foreignField = "name";
+  let from = "devices";
+  let _as = "_deviceDetails";
+  let as = "deviceDetails";
+  let pm2_5 = "$average_pm2_5";
+  let pm10 = "$average_pm10";
+  let s1_pm2_5 = "$pm2_5";
+  let s1_pm10 = "$pm10";
+  let elementAtIndex0 = elementAtIndexName(metadata, recent);
+  let projection = {
+    _id: 0,
+  };
+  let meta = {
+    total: { $arrayElemAt: ["$total.device", 0] },
+    skip: { $literal: skip },
+    limit: { $literal: limit },
+    page: {
+      $trunc: {
+        $literal: skip / limit + 1,
+      },
+    },
+    pages: {
+      $ifNull: [
+        {
+          $ceil: {
+            $divide: [{ $arrayElemAt: ["$total.device", 0] }, limit],
+          },
+        },
+        1,
+      ],
+    },
+    startTime,
+    endTime,
+  };
+  let siteProjection = {};
+  let sort = { time: -1 };
+
+  delete search["external"];
+  delete search["frequency"];
+  delete search["metadata"];
+  delete search["tenant"];
+  delete search["device"];
+  delete search["recent"];
+  delete search["page"];
+  delete search["running"];
+  delete search["brief"];
+  delete search["index"];
+  delete search["limit"];
+  delete search["skip"];
+
+  projection["s2_pm10"] = 0;
+  projection["s1_pm10"] = 0;
+  projection["s2_pm2_5"] = 0;
+  projection["s1_pm2_5"] = 0;
+  projection["rtc_adc"] = 0;
+  projection["rtc_v"] = 0;
+  projection["rtc"] = 0;
+  projection["stc_adc"] = 0;
+  projection["stc_v"] = 0;
+  projection["stc"] = 0;
+  projection["pm1"] = 0;
+  projection["externalHumidity"] = 0;
+  projection["externalAltitude"] = 0;
+  projection["internalHumidity"] = 0;
+  projection["externalTemperature"] = 0;
+  projection["internalTemperature"] = 0;
+  projection["hdop"] = 0;
+
+  projection["tvoc"] = 0;
+  projection["hcho"] = 0;
+  projection["co2"] = 0;
+  projection["intaketemperature"] = 0;
+  projection["intakehumidity"] = 0;
+
+  projection["satellites"] = 0;
+  projection["speed"] = 0;
+  projection["altitude"] = 0;
+  projection["site_image"] = 0;
+  projection["location"] = 0;
+  projection["network"] = 0;
+  projection["battery"] = 0;
+  projection["average_pm10"] = 0;
+  projection["average_pm2_5"] = 0;
+  projection["device_number"] = 0;
+  projection["pm2_5.uncertaintyValue"] = 0;
+  projection["pm2_5.calibratedValue"] = 0;
+  projection["pm2_5.standardDeviationValue"] = 0;
+  projection["pm10.uncertaintyValue"] = 0;
+  projection["pm10.calibratedValue"] = 0;
+  projection["pm10.standardDeviationValue"] = 0;
+  projection["no2.uncertaintyValue"] = 0;
+  projection["no2.standardDeviationValue"] = 0;
+  projection["no2.calibratedValue"] = 0;
+  projection["site"] = 0;
+  projection[as] = 0;
 
   idField = "$site_id";
   groupId = "$" + metadata;
@@ -580,6 +1335,7 @@ async function fetchData(model, filter) {
       "cohort_details.visibility": { $ne: false },
       "cohort_details.name": "map",
     })
+    // .match({ "device_details.visibility": visibilityFilter })
     .lookup({
       from,
       localField,
@@ -595,10 +1351,10 @@ async function fetchData(model, filter) {
             $expr: {
               $and: [
                 {
-                  $lte: ["$aqi_category.min", "$pollutantValue"],
+                  $lte: ["$aqi_category.min", "$$pollutantValue"],
                 },
                 {
-                  $gte: ["$aqi_category.max", "$pollutantValue"],
+                  $gte: ["$aqi_category.max", "$$pollutantValue"],
                 },
               ],
             },
@@ -608,17 +1364,61 @@ async function fetchData(model, filter) {
       as: "healthTips",
     })
     .sort(sort)
-    .group(
-      buildGroupExpression(
-        idField,
-        as,
-        elementAtIndex0,
-        pm2_5,
-        pm10,
-        s1_pm2_5,
-        s1_pm10
-      )
-    )
+    .group({
+      _id: idField,
+      device: { $first: "$device" },
+      device_id: { $first: "$device_id" },
+      site_image: {
+        $first: { $arrayElemAt: ["$site_images.image_url", 0] },
+      },
+      is_reading_primary: {
+        $first: {
+          $arrayElemAt: ["$device_details.isPrimaryInLocation", 0],
+        },
+      },
+      device_number: { $first: "$device_number" },
+      health_tips: { $first: "$healthTips" },
+      site: { $first: "$site" },
+      site_id: { $first: "$site_id" },
+      time: { $first: "$time" },
+      average_pm2_5: { $first: "$average_pm2_5" },
+      pm2_5: { $first: pm2_5 },
+      s1_pm2_5: { $first: s1_pm2_5 },
+      s2_pm2_5: { $first: "$s2_pm2_5" },
+      average_pm10: { $first: "$average_pm10" },
+      pm10: { $first: pm10 },
+      s1_pm10: { $first: s1_pm10 },
+      s2_pm10: { $first: "$s2_pm10" },
+      frequency: { $first: "$frequency" },
+      battery: { $first: "$battery" },
+      network: { $first: "$network" },
+      location: { $first: "$location" },
+      altitude: { $first: "$altitude" },
+      speed: { $first: "$speed" },
+      satellites: { $first: "$satellites" },
+      hdop: { $first: "$hdop" },
+
+      intaketemperature: { $first: "$intaketemperature" },
+      tvoc: { $first: "$tvoc" },
+      hcho: { $first: "$hcho" },
+      co2: { $first: "$co2" },
+      intakehumidity: { $first: "$intakehumidity" },
+
+      internalTemperature: { $first: "$internalTemperature" },
+      externalTemperature: { $first: "$externalTemperature" },
+      internalHumidity: { $first: "$internalHumidity" },
+      externalHumidity: { $first: "$externalHumidity" },
+      externalAltitude: { $first: "$externalAltitude" },
+      pm1: { $first: "$pm1" },
+      no2: { $first: "$no2" },
+      rtc_adc: { $first: "$rtc_adc" },
+      rtc_v: { $first: "$rtc_v" },
+      rtc: { $first: "$rtc" },
+      stc_adc: { $first: "$stc_adc" },
+      stc_v: { $first: "$stc_v" },
+      stc: { $first: "$stc" },
+      [as]: elementAtIndex0,
+    })
     .addFields({
       timeDifferenceHours: {
         $divide: [
@@ -671,8 +1471,6 @@ async function fetchData(model, filter) {
 
   return data;
 }
-
-// Helper functions for data processing
 function filterNullAndReportOffDevices(data) {
   data.forEach((record) => {
     if (record.timeDifferenceHours > UPTIME_CHECK_THRESHOLD) {
@@ -719,12 +1517,10 @@ function filterNullAndReportOffDevices(data) {
 
   return data;
 }
-
 function filterNull(data) {
   data = data.filter((record) => record.pm2_5 !== null);
   return data;
 }
-
 function computeAveragePm2_5(transformedData) {
   let total = 0;
   transformedData.forEach((record) => {
@@ -739,123 +1535,6 @@ eventSchema.statics.createEvent = async function(args) {
     ...args,
   });
 };
-
-// Helper functions for building aggregation expressions
-function buildGroupExpression(
-  idField,
-  as,
-  elementAtIndex0,
-  pm2_5,
-  pm10,
-  s1_pm2_5,
-  s1_pm10
-) {
-  // Generate a consistent group expression using measurement registry
-  const baseGroupExpr = {
-    _id: idField,
-    device: { $first: "$device" },
-    device_id: { $first: "$device_id" },
-    site_image: { $first: { $arrayElemAt: ["$site_images.image_url", 0] } },
-    is_reading_primary: {
-      $first: { $arrayElemAt: ["$device_details.isPrimaryInLocation", 0] },
-    },
-    device_number: { $first: "$device_number" },
-    health_tips: { $first: "$healthTips" },
-    site: { $first: "$site" },
-    site_id: { $first: "$site_id" },
-    time: { $first: "$time" },
-    frequency: { $first: "$frequency" },
-    battery: { $first: "$battery" },
-    network: { $first: "$network" },
-    location: { $first: "$location" },
-  };
-
-  // Add all measurement fields from registry
-  Object.keys(MEASUREMENT_REGISTRY).forEach((key) => {
-    if (key === "pm2_5") {
-      baseGroupExpr[key] = { $first: pm2_5 };
-    } else if (key === "pm10") {
-      baseGroupExpr[key] = { $first: pm10 };
-    } else if (key === "s1_pm2_5") {
-      baseGroupExpr[key] = { $first: s1_pm2_5 };
-    } else if (key === "s1_pm10") {
-      baseGroupExpr[key] = { $first: s1_pm10 };
-    } else {
-      baseGroupExpr[key] = { $first: `${key}` };
-    }
-  });
-
-  // Add the element at index
-  baseGroupExpr[as] = elementAtIndex0;
-
-  return baseGroupExpr;
-}
-
-function buildHistoricalProjection(
-  pm2_5,
-  pm10,
-  s1_pm2_5,
-  s1_pm10,
-  _as,
-  as,
-  elementAtIndex0
-) {
-  const projection = {
-    _device: "$device",
-    _time: "$time",
-    _site_id: "$site_id",
-    _device_id: "$device_id",
-    _site: "$site",
-    _device_number: "$device_number",
-    _frequency: "$frequency",
-    _battery: "$battery",
-    _location: "$location",
-    _network: "$network",
-  };
-
-  // Add all measurement fields from registry with underscore prefix
-  Object.keys(MEASUREMENT_REGISTRY).forEach((key) => {
-    if (key === "pm2_5") {
-      projection[`_${key}`] = pm2_5;
-    } else if (key === "pm10") {
-      projection[`_${key}`] = pm10;
-    } else if (key === "s1_pm2_5") {
-      projection[`_${key}`] = s1_pm2_5;
-    } else if (key === "s1_pm10") {
-      projection[`_${key}`] = s1_pm10;
-    } else {
-      projection[`_${key}`] = `${key}`;
-    }
-  });
-
-  // Add lookup result
-  projection[_as] = elementAtIndex0;
-
-  // Create the second projection to remove underscores
-  const finalProjection = {
-    device: "$_device",
-    device_id: "$_device_id",
-    device_number: "$_device_number",
-    site: "$_site",
-    site_id: "$_site_id",
-    time: "$_time",
-    frequency: "$_frequency",
-    battery: "$_battery",
-    location: "$_location",
-    network: "$_network",
-  };
-
-  // Add all measurement fields without underscore prefix
-  Object.keys(MEASUREMENT_REGISTRY).forEach((key) => {
-    finalProjection[key] = `$_${key}`;
-  });
-
-  // Add the lookup result
-  finalProjection[as] = `${_as}`;
-
-  return finalProjection;
-}
-
 eventSchema.statics.list = async function(
   {
     skip = DEFAULT_SKIP,
@@ -882,6 +1561,7 @@ eventSchema.statics.list = async function(
     const endTime = filter["values.time"]["$lte"];
 
     let idField;
+    // const visibilityFilter = true;
 
     let search = filter;
     let groupId = "$device";
@@ -895,13 +1575,9 @@ eventSchema.statics.list = async function(
     let s1_pm2_5 = "$pm2_5";
     let s1_pm10 = "$pm10";
     let elementAtIndex0 = elementAtIndexName(metadata, recent);
-    let projection = createSimplifiedProjection(
-      external,
-      brief,
-      running,
-      tenant
-    );
-
+    let projection = {
+      _id: 0,
+    };
     let meta = {
       total: { $arrayElemAt: ["$total.device", 0] },
       skip: { $literal: skip },
@@ -939,16 +1615,69 @@ eventSchema.statics.list = async function(
     delete search["brief"];
     delete search["index"];
 
-    // Based on tenant, which PM values should we showcase?
+    /**
+     * The Alternative Flows present in this Events entity:
+     * 1. Based on tenant, which PM values should we showcase?
+     * 2. Which metadata should we show? Sites or Devices? etc....
+     * 3. Should we show recent or historical measurements?
+     */
     if (tenant !== "airqo") {
       pm2_5 = "$pm2_5";
       pm10 = "$pm10";
     }
 
+    if (external === "yes" || brief === "yes") {
+      projection["s2_pm10"] = 0;
+      projection["s1_pm10"] = 0;
+      projection["s2_pm2_5"] = 0;
+      projection["s1_pm2_5"] = 0;
+      projection["rtc_adc"] = 0;
+      projection["rtc_v"] = 0;
+      projection["rtc"] = 0;
+      projection["stc_adc"] = 0;
+      projection["stc_v"] = 0;
+      projection["stc"] = 0;
+      projection["pm1"] = 0;
+      projection["externalHumidity"] = 0;
+      projection["externalAltitude"] = 0;
+      projection["internalHumidity"] = 0;
+      projection["externalTemperature"] = 0;
+      projection["internalTemperature"] = 0;
+      projection["hdop"] = 0;
+
+      projection["tvoc"] = 0;
+      projection["hcho"] = 0;
+      projection["co2"] = 0;
+      projection["intaketemperature"] = 0;
+      projection["intakehumidity"] = 0;
+
+      projection["satellites"] = 0;
+      projection["speed"] = 0;
+      projection["altitude"] = 0;
+      projection["site_image"] = 0;
+      projection["location"] = 0;
+      projection["network"] = 0;
+      projection["battery"] = 0;
+      projection["average_pm10"] = 0;
+      projection["average_pm2_5"] = 0;
+      projection["device_number"] = 0;
+      projection["pm2_5.uncertaintyValue"] = 0;
+      projection["pm2_5.calibratedValue"] = 0;
+      projection["pm2_5.standardDeviationValue"] = 0;
+      projection["pm10.uncertaintyValue"] = 0;
+      projection["pm10.calibratedValue"] = 0;
+      projection["pm10.standardDeviationValue"] = 0;
+      projection["no2.uncertaintyValue"] = 0;
+      projection["no2.standardDeviationValue"] = 0;
+      projection["no2.calibratedValue"] = 0;
+      projection["site"] = 0;
+      projection[as] = 0;
+    }
+
     if (!metadata || metadata === "device" || metadata === "device_id") {
       idField = "$device";
-      groupId = "$" + (metadata || "device");
-      localField = metadata || "device";
+      groupId = "$" + metadata ? metadata : groupId;
+      localField = metadata ? metadata : localField;
       if (metadata === "device_id") {
         foreignField = "_id";
       }
@@ -987,6 +1716,61 @@ eventSchema.statics.list = async function(
       Object.assign(projection, siteProjection);
     }
 
+    if (running === "yes") {
+      delete projection["pm2_5.uncertaintyValue"];
+      delete projection["pm2_5.standardDeviationValue"];
+      delete projection["pm2_5.calibratedValue"];
+
+      Object.assign(projection, {
+        site_image: 0,
+        is_reading_primary: 0,
+        deviceDetails: 0,
+        aqi_color: 0,
+        aqi_category: 0,
+        aqi_color_name: 0,
+        pm2_5: 0,
+        average_pm10: 0,
+        average_pm2_5: 0,
+        pm10: 0,
+        frequency: 0,
+        network: 0,
+        location: 0,
+        altitude: 0,
+        speed: 0,
+        satellites: 0,
+        hdop: 0,
+
+        intaketemperature: 0,
+        tvoc: 0,
+        hcho: 0,
+        co2: 0,
+        intakehumidity: 0,
+
+        internalTemperature: 0,
+        externalTemperature: 0,
+        internalHumidity: 0,
+        externalHumidity: 0,
+        externalAltitude: 0,
+        pm1: 0,
+        no2: 0,
+        site: 0,
+        site_id: 0,
+        health_tips: 0,
+        s1_pm2_5: 0,
+        s2_pm2_5: 0,
+        s1_pm10: 0,
+        s2_pm10: 0,
+        battery: 0,
+        rtc_adc: 0,
+        rtc_v: 0,
+        rtc: 0,
+        stc_adc: 0,
+        stc_v: 0,
+        stc: 0,
+        siteDetails: 0,
+      });
+    }
+
     if (!isEmpty(index)) {
       sort = { "pm2_5.value": 1 };
     }
@@ -1018,6 +1802,7 @@ eventSchema.statics.list = async function(
         .match({
           "cohort_details.visibility": { $ne: false },
         })
+        // .match({ "device_details.visibility": visibilityFilter })
         .lookup({
           from,
           localField,
@@ -1046,17 +1831,59 @@ eventSchema.statics.list = async function(
           as: "healthTips",
         })
         .sort(sort)
-        .group(
-          buildGroupExpression(
-            idField,
-            as,
-            elementAtIndex0,
-            pm2_5,
-            pm10,
-            s1_pm2_5,
-            s1_pm10
-          )
-        )
+        .group({
+          _id: idField,
+          device: { $first: "$device" },
+          device_id: { $first: "$device_id" },
+          site_image: {
+            $first: { $arrayElemAt: ["$site_images.image_url", 0] },
+          },
+          is_reading_primary: {
+            $first: {
+              $arrayElemAt: ["$device_details.isPrimaryInLocation", 0],
+            },
+          },
+          device_number: { $first: "$device_number" },
+          health_tips: { $first: "$healthTips" },
+          site: { $first: "$site" },
+          site_id: { $first: "$site_id" },
+          time: { $first: "$time" },
+          average_pm2_5: { $first: "$average_pm2_5" },
+          pm2_5: { $first: pm2_5 },
+          s1_pm2_5: { $first: s1_pm2_5 },
+          s2_pm2_5: { $first: "$s2_pm2_5" },
+          average_pm10: { $first: "$average_pm10" },
+          pm10: { $first: pm10 },
+          s1_pm10: { $first: s1_pm10 },
+          s2_pm10: { $first: "$s2_pm10" },
+          frequency: { $first: "$frequency" },
+          battery: { $first: "$battery" },
+          network: { $first: "$network" },
+          location: { $first: "$location" },
+          altitude: { $first: "$altitude" },
+          speed: { $first: "$speed" },
+          satellites: { $first: "$satellites" },
+          hdop: { $first: "$hdop" },
+          intaketemperature: { $first: "$intaketemperature" },
+          tvoc: { $first: "$tvoc" },
+          hcho: { $first: "$hcho" },
+          co2: { $first: "$co2" },
+          intakehumidity: { $first: "$intakehumidity" },
+          internalTemperature: { $first: "$internalTemperature" },
+          externalTemperature: { $first: "$externalTemperature" },
+          internalHumidity: { $first: "$internalHumidity" },
+          externalHumidity: { $first: "$externalHumidity" },
+          externalAltitude: { $first: "$externalAltitude" },
+          pm1: { $first: "$pm1" },
+          no2: { $first: "$no2" },
+          rtc_adc: { $first: "$rtc_adc" },
+          rtc_v: { $first: "$rtc_v" },
+          rtc: { $first: "$rtc" },
+          stc_adc: { $first: "$stc_adc" },
+          stc_v: { $first: "$stc_v" },
+          stc: { $first: "$stc" },
+          [as]: elementAtIndex0,
+        })
         .addFields({
           timeDifferenceHours: {
             $divide: [
@@ -1137,17 +1964,94 @@ eventSchema.statics.list = async function(
             ],
           },
         })
-        .project(
-          buildHistoricalProjection(
-            pm2_5,
-            pm10,
-            s1_pm2_5,
-            s1_pm10,
-            _as,
-            as,
-            elementAtIndex0
-          )
-        )
+        .project({
+          _device: "$device",
+          _time: "$time",
+          _average_pm2_5: "$average_pm2_5",
+          _pm2_5: pm2_5,
+          _s1_pm2_5: s1_pm2_5,
+          _s2_pm2_5: "$s2_pm2_5",
+          _average_pm10: "$average_pm10",
+          _pm10: pm10,
+          _s1_pm10: s1_pm10,
+          _s2_pm10: "$s2_pm10",
+          _frequency: "$frequency",
+          _battery: "$battery",
+          _location: "$location",
+          _altitude: "$altitude",
+          _speed: "$speed",
+          _network: "$network",
+          _satellites: "$satellites",
+          _hdop: "$hdop",
+
+          _tvoc: "$tvoc",
+          _hcho: "$hcho",
+          _co2: "$co2",
+          _intaketemperature: "$intaketemperature",
+          _intakehumidity: "$intakehumidity",
+
+          _site_id: "$site_id",
+          _device_id: "$device_id",
+          _site: "$site",
+          _device_number: "$device_number",
+          _internalTemperature: "$internalTemperature",
+          _externalTemperature: "$externalTemperature",
+          _internalHumidity: "$internalHumidity",
+          _externalHumidity: "$externalHumidity",
+          _externalAltitude: "$externalAltitude",
+          _pm1: "$pm1",
+          _no2: "$no2",
+          _rtc_adc: "$rtc_adc",
+          _rtc_v: "$rtc_v",
+          _rtc: "$rtc",
+          _stc_adc: "$stc_adc",
+          _stc_v: "$stc_v",
+          _stc: "$stc",
+          [_as]: elementAtIndex0,
+        })
+        .project({
+          device: "$_device",
+          device_id: "$_device_id",
+          device_number: "$_device_number",
+          site: "$_site",
+          site_id: "$_site_id",
+          time: "$_time",
+          average_pm2_5: "$_average_pm2_5",
+          pm2_5: "$_pm2_5",
+          s1_pm2_5: "$_s1_pm2_5",
+          s2_pm2_5: "$_s2_pm2_5",
+          average_pm10: "$_average_pm10",
+          pm10: "$_pm10",
+          s1_pm10: "$_s1_pm10",
+          s2_pm10: "$_s2_pm10",
+          frequency: "$_frequency",
+          battery: "$_battery",
+          location: "$_location",
+          altitude: "$_altitude",
+          speed: "$_speed",
+          network: "$_network",
+          satellites: "$_satellites",
+          hdop: "$_hdop",
+          intaketemperature: "$_intaketemperature",
+          tvoc: "$_tvoc",
+          hcho: "$_hcho",
+          co2: "$_co2",
+          intakehumidity: "$_intakehumidity",
+          internalTemperature: "$_internalTemperature",
+          externalTemperature: "$_externalTemperature",
+          internalHumidity: "$_internalHumidity",
+          externalHumidity: "$_externalHumidity",
+          externalAltitude: "$_externalAltitude",
+          pm1: "$_pm1",
+          no2: "$_no2",
+          rtc_adc: "$_rtc_adc",
+          rtc_v: "$_rtc_v",
+          rtc: "$_rtc",
+          stc_adc: "$_stc_adc",
+          stc_v: "$_stc_v",
+          stc: "$_stc",
+          [as]: "$" + _as,
+        })
         .project(projection)
         .facet({
           total: [{ $count: "device" }],
@@ -1219,7 +2123,6 @@ eventSchema.statics.view = async function(filter, next) {
     return;
   }
 };
-
 eventSchema.statics.fetch = async function(filter) {
   try {
     const request = filter;
@@ -1680,8 +2583,6 @@ eventSchema.statics.v2_getAirQualityAverages = async function(siteId, next) {
   }
 };
 
-// v3 methods and helper functions
-
 eventSchema.statics.v3_getAirQualityAverages = async function(siteId, next) {
   try {
     const TIMEZONE = "Africa/Kampala"; // Using a consistent timezone
@@ -1898,14 +2799,6 @@ function calculateConfidenceScore(
   return (currentWeekScore * 0.6 + baselineScore * 0.4) * 100;
 }
 
-// Model creation and export function
-
-/**
- * Create a model instance based on the tenant
- * This allows different database connections for different tenants
- * @param {string} tenant - The tenant identifier
- * @returns {mongoose.Model} - The Event model for the tenant
- */
 const eventsModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;

--- a/src/device-registry/utils/event.util-v1.js
+++ b/src/device-registry/utils/event.util-v1.js
@@ -1,0 +1,3544 @@
+const EventModel = require("@models/Event");
+const ReadingModel = require("@models/Reading");
+const SignalModel = require("@models/Signal");
+const DeviceModel = require("@models/Device");
+
+const {
+  logObject,
+  logText,
+  logElement,
+  HttpError,
+  logTextWithTimestamp,
+} = require("@utils/shared");
+const constants = require("@config/constants");
+const {
+  generateFilter,
+  generateDateFormatWithoutHrs,
+  addMonthsToProvideDateTime,
+  formatDate,
+  translate,
+  stringify,
+} = require("@utils/common");
+const isEmpty = require("is-empty");
+const cryptoJS = require("crypto-js");
+const log4js = require("log4js");
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- event-util`);
+const { transform } = require("node-json-transform");
+const Dot = require("dot-object");
+const cleanDeep = require("clean-deep");
+const redis = require("@config/redis");
+const axios = require("axios");
+const { BigQuery } = require("@google-cloud/bigquery");
+const bigquery = new BigQuery();
+const { Parser } = require("json2csv");
+const httpStatus = require("http-status");
+const util = require("util");
+const redisGetAsync = util.promisify(redis.get).bind(redis);
+const redisSetAsync = util.promisify(redis.set).bind(redis);
+const redisExpireAsync = util.promisify(redis.expire).bind(redis);
+const asyncRetry = require("async-retry");
+
+const listDevices = async (request, next) => {
+  try {
+    const { tenant, limit, skip } = request.query;
+    logObject("the request for the filter", request);
+    const filter = generateFilter.devices(request, next);
+    const responseFromListDevice = await DeviceModel(tenant).list(
+      {
+        filter,
+        limit,
+        skip,
+      },
+      next
+    );
+    if (responseFromListDevice.success === false) {
+      let errors = responseFromListDevice.errors
+        ? responseFromListDevice.errors
+        : { message: "" };
+      try {
+        let errorsString = errors ? stringify(errors) : "";
+        logger.error(
+          `responseFromListDevice was not a success -- ${responseFromListDevice.message} -- ${errorsString}`
+        );
+      } catch (error) {
+        logger.error(`internal server error -- ${error.message}`);
+      }
+      return responseFromListDevice;
+    } else if (responseFromListDevice.success === true) {
+      let data = responseFromListDevice.data;
+      // logger.info(`responseFromListDevice was a success -- ${data}`);
+      return responseFromListDevice;
+    }
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+const decryptKey = async (encryptedKey, next) => {
+  try {
+    let bytes = cryptoJS.AES.decrypt(
+      encryptedKey,
+      constants.KEY_ENCRYPTION_KEY
+    );
+    let originalText = bytes.toString(cryptoJS.enc.Utf8);
+    let isKeyUnknown = isEmpty(originalText);
+    if (isKeyUnknown) {
+      return {
+        success: true,
+        status: httpStatus.NOT_FOUND,
+        message: "the provided encrypted key is not recognizable",
+      };
+    } else {
+      return {
+        success: true,
+        message: "successfully decrypted the text",
+        data: originalText,
+        status: httpStatus.OK,
+      };
+    }
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+async function transformOneReading(
+  { data = {}, map = {}, context = {} } = {},
+  next
+) {
+  try {
+    const transformedEvent = transform(data, map, context);
+
+    const validValues = transformedEvent.values.filter((value) => {
+      let isValid = true;
+      for (const key in map.item) {
+        // Use the provided map for consistency
+        if (typeof value[key] === "number" && value[key] <= 0) {
+          isValid = false;
+          break;
+        }
+      }
+      return isValid;
+    });
+
+    if (validValues.length === 0) {
+      return {
+        success: false,
+        message: "All values zero or less; discarding.",
+      };
+    }
+    transformedEvent.values = validValues;
+    if (transformedEvent.values.length < transformedEvent.nValues) {
+      transformedEvent.nValues = validValues.length;
+    }
+    return {
+      success: true,
+      message: "successfully transformed the provided event",
+      data: transformedEvent,
+    };
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+    return;
+  }
+}
+async function transformManyReadings(request, next) {
+  try {
+    const { body } = request;
+    let promises = body.map(async (event) => {
+      const data = event;
+      const map = constants.EVENT_MAPPINGS;
+      const responseFromTransformEvent = await transformOneReading(
+        {
+          data,
+          map,
+        },
+        next
+      );
+      if (responseFromTransformEvent.success === true) {
+        logger.info(`Transformed event: ${JSON.stringify(event)}`);
+        return responseFromTransformEvent;
+      } else if (responseFromTransformEvent.success === false) {
+        let errors = responseFromTransformEvent.errors
+          ? responseFromTransformEvent.errors
+          : { message: "" };
+        logger.error(`Failed to transform event -- ${stringify(errors)}`);
+        return responseFromTransformEvent;
+      }
+    });
+
+    return Promise.allSettled(promises).then((results) => {
+      let transforms = [];
+      let errors = [];
+      for (let i = 0; i < results.length; i++) {
+        let result = results[i];
+        if (result.status === "fulfilled") {
+          if (result.value.success) {
+            transforms.push(result.value.data);
+          } else {
+            errors.push(result.value); // Collect errors about discarded events if needed
+          }
+        } else if (result.status === "rejected") {
+          let error = result.reason.errors
+            ? result.reason.errors
+            : { message: "" };
+          errors.push(error);
+        }
+      }
+      return buildResponse(errors, transforms);
+    });
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+    return;
+  }
+}
+function buildResponse(errors, transforms) {
+  if (errors.length > 0) {
+    return {
+      success: false,
+      errors,
+      message: "Some operational errors occurred while transforming",
+      data: transforms,
+      status: httpStatus.BAD_REQUEST,
+    };
+  } else if (errors.length === 0) {
+    return {
+      success: true,
+      errors,
+      message: "Transformation completed successfully",
+      data: transforms,
+      status: httpStatus.OK,
+    };
+  }
+}
+function determineResponse(nAdded, eventsAdded, eventsRejected, errors) {
+  if (errors.length > 0 && nAdded === 0) {
+    return {
+      success: false,
+      status: httpStatus.CONFLICT,
+      message: "All operations failed with conflicts",
+      errors,
+      eventsAdded,
+      eventsRejected,
+    };
+  } else if (errors.length > 0 && nAdded > 0) {
+    return {
+      success: true,
+      status: httpStatus.OK,
+      message: "Finished the operation with some conflicts",
+      errors,
+      eventsAdded,
+      eventsRejected,
+    };
+  } else if (errors.length === 0 && nAdded > 0) {
+    return {
+      success: true,
+      status: httpStatus.OK,
+      message: "Successfully added all the events",
+      eventsAdded,
+      eventsRejected,
+    };
+  }
+}
+async function processEvent(event, next) {
+  try {
+    logObject("event", event);
+    let value = event;
+    let dot = new Dot(".");
+    let options = event.options;
+    let filter = cleanDeep(event.filter);
+    let update = event.update;
+    dot.delete(["filter", "update", "options"], value);
+
+    const validValues = event.values.filter((valItem) => {
+      // Directly access the values property
+      let isValid = true;
+
+      for (const key in constants.EVENT_MAPPINGS.item) {
+        if (typeof valItem[key] === "number" && valItem[key] <= 0) {
+          isValid = false;
+          break;
+        }
+      }
+      return isValid;
+    });
+
+    if (validValues.length === 0) {
+      logger.warn(
+        `Discarding event with all zero/negative values: ${JSON.stringify(
+          value
+        )}`
+      );
+      return { added: false };
+    }
+
+    value.values = validValues;
+    update["$push"] = { values: { $each: value.values } };
+    update["$inc"] = { nValues: validValues.length };
+
+    const addedEvents = await EventModel(event.tenant).updateOne(
+      filter,
+      update,
+      options
+    );
+
+    if (addedEvents) {
+      return {
+        added: true,
+        error: null,
+      };
+    } else {
+      let errMsg = {
+        message: "Unable to add the events",
+        record: {
+          ...(event.device ? { device: event.device } : {}),
+          ...(event.frequency ? { frequency: event.frequency } : {}),
+          ...(event.time ? { time: event.time } : {}),
+          ...(event.device_id ? { device_id: event.device_id } : {}),
+          ...(event.site_id ? { site_id: event.site_id } : {}),
+        },
+      };
+      return {
+        added: false,
+        error: errMsg,
+      };
+    }
+  } catch (e) {
+    eventsRejected.push(event);
+    let errMsg = {
+      message: "System conflict detected, most likely a duplicate record",
+      more: e.message,
+      record: {
+        ...(event.device ? { device: event.device } : {}),
+        ...(event.frequency ? { frequency: event.frequency } : {}),
+        ...(event.time ? { time: event.time } : {}),
+        ...(event.device_id ? { device_id: event.device_id } : {}),
+        ...(event.site_id ? { site_id: event.site_id } : {}),
+      },
+    };
+    return {
+      added: false,
+      error: errMsg,
+    };
+  }
+}
+
+async function processEvents(events, next) {
+  let nAdded = 0;
+  let eventsAdded = [];
+  let eventsRejected = [];
+  let errors = [];
+
+  for (const event of events) {
+    try {
+      let processedEvent = await processEvent(event, next);
+      if (processedEvent.added) {
+        nAdded += 1;
+        eventsAdded.push(event);
+      } else {
+        eventsRejected.push(event);
+        errors.push(processedEvent.error);
+      }
+    } catch (e) {
+      eventsRejected.push(event);
+      let errMsg = createErrorMessage(event, e);
+      errors.push(errMsg);
+    }
+  }
+
+  return determineResponse(nAdded, eventsAdded, eventsRejected, errors);
+}
+
+class AirQualityService {
+  constructor(tenant) {
+    this.EventModel = EventModel(tenant);
+  }
+
+  async getAirQualityData(request, next, version = "v1") {
+    const { language, site_id } = { ...request.query, ...request.params };
+    let responseFromListEvents;
+
+    try {
+      // Try to get from cache first
+      const cacheResult = await this.tryGetCache(request, next);
+      if (cacheResult.success) {
+        return cacheResult.data;
+      }
+
+      const versionedFunctions = {
+        v2: this.EventModel.v2_getAirQualityAverages,
+        v3: this.EventModel.v3_getAirQualityAverages,
+        // Add more versions as needed
+      };
+
+      const defaultFunction = this.EventModel.getAirQualityAverages;
+
+      const getAveragesFunction =
+        versionedFunctions[version] || defaultFunction;
+
+      responseFromListEvents = await getAveragesFunction.call(
+        this.EventModel,
+        site_id,
+        next
+      ); // Use .call to preserve 'this' context
+
+      // Handle translation if needed (only for v1 as v2 doesn't include health tips)
+      if (version === "v1") {
+        await this.translateHealthTips(responseFromListEvents, language, next);
+      }
+
+      // Set cache if successful
+      if (responseFromListEvents.success) {
+        await this.trySetCache(responseFromListEvents.data, request, next);
+
+        return {
+          success: true,
+          message: isEmpty(responseFromListEvents.data)
+            ? "no measurements for this search"
+            : responseFromListEvents.message,
+          data: responseFromListEvents.data,
+          status: responseFromListEvents.status || "",
+          isCache: false,
+        };
+      }
+
+      logger.error(
+        `Unable to retrieve events --- ${JSON.stringify(
+          responseFromListEvents.errors
+        )}`
+      );
+      return {
+        success: false,
+        message: responseFromListEvents.message,
+        errors: responseFromListEvents.errors || { message: "" },
+        status: responseFromListEvents.status || "",
+        isCache: false,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  }
+
+  async translateHealthTips(response, language, next) {
+    if (
+      language !== undefined &&
+      !isEmpty(response) &&
+      response.success === true &&
+      !isEmpty(response.data)
+    ) {
+      const data = response.data;
+      for (const event of data) {
+        const translatedHealthTips = await translate.translateTips(
+          { healthTips: event.health_tips, targetLanguage: language },
+          next
+        );
+        if (translatedHealthTips.success === true) {
+          event.health_tips = translatedHealthTips.data;
+        }
+      }
+    }
+  }
+
+  async tryGetCache(request, next) {
+    try {
+      return await Promise.race([
+        createEvent.getCache(request, next),
+        this.getCacheTimeout(),
+      ]);
+    } catch (error) {
+      logger.error(`🐛🐛 Cache Get Error -- ${JSON.stringify(error)}`);
+      return { success: false };
+    }
+  }
+
+  async trySetCache(data, request, next) {
+    try {
+      const result = await Promise.race([
+        createEvent.setCache(data, request, next),
+        this.getCacheTimeout(),
+      ]);
+
+      if (!result.success) {
+        logger.error(
+          `🐛🐛 Cache Set Error -- ${JSON.stringify(
+            result.errors || "Unknown error"
+          )}`
+        );
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Cache Set Error -- ${JSON.stringify(error)}`);
+    }
+  }
+
+  getCacheTimeout() {
+    return new Promise((resolve) =>
+      setTimeout(resolve, 60000, {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: "Cache timeout" },
+      })
+    );
+  }
+}
+
+const createEvent = {
+  getMeasurementsFromBigQuery: async (req, next) => {
+    try {
+      const { query } = req;
+      const {
+        frequency,
+        device,
+        device_name,
+        device_id,
+        device_lat_long,
+        site_id,
+        airqloud_id,
+        airqloud_name,
+        device_number,
+        startTime,
+        endTime,
+        tenant,
+        limit,
+        skip,
+        site,
+        format,
+        access_code,
+      } = query;
+
+      const responseFromGetDeviceDetails = await listDevices(req, next);
+      let deviceDetails = {};
+
+      if (responseFromGetDeviceDetails.success === true) {
+        if (
+          !isEmpty(responseFromGetDeviceDetails.data) &&
+          Array.isArray(responseFromGetDeviceDetails.data) &&
+          responseFromGetDeviceDetails.data.length === 1
+        ) {
+          deviceDetails = responseFromGetDeviceDetails.data[0];
+        } else {
+          // logger.info(`unable to retrieve details for ONE device`);
+        }
+      } else if (responseFromGetDeviceDetails.success === false) {
+        try {
+          logger.error(
+            `unable to retrieve device details --- ${stringify(
+              responseFromGetDeviceDetails.errors
+            )}`
+          );
+        } catch (error) {
+          logger.error(`internal server error -- ${error.message}`);
+        }
+      }
+
+      if (!isEmpty(deviceDetails) && deviceDetails.visibility === false) {
+        if (isEmpty(access_code) || deviceDetails.access_code !== access_code) {
+          // next(
+          //   new HttpError(
+          //     "Unauthorized",
+          //     httpStatus.UNAUTHORIZED,
+          //     { message: "not authorized" }
+          //   )
+          // );
+        }
+      }
+
+      const currentDate = formatDate(new Date());
+
+      const twoMonthsBack = formatDate(
+        addMonthsToProvideDateTime(currentDate, -2)
+      );
+
+      const start = startTime ? startTime : twoMonthsBack;
+
+      const end = endTime ? endTime : currentDate;
+
+      let table = `${constants.DATAWAREHOUSE_AVERAGED_DATA}.hourly_device_measurements`;
+      let averaged_fields =
+        "site_id, device_id, device_number, timestamp, " +
+        "pm2_5_raw_value, pm2_5_calibrated_value, hdop, pm10_raw_value," +
+        "pm10_calibrated_value, no2_raw_value, no2_calibrated_value, pm1_raw_value," +
+        "pm1_calibrated_value, device_temperature, device_humidity, wind_speed," +
+        "humidity, temperature,";
+      let raw_fields = "";
+      let mobile = false;
+
+      if (!isEmpty(deviceDetails) && deviceDetails.category === "bam") {
+        table = `${constants.DATAWAREHOUSE_AVERAGED_DATA}.hourly_bam_device_measurements`;
+        averaged_fields =
+          "site_id, device_id, device_number, timestamp," +
+          "pm10, pm2_5, no2, pm1, latitude, longitude";
+        raw_fields = "";
+        mobile = false;
+      }
+
+      if (frequency === "raw") {
+        if (!isEmpty(deviceDetails) && deviceDetails.category === "bam") {
+          raw_fields =
+            "realtime_conc, hourly_conc," +
+            "short_time_conc , air_flow , wind_speed ," +
+            "wind_direction , temperature , humidity," +
+            "barometric_pressure , filter_temperature ," +
+            "filter_humidity, status, timestamp, device_id," +
+            "device_number,site_id, latitude, longitude";
+          averaged_fields = "";
+          table = `${constants.DATAWAREHOUSE_RAW_DATA}.bam_device_measurements`;
+        } else {
+          table = `${constants.DATAWAREHOUSE_RAW_DATA}.device_measurements`;
+          averaged_fields = "";
+          raw_fields =
+            "site_id, name, device_id, device_number, timestamp," +
+            "pm2_5, pm10, s1_pm2_5, s2_pm2_5, s1_pm10, s2_pm10, no2," +
+            "pm1, s1_pm1, s2_pm1, pressure, s1_pressure, s2_pressure, temperature," +
+            "humidity, voc, s1_voc, s2_voc, wind_speed, satellites, hdop," +
+            "device_temperature, device_humidity, battery,";
+          mobile = false;
+        }
+      }
+
+      if (tenant === "urban_better") {
+        table = `${constants.DATAWAREHOUSE_RAW_DATA}.mobile_device_measurements`;
+        mobile = true;
+        raw_fields =
+          "tenant, timestamp, device_number, device_id, latitude, longitude," +
+          "horizontal_accuracy, pm2_5_raw_value, pm1_raw_value, pm10_raw_value," +
+          "no2_raw_value, voc_raw_value, pm1_pi_value, pm2_5_pi_value, pm10_pi_value," +
+          "voc_pi_value, no2_pi_value, gps_device_timestamp, timestamp_abs_diff";
+        averaged_fields = "";
+      }
+      // \`${constants.DATAWAREHOUSE_METADATA}.sites\`.altitude AS altitude ,
+      const queryStatement = `SELECT ${averaged_fields} ${raw_fields}  \`${
+        constants.DATAWAREHOUSE_METADATA
+      }.sites\`.latitude AS latitude,
+        \`${constants.DATAWAREHOUSE_METADATA}.sites\`.longitude AS longitude, 
+        \`${constants.DATAWAREHOUSE_METADATA}.sites\`.tenant AS tenant ,
+      
+        FROM \`${table}\` 
+        JOIN \`${constants.DATAWAREHOUSE_METADATA}.sites\` 
+        ON \`${
+          constants.DATAWAREHOUSE_METADATA
+        }.sites\`.id = \`${table}\`.site_id 
+        WHERE timestamp 
+       >= "${start ? start : twoMonthsBack}" AND timestamp <= "${
+        end ? end : currentDate
+      }" 
+      ${site ? `AND site_id="${site}"` : ""}
+      ${device ? `AND device="${device}"` : ""}
+      ${device_number ? `AND device_number=${device_number}` : ""}
+      ${device_name ? `AND device_name="${device_name}"` : ""}
+      ${device_id ? `AND device_id="${device_id}"` : ""}
+      ${site_id ? `AND site_id="${site_id}"` : ""}
+      ${airqloud_id ? `AND airqloud_id="${airqloud_id}"` : ""}
+      ${airqloud_name ? `AND airqloud_name="${airqloud_name}"` : ""}
+      ${device_lat_long ? `AND device_lat_long="${device_lat_long}"` : ""}
+      ${
+        tenant
+          ? `AND \`${constants.DATAWAREHOUSE_METADATA}.sites\`.tenant="${tenant}"`
+          : ""
+      }
+      ORDER BY timestamp
+      DESC LIMIT ${limit ? limit : constants.DEFAULT_EVENTS_LIMIT} OFFSET ${
+        skip ? skip : constants.DEFAULT_EVENTS_SKIP
+      }`;
+
+      const queryStatementMobile = `SELECT ${averaged_fields} ${raw_fields}
+      FROM \`${table}\` 
+      WHERE timestamp 
+      >= "${start ? start : twoMonthsBack}" AND timestamp <= "${
+        end ? end : currentDate
+      }" 
+      ${site ? `AND site_id="${site}"` : ""}
+      ${device ? `AND device="${device}"` : ""}
+      ${device_number ? `AND device_number=${device_number}` : ""}
+      ${device_name ? `AND device_name="${device_name}"` : ""}
+      ${device_id ? `AND device_id="${device_id}"` : ""}
+      ${site_id ? `AND site_id="${site_id}"` : ""}
+      ${airqloud_id ? `AND airqloud_id="${airqloud_id}"` : ""}
+      ${airqloud_name ? `AND airqloud_name="${airqloud_name}"` : ""}
+      ${device_lat_long ? `AND device_lat_long="${device_lat_long}"` : ""}
+     ${tenant ? `AND tenant="${tenant}"` : ""}
+     ORDER BY timestamp
+     DESC LIMIT ${limit ? limit : constants.DEFAULT_EVENTS_LIMIT} OFFSET ${
+        skip ? skip : constants.DEFAULT_EVENTS_SKIP
+      }
+     `;
+
+      const queryStatementReference = `SELECT ${averaged_fields} ${raw_fields}
+      FROM \`${table}\` 
+      WHERE timestamp 
+     >= "${start ? start : twoMonthsBack}" AND timestamp <= "${
+        end ? end : currentDate
+      }" 
+    ${site ? `AND site_id="${site}"` : ""}
+    ${device ? `AND device="${device}"` : ""}
+    ${device_number ? `AND device_number=${device_number}` : ""}
+    ${device_name ? `AND device_name="${device_name}"` : ""}
+    ${device_id ? `AND device_id="${device_id}"` : ""}
+    ${site_id ? `AND site_id="${site_id}"` : ""}
+    ${airqloud_id ? `AND airqloud_id="${airqloud_id}"` : ""}
+    ${airqloud_name ? `AND airqloud_name="${airqloud_name}"` : ""}
+    ${device_lat_long ? `AND device_lat_long="${device_lat_long}"` : ""}
+    ${tenant ? `AND tenant="${tenant}"` : ""}
+    ORDER BY timestamp
+    DESC LIMIT ${limit ? limit : constants.DEFAULT_EVENTS_LIMIT} OFFSET ${
+        skip ? skip : constants.DEFAULT_EVENTS_SKIP
+      }`;
+
+      let bqQuery = "";
+
+      if (mobile === true) {
+        bqQuery = queryStatementMobile;
+      } else if (
+        (!isEmpty(deviceDetails) &&
+          deviceDetails.category !== "bam" &&
+          mobile === false) ||
+        (isEmpty(deviceDetails) && mobile === false)
+      ) {
+        bqQuery = queryStatement;
+      } else if (
+        !isEmpty(deviceDetails) &&
+        deviceDetails.category === "bam" &&
+        mobile === false
+      ) {
+        bqQuery = queryStatementReference;
+      }
+      // logObject("bqQuery", bqQuery);
+      const options = {
+        query: bqQuery,
+        location: constants.BIG_QUERY_LOCATION,
+      };
+
+      const [job] = await bigquery.createQueryJob(options);
+
+      const [rows] = await job.getQueryResults();
+
+      const sanitizedMeasurements = rows.map((item) => {
+        return {
+          ...item,
+          timestamp: item.timestamp ? item.timestamp.value : "",
+          gps_device_timestamp:
+            item.gps_device_timestamp && item.gps_device_timestamp.value
+              ? item.gps_device_timestamp.value
+              : "",
+        };
+      });
+
+      let data = cleanDeep(sanitizedMeasurements);
+
+      if (format && format === "csv") {
+        try {
+          const parser = new Parser();
+          const csv = parser.parse(sanitizedMeasurements);
+          data = csv;
+        } catch (error) {
+          logger.error(`internal server error --- ${error.message}`);
+        }
+      }
+      return {
+        success: true,
+        data,
+        message: "successfully retrieved the measurements",
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  latestFromBigQuery: async (req, next) => {
+    try {
+      const { query } = req;
+      const {
+        frequency,
+        device,
+        name,
+        startTime,
+        endTime,
+        tenant,
+        limit,
+        skip,
+        site,
+      } = query;
+
+      const currentDate = generateDateFormatWithoutHrs(new Date());
+
+      const twoMonthsBack = generateDateFormatWithoutHrs(
+        addMonthsToProvideDateTime(currentDate, -2)
+      );
+
+      const start = generateDateFormatWithoutHrs(
+        startTime ? startTime : twoMonthsBack
+      );
+      const end = generateDateFormatWithoutHrs(endTime ? endTime : currentDate);
+
+      let table = `${constants.DATAWAREHOUSE_AVERAGED_DATA}.hourly_device_measurements`;
+      let pm2_5 = "";
+      let pm10 = "";
+
+      if (frequency === "raw") {
+        table = `${constants.DATAWAREHOUSE_RAW_DATA}.device_measurements`;
+        pm2_5 = "";
+        pm10 = "";
+      }
+
+      const queryStatement = `SELECT site_id, name, device, \`${
+        constants.DATAWAREHOUSE_METADATA
+      }.sites\`.latitude AS latitude,
+        \`${
+          constants.DATAWAREHOUSE_METADATA
+        }.sites\`.longitude AS longitude, timestamp, pm2_5, pm10, pm2_5_raw_value, pm2_5_calibrated_value, pm10_raw_value, pm10_calibrated_value,
+        \`${constants.DATAWAREHOUSE_METADATA}.sites\`.tenant AS tenant 
+        FROM \`${table}\` 
+        JOIN \`${constants.DATAWAREHOUSE_METADATA}.sites\` 
+        ON \`${
+          constants.DATAWAREHOUSE_METADATA
+        }.sites\`.id = \`${table}\`.site_id 
+        WHERE timestamp  
+       >= "${start ? start : twoMonthsBack}" AND timestamp <= "${
+        end ? end : currentDate
+      }" 
+      ${site ? `AND site_id="${site}"` : ""}
+      ${device ? `AND device="${device}"` : ""}
+      ${
+        tenant
+          ? `AND \`${constants.DATAWAREHOUSE_METADATA}.sites\`.tenant="${tenant}"`
+          : ""
+      }
+       LIMIT ${limit ? limit : constants.DEFAULT_EVENTS_LIMIT}`;
+
+      const options = {
+        query: queryStatement,
+        location: constants.BIG_QUERY_LOCATION,
+      };
+
+      const [job] = await bigquery.createQueryJob(options);
+
+      const [rows] = await job.getQueryResults();
+
+      return {
+        success: true,
+        data: rows,
+        message: "successfully retrieved the measurements",
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  list: async (request, next) => {
+    try {
+      let missingDataMessage = "";
+      const { query } = request;
+      let { limit, skip } = query;
+      limit = Number(limit);
+      skip = Number(skip);
+
+      if (Number.isNaN(limit) || limit < 0) {
+        limit = 30;
+      }
+
+      if (Number.isNaN(skip) || skip < 0) {
+        skip = 0;
+      }
+
+      const { tenant } = query;
+      let page = parseInt(query.page);
+      const language = request.query.language;
+      const filter = generateFilter.events(request, next);
+
+      try {
+        const cacheResult = await Promise.race([
+          createEvent.getCache(request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+
+        logObject("Cache result", cacheResult);
+
+        if (cacheResult.success === true) {
+          logText(cacheResult.message);
+          return cacheResult.data;
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      if (page) {
+        skip = parseInt((page - 1) * limit);
+      }
+
+      const responseFromListEvents = await EventModel(tenant).list(
+        {
+          skip,
+          limit,
+          filter,
+          page,
+        },
+        next
+      );
+
+      if (!responseFromListEvents) {
+        // Handle cases where responseFromListEvents is null or undefined
+        logger.error(`🐛🐛 responseFromListEvents is null or undefined`);
+        return next(
+          new HttpError(
+            "Internal Server Error",
+            httpStatus.INTERNAL_SERVER_ERROR,
+            {
+              message: "Error retrieving events from the database",
+            }
+          )
+        );
+      }
+
+      if (
+        language !== undefined &&
+        !isEmpty(responseFromListEvents) &&
+        responseFromListEvents.success === true &&
+        !isEmpty(responseFromListEvents.data[0].data)
+      ) {
+        const data = responseFromListEvents.data[0].data;
+        for (const event of data) {
+          const translatedHealthTips = await translate.translateTips(
+            { healthTips: event.health_tips, targetLanguage: language },
+            next
+          );
+          if (translatedHealthTips.success === true) {
+            event.health_tips = translatedHealthTips.data;
+          }
+        }
+      }
+
+      if (responseFromListEvents.success === true) {
+        const data = responseFromListEvents.data;
+        data[0].data = !isEmpty(missingDataMessage) ? [] : data[0].data;
+
+        logText("Setting cache...");
+
+        try {
+          const resultOfCacheOperation = await Promise.race([
+            createEvent.setCache(data, request, next),
+            new Promise((resolve) =>
+              setTimeout(resolve, 60000, {
+                success: false,
+                message: "Internal Server Error",
+                status: httpStatus.INTERNAL_SERVER_ERROR,
+                errors: { message: "Cache timeout" },
+              })
+            ),
+          ]);
+          if (resultOfCacheOperation.success === false) {
+            const errors = resultOfCacheOperation.errors
+              ? resultOfCacheOperation.errors
+              : { message: "Internal Server Error" };
+            logger.error(`🐛🐛 Internal Server Error -- ${stringify(errors)}`);
+            // return resultOfCacheOperation;
+          }
+        } catch (error) {
+          logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+        }
+
+        logText("Cache set.");
+
+        return {
+          success: true,
+          message: !isEmpty(missingDataMessage)
+            ? missingDataMessage
+            : isEmpty(data[0].data)
+            ? "no measurements for this search"
+            : responseFromListEvents.message,
+          data,
+          status: responseFromListEvents.status || "",
+          isCache: false,
+        };
+      } else {
+        logger.error(
+          `Unable to retrieve events --- ${stringify(
+            responseFromListEvents.errors
+          )}`
+        );
+
+        return {
+          success: false,
+          message: responseFromListEvents.message,
+          errors: responseFromListEvents.errors || { message: "" },
+          status: responseFromListEvents.status || "",
+          isCache: false,
+        };
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  listAveragesV1: async (request, next) => {
+    try {
+      let missingDataMessage = "";
+      const { language, site_id, tenant } = {
+        ...request.query,
+        ...request.params,
+      };
+
+      try {
+        const cacheResult = await Promise.race([
+          createEvent.getCache(request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+
+        logObject("Cache result", cacheResult);
+
+        if (cacheResult.success === true) {
+          logText(cacheResult.message);
+          return cacheResult.data;
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      const responseFromListEvents = await EventModel(
+        tenant
+      ).getAirQualityAverages(site_id, next);
+
+      if (
+        language !== undefined &&
+        !isEmpty(responseFromListEvents) &&
+        responseFromListEvents.success === true &&
+        !isEmpty(responseFromListEvents.data)
+      ) {
+        const data = responseFromListEvents.data;
+        for (const event of data) {
+          const translatedHealthTips = await translate.translateTips(
+            { healthTips: event.health_tips, targetLanguage: language },
+            next
+          );
+          if (translatedHealthTips.success === true) {
+            event.health_tips = translatedHealthTips.data;
+          }
+        }
+      }
+
+      if (responseFromListEvents.success === true) {
+        const data = !isEmpty(missingDataMessage)
+          ? []
+          : responseFromListEvents.data;
+
+        logText("Setting cache...");
+
+        try {
+          const resultOfCacheOperation = await Promise.race([
+            createEvent.setCache(data, request, next),
+            new Promise((resolve) =>
+              setTimeout(resolve, 60000, {
+                success: false,
+                message: "Internal Server Error",
+                status: httpStatus.INTERNAL_SERVER_ERROR,
+                errors: { message: "Cache timeout" },
+              })
+            ),
+          ]);
+          if (resultOfCacheOperation.success === false) {
+            const errors = resultOfCacheOperation.errors
+              ? resultOfCacheOperation.errors
+              : { message: "Internal Server Error" };
+            logger.error(`🐛🐛 Internal Server Error -- ${stringify(errors)}`);
+            // return resultOfCacheOperation;
+          }
+        } catch (error) {
+          logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+        }
+
+        logText("Cache set.");
+
+        return {
+          success: true,
+          message: !isEmpty(missingDataMessage)
+            ? missingDataMessage
+            : isEmpty(data)
+            ? "no measurements for this search"
+            : responseFromListEvents.message,
+          data,
+          status: responseFromListEvents.status || "",
+          isCache: false,
+        };
+      } else {
+        logger.error(
+          `Unable to retrieve events --- ${stringify(
+            responseFromListEvents.errors
+          )}`
+        );
+
+        return {
+          success: false,
+          message: responseFromListEvents.message,
+          errors: responseFromListEvents.errors || { message: "" },
+          status: responseFromListEvents.status || "",
+          isCache: false,
+        };
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  listAverages: async (request, next) => {
+    const service = new AirQualityService(request.query.tenant);
+    return service.getAirQualityData(request, next);
+  },
+
+  listAveragesV2: async (request, next) => {
+    const service = new AirQualityService(request.query.tenant);
+    return service.getAirQualityData(request, next, "v2");
+  },
+  listAveragesV3: async (request, next) => {
+    const service = new AirQualityService(request.query.tenant);
+    return service.getAirQualityData(request, next, "v3");
+  },
+  view: async (request, next) => {
+    try {
+      let missingDataMessage = "";
+      const {
+        query: { tenant, language },
+      } = request;
+      const filter = generateFilter.readings(request, next);
+
+      try {
+        const cacheResult = await Promise.race([
+          createEvent.getCache(request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+
+        if (cacheResult.success === true) {
+          logText(cacheResult.message);
+          return cacheResult.data;
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      const viewEventsResponse = await EventModel(tenant).view(filter, next);
+
+      if (
+        language !== undefined &&
+        !isEmpty(viewEventsResponse) &&
+        viewEventsResponse.success === true &&
+        !isEmpty(viewEventsResponse.data[0].data)
+      ) {
+        const data = viewEventsResponse.data[0].data;
+        for (const event of data) {
+          const translatedHealthTips = await translate.translateTips(
+            { healthTips: event.health_tips, targetLanguage: language },
+            next
+          );
+          if (translatedHealthTips.success === true) {
+            event.health_tips = translatedHealthTips.data;
+          }
+        }
+      }
+
+      if (viewEventsResponse.success === true) {
+        // logObject("viewEventsResponse", viewEventsResponse);
+        const data = viewEventsResponse.data;
+        data[0].data = !isEmpty(missingDataMessage) ? [] : data[0].data;
+
+        logText("Setting cache...");
+
+        try {
+          const resultOfCacheOperation = await Promise.race([
+            createEvent.setCache(data, request, next),
+            new Promise((resolve) =>
+              setTimeout(resolve, 60000, {
+                success: false,
+                message: "Internal Server Error",
+                status: httpStatus.INTERNAL_SERVER_ERROR,
+                errors: { message: "Cache timeout" },
+              })
+            ),
+          ]);
+          if (resultOfCacheOperation.success === false) {
+            const errors = resultOfCacheOperation.errors
+              ? resultOfCacheOperation.errors
+              : { message: "Internal Server Error" };
+            logger.error(`🐛🐛 Internal Server Error -- ${stringify(errors)}`);
+            // return resultOfCacheOperation;
+          }
+        } catch (error) {
+          logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+        }
+
+        logText("Cache set.");
+
+        return {
+          success: true,
+          message: !isEmpty(missingDataMessage)
+            ? missingDataMessage
+            : isEmpty(data[0].data)
+            ? "no measurements for this search"
+            : viewEventsResponse.message,
+          data,
+          status: viewEventsResponse.status || "",
+          isCache: false,
+        };
+      } else {
+        logger.error(
+          `Unable to retrieve events --- ${stringify(
+            viewEventsResponse.errors
+          )}`
+        );
+
+        return {
+          success: false,
+          message: viewEventsResponse.message,
+          errors: viewEventsResponse.errors || { message: "" },
+          status: viewEventsResponse.status || "",
+          isCache: false,
+        };
+      }
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  fetchAndStoreData: async (request, next) => {
+    try {
+      const filter = generateFilter.fetch(request);
+      // Fetch the data
+      const viewEventsResponse = await EventModel("airqo").fetch(filter);
+      logText("we are running running the data insertion script");
+
+      if (viewEventsResponse.success === true) {
+        const data = viewEventsResponse.data[0].data;
+        if (!data) {
+          logText(`🐛🐛 Didn't find any Events to insert into Readings`);
+          logger.error(`🐛🐛 Didn't find any Events to insert into Readings`);
+          return {
+            success: true,
+            message: `🐛🐛 Didn't find any Events to insert into Readings`,
+            status: httpStatus.OK,
+          };
+        }
+        // Prepare the data for batch insertion
+        const batchSize = 50; // Adjust this value based on your requirements
+        const batches = [];
+        for (let i = 0; i < data.length; i += batchSize) {
+          batches.push(data.slice(i, i + batchSize));
+        }
+
+        // Insert each batch in the 'readings' collection with retry logic
+        for (const batch of batches) {
+          for (const doc of batch) {
+            await asyncRetry(
+              async (bail) => {
+                try {
+                  // logObject("document", doc);
+                  const res = await ReadingModel("airqo").updateOne(doc, doc, {
+                    upsert: true,
+                  });
+                  logObject("res", res);
+                  // logObject("Number of documents updated", res.modifiedCount);
+                } catch (error) {
+                  if (error.name === "MongoError" && error.code !== 11000) {
+                    logger.error(
+                      `🐛🐛 MongoError -- fetchAndStoreDataIntoReadingsModel -- ${stringify(
+                        error
+                      )}`
+                    );
+                    throw error; // Retry the operation
+                  } else if (error.code === 11000) {
+                    // Ignore duplicate key errors
+                    console.warn(
+                      `Duplicate key error for document: ${stringify(doc)}`
+                    );
+                  }
+                }
+              },
+              {
+                retries: 5, // Number of retry attempts
+                minTimeout: 1000, // Initial delay between retries (in milliseconds)
+                factor: 2, // Exponential factor for increasing delay between retries
+              }
+            );
+          }
+        }
+        return {
+          success: true,
+          message: `All data inserted successfully`,
+          status: httpStatus.OK,
+        };
+      } else {
+        logObject(
+          `🐛🐛 Unable to retrieve Events to insert into Readings`,
+          viewEventsResponse
+        );
+
+        logger.error(
+          `🐛🐛 Unable to retrieve Events to insert into Readings -- ${stringify(
+            viewEventsResponse
+          )}`
+        );
+        return {
+          success: true,
+          message: `🐛🐛 Unable to retrieve Events to insert into Readings`,
+          status: httpStatus.OK,
+        };
+      }
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  read: async (request, next) => {
+    try {
+      let missingDataMessage = "";
+      const {
+        query: { tenant, language, limit, skip },
+      } = request;
+      try {
+        const cacheResult = await Promise.race([
+          createEvent.getCache(request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+
+        if (cacheResult.success === true) {
+          logText(cacheResult.message);
+          return cacheResult.data;
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      const readingsResponse = await ReadingModel(tenant).latest(
+        {
+          skip,
+          limit,
+        },
+        next
+      );
+
+      if (
+        language !== undefined &&
+        !isEmpty(readingsResponse) &&
+        readingsResponse.success === true &&
+        !isEmpty(readingsResponse.data)
+      ) {
+        const data = readingsResponse.data;
+        for (const event of data) {
+          const translatedHealthTips = await translate.translateTips(
+            { healthTips: event.health_tips, targetLanguage: language },
+            next
+          );
+          if (translatedHealthTips.success === true) {
+            event.health_tips = translatedHealthTips.data;
+          }
+        }
+      }
+
+      if (readingsResponse.success === true) {
+        const data = readingsResponse.data;
+
+        logText("Setting cache...");
+
+        try {
+          const resultOfCacheOperation = await Promise.race([
+            createEvent.setCache(readingsResponse, request, next),
+            new Promise((resolve) =>
+              setTimeout(resolve, 60000, {
+                success: false,
+                message: "Internal Server Error",
+                status: httpStatus.INTERNAL_SERVER_ERROR,
+                errors: { message: "Cache timeout" },
+              })
+            ),
+          ]);
+          if (resultOfCacheOperation.success === false) {
+            const errors = resultOfCacheOperation.errors
+              ? resultOfCacheOperation.errors
+              : { message: "Internal Server Error" };
+            logger.error(`🐛🐛 Internal Server Error -- ${stringify(errors)}`);
+            // return resultOfCacheOperation;
+          }
+        } catch (error) {
+          logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+        }
+
+        logText("Cache set.");
+
+        return {
+          success: true,
+          message: !isEmpty(missingDataMessage)
+            ? missingDataMessage
+            : isEmpty(data)
+            ? "no measurements for this search"
+            : readingsResponse.message,
+          data,
+          status: readingsResponse.status || "",
+          isCache: false,
+        };
+      } else {
+        logger.error(
+          `Unable to retrieve events --- ${stringify(readingsResponse.errors)}`
+        );
+
+        return {
+          success: false,
+          message: readingsResponse.message,
+          errors: readingsResponse.errors || { message: "" },
+          status: readingsResponse.status || "",
+          isCache: false,
+        };
+      }
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  readRecentWithFilter: async (request, next) => {
+    try {
+      let missingDataMessage = "";
+      const {
+        query: { tenant, language, limit, skip },
+      } = request;
+      const filter = generateFilter.telemetry(request);
+      try {
+        const cacheResult = await Promise.race([
+          createEvent.getCache(request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+
+        if (cacheResult.success === true) {
+          logText(cacheResult.message);
+          return cacheResult.data;
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      const readingsResponse = await ReadingModel(tenant).recent(
+        { filter, skip, limit },
+        next
+      );
+
+      if (
+        language !== undefined &&
+        !isEmpty(readingsResponse) &&
+        readingsResponse.success === true &&
+        !isEmpty(readingsResponse.data)
+      ) {
+        const data = readingsResponse.data;
+        for (const event of data) {
+          const translatedHealthTips = await translate.translateTips(
+            { healthTips: event.health_tips, targetLanguage: language },
+            next
+          );
+          if (translatedHealthTips.success === true) {
+            event.health_tips = translatedHealthTips.data;
+          }
+        }
+      }
+
+      if (readingsResponse.success === true) {
+        const data = readingsResponse.data;
+
+        logText("Setting cache...");
+
+        try {
+          const resultOfCacheOperation = await Promise.race([
+            createEvent.setCache(readingsResponse, request, next),
+            new Promise((resolve) =>
+              setTimeout(resolve, 60000, {
+                success: false,
+                message: "Internal Server Error",
+                status: httpStatus.INTERNAL_SERVER_ERROR,
+                errors: { message: "Cache timeout" },
+              })
+            ),
+          ]);
+          if (resultOfCacheOperation.success === false) {
+            const errors = resultOfCacheOperation.errors
+              ? resultOfCacheOperation.errors
+              : { message: "Internal Server Error" };
+            logger.error(`🐛🐛 Internal Server Error -- ${stringify(errors)}`);
+            // return resultOfCacheOperation;
+          }
+        } catch (error) {
+          logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+        }
+
+        logText("Cache set.");
+
+        return {
+          success: true,
+          message: !isEmpty(missingDataMessage)
+            ? missingDataMessage
+            : isEmpty(data)
+            ? "no measurements for this search"
+            : readingsResponse.message,
+          data,
+          status: readingsResponse.status || "",
+          isCache: false,
+        };
+      } else {
+        logger.error(
+          `Unable to retrieve events --- ${stringify(readingsResponse.errors)}`
+        );
+
+        return {
+          success: false,
+          message: readingsResponse.message,
+          errors: readingsResponse.errors || { message: "" },
+          status: readingsResponse.status || "",
+          isCache: false,
+        };
+      }
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  getWorstReadingForSites: async (req, res, next) => {
+    try {
+      const siteIds = req.body.siteIds; // Assuming you pass the siteIds in the request body
+
+      const result = await ReadingModel("airqo").getWorstPm2_5Reading({
+        siteIds,
+        next,
+      });
+
+      if (result.success) {
+        res.status(result.status).json(result);
+      } else {
+        // Handle errors based on result.message and result.errors
+        next(result);
+      }
+    } catch (error) {
+      // Handle unexpected errors
+      next(error);
+    }
+  },
+  getWorstReadingForDevices: async ({ deviceIds = [], next } = {}) => {
+    try {
+      if (isEmpty(deviceIds) || !Array.isArray(deviceIds)) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message: "deviceIds array is required",
+          })
+        );
+        return;
+      }
+      if (deviceIds.length === 0) {
+        return {
+          success: true,
+          message: "No device_ids were provided",
+          data: [],
+          status: httpStatus.OK,
+        };
+      }
+
+      // Validate deviceIds type
+      if (!deviceIds.every((id) => typeof id === "string")) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message: "deviceIds must be an array of strings",
+          })
+        );
+        return;
+      }
+
+      const formattedDeviceIds = deviceIds.map((id) => id.toString());
+      const threeDaysAgo = new Date();
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+      const pipeline = ReadingModel("airqo")
+        .aggregate([
+          {
+            $match: {
+              device_id: { $in: formattedDeviceIds },
+              time: { $gte: threeDaysAgo },
+              "pm2_5.value": { $exists: true }, // Ensure pm2_5.value exists
+            },
+          },
+          {
+            $sort: { "pm2_5.value": -1, time: -1 }, // Sort by pm2_5 descending, then by time
+          },
+          {
+            $limit: 1, // Take only the worst reading
+          },
+          {
+            $project: {
+              _id: 0, // Exclude the MongoDB-generated _id
+              device_id: 1,
+              time: 1,
+              pm2_5: 1,
+              device: 1,
+              siteDetails: 1,
+            },
+          },
+        ])
+        .allowDiskUse(true);
+
+      const worstReading = await pipeline.exec();
+
+      if (!isEmpty(worstReading)) {
+        return {
+          success: true,
+          message: "Successfully retrieved the worst pm2_5 reading.",
+          data: worstReading[0],
+          status: httpStatus.OK,
+        };
+      } else {
+        return {
+          success: true,
+          message:
+            "No pm2_5 readings found for the specified device_ids in the last three days.",
+          data: {},
+          status: httpStatus.OK,
+        };
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          {
+            message: error.message,
+          }
+        )
+      );
+      return;
+    }
+  },
+  listReadingAverages: async (request, next) => {
+    try {
+      let missingDataMessage = "";
+      const { tenant, language, site_id } = {
+        ...request.query,
+        ...request.params,
+      };
+      try {
+        const cacheResult = await Promise.race([
+          createEvent.getCache(request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+
+        if (cacheResult.success === true) {
+          logText(cacheResult.message);
+          return cacheResult.data;
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      const readingsResponse = await ReadingModel(
+        tenant
+      ).getAirQualityAnalytics(site_id, next);
+
+      if (
+        language !== undefined &&
+        !isEmpty(readingsResponse) &&
+        readingsResponse.success === true &&
+        !isEmpty(readingsResponse.data)
+      ) {
+        const data = readingsResponse.data;
+        for (const event of data) {
+          const translatedHealthTips = await translate.translateTips(
+            { healthTips: event.health_tips, targetLanguage: language },
+            next
+          );
+          if (translatedHealthTips.success === true) {
+            event.health_tips = translatedHealthTips.data;
+          }
+        }
+      }
+
+      if (readingsResponse.success === true) {
+        const data = readingsResponse.data;
+
+        logText("Setting cache...");
+
+        try {
+          const resultOfCacheOperation = await Promise.race([
+            createEvent.setCache(readingsResponse, request, next),
+            new Promise((resolve) =>
+              setTimeout(resolve, 60000, {
+                success: false,
+                message: "Internal Server Error",
+                status: httpStatus.INTERNAL_SERVER_ERROR,
+                errors: { message: "Cache timeout" },
+              })
+            ),
+          ]);
+          if (resultOfCacheOperation.success === false) {
+            const errors = resultOfCacheOperation.errors
+              ? resultOfCacheOperation.errors
+              : { message: "Internal Server Error" };
+            logger.error(`🐛🐛 Internal Server Error -- ${stringify(errors)}`);
+            // return resultOfCacheOperation;
+          }
+        } catch (error) {
+          logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+        }
+
+        logText("Cache set.");
+
+        return {
+          success: true,
+          message: !isEmpty(missingDataMessage)
+            ? missingDataMessage
+            : isEmpty(data)
+            ? "no measurements for this search"
+            : readingsResponse.message,
+          data,
+          status: readingsResponse.status || "",
+          isCache: false,
+        };
+      } else {
+        logger.error(
+          `Unable to retrieve events --- ${stringify(readingsResponse.errors)}`
+        );
+
+        return {
+          success: false,
+          message: readingsResponse.message,
+          errors: readingsResponse.errors || { message: "" },
+          status: readingsResponse.status || "",
+          isCache: false,
+        };
+      }
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  getBestAirQuality: async (request, next) => {
+    try {
+      const {
+        query: { tenant, threshold, pollutant, language, limit, skip },
+      } = request;
+
+      try {
+        const cacheResult = await Promise.race([
+          createEvent.getCache(request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+
+        if (cacheResult.success === true) {
+          logText(cacheResult.message);
+          return cacheResult.data;
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      const readingsResponse = await ReadingModel(
+        tenant
+      ).getBestAirQualityLocations({ threshold, pollutant, limit, skip }, next);
+
+      // Handle language translation for health tips if applicable
+      if (
+        language !== undefined &&
+        readingsResponse.success === true &&
+        !isEmpty(readingsResponse.data)
+      ) {
+        const data = readingsResponse.data;
+        for (const event of data) {
+          const translatedHealthTips = await translate.translateTips(
+            { healthTips: event.health_tips, targetLanguage: language },
+            next
+          );
+          if (translatedHealthTips.success === true) {
+            event.health_tips = translatedHealthTips.data;
+          }
+        }
+      }
+
+      try {
+        const resultOfCacheOperation = await Promise.race([
+          createEvent.setCache(readingsResponse, request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+        if (resultOfCacheOperation.success === false) {
+          const errors = resultOfCacheOperation.errors || {
+            message: "Internal Server Error",
+          };
+          logger.error(`🐛🐛 Internal Server Error -- ${stringify(errors)}`);
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      return {
+        success: true,
+        message:
+          readingsResponse.message ||
+          "Successfully retrieved air quality data.",
+        data: readingsResponse.data,
+        status: readingsResponse.status || "",
+        isCache: false,
+      };
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  signal: async (request, next) => {
+    try {
+      let missingDataMessage = "";
+      const {
+        query: { tenant, language, limit, skip },
+      } = request;
+      try {
+        const cacheResult = await Promise.race([
+          createEvent.getCache(request, next),
+          new Promise((resolve) =>
+            setTimeout(resolve, 60000, {
+              success: false,
+              message: "Internal Server Error",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              errors: { message: "Cache timeout" },
+            })
+          ),
+        ]);
+
+        if (cacheResult.success === true) {
+          logText(cacheResult.message);
+          return cacheResult.data;
+        }
+      } catch (error) {
+        logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+      }
+
+      const readingsResponse = await SignalModel(tenant).latest(
+        {
+          skip,
+          limit,
+        },
+        next
+      );
+
+      if (
+        language !== undefined &&
+        !isEmpty(readingsResponse) &&
+        readingsResponse.success === true &&
+        !isEmpty(readingsResponse.data)
+      ) {
+        const data = readingsResponse.data;
+        for (const event of data) {
+          const translatedHealthTips = await translate.translateTips(
+            { healthTips: event.health_tips, targetLanguage: language },
+            next
+          );
+          if (translatedHealthTips.success === true) {
+            event.health_tips = translatedHealthTips.data;
+          }
+        }
+      }
+
+      if (readingsResponse.success === true) {
+        const data = readingsResponse.data;
+
+        logText("Setting cache...");
+
+        try {
+          const resultOfCacheOperation = await Promise.race([
+            createEvent.setCache(readingsResponse, request, next),
+            new Promise((resolve) =>
+              setTimeout(resolve, 60000, {
+                success: false,
+                message: "Internal Server Error",
+                status: httpStatus.INTERNAL_SERVER_ERROR,
+                errors: { message: "Cache timeout" },
+              })
+            ),
+          ]);
+          if (resultOfCacheOperation.success === false) {
+            const errors = resultOfCacheOperation.errors
+              ? resultOfCacheOperation.errors
+              : { message: "Internal Server Error" };
+            logger.error(`🐛🐛 Internal Server Error -- ${stringify(errors)}`);
+            // return resultOfCacheOperation;
+          }
+        } catch (error) {
+          logger.error(`🐛🐛 Internal Server Errors -- ${stringify(error)}`);
+        }
+
+        logText("Cache set.");
+
+        return {
+          success: true,
+          message: !isEmpty(missingDataMessage)
+            ? missingDataMessage
+            : isEmpty(data)
+            ? "no measurements for this search"
+            : readingsResponse.message,
+          data,
+          status: readingsResponse.status || "",
+          isCache: false,
+        };
+      } else {
+        logger.error(
+          `Unable to retrieve events --- ${stringify(readingsResponse.errors)}`
+        );
+
+        return {
+          success: false,
+          message: readingsResponse.message,
+          errors: readingsResponse.errors || { message: "" },
+          status: readingsResponse.status || "",
+          isCache: false,
+        };
+      }
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  create: async (request, next) => {
+    try {
+      const transformEventsResponse = await createEvent.transformManyEvents(
+        request,
+        next
+      );
+      // logObject("transformEventsResponse man", transformEventsResponse);
+      if (transformEventsResponse.success === true) {
+        let transformedEvents = transformEventsResponse.data;
+        let nAdded = 0;
+        let eventsAdded = [];
+        let eventsRejected = [];
+        let errors = [];
+
+        for (const event of transformedEvents) {
+          try {
+            // logObject("event", event);
+            let value = event;
+            let dot = new Dot(".");
+            let options = event.options;
+            let filter = cleanDeep(event.filter);
+            let update = event.update;
+            dot.delete(["filter", "update", "options"], value);
+            update["$push"] = { values: value };
+
+            // logObject("event.tenant", event.tenant);
+            // logObject("update", update);
+            // logObject("filter", filter);
+            // logObject("options", options);
+
+            const addedEvents = await EventModel(event.tenant).updateOne(
+              filter,
+              update,
+              options
+            );
+            // logObject("addedEvents", addedEvents);
+            if (addedEvents) {
+              nAdded += 1;
+              eventsAdded.push(event);
+            } else if (!addedEvents) {
+              let errMsg = {
+                message: "unable to add the events",
+                record: {
+                  ...(event.device ? { device: event.device } : {}),
+                  ...(event.frequency ? { frequency: event.frequency } : {}),
+                  ...(event.time ? { time: event.time } : {}),
+                  ...(event.device_id ? { device_id: event.device_id } : {}),
+                  ...(event.site_id ? { site_id: event.site_id } : {}),
+                },
+              };
+              errors.push(errMsg);
+            } else {
+              eventsRejected.push(event);
+              let errMsg = {
+                message: "unable to add the events",
+                record: {
+                  ...(event.device ? { device: event.device } : {}),
+                  ...(event.frequency ? { frequency: event.frequency } : {}),
+                  ...(event.time ? { time: event.time } : {}),
+                  ...(event.device_id ? { device_id: event.device_id } : {}),
+                  ...(event.site_id ? { site_id: event.site_id } : {}),
+                },
+              };
+              errors.push(errMsg);
+            }
+          } catch (e) {
+            // logger.error(`internal server error -- ${e.message}`);
+            eventsRejected.push(event);
+            let errMsg = {
+              message:
+                "system conflict detected, most likely a duplicate record",
+              more: e.message,
+              record: {
+                ...(event.device ? { device: event.device } : {}),
+                ...(event.frequency ? { frequency: event.frequency } : {}),
+                ...(event.time ? { time: event.time } : {}),
+                ...(event.device_id ? { device_id: event.device_id } : {}),
+                ...(event.site_id ? { site_id: event.site_id } : {}),
+              },
+            };
+            errors.push(errMsg);
+          }
+        }
+
+        if (errors.length > 0 && nAdded === 0) {
+          return {
+            success: false,
+            status: httpStatus.CONFLICT,
+            message: "all operations failed with conflicts",
+            errors,
+          };
+        } else if (errors.length > 0 && nAdded > 0) {
+          return {
+            success: true,
+            status: httpStatus.OK,
+            message: "finished the operation with some conflicts",
+            errors,
+          };
+        } else if (errors.length === 0 && nAdded > 0) {
+          return {
+            success: true,
+            status: httpStatus.OK,
+            message: "successfully added all the events",
+          };
+        }
+      } else if (transformEventsResponse.success === false) {
+        // logText("maan, things have jam!");
+        return transformEventsResponse;
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  deleteEvents: async (
+    tenant,
+    startTime,
+    endTime,
+    device,
+    site,
+    next,
+    limit = 1000
+  ) => {
+    try {
+      let filter = {
+        ...(device ? { device } : {}), // Add device filter if provided
+        ...(site ? { site } : {}), // Add site filter if provided
+      };
+
+      if (startTime && endTime) {
+        filter["values.time"] = {
+          $gte: new Date(startTime),
+          $lte: new Date(endTime),
+        };
+      }
+
+      let deletedCount = 0;
+      let totalDeletedCount = 0;
+      let shouldContinue = true;
+      let lastDeletedEventTime = new Date(endTime); // Initialize with endTime
+
+      do {
+        const eventsToDelete = await EventModel(tenant)
+          .find(filter)
+          .sort({ "values.time": -1 }) //sort in decending order of time to consistently pick the last time in every batch
+          .limit(limit)
+          .lean();
+
+        if (eventsToDelete.length === 0) {
+          shouldContinue = false;
+        } else {
+          const eventIds = eventsToDelete.map((event) => event._id);
+          try {
+            const result = await EventModel(tenant).deleteMany({
+              _id: { $in: eventIds },
+            });
+            deletedCount = result.deletedCount;
+            totalDeletedCount += deletedCount;
+          } catch (error) {
+            logger.error(`Batch deletion failed: ${error.message}`);
+            return {
+              success: false,
+              message: "Batch deletion failed",
+              error: error.message,
+              deletedCount: totalDeletedCount,
+              lastEndTimeProcessed: lastDeletedEventTime,
+            };
+          }
+
+          if (deletedCount > 0) {
+            //pick the minimum time in the current batch since the query sorts in descending order
+            lastDeletedEventTime = Math.min(
+              ...eventsToDelete.map((event) => {
+                if (event.values && Array.isArray(event.values)) {
+                  return Math.min(
+                    ...event.values.map((val) => new Date(val.time))
+                  );
+                }
+                return new Date(); // Return current time if no values to avoid affecting Math.min
+              })
+            );
+
+            filter["values.time"]["$lte"] = lastDeletedEventTime; // Adjust $lte
+          } else {
+            shouldContinue = false; // Stop if nothing deleted in this batch
+          }
+        }
+      } while (shouldContinue);
+
+      logObject("totalDeletedCount", totalDeletedCount);
+      logObject("lastDeletedEventTime", lastDeletedEventTime);
+
+      return {
+        success: true,
+        message: "Events deleted successfully",
+        deletedCount: totalDeletedCount,
+        lastEndTimeProcessed: lastDeletedEventTime,
+      };
+    } catch (error) {
+      logObject("the error in the util", error);
+      logger.error(`Error deleting events: ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  store: async (request, next) => {
+    try {
+      const transformReadingsResponse = await transformManyReadings(
+        request,
+        next
+      );
+      logObject("transformReadingsResponse man", transformReadingsResponse);
+      if (transformReadingsResponse.success === true) {
+        let transformedReadings = transformReadingsResponse.data;
+        let result = await processEvents(transformedReadings, next);
+        return result;
+      } else if (transformReadingsResponse.success === false) {
+        logText("maan, things have jam!");
+        return transformReadingsResponse;
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  generateOtherDataString: (inputObject, next) => {
+    try {
+      const str = Object.values(inputObject).join(",");
+      return str;
+    } catch (error) {
+      logger.error(`internal server error -- ${error.message}`);
+    }
+  },
+  createThingSpeakRequestBody: (req, next) => {
+    try {
+      const {
+        api_key,
+        time,
+        s1_pm2_5,
+        s1_pm10,
+        s2_pm2_5,
+        s2_pm10,
+        latitude,
+        longitude,
+        battery,
+        status,
+        altitude,
+        wind_speed,
+        satellites,
+        hdop,
+        internal_temperature,
+        internal_humidity,
+        external_temperature,
+        external_humidity,
+        external_pressure,
+        external_altitude,
+        category,
+        rtc_adc,
+        rtc_v,
+        rtc,
+        stc_adc,
+        stc_v,
+        stc,
+      } = req.body;
+
+      let stringPositionsAndValues = {};
+      stringPositionsAndValues[0] = latitude || null;
+      stringPositionsAndValues[1] = longitude || null;
+      stringPositionsAndValues[2] = altitude || null;
+      stringPositionsAndValues[3] = wind_speed || null;
+      stringPositionsAndValues[4] = satellites || null;
+      stringPositionsAndValues[5] = hdop || null;
+      stringPositionsAndValues[6] = internal_temperature || null;
+      stringPositionsAndValues[7] = internal_humidity || null;
+      stringPositionsAndValues[8] = external_temperature || null;
+      stringPositionsAndValues[9] = external_humidity || null;
+      stringPositionsAndValues[10] = external_pressure || null;
+      stringPositionsAndValues[11] = external_altitude || null;
+      stringPositionsAndValues[12] = category || null;
+
+      const otherDataString = createEvent.generateOtherDataString(
+        stringPositionsAndValues,
+        next
+      );
+      let requestBody = {};
+      const lowCostRequestBody = {
+        api_key: api_key,
+        created_at: time,
+        field1: s1_pm2_5,
+        field2: s1_pm10,
+        field3: s2_pm2_5,
+        field4: s2_pm10,
+        field5: latitude,
+        field6: longitude,
+        field7: battery,
+        field8: otherDataString,
+        latitude: latitude,
+        longitude: longitude,
+        status: status,
+      };
+
+      const bamRequestBody = {
+        api_key: api_key,
+        created_at: time,
+        field1: rtc_adc,
+        field2: rtc_v,
+        field3: rtc,
+        field4: stc_adc,
+        field5: stc_v,
+        field6: stc,
+        field7: battery,
+        field8: otherDataString,
+        latitude: latitude,
+        longitude: longitude,
+        status: status,
+      };
+
+      if (category === "bam") {
+        requestBody = bamRequestBody;
+      } else if (category === "lowcost") {
+        requestBody = lowCostRequestBody;
+      }
+
+      return {
+        success: true,
+        message: "successfully created ThingSpeak body",
+        data: requestBody,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  transmitMultipleSensorValues: async (request, next) => {
+    try {
+      let requestBody = {};
+      const responseFromListDevice = await listDevices(request, next);
+      let deviceDetail = {};
+      if (responseFromListDevice.success === true) {
+        if (responseFromListDevice.data.length === 1) {
+          deviceDetail = responseFromListDevice.data[0];
+          if (isEmpty(deviceDetail.category)) {
+            return {
+              success: false,
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              message:
+                "unable to categorise this device, please first update device details",
+              errors: {
+                message:
+                  "unable to categorise this device, please first update device details",
+              },
+            };
+          }
+        } else {
+          return {
+            success: false,
+            status: httpStatus.NOT_FOUND,
+            message: "no matching devices found",
+            errors: { message: "no matching devices found" },
+          };
+        }
+      } else if (responseFromListDevice.success === false) {
+        return {
+          success: false,
+          message: responseFromListDevice.message,
+          errors: responseFromListDevice.errors
+            ? responseFromListDevice.errors
+            : { message: "" },
+          status: responseFromListDevice.status
+            ? responseFromListDevice.status
+            : httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+
+      let requestBodyForCreateThingsSpeakBody = request;
+      requestBodyForCreateThingsSpeakBody["body"]["category"] =
+        deviceDetail.category;
+
+      const responseFromCreateRequestBody = createEvent.createThingSpeakRequestBody(
+        requestBodyForCreateThingsSpeakBody,
+        next
+      );
+
+      if (responseFromCreateRequestBody.success === true) {
+        requestBody = responseFromCreateRequestBody.data;
+      } else {
+        return {
+          success: false,
+          message: responseFromCreateRequestBody.message,
+          status: responseFromCreateRequestBody.status,
+        };
+      }
+
+      let api_key = deviceDetail.writeKey;
+      const responseFromDecryptKey = await decryptKey(api_key);
+      if (responseFromDecryptKey.success === true) {
+        api_key = responseFromDecryptKey.data;
+      } else if (responseFromDecryptKey.success === false) {
+        return responseFromDecryptKey;
+      }
+      requestBody.api_key = api_key;
+      return await axios
+        .post(constants.ADD_VALUE_JSON, requestBody)
+        .then(function(response) {
+          let resp = {};
+          if (isEmpty(response.data)) {
+            return {
+              success: false,
+              message: "successful operation but no data sent",
+              status: httpStatus.CONFLICT,
+              data: resp,
+              errors: {
+                message: "likely a duplicate value or system conflict",
+              },
+            };
+          } else if (!isEmpty(response.data)) {
+            resp.channel_id = response.data.channel_id;
+            resp.created_at = response.data.created_at;
+            resp.entry_id = response.data.entry_id;
+            return {
+              message: "successfully transmitted the data",
+              success: true,
+              data: resp,
+            };
+          }
+        })
+        .catch(function(error) {
+          try {
+            logger.error(
+              `internal server error -- ${stringify(
+                error.response.data.error.details
+              )}`
+            );
+          } catch (error) {
+            logger.error(`internal server error -- ${error.message}`);
+          }
+          return {
+            success: false,
+            message: "Internal Server Error",
+            errors: {
+              message: error.response
+                ? error.response.data.error.details
+                : "Unable to establish connection with external system",
+            },
+            status: error.response
+              ? error.response.data.status
+              : httpStatus.INTERNAL_SERVER_ERROR,
+          };
+        });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  bulkTransmitMultipleSensorValues: async (request, next) => {
+    try {
+      logText("bulk write to thing.......");
+      const { body } = request;
+
+      const responseFromListDevice = await listDevices(request, next);
+
+      let deviceDetail = {};
+
+      if (responseFromListDevice.success === true) {
+        if (responseFromListDevice.data.length === 1) {
+          deviceDetail = responseFromListDevice.data[0];
+          if (isEmpty(deviceDetail.category)) {
+            return {
+              success: false,
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+              message:
+                "unable to categorise this device, please first update device details",
+            };
+          }
+        } else {
+          return {
+            success: false,
+            status: httpStatus.NOT_FOUND,
+            message: "device not found for this organisation",
+          };
+        }
+      } else if (responseFromListDevice.success === false) {
+        return responseFromListDevice;
+      }
+
+      const channel = deviceDetail.device_number;
+      let api_key = deviceDetail.writeKey;
+
+      const responseFromDecryptKey = await decryptKey(api_key);
+      if (responseFromDecryptKey.success === true) {
+        api_key = responseFromDecryptKey.data;
+      } else if (responseFromDecryptKey.success === false) {
+        return responseFromDecryptKey;
+      }
+      let enrichedBody = [];
+
+      body.forEach((value) => {
+        value["category"] = deviceDetail.category;
+        enrichedBody.push(value);
+      });
+
+      let responseFromTransformMeasurements = await createEvent.transformMeasurementFields(
+        enrichedBody,
+        next
+      );
+
+      let transformedUpdates = {};
+      if (responseFromTransformMeasurements.success === true) {
+        transformedUpdates = responseFromTransformMeasurements.data;
+      } else {
+        return responseFromTransformMeasurements;
+      }
+
+      let requestObject = {};
+      requestObject.write_api_key = api_key;
+      requestObject.updates = transformedUpdates;
+      return await axios
+        .post(constants.BULK_ADD_VALUES_JSON(channel), requestObject)
+        .then(function(response) {
+          if (isEmpty(response)) {
+            return {
+              success: false,
+              message: "successful operation but no data sent",
+              status: httpStatus.CONFLICT,
+              errors: {
+                message: "likely duplicate values or system conflicts",
+              },
+            };
+          } else if (!isEmpty(response)) {
+            let output = JSON.parse(response.config.data).updates;
+            return {
+              message: "successfully transmitted the data",
+              success: true,
+              data: output,
+              status: httpStatus.OK,
+            };
+          }
+        })
+        .catch(function(error) {
+          try {
+            logger.error(
+              `internal server error -- ${stringify(error.response.data.error)}`
+            );
+          } catch (error) {
+            logger.error(`internal server error -- ${error.message}`);
+          }
+          return {
+            success: false,
+            message: "Internal Server Error",
+            errors: {
+              message: error.response
+                ? error.response.data.error
+                : "Unable to establish connection with external system",
+            },
+            status: error.response
+              ? error.response.data.status
+              : httpStatus.INTERNAL_SERVER_ERROR,
+          };
+        });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  generateCacheID: (request, next) => {
+    try {
+      const {
+        device,
+        device_number,
+        device_id,
+        site,
+        site_id,
+        airqloud_id,
+        airqloud,
+        tenant,
+        skip,
+        limit,
+        frequency,
+        startTime,
+        endTime,
+        metadata,
+        external,
+        recent,
+        lat_long,
+        page,
+        index,
+        running,
+        brief,
+        latitude,
+        longitude,
+        network,
+        language,
+        averages,
+        threshold,
+        pollutant,
+        quality_checks,
+      } = { ...request.query, ...request.params };
+      const currentTime = new Date().toISOString();
+      const day = generateDateFormatWithoutHrs(currentTime);
+      return `list_events
+      _${device ? device : "noDevice"}
+      _${tenant}
+      _${skip ? skip : 0}
+      _${limit ? limit : 0}
+      _${recent ? recent : "noRecent"}
+      _${frequency ? frequency : "noFrequency"}
+      _${endTime ? endTime : "noEndTime"}
+      _${startTime ? startTime : "noStartTime"}
+      _${device_id ? device_id : "noDeviceId"}
+      _${site ? site : "noSite"}
+      _${site_id ? site_id : "noSiteId"}
+      _${day ? day : "noDay"}
+      _${device_number ? device_number : "noDeviceNumber"}
+      _${metadata ? metadata : "noMetadata"}
+      _${external ? external : "noExternal"}
+      _${airqloud ? airqloud : "noAirQloud"}
+      _${airqloud_id ? airqloud_id : "noAirQloudID"}
+      _${lat_long ? lat_long : "noLatLong"}
+      _${page ? page : "noPage"}
+      _${running ? running : "noRunning"}
+      _${index ? index : "noIndex"}
+      _${brief ? brief : "noBrief"}
+      _${latitude ? latitude : "noLatitude"}
+      _${longitude ? longitude : "noLongitude"}
+      _${network ? network : "noNetwork"}
+      _${language ? language : "noLanguage"}
+      _${averages ? averages : "noAverages"}
+      _${threshold ? threshold : "noThreshold"}
+      _${pollutant ? pollutant : "noPollutant"}
+      _${quality_checks ? quality_checks : "noQualityChecks"}
+      `;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  setCache: async (data, request, next) => {
+    try {
+      const cacheID = createEvent.generateCacheID(request, next);
+      await redisSetAsync(
+        cacheID,
+        stringify({
+          isCache: true,
+          success: true,
+          message: "Successfully retrieved the measurements",
+          data,
+        })
+      );
+      await redisExpireAsync(
+        cacheID,
+        parseInt(constants.EVENTS_CACHE_LIMIT) || 0
+      );
+
+      return {
+        success: true,
+        message: "Response stored in cache",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  getCache: async (request, next) => {
+    try {
+      const cacheID = createEvent.generateCacheID(request, next);
+      const result = await redisGetAsync(cacheID); // Use the promise-based version
+
+      const resultJSON = JSON.parse(result);
+
+      if (result) {
+        return {
+          success: true,
+          message: "Utilizing cache...",
+          data: resultJSON,
+          status: httpStatus.OK,
+        };
+      } else {
+        return {
+          success: false,
+          message: "No cache present",
+          errors: { message: "No cache present" },
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  transformOneEvent: async (
+    { data = {}, map = {}, context = {} } = {},
+    next
+  ) => {
+    try {
+      let dot = new Dot(".");
+      let modifiedFilter = {};
+
+      let result = {};
+      let transformedEvent = transform(data, map, context);
+
+      return {
+        success: true,
+        message: "successfully transformed the provided event",
+        data: transformedEvent,
+      };
+
+      const responseFromEnrichOneEvent = await createEvent.enrichOneEvent(
+        transformedEvent,
+        next
+      );
+
+      logObject("responseFromEnrichOneEvent", responseFromEnrichOneEvent);
+
+      if (responseFromEnrichOneEvent.success === true) {
+        result = responseFromEnrichOneEvent.data;
+        logObject("the result", result);
+        if (!isEmpty(result)) {
+          dot.object(result);
+          let cleanedResult = cleanDeep(result);
+          return {
+            success: true,
+            message: "successfully transformed the provided event",
+            data: cleanedResult,
+          };
+        } else {
+          logger.warn(
+            `the request body for the external system is empty after transformation`
+          );
+          return {
+            success: false,
+            message:
+              "the request body for the external system is empty after transformation",
+          };
+        }
+      } else if (responseFromEnrichOneEvent.success === false) {
+        logger.error(
+          `responseFromEnrichOneEvent , not a success -- ${responseFromEnrichOneEvent.message}`
+        );
+        return {
+          success: false,
+          message: "unable to enrich event using device details",
+          errors: { message: responseFromEnrichOneEvent.message },
+          status: responseFromEnrichOneEvent.status,
+        };
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  enrichOneEvent: async (transformedEvent, next) => {
+    try {
+      let request = {};
+      let enrichedEvent = transformedEvent;
+
+      logObject("transformed event received for enrichment", transformedEvent);
+      logObject(
+        "transformedEvent[filter][$or]",
+        transformedEvent["filter"]["$or"]
+      );
+      request["query"] = {};
+      request["query"]["device"] = transformedEvent.filter.device;
+      request["query"]["tenant"] = transformedEvent.tenant;
+
+      const responseFromGetDeviceDetails = await listDevices(request, next);
+
+      if (responseFromGetDeviceDetails.success === true) {
+        if (responseFromGetDeviceDetails.data.length === 1) {
+          let deviceDetails = responseFromGetDeviceDetails.data[0];
+
+          enrichedEvent["is_test_data"] = !deviceDetails.isActive;
+          enrichedEvent["is_device_primary"] =
+            deviceDetails.isPrimaryInLocation;
+
+          return {
+            success: true,
+            message: "successfully enriched",
+            data: enrichedEvent,
+          };
+        } else {
+          return {
+            success: false,
+            message: "unable to find one device matching provided details",
+            status: httpStatus.BAD_REQUEST,
+          };
+        }
+      } else if (responseFromGetDeviceDetails.success === false) {
+        let errors = responseFromGetDeviceDetails.errors
+          ? responseFromGetDeviceDetails.errors
+          : { message: "" };
+        try {
+          logger.error(
+            `responseFromGetDeviceDetails was not a success -- ${
+              responseFromGetDeviceDetails.message
+            } -- ${stringify(errors)}`
+          );
+        } catch (error) {
+          logger.error(`internal server error -- ${error.message}`);
+        }
+        return {
+          success: false,
+          message: responseFromGetDeviceDetails.message,
+          errors,
+        };
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  transformManyEvents: async (request, next) => {
+    try {
+      const { body } = request;
+
+      let promises = body.map(async (event) => {
+        const data = event;
+        const map = constants.EVENT_MAPPINGS;
+
+        const transformEventsResponse = await createEvent.transformOneEvent(
+          {
+            data,
+            map,
+          },
+          next
+        );
+
+        if (transformEventsResponse.success === true) {
+          return transformEventsResponse;
+        } else if (transformEventsResponse.success === false) {
+          let errors = transformEventsResponse.errors
+            ? transformEventsResponse.errors
+            : { message: "" };
+          try {
+            logger.error(
+              `transformEventsResponse is not a success -- unable to transform -- ${stringify(
+                errors
+              )}`
+            );
+          } catch (error) {
+            logger.error(`internal server error -- ${error.message}`);
+          }
+          return transformEventsResponse;
+        }
+      });
+
+      return Promise.all(promises).then((results) => {
+        let transforms = [];
+        let errors = [];
+        if (results.every((res) => res.success === true)) {
+          for (const result of results) {
+            transforms.push(result.data);
+          }
+        } else if (results.every((res) => res.success === false)) {
+          for (const result of results) {
+            let error = result.errors ? result.errors : { message: "" };
+            errors.push(error);
+          }
+          try {
+          } catch (error) {
+            logger.error(`internal server error -- ${error.message}`);
+          }
+        }
+        if (errors.length > 0) {
+          return {
+            success: false,
+            errors,
+            message: "some operational errors as we were trying to transform",
+            data: transforms,
+            status: httpStatus.BAD_REQUEST,
+          };
+        } else if (errors.length === 0) {
+          return {
+            success: true,
+            errors,
+            message: "transformation successfully done",
+            data: transforms,
+            status: httpStatus.OK,
+          };
+        }
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  addEvents: async (request, next) => {
+    try {
+      // logText("adding the events insertTransformedEvents to the util.....");
+      // logger.info(`adding events in the util.....`);
+      /**
+       * Step One: trasform or prepare for insertion into Events collection -- prepare the nesting expexctation
+       * Step Two: Insert
+       */
+      const { tenant } = request.query;
+      const transformEventsResponses = await createEvent.transformManyEvents(
+        request,
+        next
+      );
+
+      if (transformEventsResponses.success === false) {
+        // logElement("transformEventsResponses was false?", true);
+        return transformEventsResponses;
+      } else if (transformEventsResponses.success === true) {
+        const transformedMeasurements = transformEventsResponses.data;
+        const responseFromInsertEvents = await createEvent.insertTransformedEvents(
+          tenant,
+          transformedMeasurements,
+          next
+        );
+        return responseFromInsertEvents;
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  insertTransformedEvents: async (tenant, events, next) => {
+    try {
+      let errors = [];
+      let data = [];
+      let filter = {};
+      let options = {};
+      let value = {};
+      let update = {};
+      let modifiedFilter = {};
+      let dot = new Dot(".");
+
+      for (const event of events) {
+        try {
+          options = event.options;
+          value = event;
+          filter = event.filter;
+          update = event.update;
+          modifiedFilter = event.modifiedFilter;
+
+          dot.object(filter);
+
+          dot.delete(
+            ["filter", "update", "options", "modifiedFilter", "tenant", "day"],
+            value
+          );
+
+          update["$push"] = { values: value };
+
+          const addedEvents = await Model(tenant).updateOne(
+            modifiedFilter,
+            update,
+            options
+          );
+
+          dot.delete("nValues", filter);
+          if (!isEmpty(addedEvents)) {
+            let insertion = {
+              msg: "successfuly added the event",
+              event_details: filter,
+              status: httpStatus.CREATED,
+            };
+            data.push(insertion);
+          }
+
+          if (isEmpty(addedEvents)) {
+            let errMsg = {
+              msg: "unable to add the event",
+              event_details: filter,
+              status: httpStatus.NOT_MODIFIED,
+            };
+            errors.push(errMsg);
+          }
+        } catch (error) {
+          dot.delete("nValues", filter);
+          let errMsg = {
+            msg: "duplicate event",
+            event_details: filter,
+            status: httpStatus.FORBIDDEN,
+          };
+          errors.push(errMsg);
+        }
+      }
+
+      if (errors.length > 0 && isEmpty(data)) {
+        logger.error(
+          `finished the operation with some errors -- ${stringify(errors)}`
+        );
+        return {
+          success: false,
+          message: "finished the operation with some errors",
+          errors,
+        };
+      } else {
+        return {
+          success: true,
+          message: "successfully added the events",
+          data,
+          errors,
+        };
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  clearEventsOnClarity: (request, next) => {
+    return {
+      success: false,
+      message: "coming soon - unavailable option",
+      status: httpStatus.NOT_IMPLEMENTED,
+      errors: { message: "coming soon" },
+    };
+  },
+  insertMeasurements: async (measurements, next) => {
+    try {
+      const responseFromInsertMeasurements = await createEvent.insert(
+        "airqo",
+        measurements,
+        next
+      );
+      return responseFromInsertMeasurements;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  insert: async (tenant, measurements, next) => {
+    try {
+      let nAdded = 0;
+      let eventsAdded = [];
+      let eventsRejected = [];
+      let errors = [];
+
+      const responseFromTransformMeasurements = await createEvent.transformMeasurements_v2(
+        measurements,
+        next
+      );
+
+      if (!responseFromTransformMeasurements.success) {
+        logger.error(
+          `internal server error -- unable to transform measurements -- ${
+            responseFromTransformMeasurements.message
+          }, ${stringify(measurements)}`
+        );
+      }
+
+      for (const measurement of responseFromTransformMeasurements.data) {
+        try {
+          // logObject("the measurement in the insertion process", measurement);
+          const eventsFilter = {
+            day: measurement.day,
+            site_id: measurement.site_id,
+            device_id: measurement.device_id,
+            nValues: { $lt: parseInt(constants.N_VALUES || 500) },
+            $or: [
+              { "values.time": { $ne: measurement.time } },
+              { "values.device": { $ne: measurement.device } },
+              { "values.frequency": { $ne: measurement.frequency } },
+              { "values.device_id": { $ne: measurement.device_id } },
+              { "values.site_id": { $ne: measurement.site_id } },
+              { day: { $ne: measurement.day } },
+            ],
+          };
+          let someDeviceDetails = {};
+          someDeviceDetails["device_id"] = measurement.device_id;
+          someDeviceDetails["site_id"] = measurement.site_id;
+          // logObject("someDeviceDetails", someDeviceDetails);
+
+          // logObject("the measurement", measurement);
+
+          const eventsUpdate = {
+            $push: { values: measurement },
+            $min: { first: measurement.time },
+            $max: { last: measurement.time },
+            $inc: { nValues: 1 },
+          };
+          // logObject("eventsUpdate", eventsUpdate);
+          // logObject("eventsFilter", eventsFilter);
+
+          const addedEvents = await EventModel(tenant).updateOne(
+            eventsFilter,
+            eventsUpdate,
+            {
+              upsert: true,
+            }
+          );
+          // logObject("addedEvents", addedEvents);
+          if (addedEvents) {
+            nAdded += 1;
+            eventsAdded.push(measurement);
+          } else if (!addedEvents) {
+            eventsRejected.push(measurement);
+            let errMsg = {
+              msg: "unable to add the events",
+              record: {
+                ...(measurement.device ? { device: measurement.device } : {}),
+                ...(measurement.frequency
+                  ? { frequency: measurement.frequency }
+                  : {}),
+                ...(measurement.time ? { time: measurement.time } : {}),
+                ...(measurement.device_id
+                  ? { device_id: measurement.device_id }
+                  : {}),
+                ...(measurement.site_id
+                  ? { site_id: measurement.site_id }
+                  : {}),
+              },
+            };
+            errors.push(errMsg);
+          } else {
+            eventsRejected.push(measurement);
+            let errMsg = {
+              msg: "unable to add the events",
+              record: {
+                ...(measurement.device ? { device: measurement.device } : {}),
+                ...(measurement.frequency
+                  ? { frequency: measurement.frequency }
+                  : {}),
+                ...(measurement.time ? { time: measurement.time } : {}),
+                ...(measurement.device_id
+                  ? { device_id: measurement.device_id }
+                  : {}),
+                ...(measurement.site_id
+                  ? { site_id: measurement.site_id }
+                  : {}),
+              },
+            };
+            errors.push(errMsg);
+          }
+        } catch (e) {
+          // logger.error(`internal server serror -- ${e.message}`);
+          eventsRejected.push(measurement);
+          let errMsg = {
+            msg:
+              "there is a system conflict, most likely a cast error or duplicate record",
+            more: e.message,
+            record: {
+              ...(measurement.device ? { device: measurement.device } : {}),
+              ...(measurement.frequency
+                ? { frequency: measurement.frequency }
+                : {}),
+              ...(measurement.time ? { time: measurement.time } : {}),
+              ...(measurement.device_id
+                ? { device_id: measurement.device_id }
+                : {}),
+              ...(measurement.site_id ? { site_id: measurement.site_id } : {}),
+            },
+          };
+          errors.push(errMsg);
+        }
+      }
+
+      if (errors.length > 0 && isEmpty(eventsAdded)) {
+        logTextWithTimestamp(
+          "API: failed to store measurements, most likely DB cast errors or duplicate records"
+        );
+        return {
+          success: false,
+          message: "finished the operation with some errors",
+          errors,
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      } else {
+        logTextWithTimestamp("API: successfully added the events");
+        return {
+          success: true,
+          message: "successfully added the events",
+          status: httpStatus.OK,
+          errors,
+        };
+      }
+    } catch (error) {
+      logTextWithTimestamp(`API: Internal Server Error ${error.message}`);
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  transformMeasurements: async (device, measurements, next) => {
+    let promises = measurements.map(async (measurement) => {
+      try {
+        let time = measurement.time;
+        const day = generateDateFormatWithoutHrs(time);
+        return {
+          device: device,
+          day: day,
+          ...measurement,
+          success: true,
+        };
+      } catch (e) {
+        logger.error(`internal server error -- ${e.message}`);
+        return {
+          device: device,
+          success: false,
+          message: e.message,
+          errors: { message: e.message },
+        };
+      }
+    });
+    return Promise.all(promises).then((results) => {
+      if (results.every((res) => res.success)) {
+        return results;
+      } else {
+        logObject("the results for no success", results);
+      }
+    });
+  },
+  transformMeasurements_v2: async (measurements, next) => {
+    try {
+      logText("we are transforming version 2....");
+      let promises = measurements.map(async (measurement) => {
+        try {
+          let time = measurement.time;
+          const day = generateDateFormatWithoutHrs(time);
+          let data = {
+            day: day,
+            ...measurement,
+          };
+          return data;
+        } catch (e) {
+          logger.error(`internal server error -- ${e.message}`);
+          return {
+            success: false,
+            message: "server side error",
+            errors: { message: e.message },
+          };
+        }
+      });
+      return Promise.all(promises).then((results) => {
+        if (results.every((res) => res.success)) {
+          return {
+            success: true,
+            data: results,
+          };
+        } else {
+          return {
+            success: true,
+            data: results,
+          };
+        }
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  transformField: (field, next) => {
+    try {
+      switch (field) {
+        case "s1_pm2_5":
+          return "field1";
+        case "s1_pm10":
+          return "field2";
+        case "s2_pm2_5":
+          return "field3";
+        case "s2_pm10":
+          return "field4";
+        case "latitude":
+          return "field5";
+        case "longitude":
+          return "field6";
+        case "battery":
+          return "field7";
+        case "others":
+          return "field8";
+        case "time":
+          return "created_at";
+        case "elevation":
+          return "elevation";
+        case "status":
+          return "status";
+        default:
+          return field;
+      }
+    } catch (error) {
+      logger.error(`internal server error -- ${error.message}`);
+    }
+  },
+  transformMeasurementFields: async (measurements, next) => {
+    try {
+      let transformed = [];
+      let request = {};
+      for (const measurement of measurements) {
+        request["body"] = measurement;
+        const responseFromCreateThingSpeakBody = createEvent.createThingSpeakRequestBody(
+          request,
+          next
+        );
+
+        if (responseFromCreateThingSpeakBody.success === true) {
+          transformed.push(responseFromCreateThingSpeakBody.data);
+        } else {
+          logObject(
+            "responseFromCreateThingSpeakBody",
+            responseFromCreateThingSpeakBody
+          );
+        }
+      }
+      return {
+        message: "successfully transformed the measurements",
+        data: transformed,
+        success: true,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  deleteValuesOnThingspeak: async (req, res, next) => {
+    try {
+      const { device, tenant, chid, name, device_number } = req.query;
+
+      let request = {};
+      request["query"] = {};
+      request["query"]["name"] = device || name;
+      request["query"]["tenant"] = tenant;
+      request["query"]["device_number"] = chid || device_number;
+
+      const responseFromListDevice = await listDevices(request, next);
+
+      let deviceDetail = {};
+
+      if (responseFromListDevice.success === true) {
+        if (responseFromListDevice.data.length === 1) {
+          deviceDetail = responseFromListDevice.data[0];
+        }
+      } else if (responseFromListDevice.success === false) {
+        logObject(
+          "responseFromListDevice has an error",
+          responseFromListDevice
+        );
+      }
+
+      const doesDeviceExist = !isEmpty(deviceDetail);
+      logElement("isDevicePresent ?", doesDeviceExist);
+      if (doesDeviceExist) {
+        const device_number = await getChannelID(
+          req,
+          res,
+          device,
+          tenant.toLowerCase()
+        );
+        logText("...................................");
+        logText("clearing the Thing....");
+        logElement("url", constants.CLEAR_THING_URL(device_number));
+        await axios
+          .delete(constants.CLEAR_THING_URL(device_number))
+          .then(async (response) => {
+            logText("successfully cleared the device in TS");
+            logObject("response from TS", response.data);
+            return {
+              message: `successfully cleared the data for device ${device}`,
+              success: true,
+              updatedDevice,
+            };
+          })
+          .catch(function(error) {
+            logger.error(`internal server error -- ${error.message}`);
+            return {
+              message: `unable to clear the device data, device ${device} does not exist`,
+              success: false,
+              errors: {
+                message: `unable to clear the device data, device ${device} does not exist`,
+              },
+            };
+          });
+      } else {
+        logText(`device ${device} does not exist in the system`);
+        return {
+          message: `device ${device} does not exist in the system`,
+          success: false,
+          errors: { message: `device ${device} does not exist in the system` },
+        };
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+};
+
+module.exports = createEvent;

--- a/src/device-registry/utils/measurement-registry.js
+++ b/src/device-registry/utils/measurement-registry.js
@@ -1,0 +1,842 @@
+/**
+ * @fileoverview Centralized Measurement Registry
+ *
+ * This file serves as a single source of truth for all measurement types,
+ * pollutants, and sensor readings in the AirQo system. When adding a new
+ * measurement type, you only need to modify this file.
+ */
+
+// Measurement type definition schema
+/**
+ * @typedef {Object} MeasurementDefinition
+ * @property {string} name - The human-readable name of the measurement
+ * @property {string} [description] - Optional description of the measurement
+ * @property {Object} schema - MongoDB schema definition for this measurement
+ * @property {Object} mappings - Field mapping information for transformations
+ * @property {boolean} [isPollutant=false] - Whether this is considered a pollutant
+ * @property {boolean} [includeInAggregation=true] - Whether to include in aggregation pipelines
+ * @property {string} [unit] - The unit of measurement (e.g., 'μg/m³')
+ * @property {string} [category] - Category this measurement belongs to (e.g., 'particulate', 'gas')
+ */
+
+/**
+ * The registry of all measurement types in the system.
+ * When adding a new measurement type, simply add a new entry here.
+ */
+const MEASUREMENT_REGISTRY = {
+  // Particulate Matter
+  pm1: {
+    name: "PM1",
+    description: "Particulate Matter less than 1 micron in diameter",
+    schema: {
+      value: { type: Number, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "pm1_raw_value",
+      calibratedValue: "pm1_calibrated_value",
+      uncertaintyValue: "pm1_uncertainty_value",
+      standardDeviationValue: "pm1_standard_deviation_value",
+    },
+    isPollutant: true,
+    includeInAggregation: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  s1_pm1: {
+    name: "Sensor 1 PM1",
+    schema: {
+      value: { type: Number, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "s1_pm1",
+      calibratedValue: "s1_pm1_calibrated_value",
+      uncertaintyValue: "s1_pm1_uncertainty_value",
+      standardDeviationValue: "s1_pm1_standard_deviation_value",
+    },
+    isPollutant: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  s2_pm1: {
+    name: "Sensor 2 PM1",
+    schema: {
+      value: { type: Number, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "s2_pm1",
+      calibratedValue: "s2_pm1_calibrated_value",
+      uncertaintyValue: "s2_pm1_uncertainty_value",
+      standardDeviationValue: "s2_pm1_standard_deviation_value",
+    },
+    isPollutant: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  pm2_5: {
+    name: "PM2.5",
+    description: "Particulate Matter less than 2.5 microns in diameter",
+    schema: {
+      value: { type: Number, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "pm2_5_raw_value",
+      calibratedValue: "pm2_5_calibrated_value",
+      uncertaintyValue: "pm2_5_uncertainty_value",
+      standardDeviationValue: "pm2_5_standard_deviation_value",
+    },
+    isPollutant: true,
+    includeInAggregation: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  s1_pm2_5: {
+    name: "Sensor 1 PM2.5",
+    schema: {
+      value: { type: Number, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "s1_pm2_5",
+      calibratedValue: "s1_pm2_5_calibrated_value",
+      uncertaintyValue: "s1_pm2_5_uncertainty_value",
+      standardDeviationValue: "s1_pm2_5_standard_deviation_value",
+    },
+    isPollutant: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  s2_pm2_5: {
+    name: "Sensor 2 PM2.5",
+    schema: {
+      value: { type: Number, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "s2_pm2_5",
+      calibratedValue: "s2_pm2_5_calibrated_value",
+      uncertaintyValue: "s2_pm2_5_uncertainty_value",
+      standardDeviationValue: "s2_pm2_5_standard_deviation_value",
+    },
+    isPollutant: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  average_pm2_5: {
+    name: "Average PM2.5",
+    schema: {
+      value: { type: Number, trim: true, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "pm2_5_raw_value",
+      calibratedValue: "pm2_5_calibrated_value",
+      uncertaintyValue: "pm2_5_uncertainty_value",
+      standardDeviationValue: "pm2_5_standard_deviation_value",
+    },
+    isPollutant: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  pm10: {
+    name: "PM10",
+    description: "Particulate Matter less than 10 microns in diameter",
+    schema: {
+      value: { type: Number, trim: true, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "pm10_raw_value",
+      calibratedValue: "pm10_calibrated_value",
+      uncertaintyValue: "pm10_uncertainty_value",
+      standardDeviationValue: "pm10_standard_deviation_value",
+    },
+    isPollutant: true,
+    includeInAggregation: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  s1_pm10: {
+    name: "Sensor 1 PM10",
+    schema: {
+      value: { type: Number, trim: true, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "s1_pm10",
+      calibratedValue: "s1_pm10_calibrated_value",
+      uncertaintyValue: "s1_pm10_uncertainty_value",
+      standardDeviationValue: "s1_pm10_standard_deviation_value",
+    },
+    isPollutant: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  s2_pm10: {
+    name: "Sensor 2 PM10",
+    schema: {
+      value: { type: Number, trim: true, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "s2_pm10",
+      calibratedValue: "s2_pm10_calibrated_value",
+      uncertaintyValue: "s2_pm10_uncertainty_value",
+      standardDeviationValue: "s2_pm10_standard_deviation_value",
+    },
+    isPollutant: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  average_pm10: {
+    name: "Average PM10",
+    schema: {
+      value: { type: Number, trim: true, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "pm10_raw_value",
+      calibratedValue: "pm10_calibrated_value",
+      uncertaintyValue: "pm10_uncertainty_value",
+      standardDeviationValue: "pm10_standard_deviation_value",
+    },
+    isPollutant: true,
+    unit: "μg/m³",
+    category: "particulate",
+  },
+
+  // Gases
+  no2: {
+    name: "NO2",
+    description: "Nitrogen Dioxide",
+    schema: {
+      value: { type: Number, default: null },
+      calibratedValue: { type: Number, default: null },
+      uncertaintyValue: { type: Number, default: null },
+      standardDeviationValue: { type: Number, default: null },
+    },
+    mappings: {
+      value: "no2_raw_value",
+      calibratedValue: "no2_calibrated_value",
+      uncertaintyValue: "no2_uncertainty_value",
+      standardDeviationValue: "no2_standard_deviation_value",
+    },
+    isPollutant: true,
+    includeInAggregation: true,
+    unit: "ppb",
+    category: "gas",
+  },
+
+  co2: {
+    name: "CO2",
+    description: "Carbon Dioxide",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "co2",
+    },
+    isPollutant: true,
+    includeInAggregation: true,
+    unit: "ppm",
+    category: "gas",
+  },
+
+  tvoc: {
+    name: "TVOC",
+    description: "Total Volatile Organic Compounds",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "tvoc",
+    },
+    isPollutant: true,
+    unit: "ppb",
+    category: "gas",
+  },
+
+  hcho: {
+    name: "HCHO",
+    description: "Formaldehyde",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "hcho",
+    },
+    isPollutant: true,
+    unit: "ppb",
+    category: "gas",
+  },
+
+  // Environmental parameters
+  battery: {
+    name: "Battery",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "battery",
+    },
+    isPollutant: false,
+    category: "device",
+  },
+
+  location: {
+    name: "Location",
+    schema: {
+      latitude: {
+        value: { type: Number, default: null },
+      },
+      longitude: {
+        value: { type: Number, default: null },
+      },
+    },
+    mappings: {
+      "latitude.value": "latitude",
+      "longitude.value": "longitude",
+    },
+    isPollutant: false,
+    category: "location",
+  },
+
+  altitude: {
+    name: "Altitude",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "altitude",
+    },
+    isPollutant: false,
+    unit: "m",
+    category: "location",
+  },
+
+  speed: {
+    name: "Speed",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "wind_speed",
+    },
+    isPollutant: false,
+    unit: "m/s",
+    category: "environmental",
+  },
+
+  satellites: {
+    name: "Satellites",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "satellites",
+    },
+    isPollutant: false,
+    category: "device",
+  },
+
+  hdop: {
+    name: "HDOP",
+    description: "Horizontal Dilution of Precision",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "hdop",
+    },
+    isPollutant: false,
+    category: "device",
+  },
+
+  intaketemperature: {
+    name: "Intake Temperature",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "intaketemperature",
+    },
+    isPollutant: false,
+    unit: "°C",
+    category: "environmental",
+  },
+
+  intakehumidity: {
+    name: "Intake Humidity",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "intakehumidity",
+    },
+    isPollutant: false,
+    unit: "%",
+    category: "environmental",
+  },
+
+  internalTemperature: {
+    name: "Internal Temperature",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "device_temperature",
+    },
+    isPollutant: false,
+    unit: "°C",
+    category: "device",
+  },
+
+  internalHumidity: {
+    name: "Internal Humidity",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "device_humidity",
+    },
+    isPollutant: false,
+    unit: "%",
+    category: "device",
+  },
+
+  externalTemperature: {
+    name: "External Temperature",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "temperature",
+    },
+    isPollutant: false,
+    unit: "°C",
+    category: "environmental",
+  },
+
+  externalHumidity: {
+    name: "External Humidity",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "humidity",
+    },
+    isPollutant: false,
+    unit: "%",
+    category: "environmental",
+  },
+
+  externalPressure: {
+    name: "External Pressure",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "external_pressure",
+    },
+    isPollutant: false,
+    unit: "hPa",
+    category: "environmental",
+  },
+
+  externalAltitude: {
+    name: "External Altitude",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "external_altitude",
+    },
+    isPollutant: false,
+    unit: "m",
+    category: "environmental",
+  },
+
+  // BAM specific calibration factors
+  rtc_adc: {
+    name: "RTC ADC",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "rtc_adc",
+    },
+    isPollutant: false,
+    category: "calibration",
+  },
+
+  rtc_v: {
+    name: "RTC Voltage",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "rtc_v",
+    },
+    isPollutant: false,
+    unit: "V",
+    category: "calibration",
+  },
+
+  rtc: {
+    name: "RTC",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "rtc",
+    },
+    isPollutant: false,
+    category: "calibration",
+  },
+
+  stc_adc: {
+    name: "STC ADC",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "stc_adc",
+    },
+    isPollutant: false,
+    category: "calibration",
+  },
+
+  stc_v: {
+    name: "STC Voltage",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "stc_v",
+    },
+    isPollutant: false,
+    unit: "V",
+    category: "calibration",
+  },
+
+  stc: {
+    name: "STC",
+    schema: {
+      value: { type: Number, default: null },
+    },
+    mappings: {
+      value: "stc",
+    },
+    isPollutant: false,
+    category: "calibration",
+  },
+};
+
+// Helper functions to extract specific information from the registry
+
+/**
+ * Generates a MongoDB schema object for all measurements
+ * @returns {Object} A schema object ready to be used in Mongoose
+ */
+function generateValueSchema() {
+  const schema = {};
+
+  Object.entries(MEASUREMENT_REGISTRY).forEach(([key, measurement]) => {
+    schema[key] = measurement.schema;
+  });
+
+  return schema;
+}
+
+/**
+ * Generates mappings for the EVENT_MAPPINGS.item object
+ * @returns {Object} Mappings for event transformation
+ */
+function generateEventMappings() {
+  const mappings = {};
+
+  Object.entries(MEASUREMENT_REGISTRY).forEach(([key, measurement]) => {
+    // For measurements with nested fields like pollutants
+    if (
+      typeof measurement.schema === "object" &&
+      Object.keys(measurement.schema).includes("value")
+    ) {
+      // For each field in the measurement type (value, calibratedValue, etc.)
+      Object.entries(measurement.mappings).forEach(([field, mappedName]) => {
+        mappings[`${key}.${field}`] = mappedName;
+      });
+    }
+    // For complex structures like location
+    else if (key === "location") {
+      Object.entries(measurement.mappings).forEach(([field, mappedName]) => {
+        mappings[field] = mappedName;
+      });
+    }
+  });
+
+  return mappings;
+}
+
+/**
+ * Generates default values for EVENT_MAPPINGS.defaults
+ * @returns {Object} Default values for each field
+ */
+function generateEventDefaults() {
+  const defaults = {
+    time: null,
+    tenant: "airqo",
+    network: "airqo",
+    device: null,
+    device_id: null,
+    site_id: null,
+    day: null,
+    frequency: "hourly",
+    site: null,
+    device_number: null,
+    is_test_data: null,
+    is_device_primary: null,
+  };
+
+  Object.entries(MEASUREMENT_REGISTRY).forEach(([key, measurement]) => {
+    // For measurements with nested fields like pollutants
+    if (
+      typeof measurement.schema === "object" &&
+      Object.keys(measurement.schema).includes("value")
+    ) {
+      // For each field in the measurement type (value, calibratedValue, etc.)
+      Object.keys(measurement.schema).forEach((field) => {
+        defaults[`${key}.${field}`] = null;
+      });
+    }
+    // For complex structures like location
+    else if (key === "location") {
+      defaults[`${key}.latitude.value`] = null;
+      defaults[`${key}.longitude.value`] = null;
+    }
+  });
+
+  return defaults;
+}
+
+/**
+ * Gets a list of all pollutant keys
+ * @returns {string[]} Array of pollutant keys
+ */
+function getPollutantKeys() {
+  return Object.entries(MEASUREMENT_REGISTRY)
+    .filter(([_, measurement]) => measurement.isPollutant)
+    .map(([key, _]) => key);
+}
+
+/**
+ * Gets a list of pollutants to include in aggregation pipelines
+ * @returns {string[]} Array of pollutant keys for aggregation
+ */
+function getAggregationPollutants() {
+  return Object.entries(MEASUREMENT_REGISTRY)
+    .filter(
+      ([_, measurement]) =>
+        measurement.isPollutant && measurement.includeInAggregation !== false
+    )
+    .map(([key, _]) => key);
+}
+
+/**
+ * Gets a list of all measurement keys by category
+ * @param {string} category - The category to filter by
+ * @returns {string[]} Array of measurement keys in the given category
+ */
+function getMeasurementsByCategory(category) {
+  return Object.entries(MEASUREMENT_REGISTRY)
+    .filter(([_, measurement]) => measurement.category === category)
+    .map(([key, _]) => key);
+}
+
+/**
+ * Gets an object mapping field names to their human-readable names
+ * @returns {Object} Map of field keys to display names
+ */
+function getFieldNameMapping() {
+  const mapping = {};
+
+  Object.entries(MEASUREMENT_REGISTRY).forEach(([key, measurement]) => {
+    mapping[key] = measurement.name;
+  });
+
+  return mapping;
+}
+
+/**
+ * Gets a list of fields to include in projection for a specific view
+ * @param {string} viewType - Type of view (e.g., 'brief', 'full')
+ * @param {string[]} [excludeCategories] - Categories to exclude from projection
+ * @returns {Object} Projection object for MongoDB query
+ */
+function getProjectionFields(viewType, excludeCategories = []) {
+  const projection = {};
+
+  // Define which measurements to exclude based on view type
+  const excludeForViewType = {
+    brief: ["calibration"],
+    running: ["calibration", "device", "environmental"],
+    // Add more view types as needed
+  };
+
+  // Combine exclude categories
+  const categoriesExcluded = [
+    ...(excludeForViewType[viewType] || []),
+    ...excludeCategories,
+  ];
+
+  // Get measurements to exclude based on categories
+  const measurementsToExclude = categoriesExcluded.flatMap((category) =>
+    getMeasurementsByCategory(category)
+  );
+
+  // Set projection value (0 means exclude)
+  measurementsToExclude.forEach((key) => {
+    projection[key] = 0;
+  });
+
+  return projection;
+}
+
+/**
+ * Gets an object with all pollutant field names and their raw value mappings
+ * @returns {Object} Map of pollutant keys to their raw value field names
+ */
+function getPollutantRawFields() {
+  const rawFields = {};
+
+  Object.entries(MEASUREMENT_REGISTRY)
+    .filter(([_, def]) => def.isPollutant)
+    .forEach(([key, def]) => {
+      rawFields[key] = def.mappings.value;
+    });
+
+  return rawFields;
+}
+
+/**
+ * Gets an object with all pollutant field names and their calibrated value mappings
+ * @returns {Object} Map of pollutant keys to their calibrated value field names
+ */
+function getPollutantCalibratedFields() {
+  const calibratedFields = {};
+
+  Object.entries(MEASUREMENT_REGISTRY)
+    .filter(([_, def]) => def.isPollutant && def.mappings.calibratedValue)
+    .forEach(([key, def]) => {
+      calibratedFields[key] = def.mappings.calibratedValue;
+    });
+
+  return calibratedFields;
+}
+
+/**
+ * Gets a list of field mappings for a specific device type
+ * @param {string} deviceType - The type of device (e.g., 'bam', 'gas', 'standard')
+ * @returns {Object} Mapping of ThingSpeak fields to measurement fields
+ */
+function getThingSpeakFieldMappings(deviceType) {
+  let mappings = {};
+
+  switch (deviceType) {
+    case "bam":
+      mappings = {
+        field1: "date",
+        field2: "real_time_concetration",
+        field3: "hourly_concetration",
+        field4: "short_time_concetration",
+        field5: "litres_per_minute",
+        field6: "device_status",
+        field7: "battery_voltage",
+        field8: "other_data",
+      };
+      break;
+
+    case "gas":
+      mappings = {
+        field1: MEASUREMENT_REGISTRY.pm2_5.mappings.value.replace(
+          "_raw_value",
+          ""
+        ),
+        field2: MEASUREMENT_REGISTRY.tvoc.mappings.value,
+        field3: MEASUREMENT_REGISTRY.hcho.mappings.value,
+        field4: MEASUREMENT_REGISTRY.co2.mappings.value,
+        field5: "intaketemperature",
+        field6: "intakehumidity",
+        field7: "battery",
+        field8: "other_data",
+      };
+      break;
+
+    default:
+      // standard airqo device
+      mappings = {
+        field1: MEASUREMENT_REGISTRY.s1_pm2_5.mappings.value,
+        field2: MEASUREMENT_REGISTRY.s1_pm10.mappings.value,
+        field3: MEASUREMENT_REGISTRY.s2_pm2_5.mappings.value,
+        field4: MEASUREMENT_REGISTRY.s2_pm10.mappings.value,
+        field5: MEASUREMENT_REGISTRY.location.mappings["latitude.value"],
+        field6: MEASUREMENT_REGISTRY.location.mappings["longitude.value"],
+        field7: MEASUREMENT_REGISTRY.battery.mappings.value,
+        field8: "other_data",
+      };
+  }
+
+  // Add created_at mapping which is common to all types
+  mappings.created_at = "created_at";
+
+  return mappings;
+}
+
+module.exports = {
+  MEASUREMENT_REGISTRY,
+  generateValueSchema,
+  generateEventMappings,
+  generateEventDefaults,
+  getPollutantRawFields,
+  getPollutantCalibratedFields,
+  getPollutantKeys,
+  getThingSpeakFieldMappings,
+  getAggregationPollutants,
+  getMeasurementsByCategory,
+  getFieldNameMapping,
+  getProjectionFields,
+};


### PR DESCRIPTION
## Description

Refactors the events module to use a centralized measurement registry for easier addition of new pollutants and consistent handling across the codebase.

## Changes Made

- [ ]  Created a centralized measurement registry as a single source of truth for all measurement types
- [ ]  Refactored Event model to use measurement registry for schema generation
- [ ]  Updated BigQuery field generation to use registry for consistent queries
- [ ]  Added helper functions for extracting measurements by category
- [ ]  Fixed missing imports and functions for backward compatibility
- [ ]  Ensured error handling is consistent with previous implementation
- [ ]  Updated ThingSpeak field mapping to use registry definitions
- [ ]  Made adding new pollutants require changes to only one file

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Get Events
  - [ ] Get Readings
  - [ ] Get Measurements
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating
