### PR TITLE
Remove info logs from backfill job and replace with error-only summary

### DIFF
--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -264,7 +264,6 @@ const backfillSiteMetadata = async (tenant) => {
       sitesFailedCount += batchFailures;
     }
 
-    // Single summary log at the end — one line instead of one per site.
     if (sitesFailedCount > 0) {
       logger.error(
         `[${POD_ID}] ${jobName} finished. Updated: ${sitesProcessed}, Failed: ${sitesFailedCount}.`,
@@ -298,15 +297,18 @@ if (constants.BACKFILL_SITE_METADATA_SCHEDULER_ENABLED === true) {
     },
   );
 
+  // SIGTERM and SIGINT are normal Kubernetes lifecycle events (rolling
+  // deployments, scaling down) — log as warn rather than error to avoid
+  // triggering false alerts in monitoring.
   process.on("SIGTERM", async () => {
-    logger.error(
+    logger.warn(
       `[${POD_ID}] SIGTERM received — releasing lock and shutting down.`,
     );
     await releaseLock("airqo");
   });
 
   process.on("SIGINT", async () => {
-    logger.error(
+    logger.warn(
       `[${POD_ID}] SIGINT received — releasing lock and shutting down.`,
     );
     await releaseLock("airqo");


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Removes all `logger.info` calls from `backfill-site-metadata-job.js` and replaces per-site success logging with a single end-of-run error summary that only fires when there are failures.

**Removed log lines:**
- `"BACKFILL_SITE_METADATA_SCHEDULER_ENABLED=true — this instance will participate..."` — startup noise on every pod restart
- `"Lock acquired — starting backfill-site-metadata-airqo..."` — per-run noise
- `"Lock released for job..."` — per-run noise
- `"Could not acquire lock — another pod is already running it. Skipping this tick."` — fires on 2 of 3 pods every hour
- `"Processing batch of X sites"` — per-batch noise
- `"No more sites to backfill. Job complete."` — informational only
- `"Successfully backfilled metadata for site X"` — the primary culprit; one log per site per batch was flooding Slack and hitting Slack rate limits

**Added:**
- A single end-of-run summary logged at `error` level only when failures occurred: `"backfill-site-metadata-airqo finished. Updated: X, Failed: Y."` — gives a clear picture of batch outcomes without per-site noise
- `sitesFailedCount` counter to track failures across all batches for the summary

**Changed:**
- `SIGTERM`/`SIGINT` handlers changed from `logger.info` to `logger.error` — a shutdown mid-run is worth alerting on
- Removed the `else` branch logging the skipped scheduler registration — if the scheduler is not enabled, nothing is logged

### Why is this change needed?
With 100+ sites per batch and multiple batches per run, the per-site `"Successfully backfilled"` logs were generating hundreds of `INFO` messages per job tick, flooding the Slack alerts channel and consistently hitting Slack's rate limits — causing the `"Due to a high volume of activity, we are not displaying some messages"` warning. The job now only logs when something goes wrong.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/bin/jobs/backfill-site-metadata-job.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Ran the job against production and confirmed zero info logs are emitted during a successful batch run.
- Confirmed the end-of-run summary error log fires correctly when one or more sites fail metadata generation.
- Confirmed the altitude circuit breaker error log still fires when `GOOGLE_MAPS_API_KEY` is misconfigured.
- Verified Slack no longer hits rate limits during a backfill run.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The job still processes and updates sites correctly — this is a logging-only change with no functional impact.
- If visibility into successful runs is needed in future, consider pushing a single summary metric to a monitoring system (e.g. Prometheus/Grafana) rather than logging individual site successes.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined logging in the site metadata backfill job to reduce verbosity during batch processing.
  * Consolidated per-site logs into batch-level summaries and added a sitesProcessed/sitesFailed count for clearer reporting.
  * Adjusted lifecycle log levels (more WARN/ERROR for failures and shutdown signals) and included pod identification in error messages.
* **Bug Fixes**
  * Clarified preflight error handling and consolidated failure reporting without changing overall job behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->