### PR TITLE
refactor: Create dedicated filter for readings job

### DIFF
--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -312,7 +312,7 @@ async function fetchAllRecentEvents(lastProcessedTime) {
         },
       };
 
-      const filter = generateFilter.fetch(request);
+      const filter = generateFilter.readingsJob(request);
 
       const FETCH_TIMEOUT = 45000; // 45 seconds
       const response = await Promise.race([


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This pull request introduces a dedicated filter function, `readingsJob`, within `generate-filter.js` specifically for the `store-readings-job`. The job has been updated to use this new function instead of the general-purpose `fetch` filter.

The new `readingsJob` filter is a lean version of the `fetch` filter but critically omits the "safety net" logic that overrides the query's time window if it's too large.

### Why is this change needed?
The `store-readings-job` uses a "sliding window" approach, querying for new data based on the timestamp of the last event it processed. However, the general `fetch` filter contained logic to automatically shorten any query window larger than a few days to prevent performance issues.

This created a conflict: if the job hadn't run for a while, its valid, large time window was being incorrectly overridden by the filter, causing the job to miss new data and the `readings` collection to become stale.

By creating a dedicated filter that always respects the `startTime` and `endTime` provided by the job, we ensure the job can reliably process all new events without interference. This makes the data pipeline more robust and prevents data staleness, while safely leaving the original `fetch` filter intact for other parts of the application.

---

## :link: Related Issues
- [ ] Closes #
- [x] Fixes # (Issue where `readings` collection was not being updated with the latest events)
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `device-registry` (specifically `utils/common/generate-filter.js` and `bin/jobs/store-readings-job.js`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
After implementing the dedicated `readingsJob` filter and updating the `store-readings-job` to use it:
1.  The job was run manually.
2.  It was confirmed that the job now correctly queries the full time window since its last run.
3.  The `readings` collection is now being updated with the latest events from the `events` collection, resolving the data staleness issue.
4.  Other API endpoints that use the original `fetch` filter were checked to ensure their behavior remains unchanged.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This change isolates the job's specific requirements from the general-purpose filter, leading to a more stable and predictable system. This is a safer approach than modifying a shared utility.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized background job processing for device readings with improved time window handling for recent data queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->