### PR TITLE
fix: Add deduplication and fix variable scoping in admin alert emails

### DIFF
--- a/src/auth-service/utils/common/email-deduplication.util.js
+++ b/src/auth-service/utils/common/email-deduplication.util.js
@@ -56,9 +56,9 @@ class EmailDeduplicator {
    *
    * @returns {Promise<boolean>} true = send the email, false = duplicate, skip it
    */
-  async checkAndMarkEmail(emailData) {
+  async checkAndMarkEmail(emailData, { overrideKey } = {}) {
     try {
-      const key = this.generateEmailKey(emailData);
+      const key = overrideKey || this.generateEmailKey(emailData);
       const SentEmailLog = SentEmailLogModel("airqo");
 
       // Atomic insert: succeeds only if `hash` is unique.
@@ -91,9 +91,9 @@ class EmailDeduplicator {
    * Remove a deduplication key — useful for testing or manual overrides.
    * @returns {Promise<boolean>}
    */
-  async removeEmailKey(emailData) {
+  async removeEmailKey(emailData, { overrideKey } = {}) {
     try {
-      const key = this.generateEmailKey(emailData);
+      const key = overrideKey || this.generateEmailKey(emailData);
       const SentEmailLog = SentEmailLogModel("airqo");
       const result = await SentEmailLog.deleteOne({ hash: key });
       return result.deletedCount > 0;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds DB-backed deduplication to `createAdminAlertFunction` in `mailer.util.js` by integrating `emailDeduplicator.checkAndMarkEmail()` before the email queue insertion. Also rolls back the daily rate limit counter when a duplicate is detected to keep the count accurate, and fixes a variable scoping bug where `tenant` and `recipients` were declared outside the `try` block then shadowed by inner `const`/`let` destructuring.

### Why is this change needed?

`sendBotAlert` emails (e.g. "Security Alert: Automated Bot Activity Detected") were being sent as duplicates because `createAdminAlertFunction` called `addToEmailQueue` directly without any short-term deduplication check. When multiple Kubernetes pods detected the same bot pattern simultaneously, each pod independently queued and sent the same alert email. The daily rate limiter (`maxAlertsPerDay`) only caps the total count per day — it does not prevent near-simultaneous duplicate sends within the same minute. The variable scoping bug also meant `tenant` and `recipients` resolved to their outer empty defaults rather than the values from `params`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`
  - `src/auth-service/utils/common/mailer.util.js` — `createAdminAlertFunction`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Triggered bot pattern detection twice in quick succession from two simulated pods and confirmed only one alert email was queued.
- Verified the daily rate limit counter remains accurate after a duplicate is blocked (counter is rolled back correctly).
- Confirmed that a DB error during the dedup check does not suppress the alert — fail-open behavior verified.
- Confirmed `tenant` and `recipients` resolve correctly from `params` after the scoping fix.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`createAdminAlertFunction` behaviour is unchanged for non-duplicate calls. The only observable difference is that identical bot alerts fired within the 5-minute deduplication window are now collapsed to a single email instead of being sent once per pod.

---

## :memo: Additional Notes

- The deduplication window for bot alerts is 5 minutes, inherited from the `SentEmailLog` TTL index introduced in the `db-email-dedup` branch. If the same bot IP triggers another detection cycle after 5 minutes, a new alert will be sent normally.
- The counter rollback on duplicate is a best-effort operation — if the rollback itself fails, it is logged as a warning and the flow continues. A small counter inaccuracy in this edge case is acceptable and preferable to blocking the main path.
- `createAdminAlertFunction` is currently only used by `sendBotAlert`. Any future admin alert functions created with this factory will automatically inherit the deduplication and scoping fix.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized admin alert flow to normalize recipients, perform deduplication and cooldown checks earlier, and adjust step sequencing.
  * Improved rate-limit handling with explicit increment/rollback semantics and clearer logging; no changes to public API signatures.

* **Bug Fixes**
  * Prevent duplicate admin alert emails by checking/storing deduplication keys before queueing; duplicates return a handled success response.
  * Treat rate-limit failures as fail-open and ensure counters are rolled back when duplicates or short-circuits occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->