### PR TITLE
Refactor: Enhance admin access middleware for clarity and performance

### DIFF
--- a/src/auth-service/middleware/adminAccess.js
+++ b/src/auth-service/middleware/adminAccess.js
@@ -84,9 +84,7 @@ const adminCheck = (options = {}) => {
       const rbacService = getRBACService(tenant);
 
       // Always allow the system-wide super admin
-      const isSystemSuperAdmin = await rbacService.hasRole(user._id, [
-        "AIRQO_SUPER_ADMIN",
-      ]);
+      const isSystemSuperAdmin = await rbacService.isSystemSuperAdmin(user._id);
       if (isSystemSuperAdmin) return next();
 
       // Find the target group/network

--- a/src/auth-service/migrations/rbac-migration.util.js
+++ b/src/auth-service/migrations/rbac-migration.util.js
@@ -439,7 +439,7 @@ class RBACMigrationUtility {
               // Get group from our pre-fetched map
               const group = groupMap.get(groupRole.group.toString());
               if (group) {
-                const organizationName = group.grp_title.toUpperCase();
+                const organizationName = this.normalizeName(group.grp_title);
                 const defaultRoleName = `${organizationName}_DEFAULT_MEMBER`;
                 const roleKey = `${groupRole.group}_${this.normalizeName(
                   defaultRoleName

--- a/src/auth-service/utils/role-permissions.util.js
+++ b/src/auth-service/utils/role-permissions.util.js
@@ -1297,7 +1297,7 @@ const createDefaultRolesForOrganization = async (
   tenant = "airqo"
 ) => {
   try {
-    const orgName = organizationName.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+    const orgName = normalizeName(organizationName);
 
     // Use the new centralized definitions
     const roleTemplates = [


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
**What does this PR do?**
This pull request refactors and enhances the adminAccess middleware and the underlying RBACService for better clarity, performance, and developer experience.

1. **Clarifies Super Admin Logic:** The middleware now explicitly distinguishes between the system-wide `AIRQO_SUPER_ADMIN` (who can bypass all checks) and organization-specific super admins.
2. **Improves Error Responses:** When access is denied, the API response now includes the user's current roles within the context, making it much easier to debug permission issues.
3. **Enhances Performance:** The middleware now uses a shared, pooled instance of the RBACService for each tenant, preventing the creation of a new service instance on every request and improving memory efficiency.
4. **Adds New RBAC Helper:** A new getUserRolesInContext function has been added to the `RBACService` to efficiently retrieve role names for logging and API responses.

**Why is this change needed?**
 The previous implementation of the adminAccess middleware was ambiguous about the definition of a "super admin," which could lead to confusion. Furthermore, its error responses were generic, and its performance could be improved. These changes make the authorization layer more precise, secure, performant, and easier to debug.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [ ] 🐛 Bug fix
- [x] 🔧 Enhancement/improvement
- [x] ♻️ Refactor
- [ ] 📚 Documentation update
- [ ] ✨ New feature
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** `auth-service`
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**  Manual testing was performed on endpoints protected by the adminCheck middleware:

1. Verified that a user with the system-wide `AIRQO_SUPER_ADMIN` role can successfully access any protected resource.
2. Verified that a user with an organization-specific `SUPER_ADMIN` role can access resources within their organization.
3. Verified that a user without the required role is correctly denied access.
4. Inspected the `403 Forbidden` API response for a denied user and confirmed it now contains the `required` roles and the `userRoles` they currently have.
5. Checked server logs for a denied request and confirmed the new, clearer log message is present.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

The API contract remains the same, but the error response for `403 Forbidden` errors is now richer and more informative, which is a non-breaking enhancement

---

## 📝 Additional Notes
This refactor establishes a clear security principle: the system-wide `AIRQO_SUPER_ADMIN` has universal access, while organization-specific admins are scoped to their context. The move to a pooled `RBACService` instance is a key performance improvement that reduces memory overhead.

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Immediate access for system super admins on admin-protected routes.
  - Denied-access responses now include user roles and target context IDs for clearer feedback.

- Refactor
  - Per-tenant RBAC caching to reduce overhead and avoid lingering timers.
  - Access checks now use role-based context data; logs reference org-level super-admin roles and target context IDs.
  - Improved role consolidation and name normalization to remove duplicates and deprecated roles.

- Chores
  - Enhanced RBAC cache clearing for fresher authorization state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->