### PR TITLE
Throttle network status job logs to prevent duplicates

### DIFF
--- a/src/device-registry/models/LogThrottle.js
+++ b/src/device-registry/models/LogThrottle.js
@@ -26,8 +26,9 @@ const logThrottleSchema = new Schema(
       required: [true, "logType is required!"],
       trim: true,
       enum: {
-        values: ["METRICS", "ACCURACY_REPORT"],
-        message: "logType must be either METRICS or ACCURACY_REPORT",
+        values: ["METRICS", "ACCURACY_REPORT", "NETWORK_STATUS_ALERT"],
+        message:
+          "logType must be one of METRICS, ACCURACY_REPORT, NETWORK_STATUS_ALERT",
       },
     },
     count: {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This pull request implements a log throttling mechanism for the `check-network-status-job`. It leverages the existing `LogThrottleModel` to ensure that network status alerts are logged only once per day for each environment.

Key changes include:
1.  Adding a new `NETWORK_STATUS_ALERT` type to the `LogThrottleModel`.
2.  Integrating a `LogThrottleManager` class into the job to atomically check and increment the daily log count.
3.  Wrapping the logging logic within the job to respect the throttle, preventing duplicate log entries from concurrent job executions.

### Why is this change needed?
The `check-network-status-job` was producing multiple identical log entries for each environment (e.g., STAGING, PRODUCTION). This is attributed to multiple service instances running in a containerized environment (like Kubernetes) and executing the same scheduled job concurrently.

These duplicate logs create unnecessary noise, making it difficult to monitor the system effectively. This change ensures that critical alerts are sent only once, making them more actionable and keeping the logs clean.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
The changes were deployed to the staging and production environments where duplicate logs were observed. After deployment, the job was monitored, and it was confirmed that only a single log entry for the network status alert is now generated per day for each environment. The `log_throttle_tracking` collection in the database was also inspected to verify that the log counts are being correctly managed.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This solution provides a robust and scalable way to manage logging for cron jobs in a distributed system, and the `LogThrottleManager` can be adapted for use in other jobs that face similar issues with duplicate logging.

---

## :white_check_mark: Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Implemented a log-throttling mechanism for network status alerts to regulate the frequency of alert logging based on daily limits per environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->