### PR TITLE
Feat: Enhance device online status and uptime accuracy logic

### DIFF
--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -1,0 +1,236 @@
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/update-raw-online-status-job`
+);
+const DeviceModel = require("@models/Device");
+const createFeedUtil = require("@utils/feed.util");
+const { logObject, logText } = require("@utils/shared");
+const cron = require("node-cron");
+const moment = require("moment-timezone");
+
+// Constants
+const TIMEZONE = moment.tz.guess();
+const RAW_INACTIVE_THRESHOLD = 1 * 60 * 60 * 1000; // 1 hour in milliseconds
+const BATCH_SIZE = 100;
+
+const JOB_NAME = "update-raw-online-status-job";
+const JOB_SCHEDULE = "0 * * * *"; // Every hour
+
+const isDeviceRawActive = (lastFeedTime) => {
+  if (!lastFeedTime) {
+    return false;
+  }
+  const timeDiff = new Date().getTime() - new Date(lastFeedTime).getTime();
+  return timeDiff < RAW_INACTIVE_THRESHOLD;
+};
+
+const mockNext = (error) => {
+  logger.error(`Error passed to mock 'next' function in job: ${error.message}`);
+};
+
+const processDeviceBatch = async (devices) => {
+  const devicePromises = devices.map(async (device) => {
+    if (!device.device_number) {
+      logger.warn(
+        `Skipping device ${device.name || device._id} - missing device_number`
+      );
+      return null;
+    }
+
+    try {
+      const apiKeyResponse = await createFeedUtil.getAPIKey(
+        device.device_number,
+        mockNext
+      );
+
+      if (!apiKeyResponse.success) {
+        logger.warn(
+          `Could not get API key for device ${device.name}: ${apiKeyResponse.message}`
+        );
+        return null;
+      }
+
+      const request = {
+        channel: device.device_number,
+        api_key: apiKeyResponse.data,
+      };
+      const thingspeakData = await createFeedUtil.fetchThingspeakData(request);
+
+      let isRawOnline = false;
+      let lastFeedTime = null;
+      let updateFields = {};
+
+      if (thingspeakData && thingspeakData.feeds && thingspeakData.feeds[0]) {
+        const lastFeed = thingspeakData.feeds[0];
+        lastFeedTime = lastFeed.created_at;
+        isRawOnline = isDeviceRawActive(lastFeedTime);
+      }
+
+      // Update raw status for ALL devices
+      updateFields.rawOnlineStatus = isRawOnline;
+      if (lastFeedTime) {
+        updateFields.lastRawData = new Date(lastFeedTime);
+      }
+
+      // ALSO update primary online status for UNDEPLOYED devices
+      if (device.status === "not deployed") {
+        updateFields.isOnline = isRawOnline;
+        if (lastFeedTime) {
+          updateFields.lastActive = new Date(lastFeedTime);
+        }
+      }
+
+      return {
+        updateOne: {
+          filter: { _id: device._id },
+          update: {
+            $set: updateFields,
+          },
+        },
+      };
+    } catch (error) {
+      logger.error(
+        `Error processing raw status for device ${device.name}: ${error.message}`
+      );
+      return null;
+    }
+  });
+
+  const bulkOps = (await Promise.all(devicePromises)).filter(Boolean);
+
+  if (bulkOps.length > 0) {
+    await DeviceModel("airqo").bulkWrite(bulkOps);
+  }
+
+  return bulkOps.length;
+};
+
+const updateRawOnlineStatus = async () => {
+  try {
+    const startTime = Date.now();
+    logText(`Starting raw online status check for ALL devices...`);
+
+    const cursor = DeviceModel("airqo")
+      .find({})
+      .select("_id name device_number status")
+      .lean()
+      .cursor();
+
+    let batch = [];
+    let totalProcessed = 0;
+
+    for await (const device of cursor) {
+      if (global.isShuttingDown) {
+        logText(
+          `${JOB_NAME} stopping during processing due to application shutdown.`
+        );
+        await cursor.close();
+        return;
+      }
+
+      batch.push(device);
+      if (batch.length >= BATCH_SIZE) {
+        const updatedCount = await processDeviceBatch(batch);
+        totalProcessed += batch.length;
+        logText(
+          `Processed batch. ${updatedCount} updates. Total processed: ${totalProcessed}`
+        );
+        batch = []; // Clear the batch
+      }
+    }
+
+    // Process the final batch if it's not empty
+    if (batch.length > 0) {
+      const updatedCount = await processDeviceBatch(batch);
+      totalProcessed += batch.length;
+      logText(
+        `Processed final batch. ${updatedCount} updates. Total processed: ${totalProcessed}`
+      );
+    }
+
+    const duration = (Date.now() - startTime) / 1000;
+    logger.info(
+      `Raw online status check complete in ${duration}s. Processed ${totalProcessed} devices.`
+    );
+  } catch (error) {
+    logger.error(`Error in raw online status job: ${error.message}`);
+    logger.error(`Stack trace: ${error.stack}`);
+  }
+};
+
+const startJob = () => {
+  try {
+    let isJobRunning = false;
+    let currentJobPromise = null;
+
+    const cronJobInstance = cron.schedule(
+      JOB_SCHEDULE,
+      async () => {
+        if (isJobRunning) {
+          logger.warn(
+            `${JOB_NAME} is already running, skipping this execution.`
+          );
+          return;
+        }
+        isJobRunning = true;
+        currentJobPromise = updateRawOnlineStatus();
+        await currentJobPromise;
+        isJobRunning = false;
+        currentJobPromise = null;
+      },
+      {
+        scheduled: true,
+        timezone: TIMEZONE,
+      }
+    );
+
+    if (!global.cronJobs) {
+      global.cronJobs = {};
+    }
+
+    global.cronJobs[JOB_NAME] = {
+      job: cronJobInstance,
+      stop: async () => {
+        logText(`🛑 Stopping ${JOB_NAME}...`);
+        try {
+          // Stop the cron schedule to prevent new runs
+          cronJobInstance.stop();
+          logText(`📅 ${JOB_NAME} schedule stopped.`);
+
+          // If a job is currently running, wait for it to complete
+          if (currentJobPromise) {
+            logText(
+              `⏳ Waiting for current ${JOB_NAME} execution to finish...`
+            );
+            await currentJobPromise;
+            logText(`✅ Current ${JOB_NAME} execution completed.`);
+          }
+
+          // Destroy the job instance to clean up resources
+          if (typeof cronJobInstance.destroy === "function") {
+            cronJobInstance.destroy();
+          }
+          logText(`💥 ${JOB_NAME} destroyed successfully.`);
+
+          // Remove from global registry
+          delete global.cronJobs[JOB_NAME];
+        } catch (error) {
+          logger.error(`❌ Error stopping ${JOB_NAME}: ${error.message}`);
+        }
+      },
+    };
+
+    console.log(`✅ ${JOB_NAME} started`);
+  } catch (error) {
+    logger.error(`💥 Failed to initialize ${JOB_NAME}: ${error.message}`);
+  }
+};
+
+// Defer the job start to the next tick of the event loop
+// This prevents it from blocking the main application startup
+process.nextTick(startJob);
+
+module.exports = {
+  updateRawOnlineStatus,
+};

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -81,6 +81,7 @@ const { stringify } = require("@utils/common");
 // Initialize all background jobs
 require("@bin/jobs/store-signals-job");
 require("@bin/jobs/store-readings-job");
+require("@bin/jobs/update-raw-online-status-job");
 require("@bin/jobs/update-online-status-job");
 require("@bin/jobs/check-network-status-job");
 require("@bin/jobs/check-unassigned-devices-job");

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -143,6 +143,16 @@ const deviceSchema = new mongoose.Schema(
       trim: true,
       default: false,
     },
+    rawOnlineStatus: {
+      type: Boolean,
+      trim: true,
+      default: false,
+    },
+    lastRawData: {
+      type: Date,
+      trim: true,
+      default: null,
+    },
     generation_version: {
       type: Number,
     },
@@ -315,6 +325,7 @@ const deviceSchema = new mongoose.Schema(
     },
 
     onlineStatusAccuracy: {
+      // Old fields for backward compatibility
       totalAttempts: { type: Number, default: 0 },
       successfulUpdates: { type: Number, default: 0 },
       failedUpdates: { type: Number, default: 0 },
@@ -323,6 +334,16 @@ const deviceSchema = new mongoose.Schema(
       lastFailureReason: { type: String },
       successPercentage: { type: Number, default: 0 },
       failurePercentage: { type: Number, default: 0 },
+
+      // New, more descriptive fields for "truthfulness"
+      totalChecks: { type: Number, default: 0 },
+      correctChecks: { type: Number, default: 0 },
+      incorrectChecks: { type: Number, default: 0 },
+      lastCheck: { type: Date },
+      lastCorrectCheck: { type: Date },
+      lastIncorrectCheck: { type: Date },
+      lastIncorrectReason: { type: String },
+      accuracyPercentage: { type: Number, default: 0 },
     },
     // Precomputed activity fields for performance
     cached_activities_by_type: {


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This pull request introduces a comprehensive overhaul of the device online status and uptime accuracy logic. Key changes include:

1. New rawOnlineStatus Feature: A new field, rawOnlineStatus, has been added to the Device model to track whether a device is sending any raw, uncalibrated data to its feed. This provides a crucial diagnostic tool to differentiate between communication issues and data processing issues.
2. New Background Job: A new, non-blocking background job (update-raw-online-status-job.js) has been created. This job:

  - Updates the rawOnlineStatus for all devices.
  - Updates the primary isOnline status for undeployed devices, making their status reflect their raw data activity.
  - Is designed with a database cursor and parallel batch processing to prevent blocking the application's event loop.

3. Refactored Accuracy Score: The onlineStatusAccuracy metric has been redefined to measure the "truthfulness" of the isOnline flag, by comparing its state before and after a check. This provides a more intuitive and accurate measure of the status flag's reliability.
4. Backward Compatibility: The onlineStatusAccuracy object has been augmented with new, clearer field names (correctChecks, accuracyPercentage, etc.) while retaining the old fields (successfulUpdates, successPercentage, etc.) to ensure existing frontend applications continue to function without breaking changes.

### Why is this change needed?
The previous accuracy score was misleading, as it measured the success of the database operation rather than the correctness of the device's status. There was also a critical need to distinguish between a device that is communicating (sending raw data) and one whose calibrated data is successfully being processed.

Furthermore, the initial implementation of the new job was blocking the application's main thread, making the service unresponsive. This refactor resolves that stability issue, ensuring the job runs efficiently in the background.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [x] ♻️ Refactor
- [ ] 📚 Documentation update
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** device-registry
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manual testing was performed to validate the following:

1. The new update-raw-online-status-job runs at its scheduled interval without blocking API endpoints or other application processes.
2. The rawOnlineStatus field is correctly updated for all devices based on their raw data feeds.
3. The isOnline field for undeployed devices is now correctly updated by the new job.
4. The update-online-status-job continues to correctly update the isOnline status for deployed devices based on calibrated data.
5. The onlineStatusAccuracy object in the database now contains both the old and new fields, and the values are updated as expected after each job run.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

The changes to the onlineStatusAccuracy object are additive. Old fields are still present and populated to ensure backward compatibility with existing clients. New clients can adopt the new, more descriptive fields.

---

## 📝 Additional Notes
The update-raw-online-status-job.js has been carefully refactored to use a non-blocking database cursor (for await...of) and parallel processing within batches (Promise.all) to ensure it does not impact the application's performance or responsiveness.

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
