### PR TITLE
fix: Correctly filter deployed devices in shipping status API

### DIFF
--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2877,7 +2877,7 @@ const deviceUtil = {
       const devices = await DeviceModel(tenant)
         .find(filter)
         .select(
-          "name long_name claim_status claim_token shipping_prepared_at owner_id claimed_at"
+          "name long_name claim_status claim_token shipping_prepared_at owner_id claimed_at status"
         )
         .sort({ shipping_prepared_at: -1 })
         .lean();


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This pull request fixes a bug in the `GET /api/v2/devices/shipping-status` endpoint where deployed devices were not being included in the response. The filtering logic has been corrected to check the `status` field instead of the `claim_status` field when identifying deployed devices.

### Why is this change needed?
The shipping status API was incorrectly filtering out devices that were both prepared for shipping and had a `status` of "deployed". This was because the code was checking `claim_status === "deployed"`, a condition that never occurs, instead of the correct `status === "deployed"`. This fix ensures that all prepared devices, regardless of their deployment status, are correctly reported by the API.

---

## :link: Related Issues

- [ ] Closes #
- [x] Fixes # (bug where deployed devices were missing from shipping status)
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
1.  Prepared a device for shipping using `POST /devices/prepare-for-shipping`.
2.  Ensured the same device had a `status` of "deployed".
3.  Called the `GET /api/v2/devices/shipping-status` endpoint.
4.  Verified that the deployed device now correctly appears in the `deployed_devices` section of the response, whereas previously it was missing.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

This is a non-breaking bug fix that corrects the API's output to match its intended behavior.

---

## :memo: Additional Notes
This fix highlights the distinction between a device's `claim_status` (unclaimed, claimed) and its operational `status` (deployed, recalled, not deployed). The logic now correctly uses the operational `status` for filtering.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device categorization so deployed devices are correctly counted and shown in shipping preparation status summaries.

* **Tests**
  * Added end-to-end tests to validate shipping preparation status counts and categorizations, including empty-result behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->