### PR TITLE
Fix batch deployment site creation failure due to missing required fields

### DIFF
--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -1450,20 +1450,133 @@ const createActivity = {
         }
       }
 
-      // Site creation using find-then-create with all required fields
+      // Site creation using find-then-create with all required fields.
+      //
+      // IMPORTANT — two-phase approach for generated_name:
+      //
+      // createSite.generateName() increments a shared counter document
+      // in UniqueIdentifierCounterModel via $inc. Running it in parallel
+      // inside Promise.all would cause a race condition where concurrent
+      // increments collide and produce duplicate generated_name values,
+      // which would then hit the unique index and throw 11000 errors.
+      //
+      // Phase A (sequential): For each site that does NOT already exist
+      //   in the DB, call generateName once in order to claim a counter
+      //   slot and reserve a unique name. Sites that already exist skip
+      //   this step entirely — they keep their existing generated_name.
+      //
+      // Phase B (parallel): With all names pre-reserved, run the actual
+      //   SiteModel.create() calls concurrently via Promise.all — safe
+      //   because the uniqueness concern is already resolved.
+
+      // Phase A: Pre-generate names sequentially for new sites only
+      // Map: coordsKey -> pre-generated name (only populated for new sites)
+      const preGeneratedNames = new Map();
+
+      for (const [coordsKey, siteData] of uniqueSites) {
+        const lat_long = `${siteData.latitude}_${siteData.longitude}`;
+
+        // Check if site already exists — if so, skip name generation
+        const existingCheck = await SiteModel(tenant)
+          .findOne({ lat_long })
+          .select("_id")
+          .lean();
+
+        if (!existingCheck) {
+          // Site does not exist yet — claim a counter slot now,
+          // sequentially, before any parallel work begins
+          const responseFromGenerateName = await createSiteUtil.generateName(
+            tenant,
+            next,
+          );
+
+          if (!responseFromGenerateName || !responseFromGenerateName.success) {
+            // Propagate failure: mark every device mapped to this site
+            // as failed immediately so Phase B skips this coordsKey
+            logger.error(
+              `generateName failed for site "${
+                siteData.name
+              }" at ${coordsKey}: ${
+                responseFromGenerateName
+                  ? responseFromGenerateName.errors
+                    ? responseFromGenerateName.errors.message
+                    : responseFromGenerateName.message
+                  : "generateName returned undefined"
+              }`,
+            );
+            preGeneratedNames.set(coordsKey, {
+              error: {
+                message:
+                  responseFromGenerateName && responseFromGenerateName.errors
+                    ? responseFromGenerateName.errors.message
+                    : "Unable to generate unique name for site, contact support",
+              },
+            });
+          } else {
+            preGeneratedNames.set(coordsKey, {
+              generated_name: responseFromGenerateName.data,
+            });
+          }
+        }
+        // If site exists, preGeneratedNames has no entry for this
+        // coordsKey — Phase B will detect the existing site via findOne
+        // and use its own generated_name without touching the counter
+      }
+
+      // Phase B: Create/find sites in parallel now that all names are
+      // pre-reserved and no further counter increments are needed
       const sitePromises = [];
 
       for (const [coordsKey, siteData] of uniqueSites) {
         sitePromises.push(
           (async () => {
             try {
-              // First try to find an existing site by name
+              // Compute lat_long once — used for lookup, create, and
+              // race-condition re-fetch
+              const lat_long = `${siteData.latitude}_${siteData.longitude}`;
+
+              // Use an explicit flag to correctly track whether the site
+              // was found or newly created, since lean() returns a plain
+              // object with no $isNew/isNew properties, and isNew is
+              // always false on a document returned from create()
+              let wasExisting = false;
+
+              // Look up by lat_long (unique + immutable) not by name,
+              // since multiple sites can share the same name at different
+              // coordinates
               let site = await SiteModel(tenant)
-                .findOne({ name: siteData.name })
+                .findOne({ lat_long })
                 .lean();
 
-              if (!site) {
-                // Compute all required derived fields before creating
+              if (site) {
+                wasExisting = true;
+              } else {
+                // Site does not exist — check that Phase A successfully
+                // reserved a generated_name for this coordsKey
+                const nameReservation = preGeneratedNames.get(coordsKey);
+
+                if (!nameReservation) {
+                  // Phase A found the site existed at the time of the
+                  // existence check, but it has since been deleted or
+                  // was never written — treat as a new site needing a
+                  // name. This is an extremely unlikely edge case but
+                  // we handle it defensively.
+                  throw new Error(
+                    `No pre-generated name found for site "${siteData.name}" at ${lat_long} — counter reservation was skipped`,
+                  );
+                }
+
+                if (nameReservation.error) {
+                  // Phase A already logged the error; re-throw so this
+                  // site lands in failed_deployments with a clear message
+                  throw new Error(nameReservation.error.message);
+                }
+
+                const generated_name = nameReservation.generated_name;
+
+                // Compute approximate coordinates — createApproximateCoordinates
+                // calls next() on error but does not return a value, so
+                // guard against undefined
                 const approxResult = distance.createApproximateCoordinates(
                   {
                     latitude: siteData.latitude,
@@ -1472,10 +1585,11 @@ const createActivity = {
                   next,
                 );
 
-                const lat_long = `${siteData.latitude}_${siteData.longitude}`;
-                const generated_name = `${siteData.name
-                  .replace(/\s+/g, "-")
-                  .toLowerCase()}_${lat_long}`;
+                if (!approxResult) {
+                  throw new Error(
+                    `Failed to compute approximate coordinates for site "${siteData.name}" at ${lat_long}`,
+                  );
+                }
 
                 try {
                   site = await SiteModel(tenant).create({
@@ -1486,6 +1600,10 @@ const createActivity = {
                       siteData.network || constants.DEFAULT_NETWORK || "airqo",
                     lat_long,
                     generated_name,
+                    // description mirrors generated_name — unique per
+                    // site, carries no raw coordinate data, and is
+                    // consistent with the existing Site.register pattern
+                    description: generated_name,
                     approximate_latitude:
                       approxResult.approximate_latitude || siteData.latitude,
                     approximate_longitude:
@@ -1493,24 +1611,27 @@ const createActivity = {
                     approximate_distance_in_km:
                       approxResult.approximate_distance_in_km || 0,
                     bearing_in_radians: approxResult.bearing_in_radians || 0,
-                    description: siteData.name,
                   });
                 } catch (createError) {
-                  // Handle race condition: another process may have created it
+                  // Handle race condition: another process may have
+                  // created the site between Phase A's existence check
+                  // and this create() call. Re-fetch by lat_long (unique
+                  // + immutable) — a 11000 error can fire on lat_long,
+                  // generated_name, or description, not just name, so
+                  // querying by name would risk returning the wrong site
                   if (createError.code === 11000) {
                     site = await SiteModel(tenant)
-                      .findOne({ name: siteData.name })
+                      .findOne({ lat_long })
                       .lean();
                     if (!site) {
                       throw createError;
                     }
+                    wasExisting = true;
                   } else {
                     throw createError;
                   }
                 }
               }
-
-              const wasExisting = !(site.$isNew || site.isNew);
 
               // Cache site data
               siteMap.set(coordsKey, site._id);
@@ -1536,10 +1657,12 @@ const createActivity = {
 
       const siteResults = await Promise.all(sitePromises);
 
-      // Track existing vs created sites, and fail devices whose site could not be created
+      // Track existing vs created sites, and fail devices whose site
+      // could not be created
       siteResults.forEach((result) => {
         if (result.error) {
-          // Move all devices relying on this failed site into failed_deployments
+          // Move all devices relying on this failed site into
+          // failed_deployments
           for (const [deviceName, deployment] of deviceNameToDeployment) {
             if (deployment.actualDeploymentType === "static") {
               const coordsKey = `${deployment.latitude},${deployment.longitude}`;
@@ -1794,7 +1917,8 @@ const createActivity = {
 
       if (activitiesToInsert.length > 0) {
         try {
-          // Use .create() to trigger pre-save middleware (validates deployment invariants)
+          // Use .create() to trigger pre-save middleware (validates
+          // deployment invariants)
           createdActivities = await ActivityModel(tenant).create(
             activitiesToInsert,
           );
@@ -1820,7 +1944,9 @@ const createActivity = {
               failed_deployments.push({
                 deviceName,
                 deployment_type: deployment.actualDeploymentType,
-                error: { message: `Bulk operation failed: ${error.message}` },
+                error: {
+                  message: `Bulk operation failed: ${error.message}`,
+                },
                 user_id: deployment.user_id || null,
               });
             }
@@ -2507,6 +2633,7 @@ const createActivity = {
       );
     }
   },
+
   getDevicesByDeploymentType: async (request, next) => {
     try {
       const { query, params } = request;
@@ -2539,7 +2666,8 @@ const createActivity = {
             as: deploymentType === "static" ? "site_temp" : "grid_temp",
           },
         },
-        // Convert array to single object using $unwind (with preserveNullAndEmptyArrays to handle missing references)
+        // Convert array to single object using $unwind
+        // (with preserveNullAndEmptyArrays to handle missing references)
         {
           $unwind: {
             path: deploymentType === "static" ? "$site_temp" : "$grid_temp",
@@ -2612,6 +2740,7 @@ const createActivity = {
       );
     }
   },
+
   recalculateNextMaintenance: async (request, next) => {
     try {
       const { tenant } = request.query;
@@ -2645,7 +2774,8 @@ const createActivity = {
       // Validate dates and track invalid rows
       const isValidDate = (d) => !!d && !isNaN(new Date(d).getTime());
       const invalidActivities = [];
-      // Build latest maintenance date per device across ALL maintenance activities
+      // Build latest maintenance date per device across ALL maintenance
+      // activities
       const latestMaintenanceDateByDevice = new Map();
       for (const a of maintenanceActivities) {
         if (!isValidDate(a.date)) {
@@ -2683,7 +2813,9 @@ const createActivity = {
           activityBulkOps.push({
             updateOne: {
               filter: { _id: activity._id },
-              update: { $set: { nextMaintenance: correctNextMaintenance } },
+              update: {
+                $set: { nextMaintenance: correctNextMaintenance },
+              },
             },
           });
           // Mark device as needing nextMaintenance re-evaluation
@@ -2727,7 +2859,9 @@ const createActivity = {
                 updateOne: {
                   filter: { _id: device._id },
                   update: {
-                    $set: { nextMaintenance: latestCorrectNextMaintenance },
+                    $set: {
+                      nextMaintenance: latestCorrectNextMaintenance,
+                    },
                   },
                 },
               });
@@ -2780,6 +2914,7 @@ const createActivity = {
       );
     }
   },
+
   backfillDeviceIds: async (request, next) => {
     try {
       const { tenant } = request.query;
@@ -2787,7 +2922,8 @@ const createActivity = {
 
       logText(`Starting device_id backfill for tenant: ${tenant}`);
 
-      // Build filter for activities without device_id but WITH a valid device name
+      // Build filter for activities without device_id but WITH a valid
+      // device name
       const filter = {
         $or: [{ device_id: null }, { device_id: { $exists: false } }],
         device: { $exists: true, $nin: [null, ""] },
@@ -2844,7 +2980,8 @@ const createActivity = {
         logText(`Processing batch #${batchNumber} (batch_size=${batch_size})`);
 
         // Fetch batch with minimal projection
-        // No skip needed - updated documents automatically drop out of filter
+        // No skip needed - updated documents automatically drop out of
+        // filter
         const batchActivities = await ActivityModel(tenant)
           .find(filter)
           .select("_id device activityType date")
@@ -2931,7 +3068,8 @@ const createActivity = {
         }
       }
 
-      // After successful backfill, trigger cache recalculation for affected devices
+      // After successful backfill, trigger cache recalculation for
+      // affected devices
       if (totalBackfilled > 0) {
         logText("Triggering cache updates for affected devices...");
 
@@ -3009,6 +3147,7 @@ const createActivity = {
       );
     }
   },
+
   refreshActivityCaches: async (request, next) => {
     try {
       const { tenant } = request.query;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the `batchDeployWithCoordinates` function in `src/device-registry/utils/activity.util.js` to correctly create or find sites during batch device deployment. The site creation logic in Phase 3 has been replaced with a robust find-then-create pattern that supplies all required schema fields before attempting document insertion.

### Why is this change needed?
The previous implementation used a bare `findOneAndUpdate` upsert with `$setOnInsert` that only provided `name`, `latitude`, and `longitude`. The `Site` schema enforces several additional required fields — `network`, `lat_long`, `generated_name`, `approximate_latitude`, `approximate_longitude`, `approximate_distance_in_km`, and `bearing_in_radians` — causing Mongoose validation to silently reject the document creation. The resulting error was swallowed, leaving `siteMap` with no entry for the `coordsKey`, which caused Phase 4 to report "Failed to create or find site" with no actionable context about the underlying cause.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/utils/activity.util.js` (Phase 3 of `batchDeployWithCoordinates`)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Tested the batch deployment endpoint with a static deployment payload using device `airqo_g5491` and `site_name: "Nakasajja"`. Previously this returned `"Failed to create or find site"`; after the fix the site is created successfully and the deployment completes. Also verified that re-sending the same payload correctly reuses the existing site without attempting a duplicate insert.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

Three specific issues were resolved in Phase 3:

1. **Missing required fields on insert** — The old `$setOnInsert` upsert omitted `network`, `lat_long`, `generated_name`, and all `approximate_*` fields required by the `Site` schema. The new logic computes these using `distance.createApproximateCoordinates` and constructs `lat_long` / `generated_name` before calling `SiteModel.create`.

2. **Silent error swallowing** — The original code returned `{ coordsKey, error }` from failed site promises but never checked those results before Phase 4 ran. The fix now iterates `siteResults` after `Promise.all`, moves all devices that depended on a failed site into `failed_deployments` with the actual error message, and removes them from `deviceNameToDeployment` before Phase 4 begins.

3. **Race condition handling** — A duplicate-key error (`code 11000`) during concurrent batch requests is caught and handled by re-fetching the already-created site, preventing unnecessary failures under load.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review