### PR TITLE
just optimising the summary endpoints, reducing default payload to 100 entries

### DIFF
--- a/src/device-registry/routes/v2/devices.routes.js
+++ b/src/device-registry/routes/v2/devices.routes.js
@@ -142,7 +142,7 @@ router.get(
   "/summary",
   validateTenant,
   validateListDevices,
-  pagination(),
+  pagination(100, 500),
   deviceController.listSummary
 );
 

--- a/src/device-registry/routes/v2/sites.routes.js
+++ b/src/device-registry/routes/v2/sites.routes.js
@@ -34,7 +34,7 @@ router.get(
   "/summary",
   validateTenant,
   validateSiteQueryParams,
-  pagination(),
+  pagination(100, 500),
   siteController.listSummary
 );
 router.get(


### PR DESCRIPTION
- [ ] just optimising the summary endpoints, reducing default payload to 100 entries
- [ ] reducing the default number of elements returned in summary endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent pagination limits to device and site summary listings, providing predictable page sizes and smoother navigation for large result sets.

* **Bug Fixes**
  * Improved reliability of summary endpoints by enforcing clear pagination bounds, reducing the chance of oversized responses and timing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->