### PR TITLE
accept comma-separated admin_level values

### DIFF
--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -1439,7 +1439,14 @@ const generateFilter = {
     }
 
     if (admin_level) {
-      filter["admin_level"] = admin_level;
+      // Handle both single value and array of values
+      if (Array.isArray(admin_level)) {
+        // Multiple admin levels - use $in operator
+        filter["admin_level"] = { $in: admin_level };
+      } else {
+        // Single admin level - direct assignment
+        filter["admin_level"] = admin_level;
+      }
     }
 
     if (grid_codes) {

--- a/src/device-registry/validators/grids.validators.js
+++ b/src/device-registry/validators/grids.validators.js
@@ -142,8 +142,25 @@ const commonValidations = {
       .notEmpty()
       .withMessage("admin_level is empty, should not be if provided in request")
       .bail()
-      .toLowerCase()
-      .custom(validateAdminLevels)
+      .customSanitizer((value) => {
+        // Split comma-separated values and trim whitespace
+        if (typeof value === "string" && value.includes(",")) {
+          return value.split(",").map((level) => level.trim().toLowerCase());
+        }
+        return typeof value === "string" ? value.trim().toLowerCase() : value;
+      })
+      .custom((value) => {
+        // Handle both single values and arrays
+        const adminLevels = Array.isArray(value) ? value : [value];
+
+        // Validate each admin level
+        for (const level of adminLevels) {
+          if (!validateAdminLevels(level)) {
+            throw new Error(`Invalid admin_level: ${level}`);
+          }
+        }
+        return true;
+      })
       .withMessage(
         "admin_level values include but not limited to: province, state, village, county, etc. Update your GLOBAL configs"
       ),


### PR DESCRIPTION
# 🚀 Pull Request
## 📋 Description
**What does this PR do?**
Enables support for comma-separated `admin_level` query parameter values in the grids API endpoints, allowing users to retrieve multiple admin levels in a single API request.

**Why is this change needed?**
Currently, the grids API only supports retrieving one admin_level at a time through the `admin_level` query parameter. This enhancement allows users to specify multiple admin levels (e.g., `admin_level=province,state,village`) to retrieve grids across different administrative levels in a single request, improving API efficiency and reducing the number of required API calls.

---
## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---
## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---
## 🏗️ Affected Services
**Microservices changed:**
- device-registry service (grids module)

---
## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Verify single admin_level queries continue to work (backward compatibility)
- Test comma-separated admin_level queries return correct results
- Validate proper error handling for invalid admin_level combinations
- Confirm MongoDB query generation uses `$in` operator for multiple values

---
## 💥 Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

This change maintains full backward compatibility. Existing single admin_level requests will continue to work exactly as before.

---
## 📝 Additional Notes
**Changes made:**
1. **Validation Update** (`grids.validators.js`): Enhanced `adminLevelQuery` validation to parse comma-separated values and validate each admin_level individually
2. **Filter Generation** (`generate-filter.js`): Updated `grids` filter function to handle arrays of admin_levels using MongoDB's `$in` operator

**Example usage:**
- Single: `GET /api/v2/grids?admin_level=province`
- Multiple: `GET /api/v2/grids?admin_level=province,state,village`

**Affected endpoints:**
- `GET /grids` (listGrids)
- `GET /grids/summary` (listGridSummary)
- `GET /grids/:grid_id` (getGrid, if admin_level filtering is used)

---
## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review

---
/cc @backend-team