### PR TITLE
calculate the offline percentage based only operational devices

### DIFF
--- a/src/device-registry/bin/jobs/check-network-status-job.js
+++ b/src/device-registry/bin/jobs/check-network-status-job.js
@@ -44,7 +44,8 @@ const checkNetworkStatus = async () => {
     const result = await DeviceModel("airqo").aggregate([
       {
         $match: {
-          status: "deployed", // Only consider deployed devices
+          status: "deployed",
+          isActive: true, // Consider only active and deployed devices
         },
       },
       {


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
calculate the offline percentage based only on the devices that are supposed to be operational.
To get a more accurate picture of your network's health, we should modify check-network-status-job.js to only consider devices that are both deployed AND active. This will filter out decommissioned or inactive devices and give you a true measure of the uptime of your operational network.

### Why is this change needed?
By adding isActive: true to the $match stage, the job will now calculate the offline percentage based only on the devices that are supposed to be operational. This should resolve the critically high offline percentages and provide a much more realistic and actionable network status alert.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes

- update-online-status-job.js: This is the primary job that sets the isOnline flag for your devices. It considers a device "online" if its lastActive timestamp is within the last 5 hours. If a device hasn't sent data in over 5 hours, this job correctly marks it as isOnline: false.
- check-network-status-job.js: This is the job sending the alert. It performs a simple but crucial query: it counts all devices with status: "deployed" and then calculates what percentage of them have isOnline: false.
- The problem is that the check-network-status-job only looks at devices that are marked as "deployed". It doesn't consider whether they are also marked as isActive: true.
- A device can be in a state where it is status: "deployed" but isActive: false (for example, if it has been decommissioned but not updated in the database). The update-online-status-job might not even be processing these inactive devices, so they will remain isOnline: false indefinitely.
- The check-network-status-job includes these inactive-but-deployed devices in its total count, which artificially inflates the "offline" percentage.

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
