### PR TITLE
fix: remove runValidators from group upsert to fix Mongoose 5.x startup crash

### DIFF
--- a/src/auth-service/utils/role-permissions.util.js
+++ b/src/auth-service/utils/role-permissions.util.js
@@ -59,12 +59,14 @@ const getOrCreateAirqoGroup = async (tenant) => {
     new: true,
     upsert: true,
     // setDefaultsOnInsert: ensures schema-defined defaults (e.g. theme,
-    // grp_profile_picture) are applied when the document is first created,
-    // consistent with other upsert call sites in this codebase.
+    // grp_profile_picture) are applied when the document is first created.
     setDefaultsOnInsert: true,
-    // runValidators: ensures the upserted/updated document passes schema
-    // validation, catching constraint violations early rather than at query time.
-    runValidators: true,
+    // runValidators is intentionally omitted for Mongoose 5.x compatibility.
+    // In Mongoose 5, runValidators on a findOneAndUpdate upsert runs validators
+    // with `this` set to null, causing any validator that calls
+    // this.ownerDocument() to throw "Cannot read properties of null".
+    // Schema constraints are still enforced at the database index level
+    // (e.g. the unique index on grp_title).
   };
 
   const airqoGroup = await GroupModel(tenant)


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Removes `runValidators: true` from the `getOrCreateAirqoGroup` upsert options in `role-permissions.util.js`. The option was introduced in the previous refactor (`fix/env-agnostic-group`) based on a code review suggestion. `setDefaultsOnInsert: true` is retained as it works correctly and was the valid part of that suggestion.

### Why is this change needed?
After deploying `fix/env-agnostic-group` to staging, the auth-service failed to start with the following error on every boot:

```
Validation failed: grp_title: Cannot read properties of null (reading 'ownerDocument'),
_id: Cannot read properties of null (reading 'ownerDocument'),
organization_slug: Cannot read properties of null (reading 'ownerDocument')
```

This is a known Mongoose 5.x limitation. When `runValidators: true` is set on a `findOneAndUpdate` upsert, Mongoose 5 executes validators with `this` set to `null` — there is no document instance available in query middleware context. Any validator that internally calls `this.ownerDocument()` (which Mongoose 5 does for certain field validators) throws immediately. The three fields named in the error (`grp_title`, `_id`, `organization_slug`) are exactly the fields written by the upsert in `getOrCreateAirqoGroup`. Schema-level constraints (e.g. the unique index on `grp_title`) continue to be enforced at the database level without `runValidators`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`
  - `utils/role-permissions.util.js` — removed `runValidators: true` from `getOrCreateAirqoGroup` upsert options; added explanatory comment documenting the Mongoose 5.x incompatibility so the option is not re-introduced inadvertently

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Deploy to staging and confirm auth-service starts without RBAC initialization errors
- Confirm the default `airqo` group is correctly created or verified on a fresh environment
- Confirm the default `airqo` group is correctly verified on an existing environment without overwriting the description
- Confirm `setDefaultsOnInsert` still applies schema defaults (e.g. `theme`, `grp_profile_picture`) on first creation

---

## :boom: Breaking Changes

- [x] **No breaking changes**

Removing `runValidators` from a `findOneAndUpdate` upsert does not affect any API contracts or data integrity guarantees. The unique index on `grp_title` continues to enforce schema constraints at the database level. This change restores the behaviour that was working correctly before `fix/env-agnostic-group`.

---

## :memo: Additional Notes

- This issue was introduced by a code review suggestion to add `runValidators: true` for consistency with other upsert call sites. That suggestion is valid for Mongoose 6+, but the project runtime is **Mongoose 5.12.14** where this is a documented limitation. The comment added in this PR records this explicitly to prevent the same mistake in future reviews.
- `setDefaultsOnInsert: true` from the same suggestion is **retained** — it operates at insert time before validators run and works correctly in Mongoose 5.
- No other upsert call sites in this codebase were found to use `runValidators: true`, so this is an isolated issue.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated validation handling in the authentication service for improved Mongoose compatibility. Database-level constraints continue to ensure data integrity while relying on existing validation pathways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->