### PR TITLE
Fix: Resolve auth migration errors for tenant and duplicate keys

### DIFF
--- a/src/auth-service/migrations/rename-legacy-roles.js
+++ b/src/auth-service/migrations/rename-legacy-roles.js
@@ -77,10 +77,11 @@ const runLegacyRoleMigration = async (tenant = "airqo") => {
       const newRoleName = legacyRole.role_name.replace("_GROUP_", "_");
       const newRoleCode = legacyRole.role_code.replace("_GROUP_", "_");
 
-      const conflictingRole = await RoleModel(tenant).findOne({
-        role_code: newRoleCode,
-        group_id: legacyRole.group_id,
-      });
+      // Check for conflict based on the new role name, which is the unique field.
+      // This correctly finds existing global roles like 'AIRQO_SUPER_ADMIN'.
+      const conflictingRole = await RoleModel(tenant)
+        .findOne({ role_name: newRoleName })
+        .lean();
 
       if (conflictingRole) {
         // MERGE: A new-style role already exists.


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This PR applies a hotfix to the rename-legacy-roles.js migration script in the auth-service. It resolves two critical bugs that were causing the service to crash on startup:

1. It scopes the migration to run only for the airqo tenant, preventing it from attempting to connect to other tenants' databases.
2. It corrects the logic for detecting role name conflicts to prevent E11000 duplicate key errors during the migration process.

### Why is this change needed?
The migration script was failing with two distinct errors:

- Authorization Errors: It was incorrectly trying to run for multiple tenants (e.g., nema, fortportal), which is incorrect for the single-tenant auth-service, leading to database connection failures.
- Duplicate Key Errors: A logic bug caused the migration to fail when it tried to rename a legacy role to a name that already existed (e.g., AIRQO_SUPER_ADMIN), as it wasn't correctly identifying the conflict beforehand.

---

## 🔗 Related Issues

- [ ] Closes #
- [x] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** auth-service
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
The fix was manually tested by deploying the auth-service with the updated migration script. The service now starts successfully without the previous authorization or duplicate key errors. The migration logs confirm that the script runs to completion for the airqo tenant as intended.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes

- The multi-tenant issue was resolved by hardcoding the tenants array to ["airqo"] in the script's execution block.
- The duplicate key error was fixed by changing the conflict check to query by role_name, which is the unique field, ensuring existing roles are correctly identified before a rename/merge operation.

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved legacy role migration to detect conflicts by role name, ensuring accurate merges/renames and preventing duplicate or incorrect roles. Global roles are now reliably recognized.

- Chores
  - Updated migration logic with no public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->