### PR TITLE
increase cache to 60minutes

### DIFF
--- a/src/spatial/views/heatmapViews.py
+++ b/src/spatial/views/heatmapViews.py
@@ -142,7 +142,7 @@ class AQIImageGenerator:
             Flask response with JSON containing city heatmaps or an error message.
         """
         redis_client = AQIImageGenerator.get_redis_client()
-        cache_ttl_seconds = 1800 #Cache for 30 minutes
+        cache_ttl_seconds = 3600  # Cache for 60 minutes
         all_cities_cache_key = "aqi_images_all_cities"
         
         # --- NEW: Check for the entire 'all cities' response in cache first ---
@@ -234,7 +234,7 @@ class AQIImageGenerator:
         """
         redis_client = AQIImageGenerator.get_redis_client()
         cache_key = f"aqi_image_{city_id}"
-        cache_ttl_seconds = 1800 #Cache for 30 minutes
+        cache_ttl_seconds = 3600  # Cache for 60 minutes
 
         # Try to get from cache
         if redis_client:


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
**What does this PR do?**
<!-- Brief summary of the changes -->

**Why is this change needed?**
<!-- Explain the motivation/problem this solves -->

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review

---

/cc @backend-team


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended caching for air quality heatmap images from 30 to 60 minutes across both city-wide and per-city views. This reduces reloads and improves responsiveness and reliability under high traffic.
  * Users may notice that heatmap updates appear less frequently within the hour window, but previously loaded images should display faster and with fewer timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->