### PR TITLE
Fix express-fileupload TypeError for undefined headers

### DIFF
--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -79,7 +79,22 @@ app.use(
     parameterLimit: 50000,
   })
 );
-// app.use(fileUpload());
+
+// Header protection middleware - ensures headers exist before fileUpload
+app.use((req, res, next) => {
+  // Ensure headers object exists
+  if (!req.headers) {
+    req.headers = {};
+  }
+
+  // Ensure content-type header exists (even if empty)
+  if (req.headers["content-type"] === undefined) {
+    req.headers["content-type"] = "";
+  }
+
+  next();
+});
+
 app.use(
   fileUpload({
     createParentPath: true,
@@ -154,8 +169,6 @@ app.use(function (err, req, res, next) {
         errors: { message: err.message },
       });
     } else if (err.status === 500) {
-      // logger.error(`🐛🐛 Internal Server Error --- ${stringify(err)}`);
-      // logger.error(`Stack Trace: ${err.stack}`);
       logObject("the error", err);
       res.status(err.status).json({
         success: false,


### PR DESCRIPTION
## Description

This PR fixes a rare but critical runtime error in the express-fileupload middleware that occurs when requests come in with missing or malformed headers.

The application was throwing `TypeError: Cannot read properties of undefined (reading 'includes')` errors when the express-fileupload middleware attempted to check content types on requests without proper headers. This error was happening sporadically (once or twice a week) in the production environment.

Added a protective middleware that ensures the request headers object and content-type header exist before the fileUpload middleware runs. This prevents the TypeError without modifying the fileUpload configuration, which was problematic in previous attempts.

## Error Log Reference

```
TypeError: Cannot read properties of undefined (reading 'includes')
at hasAcceptableContentType (/usr/src/app/node_modules/express-fileupload/lib/isEligibleRequest.js:32:19)
at module.exports (/usr/src/app/node_modules/express-fileupload/lib/isEligibleRequest.js:40:71)

```
## Changes Made

- [ ] Added protective middleware before fileUpload to ensure headers exist
- [ ] Ensured `req.headers` object is initialized if undefined
- [ ] Ensured `content-type` header exists (empty string if undefined)
- [ ] Maintained existing fileUpload configuration unchanged
- [ ] Positioned middleware correctly in the middleware stack

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Auth Service
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of incoming requests by ensuring required headers are present before file uploads.
- **Chores**
	- Streamlined error logging for internal server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->