### PR TITLE
Fix measurements API pagination returning incorrect total count

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -833,42 +833,6 @@ function isTimeoutError(error) {
   );
 }
 
-function buildTimeoutErrorResponse(
-  skip,
-  limit,
-  startTime,
-  endTime,
-  isHistorical,
-  metadata,
-) {
-  logger.error(
-    `⏱️ Query timeout (${AGGREGATE_TIMEOUT_MS}ms) | ` +
-      `Metadata: ${metadata || "device"} | ` +
-      `Historical: ${isHistorical} | ` +
-      `Limit: ${limit} | ` +
-      `Suggestion: Use isHistorical=true or reduce date range`,
-  );
-
-  return [
-    {
-      meta: {
-        total: 0,
-        skip: skip,
-        limit: limit,
-        page: 1,
-        pages: 1,
-        startTime,
-        endTime,
-        error:
-          "Query timeout - try using historical mode or reducing date range",
-        optimized: isHistorical,
-        timeoutMs: AGGREGATE_TIMEOUT_MS,
-      },
-      data: [],
-    },
-  ];
-}
-
 async function fetchData(model, filter) {
   let {
     metadata,
@@ -917,6 +881,11 @@ async function fetchData(model, filter) {
     // skip was absent, undefined, or non-numeric — derive from page.
     skip = (page - 1) * limit;
   }
+
+  // currentPage is derived entirely from skip and limit, both of which are
+  // now validated and immutable.  Computing it once here guarantees every
+  // branch (success, timeout, generic error) uses identical logic.
+  const currentPage = Math.trunc(skip / limit) + 1;
 
   const startTime = filter["values.time"]["$gte"];
   const endTime = filter["values.time"]["$lte"];
@@ -1372,7 +1341,6 @@ async function fetchData(model, filter) {
       const totalCount = facetResult?.totalCount?.[0]?.count ?? 0;
       const data = facetResult?.paginatedData ?? [];
 
-      const currentPage = Math.trunc(skip / limit) + 1;
       const totalPages = Math.ceil(totalCount / limit) || 1;
 
       const meta = {
@@ -1393,7 +1361,6 @@ async function fetchData(model, filter) {
       if (isTimeoutError(error)) {
         // Inline the timeout response so we can guarantee a consistent meta
         // shape (hasNextPage / hasPrevPage present) across all error branches.
-        const currentPage = limit > 0 ? Math.trunc(skip / limit) + 1 : 1;
         return [
           {
             meta: {
@@ -1611,7 +1578,6 @@ async function fetchData(model, filter) {
       const totalCount = facetResult?.totalCount?.[0]?.count ?? 0;
       const data = facetResult?.paginatedData ?? [];
 
-      const currentPage = Math.trunc(skip / limit) + 1;
       const totalPages = Math.ceil(totalCount / limit) || 1;
 
       const meta = {
@@ -1630,7 +1596,6 @@ async function fetchData(model, filter) {
       return [{ meta, data }];
     } catch (error) {
       if (isTimeoutError(error)) {
-        const currentPage = limit > 0 ? Math.trunc(skip / limit) + 1 : 1;
         return [
           {
             meta: {


### PR DESCRIPTION
<html><head></head><body><h1>:rocket: Pull Request</h1>
<h2>:clipboard: Description</h2>
<h3>What does this PR do?</h3>
<p>Fixes incorrect <code>meta.total</code> count in measurements API responses by replacing the flawed two-round-trip count strategy with a single MongoDB <code>$facet</code> aggregation that computes the true total and paginated data in one database call. Also enriches the <code>meta</code> object with <code>pages</code>, <code>hasNextPage</code>, and <code>hasPrevPage</code> fields.</p>
<h3>Why is this change needed?</h3>
<p>The <code>meta.total</code> field in paginated API responses was always equal to the <code>limit</code> parameter instead of the true total number of matching documents. This misled API consumers — particularly mobile and frontend clients — into believing there was only one page of results, breaking infinite scroll, pagination UI, and any logic that depends on total count. The root cause was a <code>shouldSkipCount()</code> guard that bypassed the count query for virtually all normal requests (limit ≤ 500, skip = 0), then fell back to <code>data.length</code> (current page size) as the total.</p>
<hr>
<h2>:link: Related Issues</h2>
<ul>
<li>[ ] Closes #</li>
<li>[ ] Fixes #</li>
<li>[ ] Related to #</li>
</ul>
<hr>
<h2>:arrows_counterclockwise: Type of Change</h2>
<ul>
<li>[x] :bug: Bug fix</li>
<li>[ ] :sparkles: New feature</li>
<li>[x] :wrench: Enhancement/improvement</li>
<li>[ ] :books: Documentation update</li>
<li>[x] :recycle: Refactor</li>
<li>[x] :wastebasket: Removal/deprecation</li>
</ul>
<hr>
<h2>:building_construction: Affected Services</h2>
<p><strong>Microservices changed:</strong></p>
<ul>
<li><code>device-registry</code> — <code>src/device-registry/models/Event.js</code></li>
</ul>
<hr>
<h2>:test_tube: Testing</h2>
<ul>
<li>[ ] Unit tests added/updated</li>
<li>[x] Manual testing completed</li>
<li>[ ] All existing tests pass</li>
</ul>
<p><strong>Test summary:</strong>
Manually tested <code>GET /api/v2/devices/measurements/grids/{GRID_ID}/recent</code> with various <code>limit</code> and <code>skip</code> values. Confirmed <code>meta.total</code> now reflects the true document count independent of the current page, <code>meta.pages</code> is computed correctly, and <code>hasNextPage</code>/<code>hasPrevPage</code> are accurate. Verified behaviour with empty result sets (total = 0, pages = 1, both nav flags false).</p>
<hr>
<h2>:boom: Breaking Changes</h2>
<ul>
<li>[ ] <strong>No breaking changes</strong></li>
<li>[x] <strong>Has breaking changes</strong> (describe below)</li>
</ul>
<p>The <code>meta</code> object shape in all paginated measurements responses has changed:</p>

Field | Before | After
-- | -- | --
meta.total | Incorrectly equalled limit | True total matching documents
meta.pages | Present but computed from wrong total | Correctly computed
meta.countSkipped | Present (internal detail) | Removed
meta.hasNextPage | Absent | Added — boolean
meta.hasPrevPage | Absent | Added — boolean


<p>Consumers that were reading <code>meta.total</code> and treating it as the page size will now receive the actual total. Any client that was working around the bug (e.g. assuming there is always only one page) should be reviewed.</p>
<p><strong>Removed internal helpers</strong> (not part of the public API surface):</p>
<ul>
<li><code>shouldSkipCount()</code></li>
<li><code>SKIP_COUNT_THRESHOLD</code> constant</li>
<li><code>performCount()</code></li>
<li><code>buildSimplifiedCountPipeline()</code></li>
<li><code>getGroupFieldsForMetadata()</code></li>
<li><code>buildValuesMatch()</code></li>
</ul>
<hr>
<h2>:memo: Additional Notes</h2>
<ul>
<li>The <code>$facet</code> approach eliminates one full database round-trip per request. Both the count and the paginated data are now computed in a single aggregation pass, which should reduce p99 latency for high-traffic endpoints such as the map and recent-readings views.</li>
<li>The fix applies to both the <code>recent === "yes"</code> and <code>recent === "no"</code> code paths inside <code>fetchData</code>.</li>
<li>Error responses (timeout, query failure) preserve the same shape as before but now include <code>hasNextPage: false</code> and <code>hasPrevPage: false</code> for consistency.</li>
<li>The Kafka/Avro schema in <code>AirQo-api/kafka/schemas/transformed-device-measurements.avsc</code> is <strong>not affected</strong> — only query response metadata changed.</li>
</ul>
<hr>
<h2>:white_check_mark: Checklist</h2>
<ul>
<li>[x] Code follows project style guidelines</li>
<li>[x] Self-review completed</li>
<li>[ ] Documentation updated (if needed)</li>
<li>[x] Ready for review</li>
</ul></body></html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Single-pass, facet-based pagination for faster queries and consistent metadata (counts/pages/next/prev).
  * Stricter pagination input handling (page/skip/limit) and coherent page computation.
  * More efficient, targeted data enrichment (site/device details, photos, related info) only for requested page; lighter response projections.

* **Bug Fixes**
  * Uniform timeout and error responses to preserve response shape.
  * Cleaner logging and stable behavior across recent and historical views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->