### PR TITLE
Differentiate weekly and monthly runs

### DIFF
--- a/src/workflows/airqo_etl_utils/constants.py
+++ b/src/workflows/airqo_etl_utils/constants.py
@@ -151,10 +151,10 @@ class Frequency(IntEnum):
     RAW_LOW_COST = 1
     HOURLY = 2
     DAILY = 3
-    WEEKLY = 4
-    MONTHLY = 5
-    YEARLY = 6
-    HISTORICAL = 7
+    WEEKLY = 7  # 7 days in a week //Don't change value
+    MONTHLY = 30  # 30 days in a month //Don't change value
+    YEARLY = 365  # 365 days in a year //Don't change value
+    HISTORICAL = 4
     NONE = 8
 
     def __str__(self) -> str:

--- a/src/workflows/airqo_etl_utils/datautils.py
+++ b/src/workflows/airqo_etl_utils/datautils.py
@@ -1888,12 +1888,15 @@ class DataUtils:
             Exception: Logs and handles unexpected errors during retrieval.
         """
         bigquery = BigQueryApi()
+        frequency_: Frequency = frequency
+        if frequency_ in Config.extra_time_grouping:
+            frequency_ = Frequency.HOURLY
         try:
             datasource = Config.DataSource
             if datatype == DataType.EXTRAS:
                 table = datasource.get(datatype).get(device_network).get(extra_type)
             else:
-                table = datasource.get(datatype).get(device_category).get(frequency)
+                table = datasource.get(datatype).get(device_category).get(frequency_)
             cols = bigquery.get_columns(table=table)
             return table, cols
         except KeyError:

--- a/src/workflows/airqo_etl_utils/datautils.py
+++ b/src/workflows/airqo_etl_utils/datautils.py
@@ -308,7 +308,11 @@ class DataUtils:
 
     @staticmethod
     def compute_device_site_metadata(
-        table: str, unique_id: str, entity: Dict[str, Any], column: Dict[str, Any]
+        table: str,
+        unique_id: str,
+        entity: Dict[str, Any],
+        column: Dict[str, Any],
+        frequency: Optional[Frequency] = Frequency.WEEKLY,
     ) -> pd.DataFrame:
         """
         Computes metadata for devices or sites based on the specified parameters.
@@ -324,9 +328,12 @@ class DataUtils:
                 - "offset_date" (str): The previous offset date.
                 - The unique identifier (e.g., "device_id" or "site_id").
             column(str): The column to compute metadata for (e.g., pollutant type).
+            frequency(Optional[Frequency], default=Frequency.WEEKLY): The frequency for metadata computation. Defaults to weekly.
 
         Returns:
             pd.DataFrame: A DataFrame containing the computed metadata. If the end date is in the future, an empty DataFrame is returned.
+
+        Note: Supported frequencies are: weekly, monthly, yearly. For other frequencies, this method may return empty or incorrect data.
         """
         device_maintenance = entity.get("device_maintenance", None)
         if device_maintenance is None or pd.isna(device_maintenance):
@@ -342,7 +349,7 @@ class DataUtils:
         )
         entity_id = entity.get(unique_id)
         extra_id = entity.get("site_id") if unique_id == "device_id" else None
-        end_date = str_to_date(start_date) + timedelta(days=30)
+        end_date = str_to_date(start_date) + timedelta(days=frequency.value)
 
         if end_date > datetime.today():
             logger.info(f"End date {end_date} cannot be in the future.")

--- a/src/workflows/airqo_etl_utils/meta_data_utils.py
+++ b/src/workflows/airqo_etl_utils/meta_data_utils.py
@@ -164,11 +164,11 @@ class MetaDataUtils:
     @staticmethod
     def compute_device_site_baseline(
         data_type: DataType,
-        frequency: Frequency,
         device_category: DeviceCategory,
         device_network: DeviceNetwork,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
+        frequency: Optional[Frequency] = Frequency.WEEKLY,
     ) -> pd.DataFrame:
         """
         Computes baseline statistics for devices or sites based on the specified parameters.
@@ -178,16 +178,16 @@ class MetaDataUtils:
             data_type (DataType): The type of data to process (e.g., air quality, weather).
             device_category (DeviceCategory): The category of the device (e.g., LOWCOST, GENERAL).
             device_network (DeviceNetwork): The network of the device (e.g., AIRQO, OTHER).
-            frequency (Frequency): The frequency of the data (e.g., HOURLY, DAILY, WEEKLY).
             start_date (str): The start date for the baseline computation in ISO 8601 format.
             end_date (str): The end date for the baseline computation in ISO 8601 format.
+            frequency (Frequency): The frequency of the data (e.g., HOURLY, DAILY, WEEKLY).
         Returns:
             pd.DataFrame: A DataFrame containing the computed baseline statistics. If no data is found, returns an empty DataFrame.
         Raises:
             ValueError: If no data is found for the specified parameters.
         """
         if start_date is None or end_date is None:
-            start_date, end_date = frequency_to_dates(Frequency.WEEKLY)
+            start_date, end_date = frequency_to_dates(frequency)
 
         device_metadata = DataUtils.extract_most_recent_record(
             MetaDataType.DEVICES, "device_id", "offset_date"
@@ -225,11 +225,11 @@ class MetaDataUtils:
                     data.loc[data.device_id == device_data["device_id"]],
                     device_data,
                     [device_data["pollutant"]],
-                    frequency,
-                    start_date,
-                    end_date,
-                    device_data["minimum"],
-                    device_data["maximum"],
+                    resolution=frequency,
+                    window_start=start_date,
+                    window_end=end_date,
+                    region_min=device_data["minimum"],
+                    region_max=device_data["maximum"],
                 )
                 for _, device_data in device_metadata.iterrows()
             ]

--- a/src/workflows/airqo_etl_utils/schema/device_computed_metadata.json
+++ b/src/workflows/airqo_etl_utils/schema/device_computed_metadata.json
@@ -45,7 +45,12 @@
     "mode": "REQUIRED"
   },
   {
-    "name": "resolution",
+    "name": "data_resolution",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "baseline_type",
     "type": "STRING",
     "mode": "REQUIRED"
   },

--- a/src/workflows/airqo_etl_utils/schema/site_computed_metadata.json
+++ b/src/workflows/airqo_etl_utils/schema/site_computed_metadata.json
@@ -35,7 +35,12 @@
     "mode": "REQUIRED"
   },
   {
-    "name": "resolution",
+    "name": "data_resolution",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "baseline_type",
     "type": "STRING",
     "mode": "REQUIRED"
   },


### PR DESCRIPTION
Some clean up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added monthly workflows for device metadata and device baselines.
  * Enabled frequency-based processing windows (weekly/monthly/yearly).
* Refactor
  * Renamed schema field “resolution” to “data_resolution” and added required “baseline_type”. Consumers should update integrations.
  * Aligned frequency durations to real-world windows (7/30/365 days).
* Chores
  * Updated weekly devices metadata to run weekly.
  * Adjusted weekly baseline schedule to run at 02:00.
  * Added monthly scheduling and tags for new workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->