### PR TITLE
Fix superset 401 by ignoring superset domain

### DIFF
--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -154,6 +154,7 @@ data:
     location /airqo-terms-and-conditions/HxYx3ysdA6k0ng6YJkU3 { return 302 /#/platform/terms_and_conditions; }
 
     location = /auth {
+      if ($host = 'superset.airqo.net') { return 200; }
       if ($request_method = 'OPTIONS') { return 204; }
       if ($request_uri ~ '/website/api/(v1|v2)/') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/users') { return 200; }

--- a/k8s/nginx/production/superset-vs.yaml
+++ b/k8s/nginx/production/superset-vs.yaml
@@ -11,7 +11,8 @@ spec:
       port: 8088
   routes:
     - path: /
-      location-snippets: "auth_request off;"
+      location-snippets: |
+        auth_request off;
       action:
         proxy:
           upstream: superset-upstream


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
Allows superset to be accessed via sll domain

### Why is this change needed?
To improve resource access

---

## 🔗 Related Issues
- [ ] OPS-408