### PR TITLE
fix(api): Remove calibrated field from device details projection

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -1308,34 +1308,8 @@ async function fetchData(model, filter) {
             pipeline: [
               // This sub-pipeline runs on the 'devices' collection
               {
-                $addFields: {
-                  // Overwrite the latest_pm2_5 field
-                  latest_pm2_5: {
-                    $cond: {
-                      if: {
-                        // First, check if the raw value is null or missing.
-                        $in: [
-                          { $type: "$latest_pm2_5.raw.value" },
-                          ["missing", "null"],
-                        ],
-                      },
-                      // If raw value is invalid, the entire object is null.
-                      then: null,
-                      // If raw value is valid, then check the calibrated value.
-                      else: {
-                        $cond: {
-                          if: {
-                            $ifNull: ["$latest_pm2_5.calibrated.value", false],
-                          },
-                          // If calibrated.value is not null/missing, return both raw and calibrated
-                          then: "$latest_pm2_5",
-                          // Otherwise (calibrated.value is null/missing), return only raw
-                          else: { raw: "$latest_pm2_5.raw" },
-                        },
-                      },
-                    },
-                  },
-                },
+                // Manually remove the 'calibrated' field from the latest_pm2_5 object
+                $unset: "latest_pm2_5.calibrated",
               },
             ],
           },


### PR DESCRIPTION
🚀 Pull Request
📋 Description
### What does this PR do?
This PR permanently removes the latest_pm2_5.calibrated field from the deviceDetails object within the Events API response. This is achieved by replacing the previous complex conditional logic with a simple $unset stage in the device_details aggregation pipeline in [Event.js](code-assist-path:/Users/balmart/Documents/github/AirQo-api/src/device-registry/models/Event.js).

### Why is this change needed?
Despite previous attempts to conditionally hide the calibrated field when its value was null, it was still appearing in API responses with just a stale timestamp. This created confusing and misleading data for API consumers. Since this calibrated value is not actively being utilized, the most robust and clean solution is to remove the field from the response entirely. This ensures a predictable and accurate API output.

🔗 Related Issues

- [ ] Closes #
- [x] Fixes # (bug where latest_pm2_5.calibrated is returned with incomplete or null data)
- [ ] Related to #

🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [x] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

🏗️ Affected Services
Microservices changed:

device-registry

🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

Test summary: Manual testing was performed by querying the Events API for various devices.

- Before: The API would sometimes return deviceDetails.latest_pm2_5.calibrated with only a time field and no value.
- After: The calibrated field is now completely and consistently removed from the deviceDetails.latest_pm2_5 object in all responses, leaving only the raw field.

💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

While the response schema for deviceDetails.latest_pm2_5 is now different (the calibrated field is always absent), this is considered a bug fix to remove misleading data. API clients should already be robust enough to handle the absence of an optional field.

📝 Additional Notes
This change simplifies the aggregation pipeline and provides a definitive fix for the issues related to the calibrated field.

✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database query logic for improved performance in event data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->