### PR TITLE
correct the account deletion URL to what frontend expects

### DIFF
--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -1077,7 +1077,7 @@ module.exports = {
   },
   accountDeletionConfirmation: ({ firstName, email, token, tenant }) => {
     const name = firstName;
-    const url = `${constants.ANALYTICS_BASE_URL}/users/delete/confirm/${token}?tenant=${tenant}`;
+    const url = `${constants.ANALYTICS_BASE_URL}/user/delete/confirm/${token}?tenant=${tenant}`;
     const content = ` <tr>
                                 <td
                                     style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">


### PR DESCRIPTION
- [x] correct the account deletion URL to what frontend expects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the account deletion confirmation email URL endpoint path to ensure deletion verification links are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->