### PR TITLE
Use path - root unavailable due to global config

### DIFF
--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -153,7 +153,7 @@ data:
     location /airqo-application-documentations { return 302 /#/mobile_app/privacy_policy; }
     location /airqo-terms-and-conditions/HxYx3ysdA6k0ng6YJkU3 { return 302 /#/platform/terms_and_conditions; }
     location /superset/ {
-      proxy_pass http://superset-svc.superset.svc.cluster.local:8088;
+      proxy_pass http://superset-svc.superset.svc.cluster.local:8088/superset/;
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
Use pass prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the configuration to correctly forward requests to the Superset service, ensuring proper handling of the `/superset/` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->