### PR TITLE
feat: Add status-based endpoints for sites

### DIFF
--- a/src/device-registry/routes/v2/sites.routes.js
+++ b/src/device-registry/routes/v2/sites.routes.js
@@ -37,6 +37,44 @@ router.get(
   pagination(),
   siteController.listSummary
 );
+
+// STATUS-BASED LISTING ENDPOINTS
+router.get(
+  "/status/operational",
+  validateTenant,
+  validateSiteQueryParams,
+  pagination(),
+  validate,
+  siteController.listOperationalSites
+);
+
+router.get(
+  "/status/transmitting",
+  validateTenant,
+  validateSiteQueryParams,
+  pagination(),
+  validate,
+  siteController.listTransmittingSites
+);
+
+router.get(
+  "/status/data-available",
+  validateTenant,
+  validateSiteQueryParams,
+  pagination(),
+  validate,
+  siteController.listDataAvailableSites
+);
+
+router.get(
+  "/status/not-transmitting",
+  validateTenant,
+  validateSiteQueryParams,
+  pagination(),
+  validate,
+  siteController.listNotTransmittingSites
+);
+
 router.get(
   "/weather",
   validateTenant,

--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -1540,6 +1540,8 @@ const generateFilter = {
       last_active,
       last_active_before,
       last_active_after,
+      isOnline,
+      rawOnlineStatus,
     } = { ...req.query, ...req.params };
     const filter = {};
 
@@ -1625,6 +1627,31 @@ const generateFilter = {
         filter["isOnline"] = true;
       } else if (online_status.toLowerCase() === "offline") {
         filter["isOnline"] = false;
+      }
+    }
+
+    const toBooleanSafe = (value) => {
+      if (value === undefined) return undefined;
+      if (typeof value === "boolean") return value;
+      const stringValue = String(value)
+        .toLowerCase()
+        .trim();
+      if (["true", "yes", "1"].includes(stringValue)) return true;
+      if (["false", "no", "0"].includes(stringValue)) return false;
+      return undefined;
+    };
+
+    if (isOnline !== undefined) {
+      const boolValue = toBooleanSafe(isOnline);
+      if (boolValue !== undefined) {
+        filter.isOnline = boolValue;
+      }
+    }
+
+    if (rawOnlineStatus !== undefined) {
+      const boolValue = toBooleanSafe(rawOnlineStatus);
+      if (boolValue !== undefined) {
+        filter.rawOnlineStatus = boolValue;
       }
     }
 

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -230,6 +230,20 @@ const validateSiteQueryParams = oneOf([
     .withMessage(
       "the online_status value is not among the expected ones which include: online, offline"
     ),
+  query("isOnline")
+    .optional()
+    .notEmpty()
+    .withMessage("isOnline should not be empty if provided")
+    .bail()
+    .isBoolean()
+    .withMessage("isOnline must be a boolean value (true or false)"),
+  query("rawOnlineStatus")
+    .optional()
+    .notEmpty()
+    .withMessage("rawOnlineStatus should not be empty if provided")
+    .bail()
+    .isBoolean()
+    .withMessage("rawOnlineStatus must be a boolean value (true or false)"),
   query("category")
     .optional()
     .notEmpty()


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This pull request introduces four new status-based endpoints for the `sites` resource to align with the existing device status endpoints. This allows clients to query sites based on their operational status in a more intuitive way.

The new endpoints are:
- `/api/v2/devices/sites/status/operational`
- `/api/v2/devices/sites/status/transmitting`
- `/api/v2/devices/sites/status/data-available`
- `/api/v2/devices/sites/status/not-transmitting`

### Why is this change needed?
To maintain API consistency and provide a standardized method for filtering sites by their online and data transmission status, mirroring the functionality recently implemented for devices.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manual testing was performed by calling each of the four new endpoints (e.g., `/api/v2/devices/sites/status/operational`) with a valid JWT. The responses were verified to ensure that only sites matching the corresponding status filters (`isOnline` and `rawOnlineStatus`) were returned. The endpoints correctly default to a `summary` detail level.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
The new endpoints default to a `summary` detail level for performance, as they are intended for high-level status checks and dashboarding.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four new site status filtering endpoints: operational, transmitting, data-available, and not-transmitting.
  * Enhanced site query filters with new online status parameters for more granular filtering options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->