### PR TITLE
Fix: Add guard to GroupSchema pre-update hook for middleware safety

### DIFF
--- a/src/auth-service/models/Group.js
+++ b/src/auth-service/models/Group.js
@@ -145,15 +145,31 @@ GroupSchema.pre(
       // This check ensures the following logic only runs for query middleware (e.g., findOneAndUpdate)
       // and skips document middleware (e.g., save), where `this.getQuery` is not a function.
       if (typeof this.getQuery === "function") {
-        // Prevent renaming of the default 'airqo' group at the schema level
+        // Query middleware (e.g., findOneAndUpdate, updateMany)
         if (actualUpdates.grp_title) {
           const query = this.getQuery();
-          const docToUpdate = await this.model.findOne(query).lean();
-          if (
-            docToUpdate &&
-            docToUpdate.grp_title &&
-            docToUpdate.grp_title.toLowerCase() === "airqo"
-          ) {
+          // For multi-document operations (e.g., updateMany), ensure that no
+          // document matching the query is the default 'airqo' group.
+          const airqoFilter = {
+            ...query,
+            grp_title: /^airqo$/i,
+          };
+          const airqoExists = await this.model.exists(airqoFilter);
+          if (airqoExists) {
+            return next(
+              new HttpError("Forbidden", httpStatus.FORBIDDEN, {
+                message: "The default 'airqo' group cannot be renamed.",
+              }),
+            );
+          }
+        }
+      } else {
+        // Document middleware (e.g., doc.save())
+        if (!this.isNew && this.isModified("grp_title")) {
+          const originalDoc = await this.constructor
+            .findOne({ _id: this._id })
+            .lean();
+          if (originalDoc && originalDoc.grp_title.toLowerCase() === "airqo") {
             return next(
               new HttpError("Forbidden", httpStatus.FORBIDDEN, {
                 message: "The default 'airqo' group cannot be renamed.",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This pull request adds a safeguard to the `pre-update` hook in the `GroupSchema` (`src/auth-service/models/Group.js`). It ensures that the logic to prevent renaming the default "airqo" group only runs for query-based middleware (like `findOneAndUpdate`) and is safely skipped for document-based middleware (like `save`).

### Why is this change needed?
The previous implementation of the schema-level protection for the "airqo" group's name used `this.getQuery()` without checking the middleware context. This would cause a `TypeError` during document middleware operations (e.g., a `.save()` call) where `this` refers to the document and does not have a `getQuery()` method. This change wraps the logic in an `if (typeof this.getQuery === "function")` block, making the hook robust and preventing potential crashes during document save operations.

---

## :link: Related Issues
- [ ] Closes #
- [x] Fixes # (a potential runtime error in the Group model's pre-update hook)
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Manually tested that updating a group's name via an API endpoint that triggers `findOneAndUpdate` still correctly prevents the "airqo" group from being renamed.
- Verified that creating a new group (which triggers a `save` operation) does not crash the application and completes successfully.
- Confirmed that other update operations on the Group model that do not modify the `grp_title` are unaffected.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
This change also includes moving the `actualUpdates` variable declaration to a higher scope within the hook to ensure it's accessible by subsequent validation logic for `grp_sites` and `grp_profile_picture`, which was a potential `ReferenceError`.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened update behavior for groups so the default "airqo" group can no longer be renamed across all update paths, ensuring consistent protection. Existing checks for duplicate site entries and profile-picture validation remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->