### PR TITLE
Feat: Add cohort filter to grid summary endpoint

### DIFF
--- a/src/device-registry/validators/grids.validators.js
+++ b/src/device-registry/validators/grids.validators.js
@@ -492,7 +492,21 @@ const gridsValidations = {
     commonValidations.validObjectId("id"),
     commonValidations.nameQuery,
     commonValidations.adminLevelQuery,
-    commonValidations.validObjectId("cohort_id"),
+    query("cohort_id")
+      .optional()
+      .notEmpty()
+      .withMessage("cohort_id cannot be empty if provided")
+      .customSanitizer((value) => {
+        if (typeof value === "string" && value.includes(",")) {
+          return value.split(",").map((id) => id.trim());
+        }
+        return value;
+      })
+      .custom((value) => {
+        const ids = Array.isArray(value) ? value : [value];
+        return ids.every((id) => isValidObjectId(id));
+      })
+      .withMessage("cohort_id must be valid ObjectId(s)"),
   ],
   deleteGrid: [
     ...commonValidations.tenant,


### PR DESCRIPTION
# :rocket: Pull Request
## :clipboard: Description
### What does this PR do?
This pull request introduces the ability to filter the `/api/v2/devices/grids/summary` endpoint by `cohort_id`. When a `cohort_id` (or a comma-separated list of `cohort_id`s) is provided, the endpoint will now only return sites within each grid that are associated with devices belonging to the specified cohort(s).

The changes involve:
1.  Adding `cohort_id` validation to `grids.validators.js` for the `listGridSummary` endpoint.
2.  Modifying `grid.util.js` to:
    *   Extract `cohort_id` from the request.
    *   Utilize `eventUtil.getDevicesFromCohort` to retrieve device IDs associated with the provided cohort(s).
    *   Fetch the `site_id`s linked to these devices.
    *   Apply an additional `$filter` stage in the aggregation pipeline to ensure only sites belonging to the cohort's devices are included in the grid summary.

### Why is this change needed?
This enhancement directly addresses the need to filter grid data based on cohort membership, aligning with the strategic shift towards using Cohort IDs for logical grouping and access control. It allows users to view grid summaries relevant to specific cohorts, improving data segmentation and user experience without relying on the deprecated `group_id` concept.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #
---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation
---

## :building_construction: Affected Services
**Microservices changed:**
-   device-registry
---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass
**Test summary:**

Manual testing was performed on the staging environment for the `/api/v2/devices/grids/summary` endpoint:
1.  **Without `cohort_id`:** Verified that the endpoint behaves as before, returning the general grid summary.
2.  **With a single valid `cohort_id`:** Verified that the returned grids only contain sites whose associated devices belong to the specified cohort.
3.  **With multiple comma-separated `cohort_id`s:** Verified that the returned grids correctly aggregate sites from devices belonging to any of the provided cohorts.
4.  **With an invalid `cohort_id`:** Verified that the endpoint returns an appropriate error message (e.g., "No distinct Cohort found").
5.  **With a valid `cohort_id` that has no associated devices:** Verified that the endpoint returns an empty list of sites within the grids, or an appropriate message indicating no sites were found for the cohort.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)
<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
This implementation leverages existing utility functions (`eventUtil.getDevicesFromCohort`) to maintain consistency and reusability across the codebase. The filtering logic ensures that only sites linked to devices within the specified cohort(s) are displayed in the grid summary, aligning with the new cohort-centric design.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grid listings now support filtering by cohort ID so users can view devices scoped to specific cohorts. Empty cohort selections return no sites/devices.

* **Improvements**
  * Added validation and sanitization for cohort ID input to ensure correct format and handling of comma-separated values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->