### PR TITLE
Increased memory limit for auth-service and device-registry  deploy preview

### DIFF
--- a/.github/workflows/deploy-previews.yml
+++ b/.github/workflows/deploy-previews.yml
@@ -180,7 +180,7 @@ jobs:
             --image=${{ env.REGISTRY_URL }}/${{ env.PROJECT_ID }}/pr-previews/auth-service-pr-previews:${{ github.sha }} \
             --port=3000 \
             --cpu=1000m \
-            --memory=256Mi \
+            --memory=300Mi \
             --update-secrets=/etc/env/.env=sta-env-auth-service:latest,/etc/config/firebase_admin_sdk.json=sta-key-auth-service-firebase-admin-sdk:latest \
             --command="/bin/sh","-c","cat /etc/env/.env >> /usr/src/app/.env; npm run stage-mac" \
             --allow-unauthenticated
@@ -258,7 +258,7 @@ jobs:
             --image=${{ env.REGISTRY_URL }}/${{ env.PROJECT_ID }}/pr-previews/device-registry-pr-previews:${{ github.sha }} \
             --port=3000 \
             --cpu=1000m \
-            --memory=256Mi \
+            --memory=300Mi \
             --update-secrets=/etc/env/.env=sta-env-device-registry:latest,/etc/config/google_application_credentials.json=sta-key-device-registry-service-account:latest \
             --command="/bin/sh","-c","cat /etc/env/.env >> /usr/src/app/.env; npm run stage-mac" \
             --allow-unauthenticated


### PR DESCRIPTION
## Description

[Provide a brief description of the changes made in this PR]

## Related Issues

- [ ] GitHub issues:
  - [ ] [Closes #123](https://github.com/your-org/your-repo/issues/123)
  - [ ] [Closes #456](https://github.com/your-org/your-repo/issues/456)
  - [ ] Any other relevant GitHub Issues...
- [ ] JIRA cards:
  - [ ] [JIRA-7890](https://your-jira-instance.atlassian.net/browse/JIRA-7890)
  - [ ] [JIRA-101112](https://your-jira-instance.atlassian.net/browse/JIRA-101112)
  - [ ] Any other relevant JIRA cards...

## Changes Made

- [ ] Brief description of change 1
- [ ] Brief description of change 2
- [ ] Brief description of change 3

## Testing

- [ ] Tested locally
- [ ] Tested against staging environment
- [ ] Relevant tests passed: [List test names]

## Affected Services

- [ ] Which services were modified:
  - [ ] Service 1
  - [ ] Service 2
  - [ ] Other...

## Endpoints Ready for Testing

- [ ] New endpoints ready for testing:
  - [ ] Endpoint 1
  - [ ] Endpoint 2
  - [ ] Other...
     
## API Documentation Updated?

- [ ] Yes, API documentation was updated
- [ ] No, API documentation does not need updating

## Additional Notes

[Add any additional notes or comments here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased memory allocation for preview deployments of the authentication and device registry services, improving resource availability during previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->