### PR TITLE
fix(api): Omit calibrated value when null in device details projection

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -1325,20 +1325,12 @@ async function fetchData(model, filter) {
                       else: {
                         $cond: {
                           if: {
-                            $in: [
-                              { $type: "$latest_pm2_5.calibrated.value" },
-                              ["missing", "null"],
-                            ],
+                            $ifNull: ["$latest_pm2_5.calibrated.value", false],
                           },
-                          // If calibrated is invalid, return only raw.
-                          then: {
-                            raw: "$latest_pm2_5.raw",
-                          },
-                          // Otherwise, explicitly reconstruct the object to ensure consistency.
-                          else: {
-                            raw: "$latest_pm2_5.raw",
-                            calibrated: "$latest_pm2_5.calibrated",
-                          },
+                          // If calibrated.value is not null/missing, return both raw and calibrated
+                          then: "$latest_pm2_5",
+                          // Otherwise (calibrated.value is null/missing), return only raw
+                          else: { raw: "$latest_pm2_5.raw" },
                         },
                       },
                     },


### PR DESCRIPTION
🚀 Pull Request
📋 Description
What does this PR do?
This PR fixes a bug in the Events API where the deviceDetails.latest_pm2_5 field would incorrectly include a calibrated object even when its value was null or missing. This led to confusing API responses containing a calibrated object with only a stale timestamp and no value.

The fix updates the aggregation pipeline in [Event.js](code-assist-path:/Users/balmart/Documents/github/AirQo-api/src/device-registry/models/Event.js) to ensure the calibrated object is completely omitted from the response unless calibrated.value is present and not null.

Why is this change needed?
The previous implementation resulted in misleading data being returned to API consumers. For example, a device's details might show a calibrated object with a timestamp from months ago but a null value, creating confusion about the data's validity and recency. This change ensures the API response is clean, accurate, and only presents calibrated data when it is actually available.

🔗 Related Issues

- [ ] Closes #
- [x] Fixes # (bug where latest_pm2_5.calibrated is returned with null values)
- [ ] Related to #

🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

🏗️ Affected Services
Microservices changed:

device-registry
🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

Test summary: Manual testing was performed by querying the Events API for devices known to have intermittent calibrated values.

- Before: The API returned deviceDetails.latest_pm2_5.calibrated with a null value and an old timestamp.
- After: The API now correctly omits the calibrated field entirely in these cases, and only includes it when a valid, non-null calibrated.value is present. The response is now accurate and less confusing.

💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

The API response schema for deviceDetails.latest_pm2_5 is now more dynamic, but this is considered a bug fix rather than a breaking change. Clients should already be robust enough to handle the absence of the calibrated field.

📝 Additional Notes
This change directly addresses the issue of inconsistent and misleading calibrated data within the deviceDetails object, improving data quality and the developer experience for API consumers.

✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized device registry logic for handling air quality sensor data retrieval, improving efficiency of PM2.5 data processing based on data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->