### PR TITLE
temporary disable of perm checks on users/networks endpoint

### DIFF
--- a/src/auth-service/routes/v2/networks.routes.js
+++ b/src/auth-service/routes/v2/networks.routes.js
@@ -26,7 +26,7 @@ router.get(
   "/",
   networkValidations.list,
   enhancedJWTAuth,
-  requirePermissions([constants.NETWORK_VIEW]),
+  // requirePermissions([constants.NETWORK_VIEW]),
   createNetworkController.list
 );
 
@@ -114,7 +114,7 @@ router.get(
   "/:net_id",
   networkValidations.getNetworkById,
   enhancedJWTAuth,
-  requireNetworkPermissions([constants.NETWORK_VIEW], "net_id"),
+  // requireNetworkPermissions([constants.NETWORK_VIEW], "net_id"),
   createNetworkController.list
 );
 


### PR DESCRIPTION
- [ ] temporary disable of perm checks on users/networks endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Relaxed access controls for viewing networks. Users can now access network listings and individual network details without requiring specific view permissions.
  * No changes to the data or behavior of these views; only the permission requirement has been removed.
  * Other routes and features remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->