### PR TITLE
Fix: Prevent frequent logouts with sliding window and grace period for JWTs

### DIFF
--- a/src/auth-service/config/global/numericals.js
+++ b/src/auth-service/config/global/numericals.js
@@ -1,12 +1,21 @@
 const mongoose = require("mongoose");
 
 const numericals = {
-  JWT_EXPIRES_IN_SECONDS:
-    parseInt(process.env.JWT_EXPIRES_IN_SECONDS, 10) || 24 * 60 * 60, // 24 hours
-  JWT_REFRESH_WINDOW_SECONDS:
-    parseInt(process.env.JWT_REFRESH_WINDOW_SECONDS, 10) || 15 * 60, // 15 minutes
-  JWT_GRACE_PERIOD_SECONDS:
-    parseInt(process.env.JWT_GRACE_PERIOD_SECONDS, 10) || 5 * 60, // 5 minutes
+  JWT_EXPIRES_IN_SECONDS: Number.isFinite(
+    Number(process.env.JWT_EXPIRES_IN_SECONDS)
+  )
+    ? Number(process.env.JWT_EXPIRES_IN_SECONDS)
+    : 24 * 60 * 60, // 24 hours
+  JWT_REFRESH_WINDOW_SECONDS: Number.isFinite(
+    Number(process.env.JWT_REFRESH_WINDOW_SECONDS)
+  )
+    ? Number(process.env.JWT_REFRESH_WINDOW_SECONDS)
+    : 15 * 60, // 15 minutes
+  JWT_GRACE_PERIOD_SECONDS: Number.isFinite(
+    Number(process.env.JWT_GRACE_PERIOD_SECONDS)
+  )
+    ? Number(process.env.JWT_GRACE_PERIOD_SECONDS)
+    : 5 * 60, // 5 mins
   SALT_ROUNDS: 10,
   BCRYPT_SALT_ROUNDS: 12,
   SLUG_MAX_LENGTH: 20,

--- a/src/auth-service/config/global/numericals.js
+++ b/src/auth-service/config/global/numericals.js
@@ -1,6 +1,12 @@
 const mongoose = require("mongoose");
 
 const numericals = {
+  JWT_EXPIRES_IN_SECONDS:
+    parseInt(process.env.JWT_EXPIRES_IN_SECONDS, 10) || 24 * 60 * 60, // 24 hours
+  JWT_REFRESH_WINDOW_SECONDS:
+    parseInt(process.env.JWT_REFRESH_WINDOW_SECONDS, 10) || 15 * 60, // 15 minutes
+  JWT_GRACE_PERIOD_SECONDS:
+    parseInt(process.env.JWT_GRACE_PERIOD_SECONDS, 10) || 5 * 60, // 5 minutes
   SALT_ROUNDS: 10,
   BCRYPT_SALT_ROUNDS: 12,
   SLUG_MAX_LENGTH: 20,


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This pull request overhauls the JWT session management in the auth-service to create a more resilient and user-friendly login experience. It replaces the existing token verification with an enhancedJWTAuth middleware that implements:

1. A proactive sliding window: Automatically issues a new token for active users before the current one expires.
2. A reactive grace period: Allows users to get a new token for a configurable period (currently 5 mins) after their token has expired, preventing logouts from short-to-medium periods of inactivity.

### Why is this change needed?
The previous implementation caused users, especially on mobile, to be logged out as soon as their token expired, regardless of recent activity. This led to a frustrating user experience. This new approach ensures that active users remain logged in seamlessly and returning users are not unnecessarily forced to re-authenticate, mimicking the persistent login experience of major applications.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:** auth-service
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manual testing was performed to validate the new token refresh logic:

1. Confirmed that a new token is issued in the X-Access-Token header when an API call is made within the "refresh window" (e.g., last 15 minutes of a 24-hour token).
2. Confirmed that after a token expires, a subsequent API call made within the 5 min grace period successfully returns data and provides a new token in the X-Access-Token header, preventing a logout.
3. Confirmed that after a token has expired for longer than the 5 mins grace period, the API correctly returns a 401 Unauthorized error, forcing a logout.

---

## 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
The client-side application (e.g., mobile app) must be updated to inspect the response headers for X-Access-Token. If this header is present, its value (the new JWT) should be stored and used for all subsequent API requests.

The token lifecycle values (lifespan, refresh window, grace period) are now centrally managed in src/auth-service/config/global/numericals.js and can be configured via environment variables.

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic JWT refresh near expiry; refreshed tokens sent in response headers for clients to update seamlessly.
* **Improvements**
  * Token lifetime, refresh window, and grace period configurable via environment variables.
  * JWT validation flow tightened with explicit checks for expiry, grace period, and proactive refresh.
* **Bug Fixes**
  * More consistent Unauthorized responses for malformed or invalid tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->