### PR TITLE
Feat: Add endpoint to list countries with site counts and flags

### DIFF
--- a/src/device-registry/bin/jobs/update-grid-flags-job.js
+++ b/src/device-registry/bin/jobs/update-grid-flags-job.js
@@ -1,0 +1,166 @@
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/update-grid-flags-job`
+);
+const GridModel = require("@models/Grid");
+const cron = require("node-cron");
+const { logObject, logText } = require("@utils/shared");
+
+const JOB_NAME = "update-grid-flags-job";
+const JOB_SCHEDULE = "0 */8 * * *"; // Every 8 hours
+
+const countryCodes = {
+  Uganda: "ug",
+  Kenya: "ke",
+  Nigeria: "ng",
+  Cameroon: "cm",
+  Ghana: "gh",
+  Senegal: "sn",
+  "Ivory Coast": "ci",
+  Tanzania: "tz",
+  Burundi: "bi",
+  Rwanda: "rw",
+  "Democratic Republic of the Congo": "cd",
+  Zambia: "zm",
+  Mozambique: "mz",
+  Malawi: "mw",
+  Zimbabwe: "zw",
+  Botswana: "bw",
+  Namibia: "na",
+  "South Africa": "za",
+  Lesotho: "ls",
+  Eswatini: "sz",
+  Angola: "ao",
+  "Republic of the Congo": "cg",
+  Gabon: "ga",
+  "Equatorial Guinea": "gq",
+  "Central African Republic": "cf",
+  Chad: "td",
+  Niger: "ne",
+  Mali: "ml",
+  "Burkina Faso": "bf",
+  Togo: "tg",
+  Benin: "bj",
+  "Sierra Leone": "sl",
+  Liberia: "lr",
+  Guinea: "gn",
+  "Guinea-Bissau": "gw",
+  Gambia: "gm",
+  "Cape Verde": "cv",
+  Mauritania: "mr",
+  "Western Sahara": "eh",
+  Morocco: "ma",
+  Algeria: "dz",
+  Tunisia: "tn",
+  Libya: "ly",
+  Egypt: "eg",
+  Sudan: "sd",
+  "South Sudan": "ss",
+  Eritrea: "er",
+  Djibouti: "dj",
+  Somalia: "so",
+  Ethiopia: "et",
+  Comoros: "km",
+  Seychelles: "sc",
+  Mauritius: "mu",
+  Madagascar: "mg",
+};
+
+const getFlagUrl = (countryName) => {
+  if (!countryName) {
+    return null;
+  }
+  const lowerCountryName = countryName.toLowerCase().trim();
+  const countryEntry = Object.entries(countryCodes).find(
+    ([key, value]) => key.toLowerCase() === lowerCountryName
+  );
+  if (countryEntry) {
+    const code = countryEntry[1];
+    return `https://flagcdn.com/w320/${code.toLowerCase()}.png`;
+  }
+  return null;
+};
+
+const updateGridFlags = async () => {
+  try {
+    logText(`Starting ${JOB_NAME}...`);
+
+    const gridsToUpdate = await GridModel("airqo")
+      .find({
+        admin_level: "country",
+        $or: [
+          { flag_url: { $exists: false } },
+          { flag_url: null },
+          { flag_url: "" },
+        ],
+      })
+      .lean();
+
+    if (gridsToUpdate.length === 0) {
+      logText("No country grids need flag URL updates.");
+      return;
+    }
+
+    logObject("Grids to update", gridsToUpdate.length);
+
+    const bulkOps = gridsToUpdate
+      .map((grid) => {
+        const flagUrl = getFlagUrl(grid.name);
+        if (flagUrl) {
+          return {
+            updateOne: {
+              filter: { _id: grid._id },
+              update: { $set: { flag_url: flagUrl } },
+            },
+          };
+        }
+        return null;
+      })
+      .filter(Boolean);
+
+    if (bulkOps.length > 0) {
+      const result = await GridModel("airqo").bulkWrite(bulkOps);
+      logText(
+        `Successfully updated flag_url for ${result.modifiedCount} grids.`
+      );
+    } else {
+      logText("No flag URLs could be generated for the pending grids.");
+    }
+  } catch (error) {
+    logger.error(`🐛🐛 Error in ${JOB_NAME}: ${error.message}`);
+  }
+};
+
+const startJob = () => {
+  let isJobRunning = false;
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, async () => {
+    if (isJobRunning) {
+      logger.warn(`${JOB_NAME} is already running, skipping this execution.`);
+      return;
+    }
+    isJobRunning = true;
+    await updateGridFlags();
+    isJobRunning = false;
+  });
+
+  if (!global.cronJobs) {
+    global.cronJobs = {};
+  }
+
+  global.cronJobs[JOB_NAME] = {
+    job: cronJobInstance,
+    stop: async () => {
+      cronJobInstance.stop();
+      delete global.cronJobs[JOB_NAME];
+    },
+  };
+
+  console.log(`✅ ${JOB_NAME} started`);
+};
+
+startJob();
+
+module.exports = {
+  updateGridFlags,
+};

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -82,6 +82,7 @@ const { stringify } = require("@utils/common");
 require("@bin/jobs/store-signals-job");
 require("@bin/jobs/store-readings-job");
 require("@bin/jobs/update-raw-online-status-job");
