### PR TITLE
Optimize Device and Site Endpoints with Pre-computed Activity Caching

### DIFF
--- a/src/device-registry/bin/jobs/precompute-activities-job.js
+++ b/src/device-registry/bin/jobs/precompute-activities-job.js
@@ -1,0 +1,388 @@
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/precompute-activities-job`
+);
+const ActivityModel = require("@models/Activity");
+const DeviceModel = require("@models/Device");
+const SiteModel = require("@models/Site");
+const { logObject, logText } = require("@utils/shared");
+const cron = require("node-cron");
+const moment = require("moment-timezone");
+
+const TIMEZONE = moment.tz.guess();
+const JOB_NAME = "precompute-activities-job";
+const JOB_SCHEDULE = "30 * * * *"; // At minute 30 of every hour
+const BATCH_SIZE = 100;
+
+class ActivityPrecomputeProcessor {
+  constructor() {
+    this.processedSites = 0;
+    this.processedDevices = 0;
+    this.errors = [];
+  }
+
+  async precomputeSiteActivities(tenant) {
+    try {
+      logText("Starting site activities precomputation...");
+
+      // Get all sites with their activity summaries
+      const pipeline = [
+        {
+          $lookup: {
+            from: "activities",
+            let: { siteId: "$_id" },
+            pipeline: [
+              { $match: { $expr: { $eq: ["$site_id", "$$siteId"] } } },
+              { $sort: { createdAt: -1 } },
+              {
+                $group: {
+                  _id: "$activityType",
+                  count: { $sum: 1 },
+                  latest: { $first: "$$ROOT" },
+                  latestDate: { $first: "$createdAt" },
+                },
+              },
+            ],
+            as: "activitySummary",
+          },
+        },
+        {
+          $lookup: {
+            from: "devices",
+            localField: "_id",
+            foreignField: "site_id",
+            pipeline: [{ $project: { _id: 1, name: 1 } }],
+            as: "devices",
+          },
+        },
+        {
+          $project: {
+            _id: 1,
+            activitySummary: 1,
+            deviceCount: { $size: "$devices" },
+            devices: 1,
+          },
+        },
+      ];
+
+      const sites = await SiteModel(tenant).aggregate(pipeline);
+
+      for (let i = 0; i < sites.length; i += BATCH_SIZE) {
+        const batch = sites.slice(i, i + BATCH_SIZE);
+        await this.processSiteBatch(tenant, batch);
+      }
+
+      logText(
+        `Completed site activities precomputation. Processed: ${this.processedSites} sites`
+      );
+    } catch (error) {
+      logger.error(`Site precomputation error: ${error.message}`);
+      this.errors.push({ type: "site", error: error.message });
+    }
+  }
+
+  async processSiteBatch(tenant, sites) {
+    const bulkOps = sites.map((site) => {
+      // Build activity summary
+      const activitiesByType = {};
+      const latestActivitiesByType = {};
+      let totalActivities = 0;
+
+      site.activitySummary.forEach((summary) => {
+        const type = summary._id || "unknown";
+        activitiesByType[type] = summary.count;
+        totalActivities += summary.count;
+
+        if (summary.latest) {
+          const {
+            groups,
+            activity_codes,
+            updatedAt,
+            __v,
+            ...cleanActivity
+          } = summary.latest;
+          latestActivitiesByType[type] = cleanActivity;
+        }
+      });
+
+      // Create device activity summary
+      const deviceActivitySummary = site.devices.map((device) => ({
+        device_id: device._id,
+        device_name: device.name,
+        activity_count: 0, // Will be computed separately if needed
+      }));
+
+      // Backward compatibility fields
+      const latestDeployment = latestActivitiesByType.deployment || null;
+      const latestMaintenance = latestActivitiesByType.maintenance || null;
+      const latestRecall =
+        latestActivitiesByType.recall ||
+        latestActivitiesByType.recallment ||
+        null;
+      const siteCreation = latestActivitiesByType["site-creation"] || null;
+
+      return {
+        updateOne: {
+          filter: { _id: site._id },
+          update: {
+            $set: {
+              // Precomputed activity data
+              cached_activities_by_type: activitiesByType,
+              cached_latest_activities_by_type: latestActivitiesByType,
+              cached_total_activities: totalActivities,
+              cached_device_activity_summary: deviceActivitySummary,
+
+              // Backward compatibility
+              cached_latest_deployment_activity: latestDeployment,
+              cached_latest_maintenance_activity: latestMaintenance,
+              cached_latest_recall_activity: latestRecall,
+              cached_site_creation_activity: siteCreation,
+
+              // Metadata
+              cached_total_devices: site.deviceCount,
+              activities_cache_updated_at: new Date(),
+            },
+          },
+          upsert: false,
+        },
+      };
+    });
+
+    if (bulkOps.length > 0) {
+      await SiteModel(tenant).bulkWrite(bulkOps);
+      this.processedSites += bulkOps.length;
+    }
+  }
+
+  async precomputeDeviceActivities(tenant) {
+    try {
+      logText("Starting device activities precomputation...");
+
+      const pipeline = [
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceName: "$name", deviceId: "$_id" },
+            pipeline: [
+              {
+                $match: {
+                  $expr: {
+                    $or: [
+                      { $eq: ["$device", "$$deviceName"] },
+                      { $eq: ["$device_id", "$$deviceId"] },
+                    ],
+                  },
+                },
+              },
+              { $sort: { createdAt: -1 } },
+              {
+                $group: {
+                  _id: "$activityType",
+                  count: { $sum: 1 },
+                  latest: { $first: "$$ROOT" },
+                  latestDate: { $first: "$createdAt" },
+                },
+              },
+            ],
+            as: "activitySummary",
+          },
+        },
+        {
+          $project: {
+            _id: 1,
+            name: 1,
+            activitySummary: 1,
+          },
+        },
+      ];
+
+      const devices = await DeviceModel(tenant).aggregate(pipeline);
+
+      for (let i = 0; i < devices.length; i += BATCH_SIZE) {
+        const batch = devices.slice(i, i + BATCH_SIZE);
+        await this.processDeviceBatch(tenant, batch);
+      }
+
+      logText(
+        `Completed device activities precomputation. Processed: ${this.processedDevices} devices`
+      );
+    } catch (error) {
+      logger.error(`Device precomputation error: ${error.message}`);
+      this.errors.push({ type: "device", error: error.message });
+    }
+  }
+
+  async processDeviceBatch(tenant, devices) {
+    const bulkOps = devices.map((device) => {
+      const activitiesByType = {};
+      const latestActivitiesByType = {};
+      let totalActivities = 0;
+
+      device.activitySummary.forEach((summary) => {
+        const type = summary._id || "unknown";
+        activitiesByType[type] = summary.count;
+        totalActivities += summary.count;
+
+        if (summary.latest) {
+          const {
+            groups,
+            activity_codes,
+            updatedAt,
+            __v,
+            ...cleanActivity
+          } = summary.latest;
+          latestActivitiesByType[type] = cleanActivity;
+        }
+      });
+
+      const latestDeployment = latestActivitiesByType.deployment || null;
+      const latestMaintenance = latestActivitiesByType.maintenance || null;
+      const latestRecall =
+        latestActivitiesByType.recall ||
+        latestActivitiesByType.recallment ||
+        null;
+
+      return {
+        updateOne: {
+          filter: { _id: device._id },
+          update: {
+            $set: {
+              cached_activities_by_type: activitiesByType,
+              cached_latest_activities_by_type: latestActivitiesByType,
+              cached_total_activities: totalActivities,
+              cached_latest_deployment_activity: latestDeployment,
+              cached_latest_maintenance_activity: latestMaintenance,
+              cached_latest_recall_activity: latestRecall,
+              activities_cache_updated_at: new Date(),
+            },
+          },
+          upsert: false,
+        },
+      };
+    });
+
+    if (bulkOps.length > 0) {
+      await DeviceModel(tenant).bulkWrite(bulkOps);
+      this.processedDevices += bulkOps.length;
+    }
+  }
+
+  async cleanupStaleCache(tenant) {
+    try {
+      const staleThreshold = moment()
+        .subtract(2, "hours")
+        .toDate();
+
+      // Clean up stale cache entries (optional - for data consistency)
+      const [siteCleanup, deviceCleanup] = await Promise.all([
+        SiteModel(tenant).updateMany(
+          {
+            activities_cache_updated_at: { $lt: staleThreshold },
+            activities_cache_updated_at: { $exists: true },
+          },
+          {
+            $unset: {
+              cached_activities_by_type: 1,
+              cached_latest_activities_by_type: 1,
+              cached_total_activities: 1,
+              activities_cache_updated_at: 1,
+            },
+          }
+        ),
+        DeviceModel(tenant).updateMany(
+          {
+            activities_cache_updated_at: { $lt: staleThreshold },
+            activities_cache_updated_at: { $exists: true },
+          },
+          {
+            $unset: {
+              cached_activities_by_type: 1,
+              cached_latest_activities_by_type: 1,
+              cached_total_activities: 1,
+              activities_cache_updated_at: 1,
+            },
+          }
+        ),
+      ]);
+
+      if (siteCleanup.modifiedCount > 0 || deviceCleanup.modifiedCount > 0) {
+        logText(
+          `Cleaned up stale cache: ${siteCleanup.modifiedCount} sites, ${deviceCleanup.modifiedCount} devices`
+        );
+      }
+    } catch (error) {
+      logger.error(`Cache cleanup error: ${error.message}`);
+    }
+  }
+}
+
+async function precomputeActivitiesAndMetrics() {
+  const processor = new ActivityPrecomputeProcessor();
+
+  try {
+    logText("Starting activities precomputation job");
+
+    // Process for each tenant (add more as needed)
+    const tenants = ["airqo"]; // Add other tenants as needed
+
+    for (const tenant of tenants) {
+      logText(`Processing tenant: ${tenant}`);
+
+      await Promise.all([
+        processor.precomputeSiteActivities(tenant),
+        processor.precomputeDeviceActivities(tenant),
+      ]);
+
+      // Optional cleanup
+      await processor.cleanupStaleCache(tenant);
+    }
+
+    const summary = {
+      processedSites: processor.processedSites,
+      processedDevices: processor.processedDevices,
+      errors: processor.errors,
+      timestamp: new Date(),
+    };
+
+    logText(`Precomputation completed: ${JSON.stringify(summary)}`);
+  } catch (error) {
+    logger.error(`Activities precomputation job failed: ${error.message}`);
+  }
+}
+
+// Create and register the job
+const startJob = () => {
+  const cronJobInstance = cron.schedule(
+    JOB_SCHEDULE,
+    precomputeActivitiesAndMetrics,
+    {
+      scheduled: true,
+      timezone: TIMEZONE,
+    }
+  );
+
+  if (!global.cronJobs) {
+    global.cronJobs = {};
+  }
+
+  global.cronJobs[JOB_NAME] = {
+    job: cronJobInstance,
+    stop: async () => {
+      cronJobInstance.stop();
+      if (typeof cronJobInstance.destroy === "function") {
+        cronJobInstance.destroy();
+      }
+      delete global.cronJobs[JOB_NAME];
+    },
+  };
+
+  console.log(`✅ ${JOB_NAME} started - precomputing activities every hour`);
+};
+
+startJob();
+
+module.exports = {
+  precomputeActivitiesAndMetrics,
+  ActivityPrecomputeProcessor,
+};

--- a/src/device-registry/bin/jobs/precompute-activities-job.js
+++ b/src/device-registry/bin/jobs/precompute-activities-job.js
@@ -35,7 +35,21 @@ class ActivityPrecomputeProcessor {
             from: activitiesColl,
             let: { siteId: "$_id" },
             pipeline: [
-              { $match: { $expr: { $eq: ["$site_id", "$$siteId"] } } },
+              {
+                $match: {
+                  $expr: {
+                    $or: [
+                      { $eq: ["$site_id", "$$siteId"] },
+                      {
+                        $eq: [
+                          { $toString: "$site_id" },
+                          { $toString: "$$siteId" },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              },
               { $sort: { createdAt: -1 } },
               {
                 $group: {

--- a/src/device-registry/bin/jobs/precompute-activities-job.js
+++ b/src/device-registry/bin/jobs/precompute-activities-job.js
@@ -73,7 +73,8 @@ class ActivityPrecomputeProcessor {
       const cursor = SiteModel(tenant)
         .aggregate(pipeline)
         .allowDiskUse(true)
-        .cursor({ batchSize: BATCH_SIZE });
+        .cursor({ batchSize: BATCH_SIZE })
+        .exec();
 
       let batch = [];
       for await (const site of cursor) {
@@ -110,13 +111,31 @@ class ActivityPrecomputeProcessor {
 
         if (summary.latest) {
           const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            ...cleanActivity
+            _id,
+            activityType,
+            maintenanceType,
+            recallType,
+            date,
+            description,
+            nextMaintenance,
+            createdAt,
+            device_id,
+            device,
+            site_id,
           } = summary.latest;
-          latestActivitiesByType[type] = cleanActivity;
+          latestActivitiesByType[type] = {
+            _id,
+            activityType,
+            maintenanceType,
+            recallType,
+            date,
+            description,
+            nextMaintenance,
+            createdAt,
+            device_id,
+            device,
+            site_id,
+          };
         }
       });
 
@@ -221,7 +240,8 @@ class ActivityPrecomputeProcessor {
       const cursor = DeviceModel(tenant)
         .aggregate(pipeline)
         .allowDiskUse(true)
-        .cursor({ batchSize: BATCH_SIZE });
+        .cursor({ batchSize: BATCH_SIZE })
+        .exec();
 
       let batch = [];
       for await (const device of cursor) {
@@ -257,13 +277,31 @@ class ActivityPrecomputeProcessor {
 
         if (summary.latest) {
           const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            ...cleanActivity
+            _id,
+            activityType,
+            maintenanceType,
+            recallType,
+            date,
+            description,
+            nextMaintenance,
+            createdAt,
+            device_id,
+            device,
+            site_id,
           } = summary.latest;
-          latestActivitiesByType[type] = cleanActivity;
+          latestActivitiesByType[type] = {
+            _id,
+            activityType,
+            maintenanceType,
+            recallType,
+            date,
+            description,
+            nextMaintenance,
+            createdAt,
+            device_id,
+            device,
+            site_id,
+          };
         }
       });
 

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -92,7 +92,7 @@ require("@bin/jobs/health-tip-checker-job");
 require("@bin/jobs/daily-activity-summary-job");
 require("@bin/jobs/site-categorization-job");
 require("@bin/jobs/site-categorization-notification-job");
-if (process.env.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== "false") {
+if (constants.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== "false") {
   try {
     require("@bin/jobs/precompute-activities-job");
   } catch (err) {

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -92,7 +92,7 @@ require("@bin/jobs/health-tip-checker-job");
 require("@bin/jobs/daily-activity-summary-job");
 require("@bin/jobs/site-categorization-job");
 require("@bin/jobs/site-categorization-notification-job");
-if (constants.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== "false") {
+if (constants.PRECOMPUTE_ACTIVITIES_JOB_ENABLED) {
   try {
     require("@bin/jobs/precompute-activities-job");
   } catch (err) {

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -92,6 +92,7 @@ require("@bin/jobs/health-tip-checker-job");
 require("@bin/jobs/daily-activity-summary-job");
 require("@bin/jobs/site-categorization-job");
 require("@bin/jobs/site-categorization-notification-job");
+require("@bin/jobs/precompute-activities-job");
 
 if (isEmpty(constants.SESSION_SECRET)) {
   throw new Error("SESSION_SECRET environment variable not set");

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -92,7 +92,15 @@ require("@bin/jobs/health-tip-checker-job");
 require("@bin/jobs/daily-activity-summary-job");
 require("@bin/jobs/site-categorization-job");
 require("@bin/jobs/site-categorization-notification-job");
-require("@bin/jobs/precompute-activities-job");
+if (process.env.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== "false") {
+  try {
+    require("@bin/jobs/precompute-activities-job");
+  } catch (err) {
+    global.dedupLogger.error(
+      `Failed to start precompute-activities-job: ${err.message}`
+    );
+  }
+}
 
 if (isEmpty(constants.SESSION_SECRET)) {
   throw new Error("SESSION_SECRET environment variable not set");

--- a/src/device-registry/config/environments/development.js
+++ b/src/device-registry/config/environments/development.js
@@ -6,6 +6,7 @@ const { logObject, logText } = require("@utils/shared");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 
 const devConfig = {
+  PRECOMPUTE_ACTIVITIES_JOB_ENABLED: true,
   API_TOKEN: process.env.DEV_API_TOKEN,
   API_BASE_URL: process.env.DEV_API_BASE_URL,
   DEFAULT_COHORT: process.env.DEV_DEFAULT_COHORT,

--- a/src/device-registry/config/environments/development.js
+++ b/src/device-registry/config/environments/development.js
@@ -6,7 +6,8 @@ const { logObject, logText } = require("@utils/shared");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 
 const devConfig = {
-  PRECOMPUTE_ACTIVITIES_JOB_ENABLED: true,
+  PRECOMPUTE_ACTIVITIES_JOB_ENABLED:
+    process.env.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== "false",
   API_TOKEN: process.env.DEV_API_TOKEN,
   API_BASE_URL: process.env.DEV_API_BASE_URL,
   DEFAULT_COHORT: process.env.DEV_DEFAULT_COHORT,

--- a/src/device-registry/config/environments/production.js
+++ b/src/device-registry/config/environments/production.js
@@ -6,7 +6,8 @@ const { logObject, logText } = require("@utils/shared");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 
 const prodConfig = {
-  PRECOMPUTE_ACTIVITIES_JOB_ENABLED: true,
+  PRECOMPUTE_ACTIVITIES_JOB_ENABLED:
+    process.env.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== "false",
   API_TOKEN: process.env.PROD_API_TOKEN,
   API_BASE_URL: process.env.PROD_API_BASE_URL,
   DEFAULT_COHORT: process.env.PROD_DEFAULT_COHORT,

--- a/src/device-registry/config/environments/production.js
+++ b/src/device-registry/config/environments/production.js
@@ -6,6 +6,7 @@ const { logObject, logText } = require("@utils/shared");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 
 const prodConfig = {
+  PRECOMPUTE_ACTIVITIES_JOB_ENABLED: true,
   API_TOKEN: process.env.PROD_API_TOKEN,
   API_BASE_URL: process.env.PROD_API_BASE_URL,
   DEFAULT_COHORT: process.env.PROD_DEFAULT_COHORT,

--- a/src/device-registry/config/environments/staging.js
+++ b/src/device-registry/config/environments/staging.js
@@ -6,7 +6,9 @@ const { logObject, logText } = require("@utils/shared");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 
 const stageConfig = {
-  PRECOMPUTE_ACTIVITIES_JOB_ENABLED: true,
+  PRECOMPUTE_ACTIVITIES_JOB_ENABLED:
+    process.env.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== "false",
+
   API_TOKEN: process.env.STAGE_API_TOKEN,
   API_BASE_URL: process.env.STAGE_API_BASE_URL,
   DEFAULT_COHORT: process.env.STAGE_DEFAULT_COHORT,

--- a/src/device-registry/config/environments/staging.js
+++ b/src/device-registry/config/environments/staging.js
@@ -6,6 +6,7 @@ const { logObject, logText } = require("@utils/shared");
 const logger = log4js.getLogger(`${this.ENVIRONMENT} -- constants-config`);
 
 const stageConfig = {
+  PRECOMPUTE_ACTIVITIES_JOB_ENABLED: true,
   API_TOKEN: process.env.STAGE_API_TOKEN,
   API_BASE_URL: process.env.STAGE_API_BASE_URL,
   DEFAULT_COHORT: process.env.STAGE_DEFAULT_COHORT,

--- a/src/device-registry/models/Activity.js
+++ b/src/device-registry/models/Activity.js
@@ -118,6 +118,10 @@ activitySchema.pre("save", function(next) {
   next();
 });
 
+activitySchema.index({ site_id: 1, createdAt: -1 });
+activitySchema.index({ device_id: 1, createdAt: -1 });
+activitySchema.index({ device: 1, createdAt: -1 });
+
 activitySchema.methods = {
   toJSON() {
     return {

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -324,6 +324,29 @@ const deviceSchema = new mongoose.Schema(
       successPercentage: { type: Number, default: 0 },
       failurePercentage: { type: Number, default: 0 },
     },
+    // Precomputed activity fields for performance
+    cached_activities_by_type: {
+      type: Object,
+      default: {},
+    },
+    cached_latest_activities_by_type: {
+      type: Object,
+      default: {},
+    },
+    cached_total_activities: {
+      type: Number,
+      default: 0,
+    },
+    cached_latest_deployment_activity: {
+      type: Object,
+    },
+    cached_latest_maintenance_activity: {
+      type: Object,
+    },
+    cached_latest_recall_activity: {
+      type: Object,
+    },
+    activities_cache_updated_at: { type: Date },
   },
   {
     timestamps: true,

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -357,6 +357,8 @@ deviceSchema.plugin(uniqueValidator, {
   message: `{VALUE} must be unique!`,
 });
 
+deviceSchema.index({ site_id: 1 });
+
 const checkDuplicates = (arr, fieldName) => {
   const duplicateValues = arr.filter(
     (value, index, self) => self.indexOf(value) !== index

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -376,6 +376,40 @@ const siteSchema = new Schema(
       successPercentage: { type: Number, default: 0 },
       failurePercentage: { type: Number, default: 0 },
     },
+    // Precomputed activity fields for performance
+    cached_activities_by_type: {
+      type: Object,
+      default: {},
+    },
+    cached_latest_activities_by_type: {
+      type: Object,
+      default: {},
+    },
+    cached_total_activities: {
+      type: Number,
+      default: 0,
+    },
+    cached_device_activity_summary: {
+      type: Array,
+      default: [],
+    },
+    cached_latest_deployment_activity: {
+      type: Object,
+    },
+    cached_latest_maintenance_activity: {
+      type: Object,
+    },
+    cached_latest_recall_activity: {
+      type: Object,
+    },
+    cached_site_creation_activity: {
+      type: Object,
+    },
+    cached_total_devices: {
+      type: Number,
+      default: 0,
+    },
+    activities_cache_updated_at: { type: Date },
   },
   {
     timestamps: true,

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -880,6 +880,13 @@ const deviceUtil = {
         detailLevel = "summary",
       } = request.query;
       const tenant = (rawTenant || constants.DEFAULT_TENANT).toLowerCase();
+      const MAX_LIMIT =
+        Number(constants.DEFAULT_LIMIT_FOR_QUERYING_DEVICES) || 1000;
+      const _skip = Math.max(0, parseInt(skip, 10) || 0);
+      const _limit = Math.min(
+        MAX_LIMIT,
+        Math.max(1, parseInt(limit, 10) || MAX_LIMIT)
+      );
       const filter = generateFilter.devices(request, next);
 
       if (!isEmpty(path)) {
@@ -1070,8 +1077,8 @@ const deviceUtil = {
       // Common sorting and pagination
       pipeline.push(
         { $sort: { createdAt: -1 } },
-        { $skip: skip || 0 },
-        { $limit: limit || 1000 }
+        { $skip: _skip },
+        { $limit: _limit }
       );
 
       const response = await DeviceModel(tenant)

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -93,6 +93,9 @@ const deviceUtil = {
       }
 
       // Build aggregation pipeline
+      if (!isValidObjectId(id)) {
+        throw new HttpError("Invalid device id", httpStatus.BAD_REQUEST);
+      }
       let pipeline = [{ $match: { _id: new ObjectId(id) } }];
 
       // Add projection early if specified
@@ -869,13 +872,14 @@ const deviceUtil = {
   list: async (request, next) => {
     try {
       const {
-        tenant,
+        tenant: rawTenant,
         path,
         limit,
         skip,
         useCache = "true",
         detailLevel = "summary",
       } = request.query;
+      const tenant = (rawTenant || constants.DEFAULT_TENANT).toLowerCase();
       const filter = generateFilter.devices(request, next);
 
       if (!isEmpty(path)) {

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -50,98 +50,213 @@ const deviceUtil = {
   getDeviceById: async (req, next) => {
     try {
       const { id } = req.params;
-      const { tenant, maxActivities = 500 } = req.query; // Make limit configurable
+      const {
+        tenant,
+        maxActivities = 500,
+        includeActivities = "true",
+        includeRelations = "true",
+        useCache = "true",
+        detailLevel = "full", // 'minimal', 'summary', 'full'
+      } = req.query;
 
-      // Use aggregation pipeline to include activities
-      const devicePipeline = await DeviceModel(tenant.toLowerCase()).aggregate([
-        {
-          $match: { _id: id },
-        },
-        // Lookup sites
-        {
-          $lookup: {
-            from: "sites",
-            localField: "site_id",
-            foreignField: "_id",
-            as: "site",
-          },
-        },
-        // Lookup hosts
-        {
-          $lookup: {
-            from: "hosts",
-            localField: "host_id",
-            foreignField: "_id",
-            as: "host",
-          },
-        },
-        // Lookup cohorts
-        {
-          $lookup: {
-            from: "cohorts",
-            localField: "cohorts",
-            foreignField: "_id",
-            as: "cohorts",
-          },
-        },
-        // Lookup grids
-        {
-          $lookup: {
-            from: "grids",
-            localField: "grid_id",
-            foreignField: "_id",
-            as: "assigned_grid",
-          },
-        },
-        // Lookup all activities for this device with field projection and optional limit
-        {
-          $lookup: {
-            from: "activities",
-            let: { deviceName: "$name", deviceId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $or: [
-                      { $eq: ["$device", "$$deviceName"] },
-                      { $eq: ["$device_id", "$$deviceId"] },
-                    ],
+      // Determine projection based on detail level
+      let projection = {};
+      if (detailLevel === "minimal") {
+        projection = {
+          _id: 1,
+          name: 1,
+          long_name: 1,
+          status: 1,
+          isActive: 1,
+          network: 1,
+          category: 1,
+          createdAt: 1,
+        };
+      } else if (detailLevel === "summary") {
+        projection = {
+          _id: 1,
+          name: 1,
+          long_name: 1,
+          status: 1,
+          isActive: 1,
+          network: 1,
+          category: 1,
+          deployment_date: 1,
+          latitude: 1,
+          longitude: 1,
+          mountType: 1,
+          powerType: 1,
+          createdAt: 1,
+          cached_total_activities: 1,
+          cached_activities_by_type: 1,
+        };
+      }
+
+      // Build aggregation pipeline
+      let pipeline = [{ $match: { _id: new ObjectId(id) } }];
+
+      // Add projection early if specified
+      if (Object.keys(projection).length > 0) {
+        pipeline.push({ $project: projection });
+      }
+
+      // Conditional lookups based on detail level and parameters
+      if (detailLevel === "full") {
+        if (includeRelations === "true") {
+          pipeline.push(
+            {
+              $lookup: {
+                from: "sites",
+                localField: "site_id",
+                foreignField: "_id",
+                as: "site",
+                pipeline: [
+                  {
+                    $project: {
+                      _id: 1,
+                      name: 1,
+                      latitude: 1,
+                      longitude: 1,
+                      district: 1,
+                      country: 1,
+                      network: 1,
+                    },
                   },
+                ],
+              },
+            },
+            {
+              $lookup: {
+                from: "hosts",
+                localField: "host_id",
+                foreignField: "_id",
+                as: "host",
+              },
+            },
+            {
+              $lookup: {
+                from: "cohorts",
+                localField: "cohorts",
+                foreignField: "_id",
+                as: "cohorts",
+              },
+            },
+            {
+              $lookup: {
+                from: "grids",
+                localField: "grid_id",
+                foreignField: "_id",
+                as: "assigned_grid",
+                pipeline: [
+                  {
+                    $project: {
+                      _id: 1,
+                      name: 1,
+                      admin_level: 1,
+                      long_name: 1,
+                    },
+                  },
+                ],
+              },
+            }
+          );
+        }
+
+        // Handle activities based on cache preference
+        if (includeActivities === "true") {
+          if (useCache === "true") {
+            // Use precomputed cache when available
+            pipeline.push({
+              $addFields: {
+                activities_by_type: {
+                  $ifNull: ["$cached_activities_by_type", {}],
+                },
+                latest_activities_by_type: {
+                  $ifNull: ["$cached_latest_activities_by_type", {}],
+                },
+                total_activities: {
+                  $ifNull: ["$cached_total_activities", 0],
+                },
+                latest_deployment_activity:
+                  "$cached_latest_deployment_activity",
+                latest_maintenance_activity:
+                  "$cached_latest_maintenance_activity",
+                latest_recall_activity: "$cached_latest_recall_activity",
+                activities_from_cache: {
+                  $cond: [
+                    { $gt: [{ $ifNull: ["$cached_total_activities", 0] }, 0] },
+                    true,
+                    false,
+                  ],
                 },
               },
-              { $sort: { createdAt: -1 } },
-              // Project only essential fields to reduce payload size
-              {
-                $project: {
-                  _id: 1,
-                  activityType: 1,
-                  date: 1,
-                  description: 1,
-                  maintenanceType: 1,
-                  recallType: 1,
-                  nextMaintenance: 1,
-                  createdAt: 1,
-                  tags: 1,
-                  device: 1,
-                  device_id: 1,
-                  site_id: 1,
-                },
+            });
+          } else {
+            // Fall back to real-time aggregation (expensive)
+            pipeline.push({
+              $lookup: {
+                from: "activities",
+                let: { deviceName: "$name", deviceId: "$_id" },
+                pipeline: [
+                  {
+                    $match: {
+                      $expr: {
+                        $or: [
+                          { $eq: ["$device", "$$deviceName"] },
+                          { $eq: ["$device_id", "$$deviceId"] },
+                        ],
+                      },
+                    },
+                  },
+                  { $sort: { createdAt: -1 } },
+                  {
+                    $project: {
+                      _id: 1,
+                      activityType: 1,
+                      date: 1,
+                      description: 1,
+                      maintenanceType: 1,
+                      recallType: 1,
+                      nextMaintenance: 1,
+                      createdAt: 1,
+                      tags: 1,
+                      device: 1,
+                      device_id: 1,
+                      site_id: 1,
+                    },
+                  },
+                  ...(maxActivities
+                    ? [{ $limit: parseInt(maxActivities) }]
+                    : []),
+                ],
+                as: "activities",
               },
-              // Optionally limit number of activities returned
-              ...(maxActivities ? [{ $limit: parseInt(maxActivities) }] : []),
-            ],
-            as: "activities",
-          },
-        },
-        // Add simple computed fields only
-        {
+            });
+          }
+        }
+
+        // Add computed fields
+        pipeline.push({
           $addFields: {
             total_activities: {
-              $cond: [{ $isArray: "$activities" }, { $size: "$activities" }, 0],
+              $cond: [
+                {
+                  $and: [
+                    { $isArray: "$activities" },
+                    { $ne: [includeActivities, "false"] },
+                  ],
+                },
+                { $size: "$activities" },
+                { $ifNull: ["$cached_total_activities", 0] },
+              ],
             },
           },
-        },
-      ]);
+        });
+      }
+
+      const devicePipeline = await DeviceModel(tenant.toLowerCase()).aggregate(
+        pipeline
+      );
 
       if (!devicePipeline || devicePipeline.length === 0) {
         throw new HttpError("Device not found", httpStatus.NOT_FOUND);
@@ -149,18 +264,20 @@ const deviceUtil = {
 
       const device = devicePipeline[0];
 
-      if (device.activities && device.activities.length > 0) {
-        // Group activities by type and get latest for each type
+      // Process activities only if not using cache and activities are included
+      if (
+        detailLevel === "full" &&
+        includeActivities === "true" &&
+        useCache === "false" &&
+        device.activities
+      ) {
         const activitiesByType = {};
         const latestActivitiesByType = {};
 
         device.activities.forEach((activity) => {
           const type = activity.activityType || "unknown";
-
-          // Count activities by type
           activitiesByType[type] = (activitiesByType[type] || 0) + 1;
 
-          // Track latest activity by type
           if (
             !latestActivitiesByType[type] ||
             new Date(activity.createdAt) >
@@ -172,8 +289,6 @@ const deviceUtil = {
 
         device.activities_by_type = activitiesByType;
         device.latest_activities_by_type = latestActivitiesByType;
-
-        // Maintain backward compatibility
         device.latest_deployment_activity =
           latestActivitiesByType.deployment || null;
         device.latest_maintenance_activity =
@@ -183,8 +298,7 @@ const deviceUtil = {
           latestActivitiesByType.recallment ||
           null;
 
-        // Since we already projected essential fields, we can simplify this filtering
-        // Just remove any remaining unwanted fields that might have slipped through
+        // Filter activities for response
         device.activities = device.activities.map((activity) => {
           const {
             groups,
@@ -202,93 +316,14 @@ const deviceUtil = {
           } = activity;
           return filteredActivity;
         });
-
-        // Filter latest activities by type
-        Object.keys(device.latest_activities_by_type).forEach(
-          (activityType) => {
-            const activity = device.latest_activities_by_type[activityType];
-            const {
-              groups,
-              activity_codes,
-              updatedAt,
-              __v,
-              firstName,
-              lastName,
-              email,
-              userName,
-              user_id,
-              host_id,
-              network,
-              ...filtered
-            } = activity;
-            device.latest_activities_by_type[activityType] = filtered;
-          }
-        );
-
-        // Filter backward compatibility fields
-        if (device.latest_deployment_activity) {
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            firstName,
-            lastName,
-            email,
-            userName,
-            user_id,
-            host_id,
-            network,
-            ...filtered
-          } = device.latest_deployment_activity;
-          device.latest_deployment_activity = filtered;
-        }
-
-        if (device.latest_maintenance_activity) {
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            firstName,
-            lastName,
-            email,
-            userName,
-            user_id,
-            host_id,
-            network,
-            ...filtered
-          } = device.latest_maintenance_activity;
-          device.latest_maintenance_activity = filtered;
-        }
-
-        if (device.latest_recall_activity) {
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            firstName,
-            lastName,
-            email,
-            userName,
-            user_id,
-            host_id,
-            network,
-            ...filtered
-          } = device.latest_recall_activity;
-          device.latest_recall_activity = filtered;
-        }
-      } else {
-        device.activities_by_type = {};
-        device.latest_activities_by_type = {};
-        device.latest_deployment_activity = null;
-        device.latest_maintenance_activity = null;
-        device.latest_recall_activity = null;
       }
 
-      // Filter assigned_grid to show only required fields
-      if (device.assigned_grid && device.assigned_grid.length > 0) {
+      // Process assigned_grid for full detail level
+      if (
+        detailLevel === "full" &&
+        device.assigned_grid &&
+        device.assigned_grid.length > 0
+      ) {
         const grid = device.assigned_grid[0];
         device.assigned_grid = {
           _id: grid._id,
@@ -296,8 +331,15 @@ const deviceUtil = {
           admin_level: grid.admin_level,
           long_name: grid.long_name,
         };
-      } else {
+      } else if (detailLevel === "full") {
         device.assigned_grid = null;
+      }
+
+      // Set default values for missing cache data
+      if (detailLevel !== "minimal") {
+        if (!device.activities_by_type) device.activities_by_type = {};
+        if (!device.latest_activities_by_type)
+          device.latest_activities_by_type = {};
       }
 
       return {
@@ -305,6 +347,12 @@ const deviceUtil = {
         message: "Device details with activities fetched successfully",
         data: device,
         status: httpStatus.OK,
+        meta: {
+          detailLevel,
+          usedCache: useCache === "true" && !!device.activities_from_cache,
+          includeActivities: includeActivities === "true",
+          includeRelations: includeRelations === "true",
+        },
       };
     } catch (error) {
       if (error instanceof HttpError) {
@@ -820,20 +868,277 @@ const deviceUtil = {
   },
   list: async (request, next) => {
     try {
-      const { tenant, path, limit, skip } = request.query;
+      const {
+        tenant,
+        path,
+        limit,
+        skip,
+        useCache = "true",
+        detailLevel = "summary",
+      } = request.query;
       const filter = generateFilter.devices(request, next);
+
       if (!isEmpty(path)) {
         filter.path = path;
       }
-      const responseFromListDevice = await DeviceModel(tenant).list(
-        {
-          filter,
-          limit,
-          skip,
-        },
-        next
+
+      let pipeline = [];
+
+      // Base match
+      pipeline.push({ $match: filter });
+
+      if (detailLevel === "minimal") {
+        // Minimal data for performance-critical scenarios
+        pipeline.push({
+          $project: {
+            _id: 1,
+            name: 1,
+            long_name: 1,
+            status: 1,
+            isActive: 1,
+            network: 1,
+            category: 1,
+            device_number: 1,
+            createdAt: 1,
+            cached_total_activities: 1,
+          },
+        });
+      } else if (detailLevel === "summary") {
+        // Summary with essential relations and cached data
+        pipeline.push(
+          {
+            $lookup: {
+              from: "sites",
+              localField: "site_id",
+              foreignField: "_id",
+              as: "site",
+              pipeline: [
+                { $project: { _id: 1, name: 1, district: 1, country: 1 } },
+              ],
+            },
+          },
+          {
+            $lookup: {
+              from: "grids",
+              localField: "grid_id",
+              foreignField: "_id",
+              as: "assigned_grid",
+              pipeline: [{ $project: { _id: 1, name: 1, admin_level: 1 } }],
+            },
+          },
+          {
+            $addFields: {
+              total_activities: { $ifNull: ["$cached_total_activities", 0] },
+              activities_by_type: {
+                $ifNull: ["$cached_activities_by_type", {}],
+              },
+              latest_deployment_activity: "$cached_latest_deployment_activity",
+              latest_maintenance_activity:
+                "$cached_latest_maintenance_activity",
+              latest_recall_activity: "$cached_latest_recall_activity",
+            },
+          },
+          {
+            $project: {
+              // Exclude heavy fields for summary
+              cohorts: 0,
+              pictures: 0,
+              device_codes: 0,
+              onlineStatusAccuracy: 0,
+              mobility_metadata: 0,
+            },
+          }
+        );
+      } else {
+        // Full detail level (existing complex aggregation)
+        const maxActivities = parseInt(request.query.maxActivities) || 500;
+
+        pipeline.push(
+          {
+            $lookup: {
+              from: "sites",
+              localField: "site_id",
+              foreignField: "_id",
+              as: "site",
+            },
+          },
+          {
+            $lookup: {
+              from: "hosts",
+              localField: "host_id",
+              foreignField: "_id",
+              as: "host",
+            },
+          },
+          {
+            $lookup: {
+              from: "sites",
+              localField: "previous_sites",
+              foreignField: "_id",
+              as: "previous_sites",
+            },
+          },
+          {
+            $lookup: {
+              from: "cohorts",
+              localField: "cohorts",
+              foreignField: "_id",
+              as: "cohorts",
+            },
+          },
+          {
+            $lookup: {
+              from: "grids",
+              localField: "site.grids",
+              foreignField: "_id",
+              as: "grids",
+            },
+          },
+          {
+            $lookup: {
+              from: "grids",
+              localField: "grid_id",
+              foreignField: "_id",
+              as: "assigned_grid",
+            },
+          }
+        );
+
+        if (useCache === "true") {
+          // Use cached activity data
+          pipeline.push({
+            $addFields: {
+              total_activities: { $ifNull: ["$cached_total_activities", 0] },
+              activities_by_type: {
+                $ifNull: ["$cached_activities_by_type", {}],
+              },
+              latest_activities_by_type: {
+                $ifNull: ["$cached_latest_activities_by_type", {}],
+              },
+              latest_deployment_activity: "$cached_latest_deployment_activity",
+              latest_maintenance_activity:
+                "$cached_latest_maintenance_activity",
+              latest_recall_activity: "$cached_latest_recall_activity",
+            },
+          });
+        } else {
+          // Real-time activity aggregation (expensive)
+          pipeline.push({
+            $lookup: {
+              from: "activities",
+              let: { deviceName: "$name", deviceId: "$_id" },
+              pipeline: [
+                {
+                  $match: {
+                    $expr: {
+                      $or: [
+                        { $eq: ["$device", "$$deviceName"] },
+                        { $eq: ["$device_id", "$$deviceId"] },
+                      ],
+                    },
+                  },
+                },
+                { $sort: { createdAt: -1 } },
+                {
+                  $project: {
+                    _id: 1,
+                    site_id: 1,
+                    device_id: 1,
+                    device: 1,
+                    activityType: 1,
+                    maintenanceType: 1,
+                    recallType: 1,
+                    date: 1,
+                    description: 1,
+                    nextMaintenance: 1,
+                    createdAt: 1,
+                    tags: 1,
+                  },
+                },
+                { $limit: maxActivities },
+              ],
+              as: "activities",
+            },
+          });
+        }
+      }
+
+      // Common sorting and pagination
+      pipeline.push(
+        { $sort: { createdAt: -1 } },
+        { $skip: skip || 0 },
+        { $limit: limit || 1000 }
       );
-      return responseFromListDevice;
+
+      const response = await DeviceModel(tenant)
+        .aggregate(pipeline)
+        .allowDiskUse(true);
+
+      // Process activities for non-cached full detail requests
+      if (
+        !isEmpty(response) &&
+        detailLevel === "full" &&
+        useCache === "false"
+      ) {
+        response.forEach((device) => {
+          if (device.activities && device.activities.length > 0) {
+            const activitiesByType = {};
+            const latestActivitiesByType = {};
+
+            device.activities.forEach((activity) => {
+              const type = activity.activityType || "unknown";
+              activitiesByType[type] = (activitiesByType[type] || 0) + 1;
+
+              if (
+                !latestActivitiesByType[type] ||
+                new Date(activity.createdAt) >
+                  new Date(latestActivitiesByType[type].createdAt)
+              ) {
+                latestActivitiesByType[type] = activity;
+              }
+            });
+
+            device.activities_by_type = activitiesByType;
+            device.latest_activities_by_type = latestActivitiesByType;
+            device.latest_deployment_activity =
+              latestActivitiesByType.deployment || null;
+            device.latest_maintenance_activity =
+              latestActivitiesByType.maintenance || null;
+            device.latest_recall_activity =
+              latestActivitiesByType.recall ||
+              latestActivitiesByType.recallment ||
+              null;
+          } else {
+            device.activities_by_type = {};
+            device.latest_activities_by_type = {};
+          }
+
+          // Process assigned_grid
+          if (device.assigned_grid && device.assigned_grid.length > 0) {
+            const grid = device.assigned_grid[0];
+            device.assigned_grid = {
+              _id: grid._id,
+              name: grid.name,
+              admin_level: grid.admin_level,
+              long_name: grid.long_name,
+            };
+          } else {
+            device.assigned_grid = null;
+          }
+        });
+      }
+
+      return {
+        success: true,
+        message: "successfully retrieved the device details",
+        data: response,
+        status: httpStatus.OK,
+        meta: {
+          detailLevel,
+          usedCache: useCache === "true",
+          totalResults: response.length,
+        },
+      };
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -32,99 +32,186 @@ const createSite = {
   getSiteById: async (req, next) => {
     try {
       const { id } = req.params;
-      const { tenant, maxActivities = 500 } = req.query;
+      const {
+        tenant,
+        maxActivities = 500,
+        includeActivities = "true",
+        includeRelations = "true",
+        useCache = "true",
+        detailLevel = "full", // 'minimal', 'summary', 'full'
+      } = req.query;
 
-      // Use aggregation pipeline to include activities and devices
-      const sitePipeline = await SiteModel(tenant.toLowerCase()).aggregate([
-        {
-          $match: { _id: id },
-        },
-        // Lookup devices associated with the site
-        {
-          $lookup: {
-            from: "devices",
-            localField: "_id",
-            foreignField: "site_id",
-            as: "devices",
-            pipeline: [
-              {
-                $project: {
-                  _id: 1,
-                  name: 1,
-                  long_name: 1,
-                  serial_number: 1,
-                  status: 1,
-                  category: 1,
-                  isActive: 1,
-                  network: 1,
-                  description: 1,
-                  createdAt: 1,
-                  latitude: 1,
-                  longitude: 1,
+      // Determine projection based on detail level
+      let projection = {};
+      if (detailLevel === "minimal") {
+        projection = {
+          _id: 1,
+          name: 1,
+          generated_name: 1,
+          status: 1,
+          network: 1,
+          createdAt: 1,
+        };
+      } else if (detailLevel === "summary") {
+        projection = {
+          _id: 1,
+          name: 1,
+          generated_name: 1,
+          status: 1,
+          network: 1,
+          latitude: 1,
+          longitude: 1,
+          country: 1,
+          district: 1,
+          createdAt: 1,
+          cached_total_devices: 1,
+          cached_total_activities: 1,
+          cached_activities_by_type: 1,
+        };
+      }
+
+      // Build aggregation pipeline
+      let pipeline = [{ $match: { _id: id } }];
+
+      // Add projection early if specified
+      if (Object.keys(projection).length > 0) {
+        pipeline.push({ $project: projection });
+      }
+
+      // Conditional lookups based on detail level and parameters
+      if (detailLevel === "full") {
+        if (includeRelations === "true") {
+          pipeline.push(
+            {
+              $lookup: {
+                from: "devices",
+                localField: "_id",
+                foreignField: "site_id",
+                as: "devices",
+                pipeline: [
+                  {
+                    $project: {
+                      _id: 1,
+                      name: 1,
+                      long_name: 1,
+                      status: 1,
+                      category: 1,
+                      isActive: 1,
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              $lookup: {
+                from: "grids",
+                localField: "grids",
+                foreignField: "_id",
+                as: "grids",
+              },
+            },
+            {
+              $lookup: {
+                from: "airqlouds",
+                localField: "airqlouds",
+                foreignField: "_id",
+                as: "airqlouds",
+              },
+            }
+          );
+        }
+
+        // Handle activities based on cache preference
+        if (includeActivities === "true") {
+          if (useCache === "true") {
+            pipeline.push({
+              $addFields: {
+                activities_by_type: {
+                  $ifNull: ["$cached_activities_by_type", {}],
+                },
+                latest_activities_by_type: {
+                  $ifNull: ["$cached_latest_activities_by_type", {}],
+                },
+                total_activities: {
+                  $ifNull: ["$cached_total_activities", 0],
+                },
+                device_activity_summary: {
+                  $ifNull: ["$cached_device_activity_summary", []],
+                },
+                latest_deployment_activity:
+                  "$cached_latest_deployment_activity",
+                latest_maintenance_activity:
+                  "$cached_latest_maintenance_activity",
+                latest_recall_activity: "$cached_latest_recall_activity",
+                site_creation_activity: "$cached_site_creation_activity",
+                activities_from_cache: {
+                  $cond: [
+                    { $gt: [{ $ifNull: ["$cached_total_activities", 0] }, 0] },
+                    true,
+                    false,
+                  ],
                 },
               },
-            ],
-          },
-        },
-        // Lookup grids
-        {
-          $lookup: {
-            from: "grids",
-            localField: "grids",
-            foreignField: "_id",
-            as: "grids",
-          },
-        },
-        // Lookup airqlouds
-        {
-          $lookup: {
-            from: "airqlouds",
-            localField: "airqlouds",
-            foreignField: "_id",
-            as: "airqlouds",
-          },
-        },
-        // Lookup all activities for this site
-        {
-          $lookup: {
-            from: "activities",
-            let: { siteId: "$_id" },
-            pipeline: [
-              { $match: { $expr: { $eq: ["$site_id", "$$siteId"] } } },
-              { $sort: { createdAt: -1 } },
-              {
-                $project: {
-                  _id: 1,
-                  activityType: 1,
-                  date: 1,
-                  description: 1,
-                  maintenanceType: 1,
-                  recallType: 1,
-                  nextMaintenance: 1,
-                  createdAt: 1,
-                  tags: 1,
-                  device: 1,
-                  device_id: 1,
-                  site_id: 1,
-                },
+            });
+          } else {
+            pipeline.push({
+              $lookup: {
+                from: "activities",
+                let: { siteId: "$_id" },
+                pipeline: [
+                  { $match: { $expr: { $eq: ["$site_id", "$$siteId"] } } },
+                  { $sort: { createdAt: -1 } },
+                  {
+                    $project: {
+                      _id: 1,
+                      activityType: 1,
+                      date: 1,
+                      description: 1,
+                      maintenanceType: 1,
+                      recallType: 1,
+                      nextMaintenance: 1,
+                      createdAt: 1,
+                      tags: 1,
+                      device: 1,
+                      device_id: 1,
+                      site_id: 1,
+                    },
+                  },
+                  ...(maxActivities
+                    ? [{ $limit: parseInt(maxActivities) }]
+                    : []),
+                ],
+                as: "activities",
               },
-              ...(maxActivities ? [{ $limit: parseInt(maxActivities) }] : []),
-            ],
-            as: "activities",
-          },
-        },
-        // Add simple computed fields only
-        {
+            });
+          }
+        }
+
+        // Add computed fields
+        pipeline.push({
           $addFields: {
             total_activities: {
-              $cond: [{ $isArray: "$activities" }, { $size: "$activities" }, 0],
+              $cond: [
+                {
+                  $and: [
+                    { $isArray: "$activities" },
+                    { $ne: [includeActivities, "false"] },
+                  ],
+                },
+                { $size: "$activities" },
+                { $ifNull: ["$cached_total_activities", 0] },
+              ],
             },
             total_devices: {
               $cond: [{ $isArray: "$devices" }, { $size: "$devices" }, 0],
             },
           },
-        },
-      ]);
+        });
+      }
+
+      const sitePipeline = await SiteModel(tenant.toLowerCase()).aggregate(
+        pipeline
+      );
 
       if (!sitePipeline || sitePipeline.length === 0) {
         throw new HttpError("Site not found", httpStatus.NOT_FOUND);
@@ -132,19 +219,19 @@ const createSite = {
 
       const site = sitePipeline[0];
 
-      // Process all activity logic in JavaScript for reliability
-      if (site.activities && site.activities.length > 0) {
-        // Group activities by type and get latest for each type
+      // Process activities only if not using cache and activities are included
+      if (
+        detailLevel === "full" &&
+        includeActivities === "true" &&
+        useCache === "false" &&
+        site.activities
+      ) {
         const activitiesByType = {};
         const latestActivitiesByType = {};
 
         site.activities.forEach((activity) => {
           const type = activity.activityType || "unknown";
-
-          // Count activities by type
           activitiesByType[type] = (activitiesByType[type] || 0) + 1;
-
-          // Track latest activity by type
           if (
             !latestActivitiesByType[type] ||
             new Date(activity.createdAt) >
@@ -156,8 +243,6 @@ const createSite = {
 
         site.activities_by_type = activitiesByType;
         site.latest_activities_by_type = latestActivitiesByType;
-
-        // Maintain backward compatibility
         site.latest_deployment_activity =
           latestActivitiesByType.deployment || null;
         site.latest_maintenance_activity =
@@ -169,7 +254,6 @@ const createSite = {
         site.site_creation_activity =
           latestActivitiesByType["site-creation"] || null;
 
-        // Create device activity summary
         const deviceActivitySummary = site.devices.map((device) => {
           const deviceActivities = site.activities.filter(
             (activity) =>
@@ -184,88 +268,14 @@ const createSite = {
           };
         });
         site.device_activity_summary = deviceActivitySummary;
+      }
 
-        // Apply field filtering to activities
-        site.activities = site.activities.map((activity) => {
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            ...filteredActivity
-          } = activity;
-          return filteredActivity;
-        });
-
-        // Filter latest activities
-        Object.keys(site.latest_activities_by_type).forEach((activityType) => {
-          const activity = site.latest_activities_by_type[activityType];
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            ...filtered
-          } = activity;
-          site.latest_activities_by_type[activityType] = filtered;
-        });
-
-        // Filter backward compatibility fields
-        if (site.latest_deployment_activity) {
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            ...filtered
-          } = site.latest_deployment_activity;
-          site.latest_deployment_activity = filtered;
-        }
-
-        if (site.latest_maintenance_activity) {
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            ...filtered
-          } = site.latest_maintenance_activity;
-          site.latest_maintenance_activity = filtered;
-        }
-
-        if (site.latest_recall_activity) {
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            ...filtered
-          } = site.latest_recall_activity;
-          site.latest_recall_activity = filtered;
-        }
-
-        if (site.site_creation_activity) {
-          const {
-            groups,
-            activity_codes,
-            updatedAt,
-            __v,
-            ...filtered
-          } = site.site_creation_activity;
-          site.site_creation_activity = filtered;
-        }
-      } else {
-        site.activities_by_type = {};
-        site.latest_activities_by_type = {};
-        site.device_activity_summary = site.devices.map((device) => ({
-          device_id: device._id,
-          device_name: device.name,
-          activity_count: 0,
-        }));
-        site.latest_deployment_activity = null;
-        site.latest_maintenance_activity = null;
-        site.latest_recall_activity = null;
-        site.site_creation_activity = null;
+      // Set default values for missing cache data
+      if (detailLevel !== "minimal") {
+        if (!site.activities_by_type) site.activities_by_type = {};
+        if (!site.latest_activities_by_type)
+          site.latest_activities_by_type = {};
+        if (!site.device_activity_summary) site.device_activity_summary = [];
       }
 
       return {
@@ -274,6 +284,12 @@ const createSite = {
           "Site details with activities and devices fetched successfully",
         data: site,
         status: httpStatus.OK,
+        meta: {
+          detailLevel,
+          usedCache: useCache === "true" && !!site.activities_from_cache,
+          includeActivities: includeActivities === "true",
+          includeRelations: includeRelations === "true",
+        },
       };
     } catch (error) {
       if (error instanceof HttpError) {
@@ -1211,30 +1227,172 @@ const createSite = {
   },
   list: async (request, next) => {
     try {
-      const { skip, limit, tenant, path } = request.query;
+      const {
+        skip,
+        limit,
+        tenant,
+        path,
+        useCache = "true",
+        detailLevel = "summary",
+      } = request.query;
       const filter = generateFilter.sites(request, next);
       if (!isEmpty(path)) {
         filter.path = path;
       }
-      const responseFromListSite = await SiteModel(tenant).list(
-        {
-          filter,
-          limit,
-          skip,
-        },
-        next
-      );
 
-      if (responseFromListSite.success === false) {
-        return responseFromListSite;
+      let pipeline = [];
+
+      // Base match
+      pipeline.push({ $match: filter });
+
+      if (detailLevel === "minimal") {
+        pipeline.push({
+          $project: {
+            _id: 1,
+            name: 1,
+            generated_name: 1,
+            latitude: 1,
+            longitude: 1,
+            network: 1,
+            createdAt: 1,
+          },
+        });
+      } else if (detailLevel === "summary") {
+        pipeline.push(
+          {
+            $addFields: {
+              total_devices: { $ifNull: ["$cached_total_devices", 0] },
+              total_activities: { $ifNull: ["$cached_total_activities", 0] },
+              activities_by_type: {
+                $ifNull: ["$cached_activities_by_type", {}],
+              },
+              latest_deployment_activity: "$cached_latest_deployment_activity",
+            },
+          },
+          {
+            $project: {
+              // Exclude heavy fields for summary
+              geometry: 0,
+              site_tags: 0,
+              weather_stations: 0,
+              images: 0,
+              share_links: 0,
+            },
+          }
+        );
+      } else {
+        // Full detail level
+        pipeline.push(
+          {
+            $lookup: {
+              from: "devices",
+              localField: "_id",
+              foreignField: "site_id",
+              as: "devices",
+            },
+          },
+          {
+            $lookup: {
+              from: "grids",
+              localField: "grids",
+              foreignField: "_id",
+              as: "grids",
+            },
+          },
+          {
+            $lookup: {
+              from: "airqlouds",
+              localField: "airqlouds",
+              foreignField: "_id",
+              as: "airqlouds",
+            },
+          }
+        );
+
+        if (useCache === "true") {
+          pipeline.push({
+            $addFields: {
+              total_activities: { $ifNull: ["$cached_total_activities", 0] },
+              activities_by_type: {
+                $ifNull: ["$cached_activities_by_type", {}],
+              },
+              latest_activities_by_type: {
+                $ifNull: ["$cached_latest_activities_by_type", {}],
+              },
+              latest_deployment_activity: "$cached_latest_deployment_activity",
+              latest_maintenance_activity:
+                "$cached_latest_maintenance_activity",
+              latest_recall_activity: "$cached_latest_recall_activity",
+              site_creation_activity: "$cached_site_creation_activity",
+            },
+          });
+        } else {
+          // Real-time aggregation (expensive)
+          pipeline.push({
+            $lookup: {
+              from: "activities",
+              localField: "_id",
+              foreignField: "site_id",
+              as: "activities",
+            },
+          });
+        }
       }
 
-      const modifiedResponseFromListSite = {
-        ...responseFromListSite,
-        data: responseFromListSite.data.filter((obj) => obj.lat_long !== "4_4"),
-      };
+      // Common sorting and pagination
+      pipeline.push(
+        { $sort: { createdAt: -1 } },
+        { $skip: skip || 0 },
+        { $limit: limit || 1000 }
+      );
 
-      return modifiedResponseFromListSite;
+      const response = await SiteModel(tenant)
+        .aggregate(pipeline)
+        .allowDiskUse(true);
+
+      // Post-processing for non-cached full detail
+      if (
+        !isEmpty(response) &&
+        detailLevel === "full" &&
+        useCache === "false"
+      ) {
+        response.forEach((site) => {
+          if (site.activities && site.activities.length > 0) {
+            const activitiesByType = {};
+            const latestActivitiesByType = {};
+            site.activities.forEach((activity) => {
+              const type = activity.activityType || "unknown";
+              activitiesByType[type] = (activitiesByType[type] || 0) + 1;
+              if (
+                !latestActivitiesByType[type] ||
+                new Date(activity.createdAt) >
+                  new Date(latestActivitiesByType[type].createdAt)
+              ) {
+                latestActivitiesByType[type] = activity;
+              }
+            });
+            site.activities_by_type = activitiesByType;
+            site.latest_activities_by_type = latestActivitiesByType;
+          } else {
+            site.activities_by_type = {};
+            site.latest_activities_by_type = {};
+          }
+        });
+      }
+
+      const filteredResponse = response.filter((obj) => obj.lat_long !== "4_4");
+
+      return {
+        success: true,
+        message: "successfully retrieved the site details",
+        data: filteredResponse,
+        status: httpStatus.OK,
+        meta: {
+          detailLevel,
+          usedCache: useCache === "true",
+          totalResults: filteredResponse.length,
+        },
+      };
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1243,6 +1243,13 @@ const createSite = {
         detailLevel = "summary",
       } = request.query;
       const tenant = (rawTenant || constants.DEFAULT_TENANT).toLowerCase();
+      const MAX_LIMIT =
+        Number(constants.DEFAULT_LIMIT_FOR_QUERYING_SITES) || 1000;
+      const _skip = Math.max(0, parseInt(skip, 10) || 0);
+      const _limit = Math.min(
+        MAX_LIMIT,
+        Math.max(1, parseInt(limit, 10) || MAX_LIMIT)
+      );
       const filter = generateFilter.sites(request, next);
       if (!isEmpty(path)) {
         filter.path = path;
@@ -1350,8 +1357,8 @@ const createSite = {
       // Common sorting and pagination
       pipeline.push(
         { $sort: { createdAt: -1 } },
-        { $skip: skip || 0 },
-        { $limit: limit || 1000 }
+        { $skip: _skip },
+        { $limit: _limit }
       );
 
       const response = await SiteModel(tenant)


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
This PR introduces a pre-computation caching strategy to significantly optimize the performance of the GET /devices and GET /sites list and detail endpoints. A new background cron job now periodically aggregates activity data and stores it directly on the Device and Site documents. The API endpoints have been refactored to read this cached data by default, resulting in dramatically faster response times.

**Why is this change needed?**
The existing endpoints were experiencing severe performance degradation and timeouts, particularly when including maintenance activities. The real-time aggregation of this data was too resource-intensive for the database, leading to a poor user experience and high server load. This solution offloads the heavy processing to a background job, ensuring the primary API remains fast and responsive.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [x] ♻️ Refactor
- [ ] 📚 Documentation update
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** device-registry
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** The changes were validated by:

1. Calling the `GET /devices` and `GET /sites` endpoints and confirming a significant reduction in response time.
2. Testing the new query parameters:

-  `useCache=false` to confirm that the original real-time aggregation logic still functions correctly.
- `detailLevel=summary` and `detailLevel=minimal` to verify that the endpoints return reduced payloads for faster, lightweight queries.

3. Manually triggering the `precompute-activities-job` and inspecting the `devices` and `sites` collections in the database to confirm that the `cached_*` fields are populated as expected.
4. Confirming that the API response structure remains backward-compatible, ensuring no breaking changes for existing frontend applications.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes

- A new cron job, `precompute-activities-job.js`, runs every hour to keep the activity cache fresh.
- The list and getById endpoints for devices and sites now support useCache and detailLevel query parameters to provide more flexible and performant data retrieval options.
- The default behavior for all updated endpoints is to serve data from the cache for maximum performance.

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Device and site endpoints support detailLevel (minimal/summary/full), includeActivities, includeRelations, useCache, maxActivities and meta; responses can include activity summaries, per-type latests, and device-activity summaries.
  - New cached activity fields on Site and Device to surface precomputed totals, per-type summaries and latest activity records.

- **Chores**
  - Toggleable scheduled background job added to precompute/refresh activity caches with stale-cache cleanup and guarded startup loading.
  - Device/site delete endpoints temporarily disabled (503).

- **Refactor**
  - Retrievals reworked to dynamic, pipeline-driven queries; added indexes to improve activity and site/device lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->