### PR TITLE
Fix: Improve graceful shutdown logic for background jobs

### DIFF
--- a/src/device-registry/bin/jobs/check-unassigned-devices-job.js
+++ b/src/device-registry/bin/jobs/check-unassigned-devices-job.js
@@ -67,26 +67,46 @@ const checkUnassignedDevices = async () => {
   }
 };
 
+let isJobRunning = false;
+let currentJobPromise = null;
+
+const jobWrapper = async () => {
+  if (isJobRunning) {
+    logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = checkUnassignedDevices();
+  try {
+    await currentJobPromise;
+  } catch (error) {
+    logger.error(`🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
 // Create and register the job
 const startJob = () => {
-  // Create the cron job instance 👇 THIS IS THE cronJobInstance!
-  const cronJobInstance = cron.schedule(JOB_SCHEDULE, checkUnassignedDevices, {
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
     scheduled: true,
     timezone: constants.TIMEZONE,
   });
 
-  // Initialize global registry
   if (!global.cronJobs) {
     global.cronJobs = {};
   }
 
-  // Register for cleanup 👇 USING cronJobInstance HERE!
   global.cronJobs[JOB_NAME] = {
     job: cronJobInstance,
     stop: async () => {
+      logText(`🛑 Stopping ${JOB_NAME}...`);
       cronJobInstance.stop();
-      if (typeof cronJobInstance.destroy === "function") {
-        cronJobInstance.destroy();
+      logText(`📅 ${JOB_NAME} schedule stopped.`);
+      if (currentJobPromise) {
+        await currentJobPromise;
       }
       delete global.cronJobs[JOB_NAME];
     },

--- a/src/device-registry/bin/jobs/check-unassigned-sites-job.js
+++ b/src/device-registry/bin/jobs/check-unassigned-sites-job.js
@@ -69,26 +69,46 @@ const checkUnassignedSites = async () => {
   }
 };
 
+let isJobRunning = false;
+let currentJobPromise = null;
+
+const jobWrapper = async () => {
+  if (isJobRunning) {
+    logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = checkUnassignedSites();
+  try {
+    await currentJobPromise;
+  } catch (error) {
+    logger.error(`🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
 // Create and register the job
 const startJob = () => {
-  // Create the cron job instance 👇 THIS IS THE cronJobInstance!
-  const cronJobInstance = cron.schedule(JOB_SCHEDULE, checkUnassignedSites, {
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
     scheduled: true,
     timezone: constants.TIMEZONE,
   });
 
-  // Initialize global registry
   if (!global.cronJobs) {
     global.cronJobs = {};
   }
 
-  // Register for cleanup 👇 USING cronJobInstance HERE!
   global.cronJobs[JOB_NAME] = {
     job: cronJobInstance,
     stop: async () => {
+      logText(`🛑 Stopping ${JOB_NAME}...`);
       cronJobInstance.stop();
-      if (typeof cronJobInstance.destroy === "function") {
-        cronJobInstance.destroy();
+      logText(`📅 ${JOB_NAME} schedule stopped.`);
+      if (currentJobPromise) {
+        await currentJobPromise;
       }
       delete global.cronJobs[JOB_NAME];
     },

--- a/src/device-registry/bin/jobs/device-status-check-job.js
+++ b/src/device-registry/bin/jobs/device-status-check-job.js
@@ -210,26 +210,48 @@ const runDeviceStatusCheck = async () => {
   await computeDeviceChannelStatus("airqo");
 };
 
+let isJobRunning = false;
+let currentJobPromise = null;
+
+const jobWrapper = async () => {
+  if (isJobRunning) {
+    logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = runDeviceStatusCheck();
+  try {
+    await currentJobPromise;
+  } catch (error) {
+    logger.error(`🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
 // Create and register the job
 const startJob = () => {
-  // Create the cron job instance 👇 THIS IS THE cronJobInstance!
-  const cronJobInstance = cron.schedule(JOB_SCHEDULE, runDeviceStatusCheck, {
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
     scheduled: true,
     timezone: TIMEZONE,
   });
 
-  // Initialize global registry
   if (!global.cronJobs) {
     global.cronJobs = {};
   }
 
-  // Register for cleanup 👇 USING cronJobInstance HERE!
   global.cronJobs[JOB_NAME] = {
     job: cronJobInstance,
     stop: async () => {
-      cronJobInstance.stop(); // 👈 Stop scheduling
-      cronJobInstance.destroy(); // 👈 Clean up resources
-      delete global.cronJobs[JOB_NAME]; // 👈 Remove from registry
+      logText(`🛑 Stopping ${JOB_NAME}...`);
+      cronJobInstance.stop();
+      logText(`📅 ${JOB_NAME} schedule stopped.`);
+      if (currentJobPromise) {
+        await currentJobPromise;
+      }
+      delete global.cronJobs[JOB_NAME];
     },
   };
 

--- a/src/device-registry/bin/jobs/device-status-hourly-check-job.js
+++ b/src/device-registry/bin/jobs/device-status-hourly-check-job.js
@@ -170,26 +170,48 @@ const deviceStatusHourlyCheck = async () => {
   }
 };
 
+let isJobRunning = false;
+let currentJobPromise = null;
+
+const jobWrapper = async () => {
+  if (isJobRunning) {
+    logger.warn(`${JOB_NAME} is already running, skipping this execution.`);
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = deviceStatusHourlyCheck();
+  try {
+    await currentJobPromise;
+  } catch (error) {
+    logger.error(`🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
 // Create and register the job
 const startJob = () => {
-  // Create the cron job instance 👇 THIS IS THE cronJobInstance!
-  const cronJobInstance = cron.schedule(JOB_SCHEDULE, deviceStatusHourlyCheck, {
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
     scheduled: true,
     timezone: TIMEZONE,
   });
 
-  // Initialize global registry
   if (!global.cronJobs) {
     global.cronJobs = {};
   }
 
-  // Register for cleanup 👇 USING cronJobInstance HERE!
   global.cronJobs[JOB_NAME] = {
     job: cronJobInstance,
     stop: async () => {
-      cronJobInstance.stop(); // 👈 Stop scheduling
-      cronJobInstance.destroy(); // 👈 Clean up resources
-      delete global.cronJobs[JOB_NAME]; // 👈 Remove from registry
+      logText(`🛑 Stopping ${JOB_NAME}...`);
+      cronJobInstance.stop();
+      logText(`📅 ${JOB_NAME} schedule stopped.`);
+      if (currentJobPromise) {
+        await currentJobPromise;
+      }
+      delete global.cronJobs[JOB_NAME];
     },
   };
 

--- a/src/device-registry/bin/jobs/device-uptime-job.js
+++ b/src/device-registry/bin/jobs/device-uptime-job.js
@@ -172,26 +172,48 @@ const runDeviceUptimeCheck = async () => {
   await saveDeviceUptime("airqo");
 };
 
+let isJobRunning = false;
+let currentJobPromise = null;
+
+const jobWrapper = async () => {
+  if (isJobRunning) {
+    logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = runDeviceUptimeCheck();
+  try {
+    await currentJobPromise;
+  } catch (error) {
+    logger.error(`🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
 // Create and register the job
 const startJob = () => {
-  // Create the cron job instance 👇 THIS IS THE cronJobInstance!
-  const cronJobInstance = cron.schedule(JOB_SCHEDULE, runDeviceUptimeCheck, {
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
     scheduled: true,
     timezone: TIMEZONE,
   });
 
-  // Initialize global registry
   if (!global.cronJobs) {
     global.cronJobs = {};
   }
 
-  // Register for cleanup 👇 USING cronJobInstance HERE!
   global.cronJobs[JOB_NAME] = {
     job: cronJobInstance,
     stop: async () => {
-      cronJobInstance.stop(); // 👈 Stop scheduling
-      cronJobInstance.destroy(); // 👈 Clean up resources
-      delete global.cronJobs[JOB_NAME]; // 👈 Remove from registry
+      logText(`🛑 Stopping ${JOB_NAME}...`);
+      cronJobInstance.stop();
+      logText(`📅 ${JOB_NAME} schedule stopped.`);
+      if (currentJobPromise) {
+        await currentJobPromise;
+      }
+      delete global.cronJobs[JOB_NAME];
     },
   };
 

--- a/src/device-registry/bin/jobs/health-tip-checker-job.js
+++ b/src/device-registry/bin/jobs/health-tip-checker-job.js
@@ -276,10 +276,19 @@ const startJob = () => {
       logText(`🛑 Stopping ${JOB_NAME}...`);
       cronJobInstance.stop();
       logText(`📅 ${JOB_NAME} schedule stopped.`);
-      if (currentJobPromise) {
-        await currentJobPromise;
+      try {
+        if (currentJobPromise) {
+          await currentJobPromise;
+        }
+      } catch (e) {
+        logger.error(
+          `🐛🐛 Error while awaiting in-flight ${JOB_NAME} during stop: ${e.message}`
+        );
+      } finally {
+        if (typeof cronJobInstance.destroy === "function")
+          cronJobInstance.destroy();
+        delete global.cronJobs[JOB_NAME];
       }
-      delete global.cronJobs[JOB_NAME];
     },
   };
 

--- a/src/device-registry/bin/jobs/precompute-activities-job.js
+++ b/src/device-registry/bin/jobs/precompute-activities-job.js
@@ -490,8 +490,20 @@ const startJob = () => {
       logText(`📅 ${JOB_NAME} schedule stopped.`);
       if (currentJobPromise) {
         logText(`⏳ Waiting for current ${JOB_NAME} execution to finish...`);
-        await currentJobPromise;
-        logText(`✅ Current ${JOB_NAME} execution completed.`);
+        try {
+          await currentJobPromise;
+          logText(`✅ Current ${JOB_NAME} execution completed.`);
+        } catch (err) {
+          logger.error(
+            `⚠️ ${JOB_NAME} in-flight run rejected during shutdown: ${err.stack ||
+              err.message}`
+          );
+        }
+      }
+      try {
+        cronJobInstance.destroy?.();
+      } catch (err) {
+        logger.warn(`Failed to destroy ${JOB_NAME}: ${err.message}`);
       }
       delete global.cronJobs[JOB_NAME];
     },

--- a/src/device-registry/bin/jobs/precompute-activities-job.js
+++ b/src/device-registry/bin/jobs/precompute-activities-job.js
@@ -448,19 +448,28 @@ async function precomputeActivitiesAndMetrics() {
 
 // Create and register the job
 const startJob = () => {
-  let running = false;
+  let isJobRunning = false;
+  let currentJobPromise = null;
+
   const cronJobInstance = cron.schedule(
     JOB_SCHEDULE,
     async () => {
-      if (running) {
-        logger.warn(`${JOB_NAME} skipped: previous run still in progress`);
+      if (isJobRunning) {
+        logger.warn(`${JOB_NAME} is already running, skipping this execution`);
         return;
       }
-      running = true;
+
+      isJobRunning = true;
+      currentJobPromise = precomputeActivitiesAndMetrics();
       try {
-        await precomputeActivitiesAndMetrics();
+        await currentJobPromise;
+      } catch (error) {
+        logger.error(
+          `🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`
+        );
       } finally {
-        running = false;
+        isJobRunning = false;
+        currentJobPromise = null;
       }
     },
     {
@@ -476,9 +485,13 @@ const startJob = () => {
   global.cronJobs[JOB_NAME] = {
     job: cronJobInstance,
     stop: async () => {
+      logText(`🛑 Stopping ${JOB_NAME}...`);
       cronJobInstance.stop();
-      if (typeof cronJobInstance.destroy === "function") {
-        cronJobInstance.destroy();
+      logText(`📅 ${JOB_NAME} schedule stopped.`);
+      if (currentJobPromise) {
+        logText(`⏳ Waiting for current ${JOB_NAME} execution to finish...`);
+        await currentJobPromise;
+        logText(`✅ Current ${JOB_NAME} execution completed.`);
       }
       delete global.cronJobs[JOB_NAME];
     },

--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -347,9 +347,30 @@ async function fetchAndStoreReadings() {
   }
 }
 
+let isJobRunning = false;
+let currentJobPromise = null;
+
+const jobWrapper = async () => {
+  if (isJobRunning) {
+    logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = fetchAndStoreReadings();
+  try {
+    await currentJobPromise;
+  } catch (error) {
+    logger.error(`🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
 // Create and register the job
 const startJob = () => {
-  const cronJobInstance = cron.schedule(JOB_SCHEDULE, fetchAndStoreReadings, {
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
     scheduled: true,
     timezone: TIMEZONE,
   });
@@ -361,9 +382,11 @@ const startJob = () => {
   global.cronJobs[JOB_NAME] = {
     job: cronJobInstance,
     stop: async () => {
+      logText(`🛑 Stopping ${JOB_NAME}...`);
       cronJobInstance.stop();
-      if (typeof cronJobInstance.destroy === "function") {
-        cronJobInstance.destroy();
+      logText(`📅 ${JOB_NAME} schedule stopped.`);
+      if (currentJobPromise) {
+        await currentJobPromise;
       }
       delete global.cronJobs[JOB_NAME];
     },

--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -384,9 +384,18 @@ const startJob = () => {
     stop: async () => {
       logText(`🛑 Stopping ${JOB_NAME}...`);
       cronJobInstance.stop();
+      if (typeof cronJobInstance.destroy === "function") {
+        cronJobInstance.destroy();
+      }
       logText(`📅 ${JOB_NAME} schedule stopped.`);
-      if (currentJobPromise) {
-        await currentJobPromise;
+      try {
+        if (currentJobPromise) {
+          await currentJobPromise;
+        }
+      } catch (e) {
+        logger.error(
+          `🐛🐛 Error while awaiting in-flight ${JOB_NAME} during stop: ${e.message}`
+        );
       }
       delete global.cronJobs[JOB_NAME];
     },

--- a/src/device-registry/bin/jobs/update-duplicate-site-fields-job.js
+++ b/src/device-registry/bin/jobs/update-duplicate-site-fields-job.js
@@ -151,30 +151,46 @@ const updateDuplicateSiteFields = async () => {
 logText("Update duplicate site fields job is now running.....");
 // Schedule the job to run every 4 hours at minute 15
 
+let isJobRunning = false;
+let currentJobPromise = null;
+
+const jobWrapper = async () => {
+  if (isJobRunning) {
+    logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = updateDuplicateSiteFields();
+  try {
+    await currentJobPromise;
+  } catch (error) {
+    logger.error(`🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
 // 3. Create and register the job
 const startJob = () => {
-  // Create the cron job instance 👇 THIS IS THE cronJobInstance!
-  const cronJobInstance = cron.schedule(
-    JOB_SCHEDULE,
-    updateDuplicateSiteFields,
-    {
-      scheduled: true,
-      timezone: constants.TIMEZONE,
-    }
-  );
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
+    scheduled: true,
+    timezone: constants.TIMEZONE,
+  });
 
-  // Initialize global registry
   if (!global.cronJobs) {
     global.cronJobs = {};
   }
 
-  // Register for cleanup 👇 USING cronJobInstance HERE!
   global.cronJobs[JOB_NAME] = {
     job: cronJobInstance,
     stop: async () => {
+      logText(`🛑 Stopping ${JOB_NAME}...`);
       cronJobInstance.stop();
-      if (typeof cronJobInstance.destroy === "function") {
-        cronJobInstance.destroy();
+      logText(`📅 ${JOB_NAME} schedule stopped.`);
+      if (currentJobPromise) {
+        await currentJobPromise;
       }
       delete global.cronJobs[JOB_NAME];
     },

--- a/src/device-registry/bin/jobs/update-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-online-status-job.js
@@ -971,6 +971,16 @@ async function updateOnlineStatusAndAccuracy() {
 
 // Create and register the job
 const startJob = () => {
+  if (global.cronJobs && global.cronJobs[JOB_NAME]) {
+    logger.warn(`${JOB_NAME} already registered. Skipping duplicate start.`);
+    return;
+  }
+
+  // Initialize global cronJobs if it doesn't exist
+  if (!global.cronJobs) {
+    global.cronJobs = {};
+  }
+
   let isJobRunning = false;
   let currentJobPromise = null;
 

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -295,6 +295,12 @@ const startJob = () => {
             logText(`✅ Current ${JOB_NAME} execution completed.`);
           }
 
+          // 4. Destroy the job instance to clean up resources
+          if (typeof cronJobInstance.destroy === "function") {
+            cronJobInstance.destroy();
+            logText(`💥 ${JOB_NAME} destroyed successfully.`);
+          }
+
           // 3. Remove from global registry
           delete global.cronJobs[JOB_NAME];
           logText(`🧹 ${JOB_NAME} removed from job registry.`);

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -247,6 +247,12 @@ const updateRawOnlineStatus = async () => {
 };
 
 const startJob = () => {
+  // Idempotency check: prevent re-registering the job
+  if (global.cronJobs && global.cronJobs[JOB_NAME]) {
+    logger.warn(`${JOB_NAME} already registered. Skipping duplicate start.`);
+    return;
+  }
+
   try {
     let isJobRunning = false;
     let currentJobPromise = null;
@@ -262,9 +268,16 @@ const startJob = () => {
         }
         isJobRunning = true;
         currentJobPromise = updateRawOnlineStatus();
-        await currentJobPromise;
-        isJobRunning = false;
-        currentJobPromise = null;
+        try {
+          await currentJobPromise;
+        } catch (err) {
+          logger.error(
+            `🐛🐛 Error executing ${JOB_NAME}: ${err.stack || err.message}`
+          );
+        } finally {
+          isJobRunning = false;
+          currentJobPromise = null;
+        }
       },
       {
         scheduled: true,
@@ -279,14 +292,10 @@ const startJob = () => {
     global.cronJobs[JOB_NAME] = {
       job: cronJobInstance,
       stop: async () => {
+        logText(`🛑 Stopping ${JOB_NAME}...`);
+        cronJobInstance.stop();
+        logText(`📅 ${JOB_NAME} schedule stopped.`);
         try {
-          logText(`🛑 Stopping ${JOB_NAME}...`);
-          // 1. Stop the cron scheduler to prevent new runs
-          cronJobInstance.stop();
-          logText(`📅 ${JOB_NAME} schedule stopped.`);
-
-          // 2. If a job is currently running, wait for it to complete.
-          //    The job's main loop will see `global.isShuttingDown` and exit.
           if (currentJobPromise) {
             logText(
               `⏳ Waiting for current ${JOB_NAME} execution to finish...`
@@ -294,18 +303,17 @@ const startJob = () => {
             await currentJobPromise;
             logText(`✅ Current ${JOB_NAME} execution completed.`);
           }
-
-          // 4. Destroy the job instance to clean up resources
+        } catch (error) {
+          logger.error(
+            `🐛🐛 Error while awaiting in-flight ${JOB_NAME} during stop: ${error.message}`
+          );
+        } finally {
           if (typeof cronJobInstance.destroy === "function") {
             cronJobInstance.destroy();
             logText(`💥 ${JOB_NAME} destroyed successfully.`);
           }
-
-          // 3. Remove from global registry
           delete global.cronJobs[JOB_NAME];
           logText(`🧹 ${JOB_NAME} removed from job registry.`);
-        } catch (error) {
-          logger.error(`❌ Error stopping ${JOB_NAME}: ${error.message}`);
         }
       },
     };

--- a/src/device-registry/models/Grid.js
+++ b/src/device-registry/models/Grid.js
@@ -15,6 +15,7 @@ const { getModelByTenant } = require("@config/database");
 const {
   validatePolygonClosure,
   TOLERANCE_LEVELS,
+  validateAndFixPolygon,
 } = require("@validators/common");
 
 const shapeSchema = new Schema(


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This PR refactors the startup and shutdown logic for several background jobs (update-online-status-job, update-grid-flags-job, update-raw-online-status-job, etc.) to make them more robust and prevent "ghost" processes.

Key changes include:

- Implementing a standardized startJob and stop pattern for all cron jobs.
- Ensuring that when the application shuts down, it waits for any in-progress job to complete its current task before exiting.
- Making long-running loops within the jobs aware of a global isShuttingDown flag, allowing them to terminate early during a graceful shutdown.
- Simplifying the main gracefulShutdown function in server.js to be more reliable and easier to maintain.

### Why is this change needed?
Previously, some background jobs were not terminating correctly when the application was restarted, especially during development. This led to "ghost" processes from old runs continuing to execute, causing confusing logs and potential resource contention. The application could also hang on shutdown if a job was in the middle of a long-running task. This fix ensures the application is more stable, predictable, and shuts down cleanly every time.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [x] ♻️ Refactor
- [ ] 📚 Documentation update
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** device-registry
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manual testing was performed to validate the new shutdown logic:

1. Started the server and waited for background jobs to begin their execution.
2. Triggered a graceful shutdown using Ctrl+C.
3. Observed the application logs to confirm that each job received the stop signal, logged its shutdown sequence (e.g., "Stopping job..."), and waited for any active task to complete.
4. Confirmed that the main process exited cleanly without hanging.
5. Restarted the server and monitored logs to ensure no "ghost" processes from the previous run were still active.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below) The changes are internal to the job management and shutdown process and do not affect any API contracts or external-facing functionality.

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
The core of this fix is the new pattern where the stop() method for each job now awaits the currentJobPromise. This ensures that the application shutdown process pauses until the job's current run is finished, preventing orphaned processes.

---

## ✅ Checklist

- [ ] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevent overlapping scheduled job runs with per-job concurrency control.
  - Respect shutdown flag to skip or halt processing safely.
  - Ensure graceful stop by waiting for in-flight runs to complete before teardown.
  - Cleanup/destroy cron job instances during teardown when supported.
  - Improve and standardize logging for start/stop/shutdown flows.
  - Improve grid polygon validation support.

- Chores
  - Removed redundant global registry initialization code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->