### PR TITLE
Fix: Resolve internal server error in feeds transform endpoint

### DIFF
--- a/src/device-registry/controllers/feed.controller.js
+++ b/src/device-registry/controllers/feed.controller.js
@@ -27,7 +27,7 @@ const createFeed = {
       const channel = ch_id;
 
       try {
-        const apiKeyResponse = await createFeedUtil.getAPIKey(channel);
+        const apiKeyResponse = await createFeedUtil.getAPIKey(channel, next);
         if (apiKeyResponse.success !== true) {
           return res.status(apiKeyResponse.status).json(apiKeyResponse);
         }
@@ -79,7 +79,7 @@ const createFeed = {
       const { channel, start, end } = req.query;
 
       try {
-        const apiKeyResponse = await createFeedUtil.getAPIKey(channel);
+        const apiKeyResponse = await createFeedUtil.getAPIKey(channel, next);
         if (apiKeyResponse.success !== true) {
           return res.status(apiKeyResponse.status).json(apiKeyResponse);
         }

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -530,7 +530,7 @@ const deviceUtil = {
       );
     }
   },
-  doesDeviceExist: async (request) => {
+  doesDeviceExist: async (request, next) => {
     logText("checking device existence...");
     const responseFromList = await deviceUtil.list(request, next);
     if (responseFromList.success === true && responseFromList.data) {
@@ -538,6 +538,7 @@ const deviceUtil = {
     }
     return false;
   },
+
   getDevicesCount: async (request, next) => {
     try {
       const { query } = request;
@@ -1284,9 +1285,12 @@ const deviceUtil = {
         });
       }
 
-      const baseUrl = `${request.protocol}://${request.get("host")}${
-        request.originalUrl.split("?")[0]
-      }`;
+      const baseUrl =
+        request.protocol && typeof request.get === "function"
+          ? `${request.protocol}://${request.get("host")}${
+              request.originalUrl.split("?")[0]
+            }`
+          : "";
 
       const meta = {
         total,
@@ -1299,16 +1303,18 @@ const deviceUtil = {
         usedCache: useCache === "true",
       };
 
-      const nextSkip = _skip + _limit;
-      if (nextSkip < total) {
-        const nextQuery = { ...request.query, skip: nextSkip, limit: _limit };
-        meta.nextPage = `${baseUrl}?${qs.stringify(nextQuery)}`;
-      }
+      if (baseUrl) {
+        const nextSkip = _skip + _limit;
+        if (nextSkip < total) {
+          const nextQuery = { ...request.query, skip: nextSkip, limit: _limit };
+          meta.nextPage = `${baseUrl}?${qs.stringify(nextQuery)}`;
+        }
 
-      const prevSkip = _skip - _limit;
-      if (prevSkip >= 0) {
-        const prevQuery = { ...request.query, skip: prevSkip, limit: _limit };
-        meta.previousPage = `${baseUrl}?${qs.stringify(prevQuery)}`;
+        const prevSkip = _skip - _limit;
+        if (prevSkip >= 0) {
+          const prevQuery = { ...request.query, skip: prevSkip, limit: _limit };
+          meta.previousPage = `${baseUrl}?${qs.stringify(prevQuery)}`;
+        }
       }
 
       return {

--- a/src/device-registry/utils/feed.util.js
+++ b/src/device-registry/utils/feed.util.js
@@ -188,7 +188,7 @@ const createFeed = {
     }
     return trimmedValues;
   },
-  getAPIKey: async (channel) => {
+  getAPIKey: async (channel, next) => {
     try {
       const tenant = "airqo";
       logText(`getAPIKey util: fetching readKey for channel: ${channel}`);
@@ -199,7 +199,7 @@ const createFeed = {
           device_number: channel,
         },
       };
-      const responseFromListDevice = await createDevice.list(request);
+      const responseFromListDevice = await createDevice.list(request, next);
 
       if (!responseFromListDevice.success) {
         return {
@@ -264,6 +264,7 @@ const createFeed = {
       };
     }
   },
+
   getFieldLabel: (field) => {
     try {
       return constants.FIELDS_AND_LABELS[field];


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This PR fixes a recurring internal server error on the GET /api/v2/devices/feeds/transform/recent endpoint. The error was caused by two main issues:

1. request.get is not a function: This occurred because the device.util.js list() function was being called internally by other utilities with a plain object, not a full Express request object, causing a crash when building pagination URLs.
2. next is not a function: The feed.util.js getAPIKey() function was not passing the next function down to device.util.list(), which prevented proper error propagation.

The fixes include:

- Making the URL generation in device.util.js more robust by defensively checking for request properties.
- Ensuring the next function is correctly passed through the call stack from the controller to the utilities.
- Correcting a similar latent bug in device.util.js's doesDeviceExist function.

### Why is this change needed?
The endpoint was consistently failing with a 500 Internal Server Error, making it unusable. This change restores its functionality and improves the overall stability of inter-utility function calls by ensuring proper error handling and making fewer assumptions about the request object's structure.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [x] ♻️ Refactor
- [ ] 📚 Documentation update
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** device-registry
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
The fix was verified by manually testing the GET /api/v2/devices/feeds/transform/recent?channel={channel_id} endpoint.

1. Before: The endpoint consistently returned a 500 Internal Server Error with next is not a function in the logs.
2. After: The endpoint now successfully processes the request and returns the transformed feed data or an appropriate error message if the device/feed is not found, without causing a 500 error.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
This fix highlights the importance of maintaining a consistent function signature (especially for request and next) when creating complex utility call chains.

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented malformed next/previous page links in device lists when base URL details are unavailable.
  * Improved stability of device existence checks by safely handling missing request properties.
  * Enhanced resilience when retrieving API keys and listing devices to reduce unexpected errors during feed and device operations.
  * Reduced risk of crashes by guarding pagination logic and URL construction behind runtime checks for request context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->