### PR TITLE
removing admin check when updating network theme

### DIFF
--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -1678,19 +1678,6 @@ const preferences = {
               })
             );
           }
-
-          // Check if user has admin privileges (optional additional check)
-          const isAdmin =
-            userNetworkRole.userType === "admin" ||
-            userNetworkRole.userType === "super_admin";
-          if (!isAdmin) {
-            return next(
-              new HttpError("Forbidden", httpStatus.FORBIDDEN, {
-                message:
-                  "Only network administrators can update network themes",
-              })
-            );
-          }
         }
       }
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
**What does this PR do?**

- [ ] removing admin check when updating network theme

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the process for updating the network theme by removing the admin role requirement. Now, any user belonging to the network can update the network theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->