### PR TITLE
Fix: Correctly update calibrated values in online status job

### DIFF
--- a/src/device-registry/bin/jobs/update-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-online-status-job.js
@@ -989,14 +989,16 @@ class OnlineStatusProcessor {
         .tz(TIMEZONE)
         .toDate();
 
-      // Prepare the pm2_5 object with calibrated value
-      const pm2_5_calibrated = doc.pm2_5
-        ? {
-            value: doc.pm2_5.calibratedValue,
-            uncertainty: doc.pm2_5.uncertaintyValue,
-            standardDeviation: doc.pm2_5.standardDeviationValue,
-          }
-        : null;
+      // Safely prepare the pm2_5 object with calibrated value.
+      // This handles cases where doc.pm2_5 or its properties might be null/undefined.
+      const pm2_5_calibrated =
+        doc.pm2_5 && doc.pm2_5.value != null
+          ? {
+              value: doc.pm2_5.value,
+              uncertainty: doc.pm2_5.uncertaintyValue || null,
+              standardDeviation: doc.pm2_5.standardDeviationValue || null,
+            }
+          : null;
 
       if (doc.site_id) {
         this.siteUpdates.push({


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

### What does this PR do?
This PR fixes a bug in the `update-online-status-job` where calibrated PM2.5 values were not being correctly updated on device documents. It corrects the data structure for the `pm2_5_calibrated` object within the `processStatusUpdates` function and adds robust error handling to prevent crashes when `calibratedValue` or its related fields are null or undefined.

### Why is this change needed?
The cron job was failing to persist calibrated PM2.5 values to the `Device` collection due to a data structure mismatch. This resulted in most devices showing `null` for their `latest_pm2_5.calibrated` field, even when valid data was available in the source `Event` documents. This fix ensures that calibrated data is correctly processed and stored, improving the accuracy and reliability of device information across the platform.

---

## 🔗 Related Issues
- [ ] Closes #
- [x] Fixes # (The issue of null calibrated values)
- [ ] Related to #

---

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Enhancement/improvement
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
- device-registry

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually ran the `update-online-status-job` after applying the fix. Verified that `Device` documents are now correctly updated with `latest_pm2_5.calibrated` values from recent `Event` documents. Confirmed that devices that previously showed `null` now reflect the correct calibrated data. The job now handles missing `uncertaintyValue` and `standardDeviationValue` fields gracefully without crashing.

---

## 💥 Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
This change addresses the root cause of the `null` calibrated values by correcting the data preparation logic within the cron job itself. This is more efficient than transforming the data on every read operation.

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of air quality data calibration handling to prevent potential errors when sensor data is incomplete or missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->