### PR TITLE
Chore: Silence non-production logs for unassigned sites job

### DIFF
--- a/src/device-registry/bin/jobs/check-unassigned-sites-job.js
+++ b/src/device-registry/bin/jobs/check-unassigned-sites-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/check-unassigned-sites-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/check-unassigned-sites-job`,
 );
 const SitesModel = require("@models/Site");
 const cron = require("node-cron");
@@ -22,9 +22,6 @@ const checkUnassignedSites = async () => {
 
   // Restrict job to run only in production
   if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") {
-    logger.info(
-      `check-unassigned-sites-job is disabled for the ${constants.ENVIRONMENT} environment.`
-    );
     return;
   }
 
@@ -68,9 +65,9 @@ const checkUnassignedSites = async () => {
 
     if (percentage > UNASSIGNED_THRESHOLD) {
       const message = `⚠️🙉 ${percentage.toFixed(
-        2
+        2,
       )}% of active sites are not assigned to any grid (${uniqueSiteNames.join(
-        ", "
+        ", ",
       )})`;
       logText(message);
       logger.info(message);
@@ -97,7 +94,7 @@ const jobWrapper = async () => {
     }
   } catch (error) {
     logText(
-      `Distributed lock check failed: ${error.message}. Proceeding with execution.`
+      `Distributed lock check failed: ${error.message}. Proceeding with execution.`,
     );
   }
 
@@ -126,7 +123,7 @@ const startJob = () => {
     {
       scheduled: true,
       timezone: constants.TIMEZONE,
-    }
+    },
   );
 
   if (!global.cronJobs) {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This Pull Request silences the informational log message "check-unassigned-sites-job is disabled for the [ENVIRONMENT] environment." that was previously appearing in non-production environments. The job will now silently return without logging this message when not running in production.

### Why is this change needed?
This change is needed to reduce log noise in staging and development environments. The previous log message, while accurate, was repetitive and non-actionable, cluttering the logs and making it harder to identify more critical information. Silencing it contributes to cleaner and more focused logging.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- device-registry

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually verified in a staging environment that the `check-unassigned-sites-job` no longer prints the "job is disabled for the STAGING ENVIRONMENT" log message. The job correctly exits without performing its main logic, and no new issues were observed. Existing automated tests cover the core logic of the job, which remains unchanged.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This is a minor change focused purely on log hygiene. No functional behavior of the `check-unassigned-sites-job` has been altered; it continues to run only in production as intended.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code formatting and cleanup improvements
  * Removed an informational log notification from the background job processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->