### PR TITLE
Fix cohort tags filter querying wrong database field

### DIFF
--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -2226,7 +2226,10 @@ const generateFilter = {
     }
 
     if (tags) {
-      const tagsArray = tags.toString().split(",");
+      const tagsArray = tags
+        .toString()
+        .split(",")
+        .map((tag) => tag.trim().toLowerCase());
       filter["cohort_tags"] = { $in: tagsArray };
     }
 
@@ -2238,13 +2241,6 @@ const generateFilter = {
       filter["visibility"] = true;
     }
 
-    if (tags) {
-      const tagsArray = tags
-        .toString()
-        .split(",")
-        .map((tag) => tag.trim().toLowerCase());
-      filter["grid_tags"] = { $in: tagsArray }; // Assuming 'grid_tags' is the field name in the Grid model
-    }
     return filter;
   },
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the `tags` query parameter filter in the `generateFilter.cohorts` function inside `src/device-registry/utils/common/generate-filter.js`. The fix removes a duplicate `if (tags)` block that was querying the wrong database field (`grid_tags` instead of `cohort_tags`), and normalizes tag values to lowercase trimmed strings before filtering.

### Why is this change needed?
The endpoint `GET /api/v2/devices/cohorts?tags=public` was not returning any results despite cohorts having matching tags. The root cause was a duplicate `if (tags)` block at the bottom of the `cohorts` filter function that silently overwrote the correct `cohort_tags` filter with a `grid_tags` filter — a field that does not exist on the Cohort model. Additionally, the original block was not normalizing tag values before querying, which would cause mismatches since the Cohort model's `pre('save')` hook stores all tags in lowercase trimmed form.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/utils/common/generate-filter.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually tested `GET /api/v2/devices/cohorts?tags=public` before and after the fix. Before the fix, the endpoint returned no results despite cohorts having the `public` tag. After the fix, cohorts with matching `cohort_tags` values are correctly returned. Also verified that comma-separated tags (e.g. `?tags=public,research`) resolve correctly via the `$in` operator.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
The bug was introduced by a copy-paste error where a second `if (tags)` block — likely copied from the `grids` filter function where `grid_tags` is the correct field — was left at the bottom of the `cohorts` function without being adapted. The fix consolidates the two blocks into one correct implementation that:
1. Uses `filter["cohort_tags"]` — the correct field on the Cohort model.
2. Applies `.trim().toLowerCase()` normalization to match how tags are stored by the Cohort schema's `pre('save')` hook.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent tag handling in cohort filtering by normalizing tags (whitespace trimming and case conversion).
  * Updated behavior for grid tag population in cohort filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->