### PR TITLE
 Redirect from netmanager to vertex

### DIFF
--- a/k8s/nginx/production/netmanager-vs.yaml
+++ b/k8s/nginx/production/netmanager-vs.yaml
@@ -60,7 +60,9 @@ spec:
   routes:
     - path: /
       action:
-        pass: platform-ui
+        redirect:
+          url: https://vertex.airqo.net
+          code: 301
     - path: ~ /api\/v[1-2]\/users
       action:
         proxy:

--- a/k8s/nginx/staging/netmanager-vs.yaml
+++ b/k8s/nginx/staging/netmanager-vs.yaml
@@ -63,7 +63,9 @@ spec:
   routes:
     - path: /
       action:
-        pass: platform-ui
+        redirect:
+          url: https://staging-vertex.airqo.net
+          code: 301      
     - path: ~ /api\/v[1-2]\/users
       action:
         proxy:


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
**What does this PR do?**
<!-- Brief summary of the changes -->

**Why is this change needed?**
<!-- Explain the motivation/problem this solves -->

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review

---

/cc @backend-team


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Visiting the root URL (“/”) now permanently redirects to Vertex in production (https://vertex.airqo.net).
  - The staging root URL (“/”) now permanently redirects to the staging Vertex site (https://staging-vertex.airqo.net).
- Changes
  - Only the root route behavior is updated; all other routes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->