### PR TITLE
Fix null lat_long site creation failure in batch deployment

### DIFF
--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -1708,7 +1708,11 @@ const createActivity = {
           // failed_deployments
           for (const [deviceName, deployment] of deviceNameToDeployment) {
             if (deployment.actualDeploymentType === "static") {
-              const coordsKey = `${deployment.latitude},${deployment.longitude}`;
+              // Parse to Numbers before stringifying so this key matches
+              // the Phase 3 siteMap keys which use parsedLat/parsedLng
+              const parsedLat = Number(deployment.latitude);
+              const parsedLng = Number(deployment.longitude);
+              const coordsKey = `${parsedLat},${parsedLng}`;
               if (coordsKey === result.coordsKey) {
                 failed_deployments.push({
                   deviceName,
@@ -1770,7 +1774,9 @@ const createActivity = {
 
         try {
           if (actualDeploymentType === "static") {
-            const coordsKey = `${latitude},${longitude}`;
+            // Parse to Numbers before stringifying so this key matches
+            // the Phase 3 siteMap keys which use parsedLat/parsedLng
+            const coordsKey = `${Number(latitude)},${Number(longitude)}`;
             const site_id = siteMap.get(coordsKey);
 
             if (!site_id) {

--- a/src/device-registry/validators/activities.validators.js
+++ b/src/device-registry/validators/activities.validators.js
@@ -1066,11 +1066,13 @@ const activitiesValidations = {
     body("*.latitude")
       .optional()
       .isFloat()
-      .withMessage("latitude must be a float if provided"),
+      .withMessage("latitude must be a float if provided")
+      .toFloat(),
     body("*.longitude")
       .optional()
       .isFloat()
-      .withMessage("longitude must be a float if provided"),
+      .withMessage("longitude must be a float if provided")
+      .toFloat(),
     body("*.site_name")
       .optional()
       .trim(),


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds an explicit null/NaN coordinate guard in Phase 3 of `batchDeployWithCoordinates` to reject static deployments with invalid coordinates before they reach the database. Also introduces a cross-field conditional validator in `batchDeployActivity` that enforces static/mobile deployment requirements at the request validation layer, and adds a `validateBatchDeploymentItems` function that holistically validates each item in the batch array.

### Why is this change needed?
A production error was observed where site creation was failing with an E11000 duplicate key error on the `lat_long_1` index with `{ lat_long: null }`. This was caused by the batch validator marking `latitude` and `longitude` as optional without enforcing the conditional requirement that static deployments must provide both. When coordinates were missing or invalid, `lat_long` was being constructed as `"null_null"`, which succeeded on the first insert and then caused every subsequent insert to fail with a confusing duplicate key error rather than a clear validation message.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/utils/activity.util.js`
- `device-registry` — `src/device-registry/validators/activities.validators.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually tested batch deployment with a static payload that previously triggered the `{ lat_long: null }` production error. With the fix applied, the invalid coordinate case is now rejected at the validator layer with a descriptive error message, and valid payloads continue to deploy successfully. Also confirmed that existing site reuse (where `wasExisting = true`) and race-condition handling (11000 duplicate key re-fetch) continue to work correctly.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- The null/NaN guard in `activity.util.js` Phase 3 and the `validateBatchDeploymentItems` validator are complementary defences — the validator rejects bad requests early at the HTTP layer, while the util guard ensures that anything which slips through (e.g. via direct API calls bypassing the router) is still caught before touching the database.
- The `generated_name` for newly created sites now uses the same counter-based `createSiteUtil.generateName()` approach as the rest of the codebase (`site_1`, `site_2`, etc.), replacing the previous coordinate-derived string. Counter increments are done sequentially in Phase A before parallel site creation in Phase B to prevent race conditions on the shared counter document.
- The `description` field on newly created sites is set to `generated_name` to satisfy the unique schema constraint without exposing raw coordinate data.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Static deployments with invalid or non-finite coordinates are now rejected and marked as failed instead of creating invalid entries.
  * Prevented creation of ghost sites and duplicate coordinate keys from malformed coordinate data.

* **New Features**
  * Batch-level validation enforces deployment-type rules (static: numeric coordinates and site name; mobile: grid ID) with per-item error reporting.
  * Improved per-item error messages and added "vehicle" as a supported mount type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->