### PR TITLE
do not send BCC emails for existing users

### DIFF
--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -176,7 +176,7 @@ const createMailerFunction = (
         "fieldActivity",
         "existingUserAccessRequest",
         "clientActivationRequest",
-        "existingUserRegistrationRequest",
+        // "existingUserRegistrationRequest",
       ].includes(functionName);
 
       if (shouldProcessBcc) {


### PR DESCRIPTION
- [ ] do not send BCC emails for existing users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated email processing so that BCC recipients are no longer filtered for subscription status when handling existing user registration requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->