### PR TITLE
Fix: Add missing pagination meta to site status endpoints

### DIFF
--- a/src/device-registry/controllers/site.controller.js
+++ b/src/device-registry/controllers/site.controller.js
@@ -63,6 +63,10 @@ const listSitesByStatus = async (req, res, next, statusFilters, logMessage) => {
 
     const result = await siteUtil.list(request, next);
 
+    if (isEmpty(result) || res.headersSent) {
+      return;
+    }
+
     if (result.success === true) {
       const status = result.status ? result.status : httpStatus.OK;
       return res.status(status).json({


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This pull request fixes an issue where the site status endpoints (e.g., `/api/v2/devices/sites/status/operational`) were not returning the `meta` object containing pagination data. The controller logic has been updated to manually construct the JSON response for these routes, ensuring the pagination metadata is always included.

### Why is this change needed?
The frontend team reported that the lack of pagination metadata made it impossible to build paginated views for site health dashboards. This fix aligns the behavior of the site status endpoints with their device-related counterparts, ensuring a consistent and predictable API response structure across the application.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually tested the site status endpoints (e.g., `GET /api/v2/devices/sites/status/transmitting`) to confirm that the API response now includes the `meta` object with all expected pagination fields (`total`, `limit`, `skip`, `page`, `totalPages`, etc.). The response structure now matches the equivalent device endpoints.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
The root cause was a generic response handler that was omitting the `meta` field from the final output. The fix replaces this with a more specific response structure for the affected routes.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized site-listing API responses to always return an explicit success flag, a message, a meta object (default {}), and a sites array; successful responses use the result status or HTTP 200.
  * Failure responses consistently return success: false with a message and either provided errors or a default internal error message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->