+require("@bin/jobs/update-grid-flags-job");
 require("@bin/jobs/update-online-status-job");
 require("@bin/jobs/check-network-status-job");
 require("@bin/jobs/check-unassigned-devices-job");

--- a/src/device-registry/config/global/db-projections.js
+++ b/src/device-registry/config/global/db-projections.js
@@ -21,6 +21,7 @@ class ProjectionFactory {
           _id: 1,
           name: 1,
           long_name: 1,
+          flag_url: 1,
           description: 1,
           grid_tags: 1,
           visibility: 1,

--- a/src/device-registry/controllers/grid.controller.js
+++ b/src/device-registry/controllers/grid.controller.js
@@ -330,6 +330,28 @@ const createGrid = {
       handleError(error, next);
     }
   },
+  listCountries: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await gridUtil.listCountries(request, next);
+      handleResponse({ res, result, key: "countries" });
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
+  listCountries: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await gridUtil.listCountries(request, next);
+      handleResponse({ res, result, key: "countries" });
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
 };
 
 module.exports = createGrid;

--- a/src/device-registry/models/Grid.js
+++ b/src/device-registry/models/Grid.js
@@ -87,6 +87,11 @@ const gridSchema = new Schema(
       trim: true,
       unique: true,
     },
+    flag_url: {
+      type: String,
+      trim: true,
+      default: null,
+    },
     description: {
       type: String,
       trim: true,
@@ -223,6 +228,7 @@ gridSchema.methods.toJSON = function() {
     name,
     long_name,
     network,
+    flag_url,
     groups,
     visibility,
     description,
@@ -242,6 +248,7 @@ gridSchema.methods.toJSON = function() {
     name,
     visibility,
     long_name,
+    flag_url,
     description,
     grid_tags,
     network,

--- a/src/device-registry/routes/v2/grids.routes.js
+++ b/src/device-registry/routes/v2/grids.routes.js
@@ -15,6 +15,11 @@ const {
 
 router.use(headers);
 
+router.get(
+  "/countries",
+  gridsValidations.listCountries,
+  createGridController.listCountries
+);
 router.post("/", gridsValidations.createGrid, createGridController.create);
 
 router.get(

--- a/src/device-registry/validators/grids.validators.js
+++ b/src/device-registry/validators/grids.validators.js
@@ -832,6 +832,38 @@ const gridsValidations = {
       next();
     },
   ],
+  listCountries: [
+    ...commonValidations.tenant,
+    (req, res, next) => {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return next(
+          new HttpError(
+            "Validation error",
+            httpStatus.BAD_REQUEST,
+            errors.mapped()
+          )
+        );
+      }
+      next();
+    },
+  ],
+  listCountries: [
+    ...commonValidations.tenant,
+    (req, res, next) => {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return next(
+          new HttpError(
+            "Validation error",
+            httpStatus.BAD_REQUEST,
+            errors.mapped()
+          )
+        );
+      }
+      next();
+    },
+  ],
 };
 
 module.exports = gridsValidations;


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This PR introduces a new endpoint GET /api/v2/devices/grids/countries to provide a summary of countries where the network has a presence.

Key changes include:

- New Endpoint: Creates an efficient endpoint that returns a list of countries, the number of sites in each, and a URL for the country's flag.
- Data Persistence: Adds a flag_url field to the Grid model to store the flag URL, improving performance by avoiding on-the-fly generation.
- New Background Job: Implements a new background job (update-grid-flags-job) that runs periodically to populate the flag_url for any existing country-level grids, ensuring data consistency.
- Bug Fixes: Resolves a routing conflict where /countries was being misinterpreted as a grid_id. It also fixes a case-sensitivity bug that was causing flag_url to be null.
- Performance Optimization: The data aggregation pipeline for this endpoint has been optimized to efficiently count sites and retrieve grid information in a single query.

### Why is this change needed?
This feature provides a simple, high-level overview of the network's geographical presence, which is essential for dashboards and client applications. The initial implementation had performance issues and bugs (null flags, routing conflicts) that are resolved by this more robust and maintainable solution.
---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [x] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** device-registry
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**  Manual testing was performed to validate the following:

1. Verified that GET /api/v2/devices/grids/countries now returns the correct list of countries, site counts, and non-null flag_url values.
2. Confirmed the routing conflict with /:grid_id is resolved by reordering the routes.
3. Tested the creation of a new country-level grid to ensure the flag_url field is populated correctly.
4. Manually triggered the update-grid-flags-job to confirm it successfully backfills missing flag_urls for existing country grids.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below) The changes are additive. The new flag_url field is added to the Grid model, and a new endpoint is created. Existing functionality is unaffected.

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
The listCountries utility was refactored from its initial implementation to use a more efficient aggregation pipeline, reducing database load. The new background job ensures data consistency for flag URLs going forward.

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
