### PR TITLE
just removing the 10-minute subtraction

### DIFF
--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -414,13 +414,6 @@ async function fetchAndStoreReadings() {
         );
       }
 
-      if (lastProcessedTime) {
-        // Add a 10-minute buffer to prevent missing data
-        lastProcessedTime = new Date(
-          lastProcessedTime.getTime() - 10 * 60 * 1000
-        );
-      }
-
       logText(
         lastProcessedTime
           ? `Processing events from: ${lastProcessedTime.toISOString()}`


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This pull request removes the 10-minute subtraction (buffer) from the `lastProcessedTime` within the `store-readings-job`. This ensures the job's query for new events starts exactly from the timestamp of the last successfully processed event.

### Why is this change needed?
It was observed that the `readings` collection was becoming stale, not reflecting the most recent data available in the `events` collection. The 10-minute buffer, originally intended to prevent data loss from clock skew, was creating a small, unnecessary overlap in the query time window.

By removing this subtraction, we simplify the logic to a clean and deterministic "sliding window." The job now queries for new data starting precisely from where the last successful run left off. This makes the process more efficient, easier to debug, and directly addresses the staleness issue by ensuring no new events are missed between job runs.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [x] Related to # (Issue of stale data in the readings collection)

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `device-registry` (specifically `bin/jobs/store-readings-job.js`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
After applying the change, the `store-readings-job` was run manually. It was confirmed that the job now correctly fetches the latest events from the `events` collection that were previously being missed. The `readings` collection is now up-to-date with the most recent event time.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This change simplifies the time window logic for the job, making it more reliable and easier to reason about. It directly resolves the observed data staleness.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readings processing accuracy by removing a 10-minute buffer. Processing now starts from the exact last processing time instead of from an earlier point, resulting in more precise data handling and eliminating unnecessary overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->