### PR TITLE
Fix: Handle single-word names during organization request approval

### DIFF
--- a/src/auth-service/utils/organization-request.util.js
+++ b/src/auth-service/utils/organization-request.util.js
@@ -450,12 +450,14 @@ const organizationRequest = {
             constants.JWT_SECRET
           );
 
+          // Parse and sanitize contact name
+          const sanitizedName = (orgRequest.contact_name || "").trim();
+          const nameParts = sanitizedName.split(/\s+/).filter(Boolean);
+
           // Create user without password (will be set during onboarding)
           const userBody = {
-            firstName:
-              orgRequest.contact_name.split(" ")[0] || orgRequest.contact_name,
-            lastName:
-              orgRequest.contact_name.split(" ").slice(1).join(" ") || "",
+            firstName: nameParts[0] || "User",
+            lastName: nameParts.slice(1).join(" ") || nameParts[0] || "User",
             email: orgRequest.contact_email,
             organization: orgRequest.organization_name,
             // Generate a temporary password that will be replaced during onboarding
@@ -478,13 +480,13 @@ const organizationRequest = {
             )
           );
 
+          // Parse and sanitize contact name
+          const sanitizedName = (orgRequest.contact_name || "").trim();
+          const nameParts = sanitizedName.split(/\s+/).filter(Boolean);
           // Create the initial admin user
           const userBody = {
-            firstName: orgRequest.contact_name.split(" ")[0] || "User",
-            lastName:
-              orgRequest.contact_name.split(" ").slice(1).join(" ") ||
-              orgRequest.contact_name.split(" ")[0] ||
-              "User",
+            firstName: nameParts[0] || "User",
+            lastName: nameParts.slice(1).join(" ") || nameParts[0] || "User",
             email: orgRequest.contact_email,
             organization: orgRequest.organization_name,
             password: generatedPassword, // ✅ Generated password


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

### What does this PR do?
This pull request fixes a critical bug in the organization request approval workflow. Previously, when an administrator approved a request from a new user with a single-word name (e.g., "Bobi"), the user creation process would fail due to a validation error. This change makes the name-splitting logic more robust to handle such cases.

### Why is this change needed?
The user creation logic in `approveOrganizationRequest` splits the `contact_name` into `firstName` and `lastName`. If the `contact_name` was a single word, `lastName` would become an empty string. This failed the `User` model's validation, which requires the `lastName` field to be present, resulting in a `user validation failed: lastName: LastName is required` error.

This fix ensures that if a `lastName` cannot be derived from the `contact_name`, it defaults to a non-empty value (the `firstName`), thus satisfying the validation and allowing the user and organization to be created successfully.

---

## 🔗 Related Issues
- [ ] Closes #
- [x] Fixes # (bug where org request approval fails for single-word names)
- [ ] Related to #

---

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
- auth-service

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually tested the organization approval endpoint (`/api/v2/users/org-requests/:request_id/approve`) with a request submitted by a new user having a single-word `contact_name`.

1.  Created a new organization request with `contact_name: "Bobi"`.
2.  Approved the request as an administrator.
3.  **Result:** The request was successfully approved, and a new user was created with `firstName: "Bobi"` and `lastName: "Bobi"`. The `lastName: LastName is required` error no longer occurs.

---

## 💥 Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
This change specifically targets the user creation logic within the `approveOrganizationRequest` utility and does not affect other user creation flows. It makes the organization onboarding process more reliable.

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Better contact name sanitization and parsing to derive consistent first/last name with sensible fallbacks.
  * Consistent use of sanitized names for user creation flows.
  * New profile-picture validation that trims, checks URL scheme/length, and skips invalid images.
  * Branding logo now only applied to groups when the validated image URL is accepted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->