### PR TITLE
Feat: Standardize network status alert terminology

### DIFF
--- a/src/device-registry/utils/network-status.util.js
+++ b/src/device-registry/utils/network-status.util.js
@@ -74,9 +74,9 @@ const networkStatusUtil = {
       };
 
       // Determine severity based on offline percentage
-      if (alertData.offline_percentage >= 50) {
+      if (alertData.not_transmitting_percentage >= 50) {
         enrichedData.severity = "HIGH";
-      } else if (alertData.offline_percentage >= 35) {
+      } else if (alertData.not_transmitting_percentage >= 35) {
         enrichedData.severity = "MEDIUM";
       } else {
         enrichedData.severity = "LOW";


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This PR refactors the network status monitoring job (`check-network-status-job`) to provide clearer and more accurate alerts. It replaces the ambiguous "online/offline" terminology with more descriptive statuses: `operational`, `transmitting`, and `not_transmitting`.

Key changes include:
- Updating the `NetworkStatusAlert` model to store `not_transmitting_devices_count` and `not_transmitting_percentage`.
- Modifying the job logic to calculate network health based on the percentage of "not transmitting" devices.
- Restricting the network status job to run only in the **production environment** to prevent alert spam from staging.
- Updating alert messages to reflect the new, clearer terminology.

### Why is this change needed?
The previous "online/offline" terminology was found to be misleading for stakeholders, as it didn't accurately capture the different states a device could be in. This change provides a more precise understanding of network health. Additionally, restricting the job to production ensures that alerts are only generated for the live environment, reducing noise and focusing attention where it's needed.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually triggered the `check-network-status-job` in a non-production environment to confirm that it exits gracefully without running. Verified in the production environment that the job runs as expected, calculates the "not transmitting" percentage correctly, and stores the new fields (`not_transmitting_devices_count`, `not_transmitting_percentage`) in the `networkstatusalerts` collection. Alert messages in logs now use the new, clearer terminology.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The changes to the `NetworkStatusAlert` model are additive and backward-compatible with the existing structure, but consumers of this data (e.g., dashboards) should be updated to use the new `not_transmitting_percentage` and `not_transmitting_devices_count` fields for the most accurate reporting. The old "offline" fields are no longer populated.

---

## :memo: Additional Notes
This update touches the following key files:
- `src/device-registry/bin/jobs/check-network-status-job.js`
- `src/device-registry/models/NetworkStatusAlert.js`
- `src/device-registry/utils/network-status.util.js`

The primary goal is to improve the clarity and accuracy of our network health monitoring.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network status checks now run exclusively in production environments.

* **Changes**
  * Updated network status monitoring terminology from "offline" to "not transmitting" devices.
  * Refactored device uptime calculations for improved accuracy.
  * Adjusted alert severity thresholds for not transmitting metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->