### PR TITLE
temporarily stop the online status jobs

### DIFF
--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -150,21 +150,21 @@ global.jobMetrics = {
 // Initialize all background jobs
 require("@bin/jobs/store-signals-job");
 require("@bin/jobs/store-readings-job");
-try {
-  require("@bin/jobs/update-raw-online-status-job");
-} catch (err) {
-  global.dedupLogger.error(
-    `update-raw-online-status-job failed to start: ${err.message}`
-  );
-}
+// try {
+//   require("@bin/jobs/update-raw-online-status-job");
+// } catch (err) {
+//   global.dedupLogger.error(
+//     `update-raw-online-status-job failed to start: ${err.message}`
+//   );
+// }
 require("@bin/jobs/update-grid-flags-job");
-try {
-  require("@bin/jobs/update-online-status-job");
-} catch (err) {
-  global.dedupLogger.error(
-    `update-online-status-job failed to start: ${err.message}`
-  );
-}
+// try {
+//   require("@bin/jobs/update-online-status-job");
+// } catch (err) {
+//   global.dedupLogger.error(
+//     `update-online-status-job failed to start: ${err.message}`
+//   );
+// }
 require("@bin/jobs/check-network-status-job");
 require("@bin/jobs/check-unassigned-devices-job");
 require("@bin/jobs/check-active-statuses");


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
temporarily stop the online status jobs

### Why is this change needed?
<!-- Explain the motivation/problem this solves -->

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled a pair of background jobs from starting automatically, reducing startup noise and potential errors.
  * Maintains all other background processing as before to ensure core functionality remains unaffected.

* **Bug Fixes**
  * Improves service stability during startup by avoiding failures from non-critical background tasks.

* **Refactor**
  * Simplified startup flow by removing error-handling paths related to the disabled jobs, leading to cleaner logs and easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->