### PR TITLE
Use stateless token for now

### DIFF
--- a/src/analytics/api/tests/test_cursor_utils.py
+++ b/src/analytics/api/tests/test_cursor_utils.py
@@ -2,8 +2,10 @@ import pytest
 from unittest.mock import patch, MagicMock
 import uuid
 import json
+import base64
+import time
 
-from api.utils.cursor_utils import CursorUtils
+from api.utils.cursor_utils import CursorUtils, RedisCursorUtils, StatelessCursorUtils
 
 
 @pytest.fixture
@@ -40,8 +42,8 @@ def parsed_cursor_string_with_site_id():
     }
 
 
-class TestCursorUtils:
-    """Tests for the CursorUtils class."""
+class TestRedisCursorUtils:
+    """Tests for the RedisCursorUtils class."""
 
     @patch("api.utils.cursor_utils.uuid")
     def test_create_cursor_minimal(self, mock_uuid):
@@ -52,13 +54,13 @@ class TestCursorUtils:
         with patch("api.utils.cursor_utils.cache") as mock_cache:
             mock_cache.set = MagicMock(return_value=True)
 
-            cursor = CursorUtils.create_cursor("2025-01-01 00:00:00Z", "device1")
+            cursor = RedisCursorUtils.create_cursor("2025-01-01 00:00:00Z", "device1")
 
             assert cursor == "00000000-0000-0000-0000-000000000000"
             mock_cache.set.assert_called_once_with(
                 "api:cursor:00000000-0000-0000-0000-000000000000",
                 "2025-01-01 00:00:00Z|device1",
-                timeout=CursorUtils.CURSOR_EXPIRATION,
+                timeout=RedisCursorUtils.CURSOR_EXPIRATION,
             )
 
     @patch("api.utils.cursor_utils.uuid")
@@ -70,7 +72,7 @@ class TestCursorUtils:
         with patch("api.utils.cursor_utils.cache") as mock_cache:
             mock_cache.set = MagicMock(return_value=True)
 
