### PR TITLE
Add comprehensive filtering to cohort devices and sites APIs

### DIFF
--- a/src/device-registry/config/global/db-projections.js
+++ b/src/device-registry/config/global/db-projections.js
@@ -1158,6 +1158,7 @@ class ProjectionFactory {
             "activities.network": 0,
             "activities.groups": 0,
             "activities.updatedAt": 0,
+            "cohorts.name_update_history": 0,
           },
         },
         public: {

--- a/src/device-registry/validators/cohorts.validators.js
+++ b/src/device-registry/validators/cohorts.validators.js
@@ -476,6 +476,11 @@ const cohortValidations = {
     body("cohort_ids.*")
       .isMongoId()
       .withMessage("Each ID in cohort_ids must be a valid MongoDB ObjectId"),
+    check("search")
+      .optional()
+      .trim()
+      .isLength({ min: 1 })
+      .withMessage("search must not be empty if provided"),
     check("category")
       .optional()
       .trim()
@@ -484,6 +489,62 @@ const cohortValidations = {
       .withMessage(
         `category must be one of: ${constants.DEVICE_FILTER_TYPES.join(", ")}`
       ),
+    check("device_category")
+      .optional()
+      .trim()
+      .toLowerCase(),
+    check("name")
+      .optional()
+      .trim(),
+    check("device")
+      .optional()
+      .trim(),
+    check("device_name")
+      .optional()
+      .trim(),
+    check("device_number")
+      .optional()
+      .isInt()
+      .toInt(),
+    check("serial_number")
+      .optional()
+      .trim(),
+    check("status")
+      .optional()
+      .trim(),
+    check("online_status")
+      .optional()
+      .isIn(["online", "offline"]),
+    check("mobility")
+      .optional()
+      .isBoolean()
+      .toBoolean(),
+    check("visibility")
+      .optional()
+      .isBoolean()
+      .toBoolean(),
+    check("authRequired")
+      .optional()
+      .isBoolean()
+      .toBoolean(),
+    check("last_active")
+      .optional()
+      .isISO8601()
+      .toDate(),
+    check("last_active_before")
+      .optional()
+      .isISO8601()
+      .toDate(),
+    check("last_active_after")
+      .optional()
+      .isISO8601()
+      .toDate(),
+    check("network")
+      .optional()
+      .trim(),
+    check("group")
+      .optional()
+      .trim(),
     handleValidationErrors,
   ],
 
@@ -498,6 +559,11 @@ const cohortValidations = {
     body("cohort_ids.*")
       .isMongoId()
       .withMessage("Each ID in cohort_ids must be a valid MongoDB ObjectId"),
+    check("search")
+      .optional()
+      .trim()
+      .isLength({ min: 1 })
+      .withMessage("search must not be empty if provided"),
     check("category")
       .optional()
       .trim()
@@ -506,6 +572,60 @@ const cohortValidations = {
       .withMessage(
         `category must be one of: ${constants.DEVICE_FILTER_TYPES.join(", ")}`
       ),
+    check("lat_long")
+      .optional()
+      .trim(),
+    check("generated_name")
+      .optional()
+      .trim(),
+    check("district")
+      .optional()
+      .trim(),
+    check("region")
+      .optional()
+      .trim(),
+    check("city")
+      .optional()
+      .trim(),
+    check("street")
+      .optional()
+      .trim(),
+    check("country")
+      .optional()
+      .trim(),
+    check("county")
+      .optional()
+      .trim(),
+    check("parish")
+      .optional()
+      .trim(),
+    check("google_place_id")
+      .optional()
+      .trim(),
+    check("online_status")
+      .optional()
+      .isIn(["online", "offline"]),
+    check("last_active")
+      .optional()
+      .isISO8601()
+      .toDate(),
+    check("last_active_before")
+      .optional()
+      .isISO8601()
+      .toDate(),
+    check("last_active_after")
+      .optional()
+      .isISO8601()
+      .toDate(),
+    check("network")
+      .optional()
+      .trim(),
+    check("group")
+      .optional()
+      .trim(),
+    check("site_codes")
+      .optional()
+      .trim(),
     handleValidationErrors,
   ],
 };


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

### What does this PR do?
Adds comprehensive search and filtering capabilities to the cohort devices and sites endpoints (`POST /api/v2/devices/cohorts/devices` and `POST /api/v2/devices/cohorts/sites`), enabling all standard query parameters from the device and site listing endpoints.

### Why is this change needed?
Previously, these endpoints only supported `cohort_ids` and `category` filtering, returning all results without search capabilities. This caused performance issues with large datasets and made it impossible to refine searches for devices and sites within cohorts using parameters like `search`, `network`, `group`, `status`, `online_status`, `mobility`, etc.

---

## 🔗 Related Issues
- [x] Fixes search parameter not working for cohort endpoints
- [ ] Closes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
- `device-registry` service
  - `cohorts.validators.js` - Added validation for all device/site query parameters
  - `cohort.util.js` - Modified `listDevices` and `listSites` functions
  - `cohort.controller.js` - No changes (uses existing handlers)
  - `cohorts.routes.js` - No changes (existing routes)

---

## 🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- ✅ Tested `search` parameter filtering devices and sites by name, description, location
- ✅ Tested `category` filtering (lowcost, bam, gas, mobile, static)
- ✅ Tested `network` and `group` filters
- ✅ Tested `online_status` and `last_active` filters
- ✅ Verified pagination works correctly with filters applied
- ✅ Confirmed site search applies only to sites (not devices) to prevent empty results
- ✅ Tested with multiple cohort IDs
- ✅ Verified backward compatibility - existing requests without new parameters still work

---

## 💥 Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All changes are additive. Existing API calls continue to work as before. New query parameters are optional.

---

## 📝 Additional Notes

**Implementation approach:**
- Used hybrid filtering by merging `generateFilter.devices()` and `generateFilter.sites()` with cohort-specific filters
- For `listSites`: Created separate device and site filter requests to prevent search parameter from incorrectly filtering devices
- Maintains single source of truth for filter logic by reusing existing `generateFilter` utilities

**Performance considerations:**
- Filters are applied at the database level before aggregation pipelines
- No additional database queries introduced
- Pagination remains efficient with proper indexing

**Supported query parameters now include:**
- **Common**: `search`, `network`, `group`, `category`
- **Devices**: `name`, `device_number`, `serial_number`, `status`, `online_status`, `mobility`, `visibility`, `authRequired`, `last_active`, `last_active_before`, `last_active_after`
- **Sites**: `district`, `region`, `city`, `country`, `county`, `parish`, `lat_long`, `google_place_id`, `generated_name`, `site_codes`, `online_status`, `last_active`

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added search validation for cohorts
  * Extended device and site queries with comprehensive filter options including device category, name, serial number, status, online status, network, group, location fields, and more

* **Refactor**
  * Streamlined cohort filtering logic and optimized data projections for improved performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->