### PR TITLE
fix(auth): Prevent email spam for token alerts with a daily limit

### DIFF
--- a/src/auth-service/models/EmailLog.js
+++ b/src/auth-service/models/EmailLog.js
@@ -2,6 +2,7 @@ const mongoose = require("mongoose");
 const { getModelByTenant } = require("@config/database");
 const constants = require("@config/constants");
 const isEmpty = require("is-empty");
+const moment = require("moment-timezone");
 
 const EmailLogSchema = new mongoose.Schema(
   {
@@ -45,7 +46,7 @@ EmailLogSchema.index(
 );
 
 EmailLogSchema.statics = {
-  async canSendEmail({ email, emailType, cooldownDays = 30 } = {}) {
+  async canSendEmail({ email, emailType, cooldownDays = 30, ip } = {}) {
     try {
       if (!email || typeof email !== "string") {
         return {
@@ -57,10 +58,11 @@ EmailLogSchema.statics = {
       const now = new Date();
       let cooldownDate;
       let cooldownMs;
+      const isDailyLimitEmail =
+        emailType === "expiringToken" || emailType === "compromisedToken";
 
-      if (emailType === "expiringToken" || emailType === "compromisedToken") {
-        // For expiring tokens, check if an email was sent *today* (EAT timezone)
-        const moment = require("moment-timezone");
+      if (isDailyLimitEmail) {
+        // For expiring and compromised tokens, check if an email was sent *today* (EAT timezone)
         const todayEAT = moment().tz("Africa/Nairobi").startOf("day");
         cooldownDate = todayEAT.toDate();
         cooldownMs = now.getTime() - cooldownDate.getTime();
@@ -70,17 +72,22 @@ EmailLogSchema.statics = {
         cooldownDate = new Date(now.getTime() - cooldownMs);
       }
 
-      const lastLog = await this.findOne({
+      let query = {
         email: email.toLowerCase().trim(),
         emailType,
         lastSentAt: { $gte: cooldownDate },
-      })
-        .sort({ lastSentAt: -1 })
-        .lean();
+      };
+
+      // For compromised tokens, also check the IP address in the metadata
+      if (emailType === "compromisedToken" && ip) {
+        query["metadata.ip"] = ip;
+      }
+
+      const lastLog = await this.findOne(query).sort({ lastSentAt: -1 }).lean();
 
       if (lastLog) {
         let daysRemaining = 0;
-        if (emailType !== "expiringToken" && emailType !== "compromisedToken") {
+        if (!isDailyLimitEmail) {
           const timeSinceLastEmail = now - new Date(lastLog.lastSentAt);
           daysRemaining = Math.ceil(
             (cooldownMs - timeSinceLastEmail) / (24 * 60 * 60 * 1000)
@@ -89,9 +96,7 @@ EmailLogSchema.statics = {
 
         return {
           canSend: false,
-          reason: ["expiringToken", "compromisedToken"].includes(emailType)
-            ? "daily_limit_reached"
-            : "cooldown_active",
+          reason: isDailyLimitEmail ? "daily_limit_reached" : "cooldown_active",
           lastSentAt: lastLog.lastSentAt,
           daysRemaining,
           nextAvailableDate: new Date(
@@ -112,13 +117,18 @@ EmailLogSchema.statics = {
     }
   },
 
-  async logEmailSent({ email, emailType, metadata = {} } = {}) {
+  async logEmailSent({ email, emailType, ip, metadata = {} } = {}) {
     try {
       if (!email || typeof email !== "string") {
         return {
           success: false,
           error: "Invalid email parameter",
         };
+      }
+
+      const logMetadata = { ...metadata };
+      if (emailType === "compromisedToken" && ip) {
+        logMetadata.ip = ip;
       }
 
       const result = await this.findOneAndUpdate(
@@ -129,7 +139,7 @@ EmailLogSchema.statics = {
         {
           $set: {
             lastSentAt: new Date(),
-            metadata,
+            metadata: logMetadata,
           },
           $setOnInsert: {
             sentCount: 0,


### PR DESCRIPTION
🚀 Pull Request
### 📋 Description
### What does this PR do?
This PR fixes a bug in the auth-service that caused users to be spammed with security alert emails. It modifies the canSendEmail logic in the EmailLog model to enforce a strict "once per day" limit for expiringToken and compromisedToken notifications, preventing multiple alerts for the same event within a 24-hour period.

### Why is this change needed?
Users were receiving an excessive number of emails (sometimes over 50 per day) for expiring or compromised tokens, leading to a poor user experience. The previous cooldown mechanism was not functioning as intended. This change ensures that users receive these important alerts only once per calendar day (in the EAT timezone), resolving the spam issue while keeping them informed.

🔗 Related Issues

- [ ] Closes #
- [x] Fixes # (bug where users are spammed with token expiry and compromised token emails)
- [ ] Related to #

🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

🏗️ Affected Services
Microservices changed:

auth-service
🧪 Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

Test summary: Manually triggered the conditions for sending expiringToken and compromisedToken emails multiple times for the same user.

- Before: Multiple emails were sent to the user for the same event.
- After: The first email was sent successfully, and all subsequent attempts within the same calendar day were correctly blocked by the daily_limit_reached logic. Other email types were confirmed to follow their original cooldown rules, unaffected by this change.

### 💥 Breaking Changes

- [x] No breaking changes
- [ ] Has breaking changes (describe below)

### 📝 Additional Notes
The fix uses moment-timezone to correctly determine the start of a calendar day in the "Africa/Nairobi" timezone, ensuring the daily limit is applied consistently. This approach is robust for the Kubernetes deployment environment as it relies on MongoDB for persistent state tracking.

✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email rate limits for token-related notifications now enforce daily limits based on Africa/Nairobi time; other email types still use multi-day cooldowns.
  * Compromised-token alerts now respect these daily limits to avoid duplicate notifications.
* **New Features**
  * Compromised-token alerts include IP-aware handling so alerts are limited per originating IP when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->