### PR TITLE
Update fix/clean up

### DIFF
--- a/src/workflows/airqo_etl_utils/datautils.py
+++ b/src/workflows/airqo_etl_utils/datautils.py
@@ -365,7 +365,7 @@ class DataUtils:
             if extra_id:
                 data["site_id"] = extra_id
             data["created"] = datetime.now(timezone.utc)
-            data["maintenance_date"] = device_maintenance
+            data["recent_maintenance_date"] = device_maintenance
             data.dropna(
                 inplace=True,
                 how="any",


### PR DESCRIPTION
Just some clean up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed the maintenance_date column to recent_maintenance_date in device-site metadata outputs. No other behavior changes. Update any integrations expecting maintenance_date.
- Tests
  - Added a unit test to verify compute_device_site_metadata returns all required columns (including recent_maintenance_date) and produces non-empty results under mocked conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->