### PR TITLE
Fix grid shape validation error in model pre-save hooks

### DIFF
--- a/src/device-registry/models/Grid.js
+++ b/src/device-registry/models/Grid.js
@@ -165,9 +165,15 @@ gridSchema.pre("save", function(next) {
   // Backup validation using geometry utility
   if ((this.isModified("shape") || this.isNew) && this.shape) {
     try {
-      const fixed = validateAndFixPolygon(this.shape);
+      // Pass only coordinates, not the whole shape object
+      const fixed = validateAndFixPolygon({
+        type: this.shape.type,
+        coordinates: this.shape.coordinates,
+      });
       validatePolygonClosure(fixed, TOLERANCE_LEVELS.STRICT);
-      this.shape = fixed;
+
+      // Update the shape with fixed coordinates
+      this.shape.coordinates = fixed.coordinates;
     } catch (error) {
       return next(
         new Error(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the grid creation API endpoint that was failing with a 409 conflict error due to incorrect shape validation in the Grid model's pre-save hooks. The model-level validation was receiving the wrong data format, causing polygon coordinate validation to fail even when the input was valid.

### Why is this change needed?
Users were unable to create new grids via the API (`POST /api/v2/devices/grids`) because the Grid model's `pre("save")` hook was calling `validateAndFixPolygon` with the entire shape object instead of just the coordinates structure it expected. This caused all grid creation requests to fail with "Invalid polygon detected at model level" errors, even when using valid shapefiles from existing grids.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- device-registry (Grid model and validators)

**Files modified:**
- `src/device-registry/models/Grid.js` - Fixed pre-save and pre-update hooks
- `src/device-registry/validators/grids.validators.js` - Cleaned up createGrid validator

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Tested grid creation with Polygon shape from existing grid shapefile
- Verified polygon coordinate validation and auto-fixing works correctly
- Confirmed grid creation returns 200 OK with valid grid data
- Tested with IQAir network configuration

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Technical Details:**
The issue was in the Grid model's `pre("save")`, `pre("findOneAndUpdate")`, `pre("updateOne")`, and `pre("updateMany")` hooks. These hooks were passing the entire `shape` object `{ type: "Polygon", coordinates: [...] }` to `validateAndFixPolygon()`, but the validation function expected an object with separate `type` and `coordinates` properties.

**Changes Made:**
1. Updated all pre-save/update hooks to correctly pass shape structure to validation functions
2. Removed update-specific validators (`confirm_update`, `update_reason`) from the `createGrid` validator - these only belong in `updateGridShape`
3. Ensured coordinate fixing properly updates `shape.coordinates` instead of replacing the entire shape object

**Backward Compatibility:**
This fix maintains full backward compatibility. Existing grids and all grid operations continue to work as expected. The fix only corrects the validation logic that was incorrectly rejecting valid grid creation requests.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid shape coordinate validation to ensure more accurate polygon coordinate handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->