### PR TITLE
Fix total_activities cache with real-time updates for activity operations

### DIFF
--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -611,8 +611,6 @@ const startJob = () => {
         }
       },
     };
-
-    console.log(`✅ ${JOB_NAME} started with non-blocking patterns`);
   } catch (error) {
     logger.error(`💥 Failed to initialize ${JOB_NAME}: ${error.message}`);
   }

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -179,10 +179,25 @@ require("@bin/jobs/site-categorization-notification-job");
 // Defensively load precompute activities job
 // Default behavior: ENABLED (runs unless explicitly disabled)
 try {
-  // Use optional chaining and nullish coalescing for safe defaults
-  const isEnabled =
-    constants?.PRECOMPUTE_ACTIVITIES_JOB_ENABLED ??
-    process.env.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== "false";
+  // Helper function to normalize flag values to boolean
+  const normalizeFlag = (value) => {
+    if (typeof value === "boolean") return value;
+    if (typeof value === "string") {
+      const lower = value.toLowerCase().trim();
+      return lower !== "false" && lower !== "0" && lower !== "";
+    }
+    return !!value; // Coerce other types to boolean
+  };
+
+  // Check constants first, then fall back to env var
+  let isEnabled;
+  if (constants?.PRECOMPUTE_ACTIVITIES_JOB_ENABLED !== undefined) {
+    isEnabled = normalizeFlag(constants.PRECOMPUTE_ACTIVITIES_JOB_ENABLED);
+  } else {
+    isEnabled = normalizeFlag(
+      process.env.PRECOMPUTE_ACTIVITIES_JOB_ENABLED ?? true
+    );
+  }
 
   if (isEnabled) {
     try {

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -175,15 +175,7 @@ require("@bin/jobs/health-tip-checker-job");
 require("@bin/jobs/daily-activity-summary-job");
 require("@bin/jobs/site-categorization-job");
 require("@bin/jobs/site-categorization-notification-job");
-if (constants.PRECOMPUTE_ACTIVITIES_JOB_ENABLED) {
-  try {
-    require("@bin/jobs/precompute-activities-job");
-  } catch (err) {
-    global.dedupLogger.error(
-      `Failed to start precompute-activities-job: ${err.message}`
-    );
-  }
-}
+require("@bin/jobs/precompute-activities-job");
 
 if (isEmpty(constants.SESSION_SECRET)) {
   throw new Error("SESSION_SECRET environment variable not set");

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -202,7 +202,6 @@ try {
   console.log("ℹ️  Attempting to start job with default behavior...");
   try {
     require("@bin/jobs/precompute-activities-job");
-    console.log("✅ precompute-activities-job started (fallback)");
   } catch (jobError) {
     console.error(`❌ Job failed to start: ${jobError.message}`);
     // Continue - server stays up


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

### What does this PR do?
Implements real-time activity cache updates for sites and devices. Adds `updateActivityCache()` helper function that immediately updates cached activity fields (`cached_total_activities`, `cached_activities_by_type`, etc.) when deployment, maintenance, or recall activities are created. Also enables the hourly `precompute-activities-job` as a consistency backup.

### Why is this change needed?
The `total_activities` field was always zero for sites and devices because:
- Cache fields existed in the schema but were never populated on activity creation
- The list endpoints default to `useCache=true`, reading from empty cache
- The hourly precompute job had up to 60-minute lag between activity creation and cache update
- This caused incorrect activity counts in API responses and dashboards

---

## 🔗 Related Issues

- [ ] Closes # *(if applicable)*
- [ ] Fixes # *(if applicable)*  
- [ ] Related to # *(if applicable)*

**Context:** Addresses issue where `total_activities` returns 0 even when activities exist in the database.

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services

**Microservices changed:**
- `device-registry` - Core activity management and caching logic

**Files modified:**
- `src/device-registry/utils/activity.util.js` - Added cache helper, updated deploy/maintain/recall
- `src/device-registry/bin/server.js` - Enabled precompute job unconditionally
- `src/device-registry/bin/jobs/precompute-activities-job.js` - (Already existed, now enabled)

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
1. **Create deployment activity** → Verify `cached_total_activities` increments immediately
2. **Create maintenance activity** → Verify cache updates for both site and device
3. **Create recall activity** → Verify cache updates correctly
4. **Query sites/devices with `useCache=true`** → Verify `total_activities` returns correct count
5. **Monitor hourly job** → Confirm backup consistency checks work

**Recommended testing steps:**
```bash
# 1. Create a deployment
POST /api/v2/devices/activities/deploy?tenant=airqo&deviceName=test_device

# 2. List devices with cache enabled
GET /api/v2/devices/devices?tenant=airqo&name=test_device&useCache=true

# 3. Verify total_activities > 0 in response
# 4. Check logs for "Updated cache for device/site" messages
```

---

## 💥 Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

This change is fully backward compatible:
- Existing API contracts unchanged
- Cache fields already existed in schema
- Falls back gracefully if cache update fails (logged, not thrown)

---

## 📝 Additional Notes

### Implementation Details
- **Real-time updates**: Cache updates happen synchronously after activity creation
- **Non-blocking**: Cache update failures don't break main operation flow
- **Parallel execution**: Site and device caches update concurrently using `Promise.all()`
- **Backward compatibility**: Maintains legacy fields like `cached_latest_deployment_activity`

### Performance Considerations
- Each activity operation now includes 2 additional DB updates (site + device)
- Updates are optimized with parallel execution and minimal queries
- Hourly job provides safety net for any missed updates

### Future Improvements
- Consider adding Redis layer for high-frequency updates
- Add monitoring/alerting for cache update failures
- Potential optimization: debounce updates for batch operations

### Dependencies
- Requires MongoDB connection (existing)
- No new external dependencies added
- Compatible with existing Kafka event system

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed) - Inline code comments added
- [x] Ready for review

### Pre-merge Verification
- [ ] Reviewer: Test deployment activity creation
- [ ] Reviewer: Verify cache updates in logs
- [ ] Reviewer: Confirm `total_activities` field populated
- [ ] Reviewer: Check hourly job runs successfully

---

## 🔍 Review Focus Areas

**Please pay special attention to:**
1. Error handling in `updateActivityCache()` - ensures cache failures don't break operations
2. ObjectId handling for both site_id and device_id parameters
3. Device lookup logic that supports both device_id and deviceName
4. Parallel Promise execution for site and device updates

**Questions for reviewers:**
- Should we add a feature flag for real-time cache updates?
- Do we need additional logging/metrics for cache hit rates?
- Should the hourly job be configurable via environment variable?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Activity summaries for sites and devices now update automatically after deployments, maintenance, recalls, and activity creation for more accurate counts and recent activity details.

- Performance
  - Faster loading of activity views due to cached summaries updated in the background.

- Reliability
  - Background processing startup made more resilient: failures in optional jobs are logged without bringing down the server, improving overall uptime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->