### PR TITLE
Feat: Enhance Mobile Device Management and API

### DIFF
--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -69,16 +69,16 @@ const processDeviceBatch = async (devices) => {
 
     const devicePromises = chunk.map(async (device) => {
       if (!device.device_number) {
-        logger.warn(
-          `Skipping device ${device.name || device._id} - missing device_number`
-        );
+        // logger.warn(
+        //   `Skipping device ${device.name || device._id} - missing device_number`
+        // );
         return null;
       }
 
       // 4. Get the API key from the pre-fetched details
       const detail = deviceDetailsMap.get(device.device_number);
       if (!detail || !detail.readKey) {
-        logger.warn(`No readKey found for device ${device.name}`);
+        // logger.warn(`No readKey found for device ${device.name}`);
         return null;
       }
 
@@ -89,9 +89,9 @@ const processDeviceBatch = async (devices) => {
           mockNext
         );
         if (!decryptResponse.success) {
-          logger.warn(
-            `Failed to decrypt key for device ${device.name}: ${decryptResponse.message}`
-          );
+          // logger.warn(
+          //   `Failed to decrypt key for device ${device.name}: ${decryptResponse.message}`
+          // );
           return null;
         }
         apiKey = decryptResponse.data;
@@ -237,9 +237,9 @@ const updateRawOnlineStatus = async () => {
     }
 
     const duration = (Date.now() - startTime) / 1000;
-    logger.info(
-      `Raw online status check complete in ${duration}s. Processed ${totalProcessed} devices.`
-    );
+    // logger.info(
+    //   `Raw online status check complete in ${duration}s. Processed ${totalProcessed} devices.`
+    // );
   } catch (error) {
     logger.error(`Error in raw online status job: ${error.message}`);
     logger.error(`Stack trace: ${error.stack}`);
@@ -249,7 +249,7 @@ const updateRawOnlineStatus = async () => {
 const startJob = () => {
   // Idempotency check: prevent re-registering the job
   if (global.cronJobs && global.cronJobs[JOB_NAME]) {
-    logger.warn(`${JOB_NAME} already registered. Skipping duplicate start.`);
+    // logger.warn(`${JOB_NAME} already registered. Skipping duplicate start.`);
     return;
   }
 
@@ -261,9 +261,9 @@ const startJob = () => {
       JOB_SCHEDULE,
       async () => {
         if (isJobRunning) {
-          logger.warn(
-            `${JOB_NAME} is already running, skipping this execution.`
-          );
+          // logger.warn(
+          //   `${JOB_NAME} is already running, skipping this execution.`
+          // );
           return;
         }
         isJobRunning = true;

--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -741,6 +741,63 @@ const deviceController = {
       return;
     }
   },
+  listMobile: async (req, res, next) => {
+    try {
+      logText(".....................................");
+      logText("list all mobile devices...");
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      // Force mobility filter
+      request.query.mobility = "true";
+
+      const result = await createDeviceUtil.list(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message,
+          meta: result.meta || {},
+          devices: result.data,
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message,
+          errors: result.errors ? result.errors : { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
   listAllByNearestCoordinates: async (req, res, next) => {
     try {
       const { tenant, latitude, longitude, radius, chid } = req.query;

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -394,130 +394,89 @@ const checkDuplicates = (arr, fieldName) => {
   return null;
 };
 
-// validation for deployment type consistency
 deviceSchema.pre(
-  [
-    "update",
-    "findByIdAndUpdate",
-    "updateMany",
-    "updateOne",
-    "save",
-    "findOneAndUpdate",
-  ],
+  ["save", "findOneAndUpdate", "update", "updateOne", "updateMany"],
   async function(next) {
     try {
-      // Determine if this is a new document or an update
       const isNew = this.isNew;
-      const updateData = this.getUpdate ? this.getUpdate() : this;
+      const update = this.getUpdate ? this.getUpdate() : this;
+      const doc = isNew ? this : update.$set || update;
 
-      // Validate deployment type consistency
-      if (isNew) {
-        // For new documents, set deployment_type based on provided data
-        if (!this.deployment_type) {
-          if (this.grid_id) {
-            this.deployment_type = "mobile";
-            this.mobility = true; // Set mobility flag for mobile devices
-          } else if (this.site_id) {
-            this.deployment_type = "static";
-            this.mobility = false;
-          } else {
-            this.deployment_type = "static"; // default
-            this.mobility = false;
-          }
-        }
+      if (!doc) return next();
 
-        // Validate deployment type consistency
-        if (this.deployment_type === "mobile") {
-          if (this.site_id && !this.grid_id) {
-            return next(
-              new Error(
-                "Mobile devices should be associated with grids, not sites"
-              )
-            );
-          }
-          this.mobility = true;
-        } else if (this.deployment_type === "static") {
-          if (this.grid_id && !this.site_id) {
-            return next(
-              new Error(
-                "Static devices should be associated with sites, not grids"
-              )
-            );
-          }
-          this.mobility = false;
+      // --- Mobility and Deployment Type Logic ---
+      // Rule 1: `mobility` is the source of truth.
+      if (typeof doc.mobility === "boolean") {
+        if (doc.mobility === true) {
+          doc.deployment_type = "mobile";
+          if (doc.site_id) doc.site_id = undefined; // Mobile devices shouldn't have a site_id
+        } else {
+          doc.deployment_type = "static";
+          if (doc.grid_id) doc.grid_id = undefined; // Static devices shouldn't have a grid_id
         }
-      } else {
-        // For updates, validate deployment type changes
-        if ("deployment_type" in updateData) {
-          if (updateData.deployment_type === "mobile") {
-            updateData.mobility = true;
-          } else if (updateData.deployment_type === "static") {
-            updateData.mobility = false;
-          }
+      }
+      // Rule 2: If mobility is not set, infer from deployment_type.
+      else if (doc.deployment_type) {
+        if (doc.deployment_type === "mobile") {
+          doc.mobility = true;
+          if (doc.site_id) doc.site_id = undefined;
+        } else if (doc.deployment_type === "static") {
+          doc.mobility = false;
+          if (doc.grid_id) doc.grid_id = undefined;
         }
-
-        // Validate location reference changes
-        if ("grid_id" in updateData && "site_id" in updateData) {
-          if (updateData.grid_id && updateData.site_id) {
-            return next(
-              new Error(
-                "Device cannot be associated with both site and grid simultaneously"
-              )
-            );
-          }
+      }
+      // Rule 3: If neither is set, infer from location reference for new documents.
+      else if (isNew && typeof doc.mobility === "undefined") {
+        if (doc.grid_id) {
+          doc.deployment_type = "mobile";
+          doc.mobility = true;
+        } else {
+          doc.deployment_type = "static";
+          doc.mobility = false;
         }
       }
 
-      // Handle category field for both new documents and updates
-      if (isNew) {
-        // For new documents
-        if ("category" in this) {
-          if (this.category === null) {
-            delete this.category;
-          } else if (
-            !DEVICE_CONFIG.ALLOWED_CATEGORIES.includes(this.category)
-          ) {
-            return next(
-              new HttpError(
-                `Invalid category. Must be one of: ${DEVICE_CONFIG.ALLOWED_CATEGORIES.join(
-                  ", "
-                )}`,
-                httpStatus.BAD_REQUEST
-              )
-            );
-          }
+      // --- Business Rule Enforcement ---
+      if (doc.mobility === true || doc.deployment_type === "mobile") {
+        if (doc.mountType && doc.mountType !== "vehicle") {
+          return next(
+            new Error("Mobile devices must have mountType 'vehicle'")
+          );
         }
-      } else {
-        // For updates
-        if ("category" in updateData) {
-          if (updateData.category === null) {
-            delete updateData.category;
-          } else if (
-            !DEVICE_CONFIG.ALLOWED_CATEGORIES.includes(updateData.category)
-          ) {
-            return next(
-              new HttpError(
-                `Invalid category. Must be one of: ${DEVICE_CONFIG.ALLOWED_CATEGORIES.join(
-                  ", "
-                )}`,
-                httpStatus.BAD_REQUEST
-              )
-            );
-          }
+        if (doc.powerType && doc.powerType !== "alternator") {
+          return next(
+            new Error("Mobile devices must have powerType 'alternator'")
+          );
+        }
+      }
+
+      // --- Other existing logic from the old hook ---
+
+      // Category validation
+      if ("category" in doc) {
+        if (doc.category === null) {
+          delete doc.category;
+        } else if (!DEVICE_CONFIG.ALLOWED_CATEGORIES.includes(doc.category)) {
+          return next(
+            new HttpError(
+              `Invalid category. Must be one of: ${DEVICE_CONFIG.ALLOWED_CATEGORIES.join(
+                ", "
+              )}`,
+              httpStatus.BAD_REQUEST
+            )
+          );
         }
       }
 
       if (isNew) {
-        // Set default network if not provided
         if (!this.network) {
           this.network = constants.DEFAULT_NETWORK;
         }
 
-        // Manage serial_number based on device_number and network
         if (this.network === "airqo" && this.device_number) {
-          this.serial_number = String(this.device_number); // Assign device_number as a string
+          this.serial_number = String(this.device_number);
         } else if (!this.serial_number && this.network !== "airqo") {
-          next(
+          return next(
             new HttpError(
               "Devices not part of the AirQo network must include a serial_number as a string.",
               httpStatus.BAD_REQUEST
@@ -525,22 +484,8 @@ deviceSchema.pre(
           );
         }
 
-        // Generate name based on generation version and count
         if (this.generation_version && this.generation_count) {
           this.name = `aq_g${this.generation_version}_${this.generation_count}`;
-        }
-
-        // Handle alias generation
-        if (!this.alias && (this.long_name || this.name)) {
-          this.alias = (this.long_name || this.name).trim().replace(/ /g, "_");
-          if (!this.alias) {
-            return next(
-              new HttpError(
-                "Unable to generate ALIAS for the device.",
-                httpStatus.INTERNAL_SERVER_ERROR
-              )
-            );
-          }
         }
 
         if (!this.name && !this.long_name) {
@@ -554,25 +499,21 @@ deviceSchema.pre(
 
         if (this.name) {
           this.name = sanitizeName(this.name);
-        } else {
-          // Use long_name if name is not provided
-          this.name = sanitizeName(this.long_name);
-        }
+        } else this.name = sanitizeName(this.long_name);
 
         if (this.long_name) {
           this.long_name = sanitizeName(this.long_name);
-        } else {
-          // Use name if long_name is not provided
-          this.long_name = this.name;
+        } else this.long_name = this.name;
+
+        if (!this.alias) {
+          this.alias = (this.long_name || this.name).trim().replace(/ /g, "_");
         }
 
-        // Encrypt keys if modified
         if (this.isModified("name") && this.writeKey && this.readKey) {
           this.writeKey = this._encryptKey(this.writeKey);
           this.readKey = this._encryptKey(this.readKey);
         }
 
-        // Generate device codes
         this.device_codes = [this._id, this.name];
         if (this.device_number) {
           this.device_codes.push(this.device_number);
@@ -584,56 +525,46 @@ deviceSchema.pre(
           this.device_codes.push(this.serial_number);
         }
 
-        // Check for duplicates in cohorts
         const cohortsDuplicateError = checkDuplicates(this.cohorts, "cohorts");
         if (cohortsDuplicateError) {
           return next(cohortsDuplicateError);
         }
 
-        // Check for duplicates in groups
         const groupsDuplicateError = checkDuplicates(this.groups, "groups");
         if (groupsDuplicateError) {
           return next(groupsDuplicateError);
         }
       }
 
-      // Handling the network condition
-      if (updateData.network === "airqo") {
-        if (updateData.device_number) {
-          updateData.serial_number = String(updateData.device_number);
-        } else if (updateData.serial_number) {
-          updateData.device_number = Number(updateData.serial_number);
+      if (update) {
+        if (doc.network === "airqo") {
+          if (doc.device_number) doc.serial_number = String(doc.device_number);
+          else if (doc.serial_number)
+            doc.device_number = Number(doc.serial_number);
         }
-      }
 
-      // Sanitize name if modified
-      if (updateData.name) {
-        updateData.name = sanitizeName(updateData.name);
-      }
+        if (doc.name) doc.name = sanitizeName(doc.name);
 
-      // Generate access code if present in update
-      if (updateData.access_code) {
-        const access_code = accessCodeGenerator.generate({
-          length: 16,
-          excludeSimilarCharacters: true,
+        if (doc.access_code) {
+          doc.access_code = accessCodeGenerator
+            .generate({ length: 16, excludeSimilarCharacters: true })
+            .toUpperCase();
+        }
+
+        const arrayFieldsToAddToSet = [
+          "device_codes",
+          "previous_sites",
+          "groups",
+          "pictures",
+        ];
+        arrayFieldsToAddToSet.forEach((field) => {
+          if (doc[field]) {
+            update.$addToSet = update.$addToSet || {};
+            update.$addToSet[field] = { $each: doc[field] };
+            delete doc[field];
+          }
         });
-        updateData.access_code = access_code.toUpperCase();
       }
-
-      // Handle array fields using $addToSet
-      const arrayFieldsToAddToSet = [
-        "device_codes",
-        "previous_sites",
-        "groups",
-        "pictures",
-      ];
-      arrayFieldsToAddToSet.forEach((field) => {
-        if (updateData[field]) {
-          updateData.$addToSet = updateData.$addToSet || {};
-          updateData.$addToSet[field] = { $each: updateData[field] };
-          delete updateData[field];
-        }
-      });
 
       next();
     } catch (error) {

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -589,7 +589,11 @@ deviceSchema.pre(
           const existingDevice = await this.model
             .findOne(this.getQuery())
             .lean();
-          if (!doc.serial_number && !existingDevice.serial_number) {
+          const hasExistingSerial =
+            existingDevice &&
+            typeof existingDevice.serial_number === "string" &&
+            existingDevice.serial_number.length > 0;
+          if (!doc.serial_number && !hasExistingSerial) {
             return next(
               new HttpError(
                 "Devices not part of the AirQo network must include a serial_number as a string.",

--- a/src/device-registry/routes/v2/devices.routes.js
+++ b/src/device-registry/routes/v2/devices.routes.js
@@ -203,6 +203,14 @@ router.put(
   deviceController.updateManyDevicesOnPlatform
 );
 
+// LIST MOBILE DEVICES
+router.get(
+  "/mobile",
+  validateTenant,
+  pagination(),
+  deviceController.listMobile
+);
+
 // =============================================================================
 // DEVICE METADATA CLEANUP ROUTES
 // =============================================================================

--- a/src/device-registry/routes/v2/devices.routes.js
+++ b/src/device-registry/routes/v2/devices.routes.js
@@ -207,6 +207,7 @@ router.put(
 router.get(
   "/mobile",
   validateTenant,
+  validateListDevices,
   pagination(),
   deviceController.listMobile
 );

--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -1031,6 +1031,7 @@ const generateFilter = {
       last_active_before,
       last_active_after,
       serial_number,
+      mobility,
       authRequired,
     } = { ...req.query, ...req.params };
 
@@ -1087,6 +1088,13 @@ const generateFilter = {
       const boolValue = toBooleanSafe(primary);
       if (boolValue !== undefined) {
         filter.primary = boolValue;
+      }
+    }
+
+    if (mobility !== undefined) {
+      const boolValue = toBooleanSafe(mobility);
+      if (boolValue !== undefined) {
+        filter.mobility = boolValue;
       }
     }
 

--- a/src/device-registry/validators/activities.validators.js
+++ b/src/device-registry/validators/activities.validators.js
@@ -31,11 +31,32 @@ const validateDeploymentType = (value) => {
 
 // Custom validator to ensure either site_id OR grid_id is provided -- prevent pole-mobile conflicts + comprehensive business rules
 const validateLocationReference = (value, { req }) => {
-  const { site_id, grid_id, deployment_type, mountType, powerType } = req.body;
+  const {
+    site_id,
+    grid_id,
+    deployment_type,
+    mountType,
+    powerType,
+    mobility,
+  } = req.body;
 
   // Determine actual deployment type
   const actualDeploymentType =
     deployment_type || (grid_id ? "mobile" : "static");
+
+  // If mobility is explicitly provided, it must match the deployment type
+  if (typeof mobility === "boolean") {
+    if (mobility === true && actualDeploymentType !== "mobile") {
+      throw new Error(
+        "mobility=true is only valid for mobile deployments (with a grid_id)."
+      );
+    }
+    if (mobility === false && actualDeploymentType !== "static") {
+      throw new Error(
+        "mobility=false is only valid for static deployments (with a site_id)."
+      );
+    }
+  }
 
   // MOBILE DEPLOYMENT VALIDATIONS
   if (actualDeploymentType === "mobile") {

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -568,12 +568,6 @@ const validateUpdateDevice = [
 
       return true;
     }),
-  body("isActive")
-    .optional()
-    .notEmpty()
-    .trim()
-    .isBoolean()
-    .withMessage("isActive must be Boolean"),
   body("groups")
     .optional()
     .custom((value) => {
@@ -589,12 +583,6 @@ const validateUpdateDevice = [
     .trim()
     .isBoolean()
     .withMessage("isRetired must be Boolean"),
-  body("mobility")
-    .optional()
-    .notEmpty()
-    .trim()
-    .isBoolean()
-    .withMessage("mobility must be Boolean"),
   body("nextMaintenance")
     .optional()
     .notEmpty()

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -473,6 +473,28 @@ const validateCreateDevice = [
 ];
 
 const validateUpdateDevice = [
+  body("mobility")
+    .not()
+    .exists()
+    .withMessage("Cannot directly update mobility. Use deployment activities."),
+  body("isActive")
+    .not()
+    .exists()
+    .withMessage(
+      "Cannot directly update isActive. Use deployment/recall activities."
+    ),
+  body("status")
+    .not()
+    .exists()
+    .withMessage(
+      "Cannot directly update status. Use deployment/recall activities."
+    ),
+  body("deployment_type")
+    .not()
+    .exists()
+    .withMessage(
+      "Cannot directly update deployment_type. Use deployment activities."
+    ),
   body("visibility")
     .optional()
     .notEmpty()
@@ -763,6 +785,14 @@ const validateListDevices = oneOf([
         "the device name can only contain letters, numbers, spaces, hyphens and underscores"
       )
       .bail(),
+    query("mobility")
+      .optional()
+      .notEmpty()
+      .withMessage("the mobility should not be empty if provided")
+      .bail()
+      .trim()
+      .isBoolean()
+      .withMessage("mobility must be a boolean value (true or false)"),
     query("online_status")
       .optional()
       .notEmpty()


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This pull request introduces a comprehensive set of enhancements to reliably manage and query for mobile devices. It addresses data integrity issues by establishing the mobility field as the definitive source of truth for a device's type (mobile vs. static).

Key changes include:

- Strengthened Data Model: The Device model's pre-save hook now automatically enforces consistency between mobility, deployment_type, and location references (site_id vs. grid_id).
- Enhanced Validation: API validation rules are tightened to prevent inconsistent data during device creation and updates.
- Protected Fields: The mobility, isActive, and status fields can no longer be updated via the generic PUT /devices endpoint, forcing changes through controlled activities like deployments and recalls.
- Corrected Query Logic: The device listing logic is fixed to ensure ?mobility=true correctly filters for mobile devices.
- New Convenience Endpoint: A new dedicated route, GET /api/v2/devices/mobile, has been added for straightforward querying of all mobile devices.

### Why is this change needed?

Previously, there was no strict enforcement of attributes for mobile vs. static devices, leading to data inconsistencies. This made it unreliable to query for mobile devices using ?mobility=true, as the field was not always accurate. These changes ensure data integrity at both the database and API layers, providing a robust and predictable system for device management.


---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** device-registry
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass Test summary:  Manual testing was performed to verify the following:

1. Creation/Update: Confirmed that creating and updating devices correctly enforces the new mobility and deployment_type rules in the Device model.
2. Endpoint Protection: Verified that direct PUT requests to /api/v2/devices attempting to change mobility, isActive, or status are rejected with a 400 Bad Request error.
3. Querying:

  - Confirmed that GET /api/v2/devices?mobility=true now returns only devices with mobility: true.
  - Confirmed that the new GET /api/v2/devices/mobile endpoint successfully returns all mobile devices.

4. Activities: Ensured that deploy and recall activities function correctly and are the sole methods for updating a device's deployment status.

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below) While not a breaking change to the API contract, the behavior of the PUT /devices endpoint is now stricter. Clients that were previously (and incorrectly) updating mobility, isActive, or status through this endpoint will now receive an error and must use the appropriate activity endpoints.

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
The core of this change is to establish mobility as the single source of truth. The pre-save hook in the [Device.js](code-assist-path:/Users/balmart/Documents/github/AirQo-api/src/device-registry/models/Device.js) model is now the central point of enforcement for data consistency, ensuring that a device's attributes always align with its mobility status.

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a paginated endpoint to list mobile devices (GET /mobile) and preserved existing list response structure.
  - Added a mobility filter for device listings.

- **Chores**
  - Prevent direct updates to mobility, isActive, status, and deployment_type with clearer error messages.
  - Validate optional mobility query parameter.
  - Enforced mobile-specific defaults/consistency for deployment type, mount and power, and improved inference between mobility, deployment type, and location references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->