### PR TITLE
just removing noisy log

### DIFF
--- a/src/auth-service/migrations/rename-legacy-roles.js
+++ b/src/auth-service/migrations/rename-legacy-roles.js
@@ -22,9 +22,6 @@ const runLegacyRoleMigration = async (tenant = "airqo") => {
   // The auth-service is single-tenant ('airqo'). This guard prevents the
   // migration from running for any other tenant, which would cause auth errors.
   if (tenant !== "airqo") {
-    logger.warn(
-      `Skipping migration '${MIGRATION_NAME}' for tenant '${tenant}': auth-service is single-tenant.`
-    );
     return;
   }
   try {


### PR DESCRIPTION
- [x] just removing noisy log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Cleaned up migration behavior by removing a redundant warning when the tenant is not AirQo during legacy role migration. The process now completes silently without emitting unnecessary logs, resulting in cleaner operational logs and less noise for monitoring, with no impact on functionality or user permissions. No changes to APIs or user flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->