### PR TITLE
Fix: Resolve default role creation warning and permission assignment …

### DIFF
--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -1155,8 +1155,6 @@ const userController = {
    */
   loginEnhanced: async (req, res, next) => {
     try {
-      logger.info("Enhanced login endpoint called");
-      logger.info(`Request body -- ${JSON.stringify(req.body)}`);
       const request = handleRequest(req, next);
       if (!request) return;
 


### PR DESCRIPTION
…error

# 🚀 Pull Request

## 📋 Description
**What does this PR do?**
This PR resolves two issues related to Role-Based Access Control (RBAC):

1. A recurring warning log about `AIRQO_DEFAULT_USER` role not found during application startup and user login.
2. A server crash (`Cannot set properties of undefined`) when attempting to assign permissions to a role with invalid permission IDs.

**Why is this change needed?**
 The missing default role indicated an incomplete RBAC setup, which could lead to downstream errors. The permission assignment crash made a key administrative endpoint unstable and prevented proper role management. These fixes ensure the RBAC system is correctly initialized and that the API handles invalid data gracefully without crashing.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] :bug: Bug fix
- [x] :wrench: Enhancement/improvement
- [x] :recycle: Refactor
- [ ] :sparkles: New feature
- [ ] :books: Documentation update
- [ ] :wastebasket: Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**

- auth-service

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

1. **Default Role Creation:** Restarted the server and confirmed that the `AIRQO_DEFAULT_USER` role not found warning no longer appears in the logs. Verified that the `AIRQO_ADMIN` and `AIRQO_DEFAULT_USER` roles are present in the database after startup.
2. **Permission Assignment Validation:**
  - Sent a` POST` request to` /api/v2/users/roles/:role_id/permissions` with an array containing an invalidly formatted permission ID. Confirmed the API returns a `400 Bad Request` with a clear error message, and the server does not crash.
  - Sent a request with a validly formatted but non-existent ObjectId. Confirmed the API returns a `400 Bad Request `indicating the permission does not exist.
  - Sent a valid request with existing permission IDs and confirmed the operation succeeds.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes

- The default role creation was fixed by adding the missing` AIRQO_ADMIN` role to the getDefaultAirqoRoles helper function in `role-permissions.util.js`.
- The permission assignment crash was resolved by adding robust validation to the `assignPermissionsToRole` utility. It now checks that all provided IDs are valid ObjectIds and that they correspond to existing documents in the `permissions` collection before attempting the update.

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

---
