### PR TITLE
feat: Expand online status updates in raw status job

### DIFF
--- a/src/device-registry/bin/jobs/test/ut_update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/test/ut_update-raw-online-status-job.js
@@ -1,12 +1,14 @@
 require("module-alias/register");
 const sinon = require("sinon");
 const { expect } = require("chai");
-const { updateRawOnlineStatus } = require("@jobs/update-raw-online-status-job");
+const {
+  updateRawOnlineStatus,
+  STATUSES_FOR_PRIMARY_UPDATE,
+} = require("@jobs/update-raw-online-status-job");
 const constants = require("@config/constants");
 const DeviceModel = require("@models/Device");
 const createDeviceUtil = require("@utils/device.util");
 const createFeedUtil = require("@utils/feed.util");
-const { getUptimeAccuracyUpdateObject } = require("@utils/common");
 
 describe("updateRawOnlineStatusJob", () => {
   let deviceModelStub;
@@ -27,10 +29,6 @@ describe("updateRawOnlineStatusJob", () => {
 
   describe("STATUSES_FOR_PRIMARY_UPDATE constant", () => {
     it("should include all valid statuses except 'deployed'", () => {
-      const STATUSES_FOR_PRIMARY_UPDATE = constants.VALID_DEVICE_STATUSES.filter(
-        (status) => status !== "deployed"
-      );
-
       const expectedStatuses = [
         "recalled",
         "ready",
@@ -60,10 +58,6 @@ describe("updateRawOnlineStatusJob", () => {
       ...overrides,
     });
 
-    const mockDeviceDetailsMap = new Map([
-      [12345, { device_number: 12345, readKey: "encrypted_key" }],
-    ]);
-
     beforeEach(() => {
       decryptKeyStub.resolves({ success: true, data: "decrypted_key" });
       fetchThingspeakDataStub.resolves({
@@ -79,24 +73,22 @@ describe("updateRawOnlineStatusJob", () => {
         },
         close: sinon.stub(),
       };
-      sinon.stub(DeviceModel("airqo"), "find").returns({
+      const findStub = sinon.stub(DeviceModel("airqo"), "find");
+
+      // Specific call for device details
+      findStub.withArgs({ device_number: { $in: [12345] } }).returns({
         select: () => ({
-          lean: () => ({
-            batchSize: () => ({
-              cursor: () => cursor,
-            }),
-          }),
+          lean: () =>
+            Promise.resolve([{ device_number: 12345, readKey: "testKey" }]),
         }),
       });
-      sinon
-        .stub(DeviceModel("airqo"), "find")
-        .withArgs({ device_number: { $in: [12345] } })
-        .returns({
-          select: () => ({
-            lean: () =>
-              Promise.resolve([{ device_number: 12345, readKey: "testKey" }]),
-          }),
-        });
+
+      // Default call for the cursor
+      findStub.returns({
+        select: () => ({
+          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+        }),
+      });
 
       await updateRawOnlineStatus();
 
@@ -114,24 +106,22 @@ describe("updateRawOnlineStatusJob", () => {
         },
         close: sinon.stub(),
       };
-      sinon.stub(DeviceModel("airqo"), "find").returns({
+      const findStub = sinon.stub(DeviceModel("airqo"), "find");
+
+      // Specific call for device details
+      findStub.withArgs({ device_number: { $in: [12345] } }).returns({
         select: () => ({
-          lean: () => ({
-            batchSize: () => ({
-              cursor: () => cursor,
-            }),
-          }),
+          lean: () =>
+            Promise.resolve([{ device_number: 12345, readKey: "testKey" }]),
         }),
       });
-      sinon
-        .stub(DeviceModel("airqo"), "find")
-        .withArgs({ device_number: { $in: [12345] } })
-        .returns({
-          select: () => ({
-            lean: () =>
-              Promise.resolve([{ device_number: 12345, readKey: "testKey" }]),
-          }),
-        });
+
+      // Default call for the cursor
+      findStub.returns({
+        select: () => ({
+          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+        }),
+      });
 
       await updateRawOnlineStatus();
 
@@ -150,24 +140,22 @@ describe("updateRawOnlineStatusJob", () => {
         },
         close: sinon.stub(),
       };
-      sinon.stub(DeviceModel("airqo"), "find").returns({
+      const findStub = sinon.stub(DeviceModel("airqo"), "find");
+
+      // Specific call for device details
+      findStub.withArgs({ device_number: { $in: [12345] } }).returns({
         select: () => ({
-          lean: () => ({
-            batchSize: () => ({
-              cursor: () => cursor,
-            }),
-          }),
+          lean: () =>
+            Promise.resolve([{ device_number: 12345, readKey: "testKey" }]),
         }),
       });
-      sinon
-        .stub(DeviceModel("airqo"), "find")
-        .withArgs({ device_number: { $in: [12345] } })
-        .returns({
-          select: () => ({
-            lean: () =>
-              Promise.resolve([{ device_number: 12345, readKey: "testKey" }]),
-          }),
-        });
+
+      // Default call for the cursor
+      findStub.returns({
+        select: () => ({
+          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+        }),
+      });
 
       await updateRawOnlineStatus();
 

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -731,4 +731,5 @@ process.nextTick(startJob);
 module.exports = {
   updateRawOnlineStatus,
   NonBlockingJobProcessor,
+  STATUSES_FOR_PRIMARY_UPDATE,
 };


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This pull request enhances the `update-raw-online-status-job` to update the primary `isOnline` status for a broader range of devices. Previously, this update was limited to devices with a status of `"not deployed"` or mobile devices. This change expands the logic to include all valid device statuses except for `"deployed"`.

### Why is this change needed?
The previous logic was too restrictive. Devices in intermediate states such as "recalled", "ready", "testing", or "assembly" were not having their primary online status updated by this job. Since these devices are not actively deployed, their online status should reflect the most recent raw data feed, similar to "not deployed" devices.

This enhancement makes the job's logic more scalable and maintainable by deriving the list of applicable statuses directly from the global `VALID_DEVICE_STATUSES` constant, rather than using a hardcoded value.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [x] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
- `device-registry`

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
The changes were manually tested by running the `update-raw-online-status-job` in a development environment.
1. Verified that devices with statuses like `ready`, `recalled`, and `testing` have their primary `isOnline` field updated based on their last raw data timestamp.
2. Confirmed that devices with the `deployed` status are correctly excluded and their `isOnline` field is not modified by this job.
3. Ensured that mobile devices continue to have their `isOnline` status updated as before, regardless of their deployment status.
4. Monitored job logs to confirm it runs without errors and the logic correctly identifies the target devices.

---

## 💥 Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
This change improves the accuracy of the `isOnline` status for non-deployed devices and makes the system more robust to future additions of new device statuses.

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded criteria for when a device's primary online status is updated; preserves mobility checks, avoids changing primary status for deployed devices while still recording raw online status, and covers more provisioning scenarios.
* **Tests**
  * Added unit tests covering varied device statuses, mobile devices, and update payload formatting to ensure correct online-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->