### PR TITLE
fix(redis): Resolve infinite recursion in set method

### DIFF
--- a/src/auth-service/config/redis.js
+++ b/src/auth-service/config/redis.js
@@ -224,19 +224,21 @@ process.on("SIGINT", async () => {
   }
 });
 
-// Export everything needed
-module.exports = redis;
-module.exports.redisGetAsync = redisGetAsync;
-module.exports.redisSetAsync = redisSetAsync;
-module.exports.redisExpireAsync = redisExpireAsync;
-module.exports.redisDelAsync = redisDelAsync;
-module.exports.redisPingAsync = redisPingAsync;
-module.exports.redisUtils = redisUtils;
-module.exports.redisSetWithTTLAsync = redisSetWithTTLAsync;
-module.exports.redisSetNXAsync = redisSetNXAsync;
+const redisWrapper = {
+  redisGetAsync,
+  redisSetAsync,
+  redisExpireAsync,
+  redisDelAsync,
+  redisPingAsync,
+  redisUtils,
+  redisSetWithTTLAsync,
+  redisSetNXAsync,
+  get: redisGetAsync,
+  del: redisDelAsync,
+};
 
 // Compatibility exports for direct redis.method() usage
-module.exports.set = async (key, value, ttlType, ttlValue) => {
+redisWrapper.set = async (key, value, ttlType, ttlValue) => {
   // Compatible with ioredis.set(key, value, 'EX', seconds) pattern
   if (!redis.isOpen) {
     console.warn(`Redis not available for SET ${key}`);
@@ -254,5 +256,6 @@ module.exports.set = async (key, value, ttlType, ttlValue) => {
     throw error;
   }
 };
-module.exports.get = redisGetAsync;
-module.exports.del = redisDelAsync;
+
+module.exports = redisWrapper;
+module.exports.redis = redis; // Export the raw client if needed elsewhere


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This PR fixes a critical bug in the Redis utility (`config/redis.js`) that was causing `Maximum call stack size exceeded` errors in the production environment. The issue stemmed from an infinite recursion loop in the custom `set` method.

The fix refactors the module to export a dedicated `redisWrapper` object, which contains our custom helper functions, rather than directly modifying the Redis client instance. This breaks the recursive loop while maintaining the intended functionality and compatibility layer.

### Why is this change needed?
The authentication service was unstable and crashing during user creation and other operations that use `redis.set()`. The previous implementation was overwriting the Redis client's native `.set()` method with a custom function that then called itself, leading to a stack overflow. This fix is essential for restoring the stability and reliability of the application.

---

## :link: Related Issues
- [x] Fixes #<ISSUE_NUMBER> <!-- (Optional) Link to the issue that reported the crashes -->
- [ ] Closes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually tested the user creation endpoint which was previously crashing in the production environment. Confirmed that the `Maximum call stack size exceeded` error is resolved and users can now be created successfully. Also verified that other Redis caching operations (get, del) continue to function as expected after the refactor.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
The root cause was that `module.exports = redis` and a subsequent `module.exports.set = ...` were modifying the same object reference. The fix introduces a `redisWrapper` object to cleanly separate our custom utility methods from the underlying Redis client instance, preventing the recursive loop. The raw client is still exported as `module.exports.redis` for any parts of the application that might require direct access.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of Redis service configuration to consolidate helper functions and improve API structure. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->