### PR TITLE
Feat: Expose writeKey in device details summary projection

### DIFF
--- a/src/device-registry/config/global/db-projections.js
+++ b/src/device-registry/config/global/db-projections.js
@@ -1159,7 +1159,6 @@ class ProjectionFactory {
             nextMaintenance: 0,
             deployment_date: 0,
             name_id: 0,
-            writeKey: 0,
             recall_date: 0,
             maintenance_date: 0,
             access_code: 0,


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

### What does this PR do?
This PR exposes the `writeKey` field in the summary projection of device details within the device registry.

### Why is this change needed?
The `writeKey` is required in the device details summary projection for certain new features in the device registry.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
- device-registry

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that the `writeKey` field is now included in the device details summary projection via manual API testing. The write key is needed to create new signals.

---

## 💥 Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
This change exposes a previously hidden field, so ensure appropriate security considerations are in place.

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized grid data projections by removing an extraneous field to streamline data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->