### PR TITLE
Fix: Correct uptime accuracy calculation for undeployed devices

### DIFF
--- a/src/device-registry/bin/jobs/update-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-online-status-job.js
@@ -313,16 +313,22 @@ async function updateEntityOnlineStatusAccuracy(
       { upsert: false }
     );
 
+    const isTruthful = isCurrentlyOnline === isNowOnline;
+
+    const totalChecks = (currentStats.totalChecks || 0) + 1;
+    const correctChecks =
+      (currentStats.correctChecks || 0) + (isTruthful ? 1 : 0);
+    const incorrectChecks = totalChecks - correctChecks;
+    const accuracyPercentage =
+      totalChecks > 0 ? (correctChecks / totalChecks) * 100 : 0;
+
     return {
       success: true,
       stats: {
-        totalChecks: (currentStats.totalChecks || 0) + 1,
-        correctChecks: (currentStats.correctChecks || 0) + (isTruthful ? 1 : 0),
-        incorrectChecks:
-          (currentStats.incorrectChecks || 0) + (isTruthful ? 0 : 1),
-        accuracyPercentage:
-          ((currentStats.correctChecks || 0) + (isTruthful ? 1 : 0)) /
-          ((currentStats.totalChecks || 0) + 1),
+        totalChecks,
+        correctChecks,
+        incorrectChecks,
+        accuracyPercentage,
       },
     };
   } catch (error) {

--- a/src/device-registry/bin/jobs/update-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-online-status-job.js
@@ -9,7 +9,11 @@ const SiteModel = require("@models/Site");
 const LogThrottleModel = require("@models/LogThrottle");
 const { logObject, logText } = require("@utils/shared");
 const asyncRetry = require("async-retry");
-const { stringify, generateFilter } = require("@utils/common");
+const {
+  stringify,
+  generateFilter,
+  getUptimeAccuracyUpdateObject,
+} = require("@utils/common");
 const cron = require("node-cron");
 const moment = require("moment-timezone");
 
@@ -296,62 +300,12 @@ async function updateEntityOnlineStatusAccuracy(
 
     const currentStats = entity?.onlineStatusAccuracy || {};
 
-    // --- New "Truthfulness" Logic ---
-    const currentTotalChecks = currentStats.totalChecks || 0;
-    const currentCorrectChecks = currentStats.correctChecks || 0;
-    const currentIncorrectChecks = currentStats.incorrectChecks || 0;
-
-    const isTruthful = isCurrentlyOnline === isNowOnline;
-
-    const newTotalChecks = currentTotalChecks + 1;
-    const newCorrectChecks = isTruthful
-      ? currentCorrectChecks + 1
-      : currentCorrectChecks;
-    const newIncorrectChecks = isTruthful
-      ? currentIncorrectChecks
-      : currentIncorrectChecks + 1;
-
-    const accuracyPercentage =
-      newTotalChecks > 0 ? (newCorrectChecks / newTotalChecks) * 100 : 0;
-
-    // --- Backward Compatibility Logic ---
-    const newTotalAttempts = newTotalChecks;
-    const newSuccessfulUpdates = newCorrectChecks;
-    const newFailedUpdates = newIncorrectChecks;
-    const successPercentage = accuracyPercentage;
-    const failurePercentage = 100 - accuracyPercentage;
-
-    const incUpdate = {
-      // New fields
-      "onlineStatusAccuracy.totalChecks": 1,
-      ...(isTruthful
-        ? { "onlineStatusAccuracy.correctChecks": 1 }
-        : { "onlineStatusAccuracy.incorrectChecks": 1 }),
-      // Old fields
-      "onlineStatusAccuracy.totalAttempts": 1,
-      ...(isTruthful
-        ? { "onlineStatusAccuracy.successfulUpdates": 1 }
-        : { "onlineStatusAccuracy.failedUpdates": 1 }),
-    };
-
-    const setUpdate = {
-      // New fields
-      "onlineStatusAccuracy.lastCheck": new Date(),
-      "onlineStatusAccuracy.accuracyPercentage": accuracyPercentage,
-      ...(isTruthful
-        ? { "onlineStatusAccuracy.lastCorrectCheck": new Date() }
-        : {
-            "onlineStatusAccuracy.lastIncorrectCheck": new Date(),
-            "onlineStatusAccuracy.lastIncorrectReason": reason,
-          }),
-      // Old fields
-      "onlineStatusAccuracy.lastUpdate": new Date(),
-      "onlineStatusAccuracy.successPercentage": successPercentage,
-      "onlineStatusAccuracy.failurePercentage": failurePercentage,
-      ...(isTruthful
-        ? { "onlineStatusAccuracy.lastSuccessfulUpdate": new Date() }
-        : { "onlineStatusAccuracy.lastFailureReason": reason }),
-    };
+    const { setUpdate, incUpdate } = getUptimeAccuracyUpdateObject({
+      isCurrentlyOnline,
+      isNowOnline,
+      currentStats,
+      reason,
+    });
 
     await Model.findByIdAndUpdate(
       entityId,
@@ -362,10 +316,13 @@ async function updateEntityOnlineStatusAccuracy(
     return {
       success: true,
       stats: {
-        totalChecks: newTotalChecks,
-        correctChecks: newCorrectChecks,
-        incorrectChecks: newIncorrectChecks,
-        accuracyPercentage,
+        totalChecks: (currentStats.totalChecks || 0) + 1,
+        correctChecks: (currentStats.correctChecks || 0) + (isTruthful ? 1 : 0),
+        incorrectChecks:
+          (currentStats.incorrectChecks || 0) + (isTruthful ? 0 : 1),
+        accuracyPercentage:
+          ((currentStats.correctChecks || 0) + (isTruthful ? 1 : 0)) /
+          ((currentStats.totalChecks || 0) + 1),
       },
     };
   } catch (error) {

--- a/src/device-registry/utils/common/index.js
+++ b/src/device-registry/utils/common/index.js
@@ -21,6 +21,8 @@ const generateFilter = require("./generate-filter");
 const handleResponse = require("./responseHandler");
 const distance = require("./distance");
 const translate = require("./translate");
+const { getUptimeAccuracyUpdateObject } = require("./uptime.util");
+
 const claimTokenUtil = require("./claimToken.util");
 const { deduplicator } = require("./slack-dedup-utility");
 const ActivityLogger = require("./activity-logger.util");
@@ -28,6 +30,7 @@ const ActivityLogger = require("./activity-logger.util");
 module.exports = {
   claimTokenUtil,
   ActivityLogger,
+  getUptimeAccuracyUpdateObject,
   deduplicator,
   translate,
   distance,

--- a/src/device-registry/utils/common/uptime.util.js
+++ b/src/device-registry/utils/common/uptime.util.js
@@ -1,0 +1,67 @@
+const getUptimeAccuracyUpdateObject = ({
+  isCurrentlyOnline,
+  isNowOnline,
+  currentStats = {}, // Pass the existing accuracy object
+  reason,
+}) => {
+  const isTruthful = isCurrentlyOnline === isNowOnline;
+
+  // --- New "Truthfulness" Logic ---
+  const currentTotalChecks = currentStats.totalChecks || 0;
+  const currentCorrectChecks = currentStats.correctChecks || 0;
+  const currentIncorrectChecks = currentStats.incorrectChecks || 0;
+
+  const newTotalChecks = currentTotalChecks + 1;
+  const newCorrectChecks = isTruthful
+    ? currentCorrectChecks + 1
+    : currentCorrectChecks;
+  const newIncorrectChecks = isTruthful
+    ? currentIncorrectChecks
+    : currentIncorrectChecks + 1;
+
+  const accuracyPercentage =
+    newTotalChecks > 0 ? (newCorrectChecks / newTotalChecks) * 100 : 0;
+
+  // --- Backward Compatibility Logic ---
+  const newTotalAttempts = newTotalChecks;
+  const newSuccessfulUpdates = newCorrectChecks;
+  const newFailedUpdates = newIncorrectChecks;
+  const successPercentage = accuracyPercentage;
+  const failurePercentage = 100 - accuracyPercentage;
+
+  const incUpdate = {
+    // New fields
+    "onlineStatusAccuracy.totalChecks": 1,
+    ...(isTruthful
+      ? { "onlineStatusAccuracy.correctChecks": 1 }
+      : { "onlineStatusAccuracy.incorrectChecks": 1 }),
+    // Old fields
+    "onlineStatusAccuracy.totalAttempts": 1,
+    ...(isTruthful
+      ? { "onlineStatusAccuracy.successfulUpdates": 1 }
+      : { "onlineStatusAccuracy.failedUpdates": 1 }),
+  };
+
+  const setUpdate = {
+    // New fields
+    "onlineStatusAccuracy.lastCheck": new Date(),
+    "onlineStatusAccuracy.accuracyPercentage": accuracyPercentage,
+    ...(isTruthful
+      ? { "onlineStatusAccuracy.lastCorrectCheck": new Date() }
+      : {
+          "onlineStatusAccuracy.lastIncorrectCheck": new Date(),
+          "onlineStatusAccuracy.lastIncorrectReason": reason,
+        }),
+    // Old fields
+    "onlineStatusAccuracy.lastUpdate": new Date(),
+    "onlineStatusAccuracy.successPercentage": successPercentage,
+    "onlineStatusAccuracy.failurePercentage": failurePercentage,
+    ...(isTruthful
+      ? { "onlineStatusAccuracy.lastSuccessfulUpdate": new Date() }
+      : { "onlineStatusAccuracy.lastFailureReason": reason }),
+  };
+
+  return { setUpdate, incUpdate };
+};
+
+module.exports = { getUptimeAccuracyUpdateObject };


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This PR fixes a bug where "not deployed" devices consistently showed a 0% onlineStatusAccuracy. It introduces a new shared utility, [uptime.util.js](code-assist-path:/Users/balmart/Documents/github/AirQo-api/src/device-registry/utils/uptime.util.js), to centralize the accuracy calculation logic. Both the update-online-status-job (for deployed devices) and the update-raw-online-status-job (for undeployed devices) have been refactored to use this new utility.

This ensures that the accuracy score for all devices now correctly reflects the "truthfulness" of their isOnline status, providing a more reliable and consistent metric across the entire fleet.

### Why is this change needed?
The accuracy score for undeployed devices was incorrect and misleading, providing no real insight into their status reliability. The previous implementation also had duplicated logic for calculating accuracy, making it difficult to maintain. This fix corrects the bug and improves code quality by establishing a single source of truth for the uptime accuracy calculation.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update -x] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** device-registry
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
The fix was verified by manually inspecting the onlineStatusAccuracy field for "not deployed" devices in the database after the update-raw-online-status-job completed its run.

1. Before: The onlineStatusAccuracy for undeployed devices was always zero.
2. After: The onlineStatusAccuracy field is now correctly calculated and updated, reflecting the reliability of the isOnline status for undeployed devices. The existing job for deployed devices continues to function as expected.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below) The onlineStatusAccuracy object in the Device model was updated to be backward compatible by retaining old fields while introducing new, more descriptive ones.

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
A new shared utility, uptime.util.js, has been created to centralize the accuracy calculation logic. This should be the single source of truth for any future work related to uptime metrics.

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved online-status accuracy tracking: richer counters, percentages, and last-check timestamps for correct/incorrect checks visible in dashboards.

- Refactor
  - Centralized uptime-accuracy calculation into a shared utility to ensure consistent metrics across background jobs.

- Chores
  - Background jobs updated to use the shared accuracy logic and process updates in smaller batches for more reliable, incremental accuracy updates; no external API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->