### PR TITLE
Add Dynamic Nearest Air Quality Readings with City Fallback

### DIFF
--- a/src/device-registry/config/global/numericals.js
+++ b/src/device-registry/config/global/numericals.js
@@ -6,6 +6,7 @@ const { logObject, logText } = require("@utils/shared");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 
 const numericals = {
+  DEFAULT_NEAREST_SITE_RADIUS: 15, // Default radius in kilometers
   MQTT_BRIDGE_PORT: 8883,
   NUM_MESSAGES: 5,
   TOKEN_EXP_MINS: 360,

--- a/src/device-registry/routes/v2/readings.routes.js
+++ b/src/device-registry/routes/v2/readings.routes.js
@@ -48,4 +48,11 @@ router.get(
   eventController.fetchAndStoreData
 );
 
+router.get(
+  "/nearest",
+  readingsValidations.nearestReadings,
+  pagination(),
+  eventController.getNearestReadings
+);
+
 module.exports = router;

--- a/src/device-registry/validators/readings.validators.js
+++ b/src/device-registry/validators/readings.validators.js
@@ -350,6 +350,48 @@ const commonValidations = {
 };
 
 const readingsValidations = {
+  nearestReadings: [
+    ...commonValidations.tenant,
+    query("latitude")
+      .exists()
+      .withMessage("latitude is required")
+      .bail()
+      .matches(constants.LATITUDE_REGEX, "i")
+      .withMessage("Invalid latitude format")
+      .bail()
+      .custom((value) => {
+        let dp = decimalPlaces(value);
+        if (dp < 2) {
+          throw new Error("Latitude must have at least 2 decimal places");
+        }
+        return true;
+      }),
+    query("longitude")
+      .exists()
+      .withMessage("longitude is required")
+      .bail()
+      .matches(constants.LONGITUDE_REGEX, "i")
+      .withMessage("Invalid longitude format")
+      .bail()
+      .custom((value) => {
+        let dp = decimalPlaces(value);
+        if (dp < 2) {
+          throw new Error("Longitude must have at least 2 decimal places");
+        }
+        return true;
+      }),
+    query("radius")
+      .optional()
+      .isFloat({ min: 0.1, max: 100 })
+      .withMessage("Radius must be between 0.1 and 100 kilometers")
+      .toFloat(),
+    query("limit")
+      .optional()
+      .isInt({ min: 1, max: 10 })
+      .withMessage("Limit must be between 1 and 10")
+      .toInt(),
+    commonValidations.errorHandler,
+  ],
   list: [
     ...commonValidations.tenant,
     ...commonValidations.timeRange,


### PR DESCRIPTION
## Description

Implementation of a new endpoint to retrieve the closest air quality readings based on GPS coordinates, falling back to nearest city if no nearby sites are found.

## Changes Made

- [ ]  Added new getNearestReadings utility function in event.util.js
- [ ]  Added findNearestCityReading helper function for city-based fallback
- [ ]  Added new controller method in event.controller.js
- [ ]  Added validation schema for the new endpoint in readings.validators.js
- [ ]  Added new route to readings.routes.js
- [ ]  Integrated with Grid model for dynamic city detection

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Device Registry

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ]  GET /api/v2/devices/readings/nearest - Get air quality readings from nearest sites or city

## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating
