### PR TITLE
Fix client activation request email subjects and admin notification routing

### DIFF
--- a/src/auth-service/utils/client.util.js
+++ b/src/auth-service/utils/client.util.js
@@ -200,10 +200,12 @@ const client = {
               : userDetails.firstName || userDetails.lastName;
 
         const email = userDetails.email;
+        const clientName = responseFromUpdateClient.data.name || "";
         const responseFromSendEmail = await mailer.afterClientActivation(
           {
             name,
             client_id,
+            clientName,
             email,
             action: isActive ? "activate" : "deactivate",
           },
@@ -257,6 +259,7 @@ const client = {
       logObject("clientDetailsResponse", clientDetailsResponse);
       const { firstName, lastName, email } = clientDetailsResponse.data[0].user;
       const name = firstName || lastName || "";
+      const clientName = clientDetailsResponse.data[0].name || "";
 
       // Send confirmation email to the user
       const responseFromSendEmail = await mailer.clientActivationRequest(
@@ -265,6 +268,7 @@ const client = {
           email,
           tenant,
           client_id,
+          clientName,
         },
         next,
       );
@@ -283,6 +287,7 @@ const client = {
               email: constants.SUPPORT_EMAIL || null,
               tenant,
               client_id,
+              clientName,
             },
             next,
           )

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -200,16 +200,23 @@ module.exports = {
     }
     return constants.EMAIL_BODY({ email, content, fullName });
   },
-  clientActivationRequest: ({ name = "", email, client_id = "" } = {}) => {
-    const content = ` <tr>
-    <td
-        style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-        <p>Your request to activate your Client ID <strong>${client_id}</strong> has been received, we shall get back to you as soon as possible.</p>
-        <p>Before utilising the AirQo API, your Client ID <strong>${client_id}</strong> has to undergo the process of approval by AirQo administration.</p>
-        <p>Once your request is approved, you will receive a confirmation email</p>
+  clientActivationRequest: ({
+    name = "",
+    email,
+    client_id = "",
+    clientName = "",
+  } = {}) => {
+    const clientLabel = clientName
+      ? `<strong>${clientName}</strong> (ID: <strong>${client_id}</strong>)`
+      : `<strong>${client_id}</strong>`;
+    const content = `<tr>
+    <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>Your request to activate your API client ${clientLabel} has been received, we shall get back to you as soon as possible.</p>
+        <p>Before utilising the AirQo API, your client ${clientLabel} has to undergo the process of approval by AirQo administration.</p>
+        <p>Once your request is approved, you will receive a confirmation email.</p>
         <p>Please visit our website to learn more about us. <a href="https://airqo.net/">AirQo</a></p>
     </td>
-</tr>`;
+  </tr>`;
     return constants.EMAIL_BODY({ email, content, name });
   },
   yearEndSummary: ({
@@ -292,17 +299,24 @@ module.exports = {
 
     return constants.EMAIL_BODY({ email, content, name: username });
   },
-  afterClientActivation: ({ name = "", email, client_id = "" } = {}) => {
+  afterClientActivation: ({
+    name = "",
+    email,
+    client_id = "",
+    clientName = "",
+  } = {}) => {
+    const clientLabel = clientName
+      ? `${clientName} (ID: <strong>${client_id}</strong>)`
+      : `<strong>${client_id}</strong>`;
     const content = `<tr>
-                          <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-                              <p>Congratulations! Your Client ID <strong>${client_id}</strong> has been successfully activated.</p>
-                              <p>If you have any questions or need assistance with anything, please don't hesitate to reach out to our customer support
-                              team. We are here to help. </p>
-                              <p>Thank you for choosing AirQo Analytics, and we look forward to helping you achieve your goals.</p
-                              <p>Sincerely,</p>
-                              <p>The AirQo Data Team </p>
-                          </td>
-                      </tr>`;
+    <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>Congratulations! Your API client ${clientLabel} has been successfully activated.</p>
+        <p>If you have any questions or need assistance, please don't hesitate to reach out to our customer support team. We are here to help.</p>
+        <p>Thank you for choosing AirQo Analytics, and we look forward to helping you achieve your goals.</p>
+        <p>Sincerely,</p>
+        <p>The AirQo Data Team</p>
+    </td>
+  </tr>`;
     return constants.EMAIL_BODY({ email, content, name });
   },
   afterClientDeactivation: ({ name = "", email, client_id = "" } = {}) => {
@@ -1287,27 +1301,30 @@ module.exports = {
   },
   clientActivationRequestAdmin: ({
     client_id = "",
+    clientName = "",
     name = "",
     email: userEmail = "",
   } = {}) => {
+    const clientLabel = clientName
+      ? `<strong>${clientName}</strong> (ID: <strong>${client_id}</strong>)`
+      : `ID: <strong>${client_id}</strong>`;
     const content = `<tr>
     <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
         <p>A new AirQo API Client Activation Request has been submitted.</p>
-        <p><strong>Client ID:</strong> ${client_id}</p>
+        <p>Client: ${clientLabel}</p>
         <p><strong>Requested by:</strong> ${name} (${userEmail})</p>
         <p>Please review and take action on this request via the admin clients management page:</p>
         <div style="text-align: center; margin: 24px 0;">
-            <a href="https://analytics.airqo.net/system/clients"
+            <a href="${constants.ANALYTICS_BASE_URL}/system/clients"
                style="display: inline-block; padding: 12px 24px; background-color: #135DFF; color: white; text-decoration: none; border-radius: 6px; font-weight: 600;">
                 Manage API Clients
             </a>
         </div>
         <p style="font-size: 14px; color: #6c757d;">
-            Direct link: <a href="https://analytics.airqo.net/system/clients">https://analytics.airqo.net/system/clients</a>
+            Direct link: <a href="${constants.ANALYTICS_BASE_URL}/system/clients">${constants.ANALYTICS_BASE_URL}/system/clients</a>
         </p>
     </td>
   </tr>`;
-    // Use a placeholder email; the actual recipient is set via BCC in the mailer
     return constants.EMAIL_BODY({ email: userEmail, content, name: "Admin" });
   },
 };

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -1256,6 +1256,7 @@ const mailer = {
         name: params.name,
         email: params.email,
         client_id: params.client_id,
+        clientName: params.clientName,
       }),
   ),
   user: createMailerFunction("user", "USER_MANAGEMENT", (params) => {
@@ -1360,11 +1361,13 @@ const mailer = {
             name: params.name,
             email: params.email,
             client_id: params.client_id,
+            clientName: params.clientName,
           })
         : msgs.afterClientDeactivation({
             name: params.name,
             email: params.email,
             client_id: params.client_id,
+            clientName: params.clientName,
           });
     },
   ),
@@ -2222,6 +2225,7 @@ const mailer = {
     (params) =>
       msgs.clientActivationRequestAdmin({
         client_id: params.client_id,
+        clientName: params.clientName,
         name: params.name,
         email: params.userEmail,
       }),


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Updates the AirQo API client activation request email flow to send two distinct emails: a user confirmation email and a separate admin notification email. Fixes the admin email subject to be action-oriented, and resolves a bug where the admin notification `to` field incorrectly fell back to the requesting user's email when `SUPPORT_EMAIL` was not configured.

### Why is this change needed?
Previously, admins received the same email as the requesting user, with identical subject line and content, making it hard to distinguish and act on. The fallback to the user's email in the `to` field when `SUPPORT_EMAIL` was missing was also confusing and a potential privacy concern. Admins now receive a clearly labelled, action-oriented email with a direct link to the clients management page (`https://analytics.airqo.net/system/clients`), and the `to` field is handled safely with a guard that skips sending entirely if no admin recipients are configured.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually tested the full activation request flow via `GET /api/v2/clients/activate-request/:client_id`. Verified that two separate emails are queued — the user receives a confirmation email with subject `"AirQo API Client Activation Request"`, and admins (via `REQUEST_ACCESS_EMAILS` BCC) receive a distinct email with subject `"Action Required: Review AirQo API Client Activation Request"` containing a direct link to `https://analytics.airqo.net/system/clients`. Also verified that when `SUPPORT_EMAIL` and `REQUEST_ACCESS_EMAILS` are both absent, the admin email is skipped and a warning is logged rather than sending to the wrong recipient.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The admin email `to` field uses `SUPPORT_EMAIL` if available; if neither `SUPPORT_EMAIL` nor `REQUEST_ACCESS_EMAILS` is configured, the notification is skipped entirely and a warning is logged — no silent misdirected emails.
- The `clientActivationRequestAdmin` mailer function was added alongside the existing `clientActivationRequest` function; the user-facing flow is unchanged.
- Admin recipients are determined by the `REQUEST_ACCESS_EMAILS` environment variable (BCC), consistent with how other admin notification emails (e.g. `existingUserAccessRequest`) are handled across the service.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sends automated admin notifications for API client activation requests, including client name/ID and requester details, with direct management links.

* **Improvements**
  * Includes client name in activation emails and confirmations for clearer context.
  * Email links updated to use system-level paths for consistency.

* **Chores**
  * Adjusted mailer routing and subject mappings; admin-notification delivery is non-blocking and logs failures without interrupting user flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->