### PR TITLE
Enhance Health Tips Bulk Update with AQI Range Validation

### DIFF
--- a/src/device-registry/validators/tips.validators.js
+++ b/src/device-registry/validators/tips.validators.js
@@ -12,6 +12,19 @@ const isEmpty = require("is-empty");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
 
+// Centralized AQI Range Configuration
+const AQI_RANGES = {
+  good: { min: 0, max: 9.1 },
+  moderate: { min: 9.101, max: 35.49 },
+  u4sg: { min: 35.491, max: 55.49 },
+  unhealthy: { min: 55.491, max: 125.49 },
+  very_unhealthy: { min: 125.491, max: 225.49 },
+  hazardous: { min: 225.491, max: null },
+};
+
+// Export AQI_RANGES so they can be used in other files if needed
+module.exports.AQI_RANGES = AQI_RANGES;
+
 const handleValidationErrors = (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -106,6 +119,9 @@ const healthTipValidations = {
         // Custom validation to check for duplicate title and aqi_category within the updates array
         const seen = new Set();
         for (const update of updates) {
+          // Skip validation if title isn't provided (for mass updates)
+          if (!update.tips.some((tip) => tip.title)) continue;
+
           const key = `${update.title}-${JSON.stringify(update.aqi_category)}`;
           if (seen.has(key)) {
             throw new Error(
@@ -126,7 +142,26 @@ const healthTipValidations = {
       .bail()
       .isObject()
       .withMessage("aqi_category must be an object")
-      .bail(),
+      .bail()
+      .custom((aqi_category) => {
+        // Validate against predefined AQI ranges
+        const { min, max } = aqi_category;
+        const isValidRange = Object.values(AQI_RANGES).some(
+          (range) =>
+            Math.abs(range.min - min) < 0.001 && // Using small epsilon for float comparison
+            ((range.max === null && max === null) ||
+              (range.max !== null &&
+                max !== null &&
+                Math.abs(range.max - max) < 0.001))
+        );
+
+        if (!isValidRange) {
+          throw new Error(
+            `Invalid AQI range: min=${min}, max=${max}. Must match one of the predefined ranges.`
+          );
+        }
+        return true;
+      }),
     body("updates.*.aqi_category.min")
       .exists()
       .withMessage("aqi_category.min is required")
@@ -137,9 +172,15 @@ const healthTipValidations = {
       .exists()
       .withMessage("aqi_category.max is required")
       .bail()
-      .isNumeric()
-      .withMessage("aqi_category.max must be a number")
+      .custom((value) => {
+        // Allow null for the max value of the hazardous range
+        return value === null || typeof value === "number";
+      })
+      .withMessage("aqi_category.max must be a number or null")
       .custom((value, { req }) => {
+        // Skip this validation if max is null
+        if (value === null) return true;
+
         if (
           value <=
           req.body.updates[
@@ -164,9 +205,12 @@ const healthTipValidations = {
       .notEmpty()
       .withMessage("tips array cannot be empty")
       .custom((tips, { req, location, path }) => {
-        // Custom validation to check for duplicate title and aqi_category within the tips array
+        // Custom validation to check for duplicate title only if title is provided
         const seen = new Set();
         for (const tip of tips) {
+          // Skip validation if title isn't provided (for mass updates)
+          if (!tip.title) continue;
+
           const updateIndex = req.body.updates.indexOf(
             req.body.updates.find((update) => update.tips === tips)
           );
@@ -187,11 +231,9 @@ const healthTipValidations = {
         return true;
       }),
     body("updates.*.tips.*.title")
-      .exists()
-      .withMessage("title is required for each tip")
-      .bail()
+      .optional() // Make title optional for mass updates
       .notEmpty()
-      .withMessage("title cannot be empty")
+      .withMessage("title cannot be empty if provided")
       .trim(),
     body("updates.*.tips.*.tag_line")
       .optional()
@@ -199,16 +241,14 @@ const healthTipValidations = {
       .withMessage("tag_line cannot be empty if provided")
       .trim(),
     body("updates.*.tips.*.description")
-      .exists()
-      .withMessage("description is required for each tip")
-      .bail()
+      .optional() // Make description optional for partial updates
       .notEmpty()
-      .withMessage("description cannot be empty")
+      .withMessage("description cannot be empty if provided")
       .trim(),
     body("updates.*.tips.*.image")
-      .optional()
+      .optional() // Make image optional for updates
       .notEmpty()
-      .withMessage("image cannot be empty")
+      .withMessage("image cannot be empty if provided")
       .trim(),
     handleValidationErrors,
   ],


### PR DESCRIPTION
## Description

This PR enhances the Health Tips bulk update functionality to support mass updates within AQI ranges and adds validation against predefined AQI range values. It allows for updating all tips within a specific AQI category without requiring individual titles while maintaining backward compatibility with title-specific updates.

## Changes Made

- [ ]  Added AQI range validation against predefined range values in the validators file
- [ ]  Modified bulk update to support updating all tips in an AQI range when no title is provided
- [ ]  Made title field optional in bulk updates to enable mass updates
- [ ]  Made description and image fields optional to support partial updates
- [ ]  Added support for null max value in hazardous AQI range
- [ ]  Enhanced error handling to provide clearer validation errors
- [ ]  Improved the bulkModify function to handle both mass updates and specific tip updates
- [ ]  Refactored duplicate title checking to skip validation for mass updates
- [ ]  Exported AQI_RANGES constant for reuse in other parts of the application

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] device registry
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating