### PR TITLE
Fix: Scope auth role migration to single airqo tenant

### DIFF
--- a/src/auth-service/migrations/rename-legacy-roles.js
+++ b/src/auth-service/migrations/rename-legacy-roles.js
@@ -216,7 +216,9 @@ const runLegacyRoleMigration = async (tenant = "airqo") => {
 if (require.main === module) {
   (async () => {
     connectToMongoDB();
-    const tenants = constants.TENANTS || ["airqo"];
+    // The auth-service is single-tenant ('airqo'), but the migration was
+    // attempting to run for all tenants listed in constants, causing errors.
+    const tenants = ["airqo"];
     try {
       const results = await Promise.allSettled(
         tenants.map((t) => runLegacyRoleMigration(t))


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This PR fixes a bug in the rename-legacy-roles.js migration script within the auth-service. The script was incorrectly attempting to run for multiple tenants (kcca, nasa, etc.), which caused the service to crash due to database authorization errors. This change scopes the migration to run only for the airqo tenant, which is the correct behavior for this single-tenant service.

### Why is this change needed?
The auth-service is designed to be a single-tenant service, operating exclusively on the auth_prod_airqo database. The migration script was erroneously borrowing a multi-tenant pattern from other services and trying to connect to databases for every tenant defined in the global constants. This led to repeated Unauthorized errors in the logs and caused deployment failures. This fix ensures the migration runs correctly and the service remains stable.

---

## 🔗 Related Issues

- [ ] Closes #
- [x] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor

---

## 🏗️ Affected Services
**Microservices changed:** auth-service
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
The fix was manually tested by deploying the auth-service with the updated migration script. The service started successfully without the previous database authorization errors. The migration logs now correctly show that the script only attempts to run for the airqo tenant, resolving the crash loop.


---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
The root cause was the line const tenants = constants.TENANTS || ["airqo"]; which pulled in a list of all tenants. This has been corrected to const tenants = ["airqo"]; to reflect the single-tenant nature of the auth-service.

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Scoped database migration to a single tenant to ensure a controlled rollout, lowering risk, limiting impact radius, and simplifying monitoring; improves operational stability during deployment and potential rollback. No user-facing changes or downtime expected.
* **Documentation**
  * Added clarifying notes on the migration’s tenant scope to aid future maintenance, on-call context, and release procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->