### PR TITLE
Add MongoDB distributed lock to prevent concurrent backfill cron runs

### DIFF
--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -1,25 +1,123 @@
 const cron = require("node-cron");
 const SiteModel = require("@models/Site");
+const JobLockModel = require("@models/JobLock");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- backfill-site-metadata-job`,
 );
-const { logObject, logText, HttpError } = require("@utils/shared");
+const { HttpError } = require("@utils/shared");
 const createSiteUtil = require("@utils/site.util");
 const httpStatus = require("http-status");
+const os = require("os");
 
 const BATCH_SIZE = 100;
+const JOB_NAME = "backfill-site-metadata";
 
-// Module-level lock to prevent overlapping cron runs. If the job takes longer
-// than its schedule interval (1 hour), the next tick is skipped entirely rather
-// than spawning a concurrent execution that would contend on the same records.
-let isBackfillRunning = false;
+// How long the lock is valid for. If the pod crashes without releasing
+// the lock, MongoDB TTL will clean it up after this many seconds,
+// unblocking the next cron tick.
+const LOCK_TTL_SECONDS = 90 * 60; // 90 minutes — comfortably longer than one run
+
+// Unique identifier for this pod so logs clearly show which instance
+// holds the lock at any given time.
+const POD_ID = process.env.HOSTNAME || os.hostname();
+
+/**
+ * Attempts to acquire a distributed lock in MongoDB.
+ * Uses findOneAndUpdate with upsert so the operation is atomic —
+ * only one pod can win even when multiple pods fire simultaneously.
+ *
+ * @param {string} tenant
+ * @returns {boolean} true if this pod acquired the lock, false otherwise
+ */
+const acquireLock = async (tenant) => {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + LOCK_TTL_SECONDS * 1000);
+
+  try {
+    // This is the atomic operation:
+    // - Find a joblock document where jobName matches AND it does not
+    //   already exist (i.e. no current lock held by anyone).
+    // - If found (or created via upsert), set acquiredBy and expiresAt.
+    // - If the document already exists, the $setOnInsert only fires on
+    //   insert — a competing pod's existing lock document is left untouched
+    //   and the upsert is a no-op, returning null.
+    const result = await JobLockModel(tenant).findOneAndUpdate(
+      {
+        jobName: JOB_NAME,
+        // Only match if the lock is not currently held by any pod.
+        // expiresAt being in the past means MongoDB TTL hasn't cleaned
+        // it yet but it's logically expired — treat as available.
+        $or: [{ jobName: { $exists: false } }, { expiresAt: { $lte: now } }],
+      },
+      {
+        $setOnInsert: {
+          jobName: JOB_NAME,
+          acquiredBy: POD_ID,
+          acquiredAt: now,
+          expiresAt,
+        },
+      },
+      {
+        upsert: true,
+        new: true,
+        // Return null if no document was found (lock already held)
+        // rather than throwing
+        rawResult: false,
+      },
+    );
+
+    // If the returned document was acquired by this pod, we won
+    return result && result.acquiredBy === POD_ID;
+  } catch (error) {
+    // A duplicate key error (code 11000) means another pod won the race
+    // and inserted the document first — this is expected and not an error.
+    if (error.code === 11000) {
+      return false;
+    }
+    // Any other error is unexpected — log and treat as failed to acquire
+    logger.error(`🐛🐛 Lock acquisition error: ${error.message}`);
+    return false;
+  }
+};
+
+/**
+ * Releases the distributed lock held by this pod.
+ * Only deletes the document if this pod is still the owner —
+ * prevents a slow pod from releasing a lock that another pod
+ * legitimately re-acquired after TTL expiry.
+ *
+ * @param {string} tenant
+ */
+const releaseLock = async (tenant) => {
+  try {
+    await JobLockModel(tenant).findOneAndDelete({
+      jobName: JOB_NAME,
+      acquiredBy: POD_ID,
+    });
+    logger.info(`[${POD_ID}] Lock released for job: ${JOB_NAME}`);
+  } catch (error) {
+    logger.error(`🐛🐛 Lock release error: ${error.message}`);
+  }
+};
 
 const backfillSiteMetadata = async (tenant) => {
   const jobName = `backfill-site-metadata-${tenant}`;
+
+  // Attempt to acquire the distributed lock before doing any work.
+  // If another pod is already running the job, skip this tick entirely.
+  const lockAcquired = await acquireLock(tenant);
+  if (!lockAcquired) {
+    logger.info(
+      `[${POD_ID}] Could not acquire lock for ${jobName} — another pod is already running it. Skipping this tick.`,
+    );
+    return;
+  }
+
+  logger.info(`[${POD_ID}] Lock acquired — starting ${jobName}...`);
+
   try {
-    logger.info(`*** Starting ${jobName}...`);
     let sitesProcessed = 0;
 
     // Track every site ID dispatched in this run so that failing sites are
@@ -163,45 +261,30 @@ const backfillSiteMetadata = async (tenant) => {
     }
 
     logger.info(
-      `*** ${jobName} finished. Total sites updated: ${sitesProcessed}`,
+      `[${POD_ID}] ${jobName} finished. Total sites updated: ${sitesProcessed}`,
     );
   } catch (error) {
     logger.error(`🐛🐛 Error in ${jobName}: ${error.message}`);
+  } finally {
+    // Always release the lock when done, whether the job succeeded or
+    // threw. This allows the next pod to acquire it on the next tick
+    // rather than waiting for TTL expiry.
+    await releaseLock(tenant);
   }
 };
 
 const schedule = "20 * * * *"; // Every hour at minute 20
 
-// Read from constants (which merges the per-environment config files) rather
-// than process.env directly. The BACKFILL_SITE_METADATA_SCHEDULER_ENABLED
-// value is a boolean set in each environment config, not a process.env string,
-// so reading process.env here would always return undefined.
 if (constants.BACKFILL_SITE_METADATA_SCHEDULER_ENABLED === true) {
   logger.info(
-    "BACKFILL_SITE_METADATA_SCHEDULER_ENABLED=true — this instance will run the backfill cron job.",
+    `[${POD_ID}] BACKFILL_SITE_METADATA_SCHEDULER_ENABLED=true — this instance will participate in the backfill cron job.`,
   );
   cron.schedule(
     schedule,
     async () => {
-      // Guard against overlapping runs. If the previous execution is still
-      // in progress when the next tick fires, skip and log rather than spawning
-      // a concurrent run that would contend on the same site records.
-      if (isBackfillRunning) {
-        logger.info(
-          "Backfill job is already running — skipping this tick to prevent overlap.",
-        );
-        return;
-      }
-
-      isBackfillRunning = true;
-      try {
-        await backfillSiteMetadata("airqo");
-        logger.info("Backfill cron tick completed successfully.");
-      } catch (error) {
-        logger.error(`Error running scheduled backfill job: ${error.message}`);
-      } finally {
-        isBackfillRunning = false;
-      }
+      // Each pod attempts to acquire the DB lock on every tick.
+      // Only the winning pod runs the job — the others log and return.
+      await backfillSiteMetadata("airqo");
     },
     {
       scheduled: true,
@@ -209,11 +292,18 @@ if (constants.BACKFILL_SITE_METADATA_SCHEDULER_ENABLED === true) {
     },
   );
 
-  process.on("SIGTERM", () => {
-    logger.info("SIGTERM received — scheduler shutting down.");
+  process.on("SIGTERM", async () => {
+    logger.info(
+      `[${POD_ID}] SIGTERM received — releasing lock and shutting down.`,
+    );
+    await releaseLock("airqo");
   });
-  process.on("SIGINT", () => {
-    logger.info("SIGINT received — scheduler shutting down.");
+
+  process.on("SIGINT", async () => {
+    logger.info(
+      `[${POD_ID}] SIGINT received — releasing lock and shutting down.`,
+    );
+    await releaseLock("airqo");
   });
 } else {
   logger.info(

--- a/src/device-registry/models/JobLock.js
+++ b/src/device-registry/models/JobLock.js
@@ -1,0 +1,49 @@
+// src/device-registry/models/JobLock.js
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+
+const jobLockSchema = new mongoose.Schema({
+  // Unique job identifier — one document per job name
+  jobName: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  // Which pod acquired the lock — useful for debugging
+  acquiredBy: {
+    type: String,
+    required: true,
+  },
+  acquiredAt: {
+    type: Date,
+    required: true,
+    default: Date.now,
+  },
+  // TTL field — MongoDB automatically deletes this document
+  // after the specified number of seconds if it is not manually
+  // released first. Acts as a dead-man's switch for crashed pods.
+  expiresAt: {
+    type: Date,
+    required: true,
+  },
+});
+
+// MongoDB TTL index — automatically removes expired lock documents.
+// This is the safety net: if a pod crashes without releasing the lock,
+// the document is cleaned up after `expiresAt` passes so the next
+// cron tick is not permanently blocked.
+jobLockSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+const JobLockModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("joblocks");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "joblock", jobLockSchema);
+  }
+};
+
+module.exports = JobLockModel;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Introduces a MongoDB-based distributed lock (`JobLock`) to prevent multiple Kubernetes pods from running the backfill cron job concurrently. Replaces the previous in-memory `isBackfillRunning` boolean flag, which only prevented overlap within a single process and was ineffective across multiple pods.

Two files changed:

1. **`src/device-registry/models/JobLock.js`** — new Mongoose model with a TTL index on `expiresAt`. One document per job name acts as the distributed lock. MongoDB's TTL index automatically deletes expired lock documents, acting as a dead-man's switch for pods that crash without releasing the lock.

2. **`src/device-registry/bin/jobs/backfill-site-metadata-job.js`** — replaces the in-memory `isBackfillRunning` flag with `acquireLock()` and `releaseLock()` functions that interact with the `JobLock` model. On each cron tick, all pods attempt to atomically acquire the lock via `findOneAndUpdate` with `upsert`. Only the winning pod runs the job — the others log and return immediately. The lock is released in a `finally` block and on `SIGTERM`/`SIGINT` for clean Kubernetes rolling deployments.

### Why is this change needed?
Production device-registry runs three pods. With `BACKFILL_SITE_METADATA_SCHEDULER_ENABLED=true` set in `production.js`, all three pods register the cron independently and all three fire at minute 20 of every hour — causing three concurrent backfill runs contending on the same site records simultaneously. The previous in-memory `isBackfillRunning` flag only prevented overlap within a single pod process and had no effect across pods.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/models/JobLock.js` *(new file)*
- `device-registry` — `src/device-registry/bin/jobs/backfill-site-metadata-job.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Deployed to production with three running pods and confirmed only one pod logs `"Lock acquired — starting backfill-site-metadata-airqo..."` per tick while the other two log `"Could not acquire lock — another pod is already running it. Skipping this tick."`.
- Verified the lock document is created in the `joblocks` collection on acquisition and deleted on release.
- Verified the TTL index is correctly created on the `expiresAt` field — confirmed via MongoDB Atlas index inspection.
- Simulated a pod crash by killing the process mid-job and confirmed the lock document was automatically removed by MongoDB TTL after 90 minutes, allowing the next tick to proceed normally.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `JobLock` model creates a `joblocks` collection in MongoDB automatically on first use. No manual migration or index creation is needed — Mongoose handles the TTL index on startup.
- `POD_ID` is read from `process.env.HOSTNAME`, which Kubernetes automatically sets to the pod name. This means lock ownership is clearly identifiable in logs and in the `joblocks` collection.
- The lock TTL is set to 90 minutes — intentionally longer than one expected job run. If a pod crashes mid-job without releasing the lock, MongoDB TTL cleans it up automatically so the next hour's tick is not permanently blocked.
- `releaseLock` is scoped to the owning pod via `acquiredBy: POD_ID` — a slow pod cannot accidentally release a lock that another pod legitimately re-acquired after TTL expiry.
- This implementation is specific to the backfill job. If other cron jobs in device-registry need the same protection in future, the `JobLock` model and `acquireLock`/`releaseLock` pattern can be reused by passing a different `JOB_NAME`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented distributed locking for the backfill-site-metadata job to prevent concurrent execution conflicts across multiple instances.
  * Added automatic TTL-based lock expiration to prevent lock accumulation and improve system reliability.
  * Enhanced service shutdown handling to ensure proper lock cleanup on termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->