### PR TITLE
Fix: Internal server error when inviting users to a group

### DIFF
--- a/src/auth-service/utils/request.util.js
+++ b/src/auth-service/utils/request.util.js
@@ -146,6 +146,14 @@ const createAccessRequest = {
       const inviterEmail = inviter.email;
       const inviterId = inviter._id;
 
+      if (!ObjectId.isValid(inviterId)) {
+        next(
+          new HttpError("Authentication Error", httpStatus.UNAUTHORIZED, {
+            message: "Invalid inviter id in token.",
+          })
+        );
+        return;
+      }
       const inviterDetails = await UserModel(tenant).findById(inviterId).lean();
       if (isEmpty(inviterDetails)) {
         next(


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

**What does this PR do?**
This pull request fixes a critical bug that was causing a `500 Internal Server Error` when an administrator tried to invite users to a group via email. The fix corrects how the authenticated user's (the inviter's) details are accessed within the `requestAccessToGroupByEmail `utility function.

**Why is this change needed?**
The "invite users to group" feature was completely broken due to a `TypeError: Cannot read properties of undefined (reading 'email')`. This happened because the code was incorrectly trying to access `req.user._doc`, which does not exist on the plain user object provided by the JWT authentication middleware. This PR restores the functionality by correctly using `req.user` and adds robust checks to prevent similar issues.

---

## 🔗 Related Issues

- [ ] Closes #
- [x] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** auth-service
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Manual testing was performed on the `POST /api/v2/users/requests/emails/groups/{group_id}` endpoint.

1. Confirmed that an authenticated user can now successfully send invitations to a list of emails without encountering a 500 Internal Server Error.
2. Verified that the correct inviter details are used when creating the access request and sending the invitation email.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

---

## 📝 Additional Notes
The root cause was an incorrect access pattern (`user._doc`) on the req.user object. The `req.user` object from the JWT payload is a plain JavaScript object, not a Mongoose document, so it does not have a `._doc` property. The fix now uses the `req.user` object directly and includes validation to ensure it's present.

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Access request flow now validates inviter information from the token and returns clear 401 errors when missing or invalid, preventing downstream failures.
  * Ensures consistent handling when inviter details are not found in the database.

* **Refactor**
  * Simplified inviter validation logic for more reliable behavior and clearer, more specific authentication error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->