### PR TITLE
Fix: Restore legacy token payload for backward compatibility

### DIFF
--- a/src/auth-service/services/atf.service.js
+++ b/src/auth-service/services/atf.service.js
@@ -288,6 +288,7 @@ class NoRolesAndPermissionsTokenStrategy extends TokenStrategy {
         lastName: user.lastName || null,
         userName: user.userName || null,
         email: user.email || null,
+        nrp: 1,
         organization: user.organization || null,
         long_organization: user.long_organization || null,
         privilege: user.privilege || null,
@@ -300,14 +301,21 @@ class NoRolesAndPermissionsTokenStrategy extends TokenStrategy {
         updatedAt: user.updatedAt
           ? moment(user.updatedAt).format("YYYY-MM-DD HH:mm:ss")
           : null,
-        rateLimit: user.rateLimit || null,
+        rateLimit: user.rateLimit ?? null,
         lastLogin: user.lastLogin ? user.lastLogin.toISOString() : null,
       };
 
+      const { jwtOptions = {} } = options || {};
+      // Strip expiration-related inputs and ignore external algorithm to prevent mismatches.
+      const {
+        expiresIn,
+        exp,
+        algorithm: _ignoredAlg,
+        ...cleanJwtOptions
+      } = jwtOptions;
       const jwtSignOptions = {
-        algorithm: "HS256",
-        // expiresIn is intentionally omitted to match the old token's behavior (no 'exp' field)
-        ...options.jwtOptions,
+        ...cleanJwtOptions,
+        algorithm: "HS256", // keep in sync with decodeToken() verification
       };
 
       return jwt.sign(tokenPayload, constants.JWT_SECRET, jwtSignOptions);


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
**What does this PR do?**
This pull request fixes a critical backward-compatibility issue in the authentication system. It modifies the default token generation strategy (`NO_ROLES_AND_PERMISSIONS`) to produce a JWT payload that is 100% structurally identical to the old token format that client applications expect. This includes:

1. Adding back all previously expected user profile fields (e.g., `profilePicture, country, phoneNumber, lastLogin`).
2. Ensuring these fields are always present in the token, using null as the value if the data doesn't exist for a user.
3. Removing the exp (expiration) claim from this specific token strategy to perfectly match the old format.

**Why is this change needed?**
Following recent refactoring of the authentication service, client applications (especially the mobile app) began exhibiting strange behavior, such as failing to display user profile pictures and other UI elements. This was traced back to a change in the structure of the JWT payload. The new, leaner tokens were missing fields that the client apps relied on. This change restores the exact token payload the clients expect, resolving the UI and functionality issues without requiring any immediate changes to the client applications.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Enhancement/improvement
- [x] ♻️ Refactor
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** auth-service
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Manual testing was performed to validate the fix:

1. Logged in using an endpoint that relies on the default token strategy (/api/v2/users/login).
2. Captured the generated JWT and decoded it using jwt.io.
3. Compared the payload of the new token with a sample of the old token and confirmed that all fields are present and correctly formatted (using null for missing values).
4. Confirmed that the exp field is no longer present in the token generated by this strategy.
5. Verified that the mobile app now functions correctly after logging in and receiving the new, backward-compatible token.

---

## 💥 Breaking Changes

- [x] No breaking changes

This change is specifically designed to fix a breaking change and restore backward compatibility.

---

## 📝 Additional Notes
This change specifically targets the NoRolesAndPermissionsTokenStrategy to ensure it is a drop-in replacement for the old token generation logic. This provides a stable foundation for existing client apps while allowing newer, more optimized token strategies to be used by modern clients in the future.

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
- 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication tokens include more profile fields (userName, names, country, profile picture, phone number, rate limit, last login) and keep the legacy nrp marker.
  * createdAt/updatedAt are standardized to "YYYY-MM-DD HH:mm:ss" or null.

* **Bug Fixes / Compatibility**
  * Tokens no longer emit expiration-related fields by default to maintain backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->