### PR TITLE
Backfill only missing site metadata fields to avoid overwriting duplicate-job fixes

### DIFF
--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -113,6 +113,27 @@ const runAltitudePreflightCheck = async (site, altitudeCircuitOpen) => {
   }
 };
 
+/**
+ * Filters the metadata returned by generateMetadata down to only the fields
+ * that are currently absent (missing, null, or empty string) on the site
+ * document. Fields that already have a value are intentionally skipped.
+ *
+ * This prevents the backfill job from overwriting fields like search_name,
+ * location_name, and formatted_name that may have been carefully renamed by
+ * check-duplicate-site-fields-job or update-duplicate-site-fields-job to
+ * resolve uniqueness conflicts.
+ */
+const buildMissingFieldsUpdate = (site, metadataFields) => {
+  return Object.fromEntries(
+    Object.entries(metadataFields).filter(([key, value]) => {
+      if (value === undefined) return false;
+      const existing = site[key];
+      // Only include if the field is missing, null, or empty string on the site
+      return existing === undefined || existing === null || existing === "";
+    }),
+  );
+};
+
 const backfillSiteMetadata = async (tenant) => {
   const jobName = `backfill-site-metadata-${tenant}`;
 
@@ -151,7 +172,14 @@ const backfillSiteMetadata = async (tenant) => {
           ...(attemptedIds.length > 0 && { _id: { $nin: attemptedIds } }),
         })
         .limit(BATCH_SIZE)
-        .select("_id latitude longitude name network")
+        // Include all metadata fields in the projection so
+        // buildMissingFieldsUpdate can check which ones are already set.
+        .select(
+          "_id latitude longitude name network country district city region " +
+            "town village parish county sub_county division street formatted_name " +
+            "geometry google_place_id location_name search_name altitude " +
+            "data_provider site_tags",
+        )
         .lean();
 
       if (sitesToUpdate.length === 0) {
@@ -213,32 +241,44 @@ const backfillSiteMetadata = async (tenant) => {
               site_tags,
             } = metadataResponse.data;
 
-            const metadataFields = Object.fromEntries(
-              Object.entries({
-                country,
-                district,
-                city,
-                region,
-                town,
-                village,
-                parish,
-                county,
-                sub_county,
-                division,
-                street,
-                formatted_name,
-                geometry,
-                google_place_id,
-                location_name,
-                search_name,
-                altitude,
-                data_provider,
-                site_tags,
-              }).filter(([, v]) => v !== undefined),
+            const allMetadataFields = {
+              country,
+              district,
+              city,
+              region,
+              town,
+              village,
+              parish,
+              county,
+              sub_county,
+              division,
+              street,
+              formatted_name,
+              geometry,
+              google_place_id,
+              location_name,
+              search_name,
+              altitude,
+              data_provider,
+              site_tags,
+            };
+
+            // Only write fields that are currently missing on this site.
+            // This prevents overwriting search_name, location_name, or
+            // formatted_name that update-duplicate-site-fields-job has
+            // already carefully renamed to resolve uniqueness conflicts.
+            const missingFields = buildMissingFieldsUpdate(
+              site,
+              allMetadataFields,
             );
 
+            if (Object.keys(missingFields).length === 0) {
+              // All metadata fields already populated — nothing to write
+              return { success: true };
+            }
+
             await SiteModel(tenant).findByIdAndUpdate(site._id, {
-              $set: metadataFields,
+              $set: missingFields,
             });
             return { success: true };
           } else {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Changes the backfill job to only write metadata fields that are currently absent (missing, null, or empty string) on each site document, rather than unconditionally writing all fields returned by `generateMetadata`.

Two supporting changes enable this:

1. **`buildMissingFieldsUpdate` helper** — compares the metadata returned by `generateMetadata` against the site's existing field values and returns only the subset that needs writing. A field is written only if its current value is `undefined`, `null`, or `""`.

2. **Expanded `.select()` on the query** — the site query now fetches all metadata fields (not just `_id`, `latitude`, `longitude`, `name`, `network`) so `buildMissingFieldsUpdate` has the full picture of what is already set on each document before deciding what to write.

3. **Early return when nothing to write** — if all metadata fields are already populated after filtering, `findByIdAndUpdate` is skipped entirely rather than making a no-op database call.

### Why is this change needed?
The backfill job calls `generateMetadata` and previously wrote all returned fields unconditionally via `$set`. This meant fields like `search_name`, `location_name`, and `formatted_name` were overwritten on every backfill run — silently undoing the work of `check-duplicate-site-fields-job` and `update-duplicate-site-fields-job`, which carefully rename these fields to resolve uniqueness conflicts across the site collection.

For example: `update-duplicate-site-fields-job` renames a duplicate `search_name` from `"Kampala Road"` to `"Kampala Road 1042"`. On the next backfill tick, `generateMetadata` returns `"Kampala Road"` for the same coordinates and the backfill job writes it back — overwriting the fix and reintroducing the duplicate. This cycle would repeat on every hourly run indefinitely.

By only writing fields that are genuinely absent, the backfill job becomes additive rather than overwriting, and the three jobs can coexist without interfering with each other.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/bin/jobs/backfill-site-metadata-job.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Verified that sites with all metadata fields already populated are skipped entirely with no DB write.
- Verified that sites with only some fields missing (e.g. `country` present, `district` absent) only receive updates for the missing fields.
- Confirmed that `search_name`, `location_name`, and `formatted_name` are not overwritten on sites where those fields are already set — even when `generateMetadata` returns different values for the same coordinates.
- Confirmed the job still correctly populates all fields on brand new sites that have no metadata at all.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The fields most at risk from the duplicate-cleanup jobs are `search_name`, `location_name`, and `formatted_name`. These are now only written during backfill if they are genuinely absent on the site document.
- The expanded `.select()` on the query fetches more data per site than before, but this is a necessary trade-off to enable field-level comparison. The query is still bounded by `BATCH_SIZE = 100` and the `$nin` exclusion of already-attempted IDs.
- `buildMissingFieldsUpdate` is intentionally strict — a field value of `0` or `false` is treated as present and will not be overwritten. Only `undefined`, `null`, and `""` are considered absent.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved site metadata backfill process to preserve existing field values and only populate missing metadata fields, preventing unintended overwrites of previously set information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->