### PR TITLE
Update fix/clean up

### DIFF
--- a/src/analytics/api/views/v2/dashboard.py
+++ b/src/analytics/api/views/v2/dashboard.py
@@ -180,7 +180,7 @@ class D3ChartDataResource(Resource):
                 else DeviceCategory.LOWCOST
             )
             datatype = DataType.CALIBRATED
-            data = DataUtils.extract_data_from_bigquery(
+            data, _ = DataUtils.extract_data_from_bigquery(
                 datatype,
                 start_date,
                 end_date,

--- a/src/analytics/api/views/v3/data.py
+++ b/src/analytics/api/views/v3/data.py
@@ -88,7 +88,7 @@ class DataExportResource(Resource):
 @rest_api_v3.route("/raw-data")
 class RawDataExportResource(Resource):
     @rest_api_v3.expect(raw_data_model)
-    @limiter.limit("5 per minute", error_message=ratelimit_response)
+    @limiter.limit("10 per minute", error_message=ratelimit_response)
     def post(self):
         try:
             json_data = RawDataSchema().load(request.json)


### PR DESCRIPTION
- Increase request rate limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Increased the rate limit for the Raw Data Export endpoint from 5 to 10 requests per minute, enabling faster, more frequent exports without throttling in typical usage.
  - This change helps reduce waiting time during bulk or repeated export operations and improves overall responsiveness for data extraction workflows.
  - No other user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->