### PR TITLE
Consolidate update function and restrict profile update email notifications

### DIFF
--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -989,7 +989,13 @@ const createUserModule = {
             }
 
             if (Object.keys(userProperties).length > 0) {
-              analyticsService.identify(distinctId, userProperties);
+              // .catch() ensures an async rejection from the PostHog client
+              // does not become an unhandled promise rejection at runtime.
+              analyticsService
+                .identify(distinctId, userProperties)
+                .catch((err) =>
+                  logger.error(`PostHog identify error: ${err.message}`),
+                );
             }
           }
         }
@@ -1041,14 +1047,29 @@ const createUserModule = {
       }
 
       // ── 7. Send notification email ────────────────────────────────────────────
+      //
+      // Prefer updated name values from the payload so the email salutation
+      // reflects the new name when firstName/lastName are part of this update.
+      // Fall back to the pre-update values from `user` for unchanged fields.
+      const emailFirstName = Object.prototype.hasOwnProperty.call(
+        emailUpdatePayload,
+        "firstName",
+      )
+        ? emailUpdatePayload.firstName
+        : user.firstName;
 
-      const { email, firstName, lastName } = user;
+      const emailLastName = Object.prototype.hasOwnProperty.call(
+        emailUpdatePayload,
+        "lastName",
+      )
+        ? emailUpdatePayload.lastName
+        : user.lastName;
 
       const responseFromSendEmail = await mailer.update(
         {
-          email,
-          firstName,
-          lastName,
+          email: user.email,
+          firstName: emailFirstName,
+          lastName: emailLastName,
           updatedUserDetails: emailUpdatePayload,
         },
         next,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Consolidates two duplicate `update` functions in `user.util.js` into a single implementation and adds a conditional guard so that the "Your AirQo Account Updated" email notification is only sent when user-facing profile fields (`firstName`, `lastName`, or `profilePicture`) are part of the update payload.

### Why is this change needed?
The `update` function existed as an unintentional duplicate in `createUserModule`, creating a maintenance risk where fixes applied to one copy would silently miss the other. Additionally, the email notification was firing on every profile update regardless of what changed — including internal fields like `loginCount`, `interests`, and `jobTitle` — leading to unnecessary email noise for users.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `src/auth-service/utils/user.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verify that a profile update containing `firstName`, `lastName`, or `profilePicture` triggers the update email as before. Verify that updates to other fields (e.g. `jobTitle`, `interests`, `organization`) complete successfully with no email sent. Confirm password update flows (`updateForgottenPassword`, `updateKnownPassword`) are unaffected.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The function signature, all return shapes, and sanitization behaviour are unchanged. Callers are unaffected.

---

## :memo: Additional Notes

- The first of the two original `update` functions had a secondary bug where PostHog PII tracking fired even when the user had set DNT=1. The merged function fixes this by keeping the entire analytics block — including `analyticsService.identify()` — inside the `if (!dnt)` guard.
- To notify users on additional field changes in future, extend the `NOTIFIABLE_FIELDS` array in step 6 of the `update` function.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Privacy-aware analytics gated by consent with PII protections.
  * Notifiability checks so notifications are sent only for specific user-facing changes.
  * Update flow split into distinct persistence and response stages for clearer outcomes.

* **Bug Fixes**
  * Early-return behavior to avoid unnecessary processing.
  * Consistent error responses for update and email failures.
  * Environment-specific notification behavior: emails sent in production only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->