### PR TITLE
Fix: Prioritize background sites for representative air quality

### DIFF
--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -1607,10 +1607,12 @@ const createEvent = {
 
       const backgroundSitesReadings = latestReadings.filter(
         (reading) =>
-          reading.siteDetails && // Check if siteDetails exists
-          reading.siteDetails.site_category && // Safely check if site_category exists
-          (reading.siteDetails.site_category.category === "urban background" ||
-            reading.siteDetails.site_category.category === "background")
+          reading.siteDetails &&
+          reading.siteDetails.site_category &&
+          typeof reading.siteDetails.site_category.category === "string" &&
+          reading.siteDetails.site_category.category
+            .toLowerCase()
+            .includes("background")
       );
 
       // Helper to ensure we only process readings with a valid pm2_5 value


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This PR fixes the logic for selecting the representative air quality reading for cohorts and grids. It ensures that sites categorized as "background" (e.g., "Urban Background", "Background Site") are correctly prioritized. If no background sites are available, the system falls back to selecting the site with the highest PM2.5 value, which was the previous, incorrect default behavior in all cases.

### Why is this change needed?
The previous implementation did not correctly filter for background sites. It was always selecting the site with the highest PM2.5 value from the entire group, regardless of its category. This led to non-background sites (e.g., "Urban Commercial") being chosen as representative, even when background sites were available in the cohort. This PR corrects the logic to align with the intended behavior.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually tested the `GET /api/v2/devices/readings/cohorts/:cohort_id/representative` endpoint using a cohort ID known to contain sites with "Urban Background" categories.

- **Before fix:** The endpoint incorrectly returned a reading from a site with an "Urban Commercial" category.
- **After fix:** The endpoint correctly prioritizes and returns a reading from a site with an "Urban Background" category.

The same logic applies to grid-based representative readings.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
The fix is located in the `getRepresentativeAirQuality` function within `src/device-registry/utils/event.util.js`. This single change corrects the behavior for both cohort and grid-based representative value lookups as they share this utility function.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of background category filtering by implementing case-insensitive matching. The filter now better handles missing or undefined data properties and expands the set of readings properly classified as "background," reducing potential runtime errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->