### PR TITLE
RemoveTshwane

### DIFF
--- a/src/spatial/models/heatmapModel.py
+++ b/src/spatial/models/heatmapModel.py
@@ -466,6 +466,7 @@ class AirQualityGrids(BaseAirQoAPI):
             "kampala_central",
             "greater_kampala",
             "city_of_tshwane",
+            
         ]
         exclude_names_set = {n.lower() for n in exclude_names}
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
It removes the City of Tshwane grid from the dataset because the new Gauteng grid already covers the entire province, including Tshwane. This prevents the heatmap from being overlaid twice in the same area.
<!-- Brief summary of the changes -->
Removes the City of Tshwane grid to avoid duplication, since the Gauteng grid already covers the province and prevents double heatmap overlays.
### Why is this change needed?
<!-- Explain the motivation/problem this solves -->
Keeping both the City of Tshwane grid and the Gauteng grid causes duplicate spatial coverage in the same area. Removing Tshwane prevents overlapping heatmap layers and ensures the dataset reflects a single, consistent provincial grid.
---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
