### PR TITLE
fix: Optimize site categorization job to prevent timeout

### DIFF
--- a/src/device-registry/bin/jobs/site-categorization-job.js
+++ b/src/device-registry/bin/jobs/site-categorization-job.js
@@ -183,8 +183,9 @@ async function collectSitesNeedingCategorization() {
   try {
     logText("=== PHASE 1: Collecting sites that need categorization ===");
 
-    // Direct database query instead of API call
-    const totalSites = await SitesModel("airqo").countDocuments({});
+    // Use estimatedDocumentCount for a fast, non-blocking overview.
+    // This is for logging only and avoids the slow collection scan that was causing timeouts.
+    const totalSites = await SitesModel("airqo").estimatedDocumentCount();
     logObject("totalSitesInSystem", totalSites);
 
     // Find sites that don't have proper categorization
@@ -192,8 +193,6 @@ async function collectSitesNeedingCategorization() {
       .find(
         {
           $or: [
-            { site_category: { $exists: false } },
-            { site_category: null },
             { "site_category.category": { $exists: false } },
             { "site_category.category": null },
             { "site_category.category": "Unknown" },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This pull request optimizes the `site-categorization-job` to prevent database timeouts. The primary change is replacing a slow `countDocuments({})` call with the highly performant `estimatedDocumentCount()` for logging purposes. A minor simplification to the subsequent `find` query's `$or` condition has also been included.

### Why is this change needed?
The job was consistently failing in the staging environment with a `MongooseError: Operation sites.countDocuments() buffering timed out after 10000ms`. This was caused by the `countDocuments({})` call performing a full collection scan on the `sites` collection, which is very slow and resource-intensive.

Since the total site count was only used for logging, replacing it with the much faster `estimatedDocumentCount()` (which retrieves the count from collection metadata) resolves the timeout issue without affecting the job's core logic. This allows the job to run successfully, especially in resource-constrained environments.

---

## :link: Related Issues
- [x] Fixes # (Issue related to `site-categorization-job` timing out)
- [ ] Closes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [x] :wrench: Enhancement/improvement
- [ ] :sparkles: New feature
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `device-registry` (specifically `bin/jobs/site-categorization-job.js`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
The modified job was deployed and run in the staging environment where the timeout error was occurring. It was confirmed that the job now completes successfully without any timeout errors. The logs show that the job still correctly identifies and processes sites needing categorization.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This is a critical performance fix. `estimatedDocumentCount()` provides an approximation of the total sites, which is perfectly acceptable for the logging context in which it is used.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined site categorization query criteria for improved accuracy and efficiency.

* **Performance**
  * Optimized site count calculation used in logging to reduce blocking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->