### PR TITLE
Fix online status threshold mismatch between fetch and job logic

### DIFF
--- a/src/device-registry/config/global/numericals.js
+++ b/src/device-registry/config/global/numericals.js
@@ -15,7 +15,7 @@ const numericals = {
   CACHE_TIMEOUT_PERIOD: 10000,
   MAX_EVENT_AGE_HOURS: 6, // Only accept events from last 6 hours
   MAX_REJECTED_LOGS: 10,
-  JOB_LOOKBACK_WINDOW_MS: 12 * 60 * 60 * 1000, // 12 hours
+  JOB_LOOKBACK_WINDOW_MS: 5 * 60 * 60 * 1000, // 5 hours in milliseconds
 };
 
 numericals.MAX_EVENT_AGE_MS = numericals.MAX_EVENT_AGE_HOURS * 60 * 60 * 1000;

--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -1010,10 +1010,13 @@ const generateFilter = {
     if (recent === "yes" && (active === "yes" || internal === "yes")) {
       // Only apply the default lookback if no specific startTime is provided
       if (!startTime) {
-        const twelveHoursBack = addHours(-12);
-        filter["values.time"] = { $gte: twelveHoursBack, $lte: today };
+        const thresholdHoursBack = new Date(
+          Date.now() - (JOB_LOOKBACK_WINDOW_MS || 5 * 60 * 60 * 1000)
+        );
+
+        filter["values.time"] = { $gte: thresholdHoursBack, $lte: today };
         filter["day"] = {
-          $gte: generateDateFormatWithoutHrs(twelveHoursBack),
+          $gte: generateDateFormatWithoutHrs(thresholdHoursBack),
           $lte: generateDateFormatWithoutHrs(today),
         };
       }


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the mismatch between the data fetch window (12 hours) and the online status determination threshold (5 hours) in the device registry service. The fetch function now uses the same `INACTIVE_THRESHOLD` constant as the online status job, ensuring consistency in online/offline status determination.

### Why is this change needed?
The system was experiencing multiple issues due to inconsistent time windows:
- Devices incorrectly showing as online despite no data for 7+ hours
- Accuracy scores incorrectly showing 0% when devices were actually offline for 12+ hours
- The fetch function queried 12 hours of data while the job used a 5-hour threshold to determine online status
- This mismatch caused the job to use stale data beyond the intended threshold

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` - specifically:
  - `src/device-registry/utils/common/generate-filter.js`
  - `src/device-registry/bin/jobs/update-online-status-job.js`
  - `src/config/constants.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Verified that devices with no data in the last 5 hours are correctly marked as offline
- Confirmed accuracy scores now reflect actual device status
- Tested that fetch window aligns with INACTIVE_THRESHOLD (5 hours)
- Validated no regression in other filtering logic

**Recommended testing:**
1. Monitor devices that haven't sent data for 5-7 hours to confirm offline status
2. Check accuracy scores for devices with no data in 12+ hours
3. Verify online status job runs without errors

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Technical details:**
- Replaced hardcoded `twelveHoursBack = addHours(-12)` with configurable `JOB_LOOKBACK_WINDOW_MS`
- Both fetch filter and online status job now use the same 5-hour threshold
- Added `JOB_LOOKBACK_WINDOW_MS` constant (5 hours in milliseconds) for single source of truth
- Maintains backward compatibility with fallback: `JOB_LOOKBACK_WINDOW_MS || 5 * 60 * 60 * 1000`

**Configuration:**
The threshold is now configurable via `constants.JOB_LOOKBACK_WINDOW_MS` making it easy to adjust if needed without code changes.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Reduced the device registry query lookback window from 12 hours to 5 hours, improving query performance for recent data retrieval.
  * Updated system to use configurable parameters for time window calculations instead of hard-coded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->