### PR TITLE
select latest reading per site

### DIFF
--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -665,13 +665,14 @@ ReadingsSchema.statics.latestForMap = async function(
   next
 ) {
   try {
+    const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
     const pipeline = [
       // 1. Match recent readings only
       {
         $match: {
-          time: { $gte: oneDayAgo },
+          time: { $gte: fourteenDaysAgo },
           "pm2_5.value": { $exists: true, $ne: null },
           ...filter,
         },

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -1953,7 +1953,7 @@ const createEvent = {
         logger.warn(`Cache get operation failed: ${stringify(error)}`);
       }
 
-      const readingsResponse = await ReadingModel(tenant).latestForMap(
+      const readingsResponse = await ReadingModel(tenant).latest(
         {
           filter: {},
           skip: skip || 0,


### PR DESCRIPTION
- [x] select latest reading per site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the time range for retrieving recent readings for map display from 1 day to 14 days, allowing users to view more historical data on the map.
  * Updated event data retrieval to use a general latest readings query, ensuring consistent and up-to-date information is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->