-            cursor = CursorUtils.create_cursor(
+            cursor = RedisCursorUtils.create_cursor(
                 "2025-01-01 00:00:00Z", "site1", "device1"
             )
 
@@ -78,7 +80,7 @@ class TestCursorUtils:
             mock_cache.set.assert_called_once_with(
                 "api:cursor:00000000-0000-0000-0000-000000000000",
                 "2025-01-01 00:00:00Z|site1|device1",
-                timeout=CursorUtils.CURSOR_EXPIRATION,
+                timeout=RedisCursorUtils.CURSOR_EXPIRATION,
             )
 
     def test_decode_cursor_basic(self, cursor_token, basic_cursor_string):
@@ -86,20 +88,20 @@ class TestCursorUtils:
         with patch("api.utils.cursor_utils.cache") as mock_cache:
             mock_cache.get = MagicMock(return_value=basic_cursor_string)
 
-            decoded = CursorUtils.retrieve_cursor(cursor_token)
+            decoded = RedisCursorUtils.retrieve_cursor(cursor_token)
             assert decoded == basic_cursor_string
 
     def test_decode_cursor_invalid(self):
         """Test decoding an invalid cursor."""
         with pytest.raises(ValueError):
-            CursorUtils.retrieve_cursor("invalid-cursor")
+            RedisCursorUtils.retrieve_cursor("invalid-cursor")
 
     def test_validate_cursor_valid(self):
         """Test validating a valid cursor."""
         with patch("api.utils.cursor_utils.cache") as mock_cache:
             mock_cache.get = MagicMock(return_value=True)
 
-            result = CursorUtils.validate_cursor("valid-cursor")
+            result = RedisCursorUtils.validate_cursor("valid-cursor")
 
             assert result is True
             mock_cache.get.assert_called_once_with("api:cursor:valid-cursor")
@@ -109,7 +111,7 @@ class TestCursorUtils:
         with patch("api.utils.cursor_utils.cache") as mock_cache:
             mock_cache.get = MagicMock(return_value=None)
 
-            result = CursorUtils.validate_cursor("invalid-cursor")
+            result = RedisCursorUtils.validate_cursor("invalid-cursor")
 
             assert result is False
             mock_cache.get.assert_called_once_with("api:cursor:invalid-cursor")
@@ -121,7 +123,7 @@ class TestCursorUtils:
         with patch("api.utils.cursor_utils.cache") as mock_cache:
             mock_cache.get = MagicMock(return_value=basic_cursor_string)
 
-            parsed = CursorUtils.parse_cursor(cursor_token)
+            parsed = RedisCursorUtils.parse_cursor(cursor_token)
 
             assert parsed == parsed_basic_cursor_string
             mock_cache.get.assert_called_once()
@@ -136,7 +138,7 @@ class TestCursorUtils:
         with patch("api.utils.cursor_utils.cache") as mock_cache:
             mock_cache.get = MagicMock(return_value=cursor_string_with_site_id)
 
-            parsed = CursorUtils.parse_cursor(cursor_token)
+            parsed = RedisCursorUtils.parse_cursor(cursor_token)
 
             assert parsed == parsed_cursor_string_with_site_id
             mock_cache.get.assert_called_once()
@@ -147,7 +149,7 @@ class TestCursorUtils:
             mock_cache.get = MagicMock(return_value=None)
 
             with pytest.raises(ValueError) as excinfo:
-                CursorUtils.parse_cursor("invalid-cursor")
+                RedisCursorUtils.parse_cursor("invalid-cursor")
 
             assert "Invalid or expired cursor" in str(excinfo.value)
             mock_cache.get.assert_called_once()
@@ -159,10 +161,74 @@ class TestCursorUtils:
             mock_cache.get = MagicMock(side_effect=Exception("Redis connection error"))
 
             with pytest.raises(Exception, match="Redis connection error"):
-                CursorUtils.create_cursor("2025-01-01 00:00:00Z", "device1")
+                RedisCursorUtils.create_cursor("2025-01-01 00:00:00Z", "device1")
 
             with pytest.raises(Exception, match="Redis connection error"):
-                CursorUtils.parse_cursor("some-token")
+                RedisCursorUtils.parse_cursor("some-token")
 
             mock_cache.set.assert_called_once()
             mock_cache.get.assert_called_once()
+
+
+class TestStatelessCursorUtils:
+    """Tests for the StatelessCursorUtils class."""
+
+    def test_create_cursor_minimal(self):
+        """Test creating a stateless cursor with minimal parameters."""
+        cursor = StatelessCursorUtils.create_cursor("2025-01-01 00:00:00Z", "device1")
+
+        # Result should be a base64 string
+        assert isinstance(cursor, str)
+        assert len(cursor) > 0
+
+        # Decoding should return the original data and a future timestamp
+        decoded = StatelessCursorUtils.retrieve_cursor(cursor)
+        assert decoded == "2025-01-01 00:00:00Z|device1"
+
+    def test_create_cursor_with_site_id(self):
+        """Test creating a stateless cursor with site_id."""
+        cursor = StatelessCursorUtils.create_cursor(
+            "2025-01-01 00:00:00Z", "site1", "device1"
+        )
+
+        decoded = StatelessCursorUtils.retrieve_cursor(cursor)
+        assert decoded == "2025-01-01 00:00:00Z|site1|device1"
+
+    def test_validate_cursor_valid(self):
+        """Test validating a valid stateless cursor."""
+        token = StatelessCursorUtils.create_cursor("2025-01-01 00:00:00Z", "device1")
+        assert StatelessCursorUtils.validate_cursor(token) is True
+
+    def test_validate_cursor_expired(self):
+        """Test validating an expired stateless cursor."""
+        # Create a payload with an expired timestamp
+        expired_time = int(time.time()) - 100
+        payload = f"2025-01-01 00:00:00Z|device1|{expired_time}"
+        expired_token = (
+            base64.urlsafe_b64encode(payload.encode()).decode("utf-8").rstrip("=")
+        )
+
+        assert StatelessCursorUtils.validate_cursor(expired_token) is False
+        with pytest.raises(ValueError, match="expired"):
+            StatelessCursorUtils.retrieve_cursor(expired_token)
+
+    def test_parse_cursor_valid(self):
+        """Test parsing a stateless cursor."""
+        token = StatelessCursorUtils.create_cursor(
+            "2025-01-01 00:00:00Z", "site1", "device1"
+        )
+        parsed = StatelessCursorUtils.parse_cursor(token)
+
+        assert parsed == {
+            "timestamp": "2025-01-01 00:00:00Z",
+            "filter_value": "site1",
+            "device_id": "device1",
+        }
+
+    def test_retrieve_cursor_invalid_format(self):
+        """Test retrieving a cursor with invalid format."""
+        # Token not containing '|'
+        invalid_token = base64.urlsafe_b64encode(b"invalid_data").decode("utf-8")
+
+        with pytest.raises(ValueError, match="Invalid cursor format"):
+            StatelessCursorUtils.retrieve_cursor(invalid_token)

--- a/src/analytics/api/utils/cursor_utils.py
+++ b/src/analytics/api/utils/cursor_utils.py
@@ -1,4 +1,6 @@
 import uuid
+import base64
+import time
 from typing import Optional, Tuple, Dict, Any
 from main import cache
 import redis
@@ -12,9 +14,9 @@ except ImportError:
     RedisConnectionError = ConnectionError
 
 
-class CursorUtils:
+class RedisCursorUtils:
     """
-    Utility class for handling pagination cursors in the API.
+    Utility class for handling pagination cursors in the API using Redis.
     Provides methods for encoding, decoding, and extracting information from cursors.
     """
 
@@ -29,7 +31,7 @@ class CursorUtils:
         Helper method to set cache expiration if supported by the cache backend.
         """
         if hasattr(cache, "expire"):
-            cache.expire(cursor_key, CursorUtils.CURSOR_EXPIRATION)
+            cache.expire(cursor_key, RedisCursorUtils.CURSOR_EXPIRATION)
 
     @staticmethod
     def encode_cursor(cursor_str: str) -> str:
@@ -44,13 +46,15 @@ class CursorUtils:
         """
         cursor_token = str(uuid.uuid4())
 
-        cursor_key = f"{CursorUtils.CURSOR_KEY_PREFIX}{cursor_token}"
+        cursor_key = f"{RedisCursorUtils.CURSOR_KEY_PREFIX}{cursor_token}"
         try:
-            cache.set(cursor_key, cursor_str, timeout=CursorUtils.CURSOR_EXPIRATION)
+            cache.set(
+                cursor_key, cursor_str, timeout=RedisCursorUtils.CURSOR_EXPIRATION
+            )
         except TypeError:
             # Fallback if 'timeout' is not supported
             cache.set(cursor_key, cursor_str)
-            CursorUtils._set_cache_expiration(cursor_key)
+            RedisCursorUtils._set_cache_expiration(cursor_key)
         except RedisConnectionError:
             logger.exception("Failed to store cursor in Redis")
             # TODO: Figure out how to handle Redis connection errors | may be retry
@@ -75,7 +79,7 @@ class CursorUtils:
         Raises:
             ValueError: If the token is invalid, doesn't exist in cache, or has already expired
         """
-        cursor_key = f"{CursorUtils.CURSOR_KEY_PREFIX}{token}"
+        cursor_key = f"{RedisCursorUtils.CURSOR_KEY_PREFIX}{token}"
         cursor_str: Optional[str] = None
         try:
             # Attempt to get the cursor string from cache
@@ -90,10 +94,12 @@ class CursorUtils:
 
         # Reset the expiration time when the cursor is accessed
         try:
-            cache.set(cursor_key, cursor_str, timeout=CursorUtils.CURSOR_EXPIRATION)
+            cache.set(
+                cursor_key, cursor_str, timeout=RedisCursorUtils.CURSOR_EXPIRATION
+            )
         except TypeError:
             cache.set(cursor_key, cursor_str)
-            CursorUtils._set_cache_expiration(cursor_key)
+            RedisCursorUtils._set_cache_expiration(cursor_key)
         except RedisConnectionError:
             logger.exception("Failed to refresh cursor expiration in Redis")
 
@@ -116,7 +122,7 @@ class CursorUtils:
         Raises:
             ValueError: If the cursor format is invalid or token is expired
         """
-        cursor_str: Optional[str] = CursorUtils.retrieve_cursor(token)
+        cursor_str: Optional[str] = RedisCursorUtils.retrieve_cursor(token)
         if not cursor_str:
             raise ValueError("Invalid or expired cursor token")
 
@@ -152,7 +158,7 @@ class CursorUtils:
         if device_id:
             cursor += f"|{device_id}"
 
-        return CursorUtils.encode_cursor(cursor)
+        return RedisCursorUtils.encode_cursor(cursor)
 
     @staticmethod
     def validate_cursor(token: str) -> bool:
@@ -165,10 +171,158 @@ class CursorUtils:
         Returns:
             bool: True if the cursor is valid, False otherwise
         """
-        cursor_key = f"{CursorUtils.CURSOR_KEY_PREFIX}{token}"
+        cursor_key = f"{RedisCursorUtils.CURSOR_KEY_PREFIX}{token}"
 
         try:
             return cache.get(cursor_key) is not None
         except RedisConnectionError:
             logger.exception("Failed to validate cursor in Redis")
             return False
+
+
+class StatelessCursorUtils:
+    """
+    Utility class for handling pagination cursors in the API using stateless tokens.
+    Provides methods for encoding, decoding, and extracting information from cursors.
+
+    Note: This implementation uses stateless base64 encoded tokens with embedded
+    expiration to ensure consistency across multiple API replicas.
+    """
+
+    # Cursor expiration time in seconds (0.1 hours)
+    CURSOR_EXPIRATION = int(0.1 * 60 * 60)
+
+    @staticmethod
+    def encode_cursor(cursor_str: str) -> str:
+        """
+        Encodes a cursor string into a stateless token with an embedded expiration.
+
+        Args:
+            cursor_str(str): The raw cursor string to store
+
+        Returns:
+            str: Stateless cursor token for API response
+        """
+        try:
+            # Embed expiration timestamp in the token
+            expiration = int(time.time()) + StatelessCursorUtils.CURSOR_EXPIRATION
+            payload = f"{cursor_str}|{expiration}"
+            # Use URL-safe base64 encoding
+            return (
+                base64.urlsafe_b64encode(payload.encode()).decode("utf-8").rstrip("=")
+            )
+        except Exception as e:
+            logger.error(f"Failed to encode cursor: {e}")
+            # Fallback to a random uuid if encoding fails
+            return str(uuid.uuid4())
+
+    @staticmethod
+    def retrieve_cursor(token: str) -> str:
+        """
+        Decodes a stateless cursor token and validates its expiration.
+
+        Args:
+            token(str): The cursor token received from a previous API response
+
+        Returns:
+            str: The retrieved cursor string containing pagination metadata
+
+        Raises:
+            ValueError: If the token is invalid or has expired
+        """
+        try:
+            # Add back padding if it was stripped
+            padding = len(token) % 4
+            if padding:
+                token += "=" * (4 - padding)
+
+            decoded = base64.urlsafe_b64decode(token.encode()).decode("utf-8")
+            parts = decoded.rsplit("|", 1)
+
+            if len(parts) != 2:
+                raise ValueError("Invalid cursor format")
+
+            cursor_raw, expiration_str = parts[0], parts[1]
+            if int(time.time()) > int(expiration_str):
+                raise ValueError("Cursor has expired")
+
+            return cursor_raw
+        except ValueError as e:
+            raise e
+        except Exception as e:
+            logger.debug(f"Cursor retrieval failed: {e}")
+            raise ValueError("Invalid or expired cursor token")
+
+    @staticmethod
+    def parse_cursor(token: str) -> Dict[str, Any]:
+        """
+        Retrieves a cursor and parses it into its component parts.
+
+        Args:
+            token (str): The cursor token from the API
+
+        Returns:
+            Dict: Dictionary with extracted values from the cursor
+                - timestamp: The timestamp value
+                - filter_value: The filter value (e.g., site_id or device_id)
+                - device_id: The device_id if present (for site filtering)
+
+        Raises:
+            ValueError: If the cursor format is invalid or token is expired
+        """
+        cursor_str = StatelessCursorUtils.retrieve_cursor(token)
+
+        parts = cursor_str.split("|")
+        if len(parts) < 2:
+            raise ValueError(
+                "Invalid cursor format: expected at least timestamp and filter value"
+            )
+
+        result = {"timestamp": parts[0], "filter_value": parts[1]}
+
+        if len(parts) >= 3:
+            result["device_id"] = parts[2]
+
+        return result
+
+    @staticmethod
+    def create_cursor(
+        timestamp: str, filter_value: str, device_id: Optional[str] = None
+    ) -> str:
+        """
+        Creates a cursor string from its component parts and encodes it.
+
+        Args:
+            timestamp (str): The timestamp value
+            filter_value (str): The filter value (e.g., site_id or device_id)
+            device_id (str, optional): The device_id if needed (for site filtering)
+
+        Returns:
+            str: A token that can be used to retrieve the cursor
+        """
+        cursor = f"{timestamp}|{filter_value}"
+        if device_id:
+            cursor += f"|{device_id}"
+
+        return StatelessCursorUtils.encode_cursor(cursor)
+
+    @staticmethod
+    def validate_cursor(token: str) -> bool:
+        """
+        Validates if a cursor token is valid and not expired.
+
+        Args:
+            token (str): The cursor token to validate
+
+        Returns:
+            bool: True if the cursor is valid, False otherwise
+        """
+        try:
+            StatelessCursorUtils.retrieve_cursor(token)
+            return True
+        except ValueError:
+            return False
+
+
+# Default CursorUtils to use Stateless for production consistency
+CursorUtils = StatelessCursorUtils


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
Introduce stateless cursor to fix temp issue of distributed cache.

### Why is this change needed?
To ensure continuity of paginated queries.

---
## 🔗 Related Issues
- [ ] OPS-454

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for pagination cursor handling, including stateless cursor validation and Redis failure scenarios.

* **Refactoring**
  * Enhanced cursor utility infrastructure to support multiple implementation strategies for improved pagination reliability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->