### PR TITLE
Fix: Resolve model schema and user registration errors

### DIFF
--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -284,11 +284,11 @@ const PreferenceSchema = new mongoose.Schema(
         ref: "site",
       },
     ],
-    selected_sites: [{ type: siteSchema }],
-    selected_grids: [{ type: gridSchema }],
-    selected_devices: [{ type: deviceSchema }],
-    selected_cohorts: [{ type: cohortSchema }],
-    selected_airqlouds: [{ type: airqloudSchema }],
+    selected_sites: [siteSchema],
+    selected_grids: [gridSchema],
+    selected_devices: [deviceSchema],
+    selected_cohorts: [cohortSchema],
+    selected_airqlouds: [airqloudSchema],
     device_ids: [
       {
         type: ObjectId,

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -647,6 +647,10 @@ UserSchema.statics = {
             logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
           }
         }
+      } else if (err instanceof HttpError) {
+        message = err.message;
+        status = err.statusCode;
+        response = err.errors || { message: err.message };
       } else if (err.keyValue) {
         Object.entries(err.keyValue).forEach(([key, value]) => {
           return (response[key] = `the ${key} must be unique`);


### PR DESCRIPTION
## 🚀 Pull Request
### 📋 Description
What does this PR do? This PR resolves two critical runtime errors:

A Mongoose schema compilation error (Cannot set properties of undefined (setting 'Symbol(mongoose#schemaType)')) originating from an incorrect schema definition in the Preference model.
A vague error during mobile user creation, which is now improved to provide more specific feedback.
Why is this change needed? The schema error was causing application instability and preventing certain operations from completing. The vague user creation error made it difficult to diagnose failures, such as a missing TenantSettings document. These fixes ensure the application runs stably and that registration failures are clearly reported.

### 🔗 Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

### 🔄 Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Enhancement/improvement
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

### 🏗️ Affected Services
Microservices changed:
auth-service

### 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

Test summary:

Verified that the application starts and runs without the Symbol(mongoose#schemaType) error after correcting the schema in [Preference.js](code-assist-path:/Users/balmart/Documents/github/AirQo-api/src/auth-service/models/Preference.js).
Tested the user registration endpoint under conditions where the pre('save') hook would fail (e.g., missing TenantSettings) and confirmed that a specific, structured error is now returned instead of a generic one.
Confirmed that the assign permissions to role endpoint now functions correctly without the schema error.
💥 Breaking Changes
[x] No breaking changes
[ ] Has breaking changes (describe below)
📝 Additional Notes
The primary schema fix in [Preference.js](code-assist-path:/Users/balmart/Documents/github/AirQo-api/src/auth-service/models/Preference.js) involved changing the definition for arrays of subdocuments from [{ type: SubSchema }] to the correct [SubSchema] syntax.
The error handling in the [User.js](code-assist-path:/Users/balmart/Documents/github/AirQo-api/src/auth-service/models/User.js) model's register method was enhanced to properly catch and propagate HttpError instances from the pre('save') hook.
✅ Checklist
[x] Code follows project style guidelines
[x] Self-review completed
[ ] Documentation updated (if needed)
[x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved user registration error handling: HTTP-related failures now return consistent, descriptive messages aligned with other error responses.

- Refactor
  - Streamlined how selected items (sites, grids, devices, cohorts, airqlouds) are stored in user preferences to enhance reliability and performance. No UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->