### PR TITLE
Add ops-alerts log4js category for WARN-level Slack visibility in operational jobs

### DIFF
--- a/src/auth-service/bin/jobs/air-quality-alerts-job.js
+++ b/src/auth-service/bin/jobs/air-quality-alerts-job.js
@@ -18,7 +18,7 @@ const {
 const isEmpty = require("is-empty");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- bin/jobs/air-quality-alerts-job`
+  `${constants.ENVIRONMENT} -- bin/jobs/air-quality-alerts-job -- ops-alerts`,
 );
 
 // Configuration
@@ -49,7 +49,7 @@ async function fetchAirQualityReadings(siteIds) {
           site_id: siteIds.join(","),
           token: API_TOKEN,
         },
-      }
+      },
     );
 
     if (response.data && response.data.success) {
@@ -58,7 +58,7 @@ async function fetchAirQualityReadings(siteIds) {
     return [];
   } catch (error) {
     logger.error(
-      `🐛🐛 Error fetching air quality readings: ${stringify(error)}`
+      `🐛🐛 Error fetching air quality readings: ${stringify(error)}`,
     );
     return [];
   }
@@ -101,10 +101,10 @@ function generateAlertEmailContent(spikes, userName, preferences) {
                 t &&
                 t.site_id &&
                 spike.site_id &&
-                t.site_id.toString() === spike.site_id.toString()
+                t.site_id.toString() === spike.site_id.toString(),
             )
               ? preferences.thresholds.find(
-                  (t) => t.site_id.toString() === spike.site_id.toString()
+                  (t) => t.site_id.toString() === spike.site_id.toString(),
                 ).pm25_threshold
               : PM25_THRESHOLD
           } µg/m³<br>
@@ -116,7 +116,7 @@ function generateAlertEmailContent(spikes, userName, preferences) {
               : ""
           }
         </td>
-      </tr>`
+      </tr>`,
     )
     .join("");
 
@@ -150,10 +150,10 @@ async function sendEmailAlertsInBatches(alertsData, batchSize = 50) {
 
     try {
       await Promise.all(emailPromises);
-      logger.info(`Successfully sent ${batch.length} air quality alert emails`);
+      logger.warn(`Successfully sent ${batch.length} air quality alert emails`);
     } catch (error) {
       logger.error(
-        `🐛🐛 Error sending batch of alert emails: ${stringify(error)}`
+        `🐛🐛 Error sending batch of alert emails: ${stringify(error)}`,
       );
     }
   }
@@ -214,7 +214,7 @@ const checkAirQualityAndAlert = async () => {
           const isQuietHours = isTimeInRange(
             currentTime,
             notificationPrefs.air_quality_alerts.quiet_hours.start,
-            notificationPrefs.air_quality_alerts.quiet_hours.end
+            notificationPrefs.air_quality_alerts.quiet_hours.end,
           );
           if (isQuietHours) continue;
         }

--- a/src/auth-service/bin/jobs/check-subscription-status.js
+++ b/src/auth-service/bin/jobs/check-subscription-status.js
@@ -9,7 +9,7 @@ const httpStatus = require("http-status");
 const cron = require("node-cron");
 
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- subscription-utils`
+  `${constants.ENVIRONMENT} -- bin/jobs/check-subscription-status -- ops-alerts`,
 );
 
 const checkSubscriptionStatuses = async () => {
@@ -35,7 +35,7 @@ const checkSubscriptionStatuses = async () => {
         try {
           // Fetch subscription status from Paddle
           const subscriptionStatus = await paddleClient.subscriptions.get(
-            user.currentSubscriptionId
+            user.currentSubscriptionId,
           );
 
           // Update local user record based on Paddle subscription status
@@ -58,7 +58,7 @@ const checkSubscriptionStatuses = async () => {
           logger.error(
             `Failed to check subscription for user ${
               user.email
-            } --- ${stringify(error)}`
+            } --- ${stringify(error)}`,
           );
         }
       }

--- a/src/auth-service/bin/jobs/daily-compromise-summary-job.js
+++ b/src/auth-service/bin/jobs/daily-compromise-summary-job.js
@@ -2,7 +2,7 @@ require("module-alias/register");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- daily-compromise-summary-job`,
+  `${constants.ENVIRONMENT} -- /bin/jobs/daily-compromise-summary-job -- ops-alerts`,
 );
 const cron = require("node-cron");
 const CompromisedTokenLogModel = require("@models/CompromisedTokenLog");
@@ -18,9 +18,6 @@ const JOB_SCHEDULE = "0 8 * * *"; // At 8:00 AM every day
 const generateAndSendSummaries = async (tenant = "airqo") => {
   try {
     if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") {
-      logger.info(
-        `${JOB_NAME} is disabled for the ${constants.ENVIRONMENT} environment.`,
-      );
       return;
     }
 
@@ -142,7 +139,6 @@ const job = cron.schedule(
 
 if (constants.ENVIRONMENT === "PRODUCTION ENVIRONMENT") {
   job.start();
-  logger.info(`✨ ${JOB_NAME} scheduled to run at ${JOB_SCHEDULE}`);
 }
 
 module.exports = {

--- a/src/auth-service/bin/jobs/dashboard-analytics-job.js
+++ b/src/auth-service/bin/jobs/dashboard-analytics-job.js
@@ -3,7 +3,7 @@ const UserModel = require("@models/User");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- bin/jobs/dashboard-analytics-job script`
+  `${constants.ENVIRONMENT} -- bin/jobs/dashboard-analytics-job script -- ops-alerts`,
 );
 const { stringify } = require("@utils/common");
 const DashboardAnalyticsModel = require("@models/DashboardAnalytics");
@@ -11,9 +11,6 @@ const DashboardAnalyticsModel = require("@models/DashboardAnalytics");
 const calculateAndCacheAnalytics = async () => {
   try {
     const tenant = constants.DEFAULT_TENANT || "airqo";
-    logger.info(
-      `Starting dashboard analytics calculation for tenant: ${tenant}`
-    );
 
     const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
     const twoMonthsAgo = new Date();
@@ -21,12 +18,12 @@ const calculateAndCacheAnalytics = async () => {
     const startOfTwoMonthsAgo = new Date(
       twoMonthsAgo.getFullYear(),
       twoMonthsAgo.getMonth(),
-      1
+      1,
     );
     const endOfTwoMonthsAgo = new Date(
       twoMonthsAgo.getFullYear(),
       twoMonthsAgo.getMonth() + 1,
-      0
+      0,
     );
 
     const aggregationPipeline = [
@@ -134,8 +131,8 @@ const calculateAndCacheAnalytics = async () => {
       dauTwoMonthsAgo > 0
         ? ((dau - dauTwoMonthsAgo) / dauTwoMonthsAgo) * 100
         : dau > 0
-        ? 100
-        : 0;
+          ? 100
+          : 0;
 
     const response = {
       userSatisfaction: null, // Placeholder
@@ -168,13 +165,9 @@ const calculateAndCacheAnalytics = async () => {
     };
 
     await DashboardAnalyticsModel(tenant).findOneOrCreate(tenant, response);
-
-    logger.info(
-      `Successfully calculated and cached dashboard analytics for tenant: ${tenant}`
-    );
   } catch (error) {
     logger.error(
-      `Error in calculateAndCacheAnalytics job: ${stringify(error)}`
+      `Error in calculateAndCacheAnalytics job: ${stringify(error)}`,
     );
   }
 };

--- a/src/auth-service/bin/jobs/inactive-users-job.js
+++ b/src/auth-service/bin/jobs/inactive-users-job.js
@@ -4,7 +4,7 @@ const constants = require("@config/constants");
 const { mailer, stringify } = require("@utils/common");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- bin/jobs/inactive-users-job script`
+  `${constants.ENVIRONMENT} -- bin/jobs/inactive-users-job script -- ops-alerts`,
 );
 
 const inactiveThresholdInDays = 45;
@@ -14,18 +14,17 @@ const CONCURRENCY_LIMIT = 10; // Number of emails to send in parallel
 
 const sendInactivityReminders = async () => {
   try {
-    logger.info("Starting job: sendInactivityReminders");
     const tenant = (constants.DEFAULT_TENANT || "airqo").toLowerCase();
     const now = new Date();
 
     const inactiveThresholdDate = new Date();
     inactiveThresholdDate.setDate(
-      inactiveThresholdDate.getDate() - inactiveThresholdInDays
+      inactiveThresholdDate.getDate() - inactiveThresholdInDays,
     );
 
     const reminderCooldownDate = new Date();
     reminderCooldownDate.setDate(
-      reminderCooldownDate.getDate() - reminderCooldownInDays
+      reminderCooldownDate.getDate() - reminderCooldownInDays,
     );
 
     while (true) {
@@ -43,7 +42,6 @@ const sendInactivityReminders = async () => {
         .lean();
 
       if (inactiveUsers.length === 0) {
-        logger.info("No more inactive users to process for this batch.");
         break;
       }
 
@@ -59,23 +57,20 @@ const sendInactivityReminders = async () => {
             })
             .then(() => {
               successfulUserIds.push(user._id);
-              logger.info(
-                `Successfully queued inactivity reminder for ${user.email}`
-              );
               return { status: "fulfilled", email: user.email };
             })
             .catch((err) => {
               logger.warn(
                 `Failed to send inactivity reminder to ${
                   user.email
-                }: ${stringify(err)}`
+                }: ${stringify(err)}`,
               );
               return {
                 status: "rejected",
                 email: user.email,
                 reason: err.message,
               };
-            })
+            }),
         );
 
         // Process in chunks to limit concurrency
@@ -94,14 +89,10 @@ const sendInactivityReminders = async () => {
       if (successfulUserIds.length > 0) {
         await UserModel(tenant).updateMany(
           { _id: { $in: successfulUserIds } },
-          { $set: { last_inactive_reminder_sent_at: now } }
-        );
-        logger.info(
-          `Updated 'last_inactive_reminder_sent_at' for ${successfulUserIds.length} users.`
+          { $set: { last_inactive_reminder_sent_at: now } },
         );
       }
     }
-    logger.info("Finished job: sendInactivityReminders");
   } catch (error) {
     logger.error(`Error in sendInactivityReminders job: ${stringify(error)}`);
   }

--- a/src/auth-service/bin/jobs/incomplete-profile-job.js
+++ b/src/auth-service/bin/jobs/incomplete-profile-job.js
@@ -3,7 +3,7 @@ const UserModel = require("@models/User");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- bin/jobs/incomplete-profile-job`,
+  `${constants.ENVIRONMENT} -- bin/jobs/incomplete-profile-job -- ops-alerts`,
 );
 const {
   winstonLogger,

--- a/src/auth-service/bin/jobs/subscription-renewal-job.js
+++ b/src/auth-service/bin/jobs/subscription-renewal-job.js
@@ -10,7 +10,7 @@ const cron = require("node-cron");
 const { mailer, stringify } = require("@utils/common");
 
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- subscription-renewal-utils`
+  `${constants.ENVIRONMENT} -- subscription-renewal-utils -- ops-alerts`,
 );
 
 const subscriptionRenewalUtils = {
@@ -42,7 +42,7 @@ const subscriptionRenewalUtils = {
           try {
             // Fetch current subscription details
             const subscriptionDetails = await paddleClient.subscriptions.get(
-              user.currentSubscriptionId
+              user.currentSubscriptionId,
             );
 
             // Prepare transaction data
@@ -58,9 +58,8 @@ const subscriptionRenewalUtils = {
             };
 
             // Create renewal transaction
-            const renewalTransaction = await paddleClient.transactions.create(
-              transactionData
-            );
+            const renewalTransaction =
+              await paddleClient.transactions.create(transactionData);
 
             // Record transaction in local database
             const transactionRecord = await TransactionModel("airqo").register({
@@ -102,8 +101,8 @@ const subscriptionRenewalUtils = {
             // Handle renewal failure
             logger.error(
               `Automatic renewal failed for user ${user.email} --- ${stringify(
-                error
-              )}`
+                error,
+              )}`,
             );
 
             // Send failure notification
@@ -127,7 +126,7 @@ const subscriptionRenewalUtils = {
       }
     } catch (error) {
       logger.error(
-        `Subscription renewal process error --- ${stringify(error)}`
+        `Subscription renewal process error --- ${stringify(error)}`,
       );
     }
   },
@@ -174,7 +173,7 @@ const subscriptionRenewalUtils = {
       }
     } catch (error) {
       logger.error(
-        `Upcoming renewal notifications error --- ${stringify(error)}`
+        `Upcoming renewal notifications error --- ${stringify(error)}`,
       );
     }
   },
@@ -188,7 +187,7 @@ cron.schedule(
   {
     scheduled: true,
     timezone: "Africa/Nairobi",
-  }
+  },
 );
 
 global.cronJobs = global.cronJobs || {};
@@ -200,7 +199,7 @@ global.cronJobs[jobName] = cron.schedule(
   {
     scheduled: true,
     timezone: "Africa/Nairobi",
-  }
+  },
 );
 
 module.exports = subscriptionRenewalUtils;

--- a/src/auth-service/bin/jobs/token-expiration-job.js
+++ b/src/auth-service/bin/jobs/token-expiration-job.js
@@ -1,11 +1,11 @@
 const AccessTokenModel = require("@models/AccessToken");
 const cron = require("node-cron");
 const constants = require("@config/constants");
-const { logObject } = require("@utils/shared");
+const { logObject, logText } = require("@utils/shared");
 const { mailer, stringify } = require("@utils/common");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- bin/jobs/token-expiration-job`
+  `${constants.ENVIRONMENT} -- bin/jobs/token-expiration-job -- ops-alerts`,
 );
 
 async function sendEmailsInBatches(tokens, batchSize = 100) {
@@ -23,7 +23,7 @@ async function sendEmailsInBatches(tokens, batchSize = 100) {
         .then((response) => {
           if (response && response.success === false) {
             logger.error(
-              `🐛🐛 Error sending email to ${email}: ${stringify(response)}`
+              `🐛🐛 Error sending email to ${email}: ${stringify(response)}`,
             );
           }
         });
@@ -60,7 +60,7 @@ const sendAlertsForExpiringTokens = async () => {
     if (tokens.length > 0) {
       await sendEmailsInBatches(tokens);
     } else {
-      logger.info("No expiring tokens found for this month.");
+      logText("No expiring tokens found for this month.");
     }
   } catch (error) {
     logger.error(`🐛🐛 Internal Server Error -- ${stringify(error)}`);
@@ -75,5 +75,5 @@ global.cronJobs[jobName] = cron.schedule(
   {
     scheduled: true,
     timezone: "Africa/Nairobi",
-  }
+  },
 );

--- a/src/auth-service/config/log4js.js
+++ b/src/auth-service/config/log4js.js
@@ -63,6 +63,14 @@ if (isDevelopment()) {
       error: { appenders: ["errors"], level: "error" },
       http: { appenders: ["access"], level: "DEBUG" },
       "api-usage-logger": { appenders: [], level: "info" },
+
+      // Dedicated category for operational jobs that need WARN visibility
+      // in Slack. Unlike the default category which is restricted to ERROR
+      // only for Slack, ops-alerts forwards WARN and above to Slack so
+      // actionable operational messages reach the team without opening up
+      // the entire codebase to warn-level Slack noise.
+      // Usage: const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- <job-name> -- ops-alerts`);
+      "ops-alerts": { appenders: ["app"], level: "info" },
     },
   };
 
@@ -75,20 +83,29 @@ if (isDevelopment()) {
         username: constants.SLACK_USERNAME,
       };
 
-      // logLevelFilter wrapping "slack" so only ERROR and above is
-      // forwarded to Slack. INFO and WARN continue to write to "app"
-      // file appender which is always present in the default category.
+      // slackErrors — ERROR and above only. Used by default and error categories.
+      // Keeps routine INFO/WARN logs out of Slack for the general codebase.
       config.appenders.slackErrors = {
         type: "logLevelFilter",
         level: "ERROR",
         appender: "slack",
       };
 
+      // slackWarn — WARN and above. Used only by the ops-alerts category so
+      // specific operational jobs can send WARNING and higher to Slack without
+      // opening up the entire codebase to warn-level Slack noise.
+      config.appenders.slackWarn = {
+        type: "logLevelFilter",
+        level: "WARN",
+        appender: "slack",
+      };
+
       config.categories.default.appenders.push("slackErrors");
       config.categories.error.appenders.push("slackErrors");
+      config.categories["ops-alerts"].appenders.push("slackWarn");
 
       console.log(
-        "✅ Slack appender configured successfully (ERROR and above only)",
+        "✅ Slack appender configured successfully (ERROR and above only, WARN and above for ops-alerts)",
       );
     } catch (error) {
       console.error("❌ Failed to configure Slack appender:", error.message);

--- a/src/device-registry/bin/jobs/check-active-statuses.js
+++ b/src/device-registry/bin/jobs/check-active-statuses.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/check-active-statuses-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/check-active-statuses-job -- ops-alerts`,
 );
 const DeviceModel = require("@models/Device");
 const cron = require("node-cron");
@@ -34,7 +34,7 @@ const checkActiveStatuses = async () => {
 
     // Check for Deployed devices with incorrect statuses
     const activeIncorrectStatusCount = await DeviceModel(
-      "airqo"
+      "airqo",
     ).countDocuments({
       isActive: true,
       status: { $ne: "deployed" },
@@ -79,10 +79,10 @@ const checkActiveStatuses = async () => {
     ]);
 
     const activeIncorrectStatusUniqueNames = activeIncorrectStatusResult.map(
-      (doc) => doc._id
+      (doc) => doc._id,
     );
     const activeMissingStatusUniqueNames = activeMissingStatusResult.map(
-      (doc) => doc._id
+      (doc) => doc._id,
     );
 
     logObject("activeIncorrectStatusCount", activeIncorrectStatusCount);
@@ -99,7 +99,7 @@ const checkActiveStatuses = async () => {
 
     logObject(
       "percentageActiveIncorrectStatus",
-      percentageActiveIncorrectStatus
+      percentageActiveIncorrectStatus,
     );
     logObject("percentageActiveMissingStatus", percentageActiveMissingStatus);
 
@@ -107,22 +107,22 @@ const checkActiveStatuses = async () => {
       percentageActiveIncorrectStatus > ACTIVE_STATUS_THRESHOLD ||
       percentageActiveMissingStatus > ACTIVE_STATUS_THRESHOLD
     ) {
-      logger.info(
+      logger.warn(
         `⁉️ Deployed devices with incorrect statuses (${activeIncorrectStatusUniqueNames.join(
-          ", "
-        )}) - ${percentageActiveIncorrectStatus.toFixed(2)}%`
+          ", ",
+        )}) - ${percentageActiveIncorrectStatus.toFixed(2)}%`,
       );
 
-      logger.info(
+      logger.warn(
         `⁉️ Deployed devices missing status (${activeMissingStatusUniqueNames.join(
-          ", "
-        )}) - ${percentageActiveMissingStatus.toFixed(2)}%`
+          ", ",
+        )}) - ${percentageActiveMissingStatus.toFixed(2)}%`,
       );
     }
   } catch (error) {
     logText(`🐛🐛 Error checking active statuses: ${error.message}`);
     logger.error(
-      `🐛🐛 ${JOB_NAME} Error checking active statuses: ${error.message}`
+      `🐛🐛 ${JOB_NAME} Error checking active statuses: ${error.message}`,
     );
     logger.error(`🐛🐛 Stack trace: ${error.stack}`);
   } finally {
@@ -162,7 +162,7 @@ const startCheckActiveStatusesJob = () => {
           // Wait for current execution to finish if running
           if (currentJobPromise) {
             logText(
-              `⏳ Waiting for current ${JOB_NAME} execution to finish...`
+              `⏳ Waiting for current ${JOB_NAME} execution to finish...`,
             );
             await currentJobPromise;
             logText(`✅ Current ${JOB_NAME} execution completed`);
@@ -215,7 +215,7 @@ process.on("unhandledRejection", (reason, promise) => {
     `🚫 Unhandled Rejection in ${JOB_NAME} at:`,
     promise,
     "reason:",
-    reason
+    reason,
   );
 });
 

--- a/src/device-registry/bin/jobs/check-duplicate-site-fields-job.js
+++ b/src/device-registry/bin/jobs/check-duplicate-site-fields-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/check-duplicate-site-fields-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/check-duplicate-site-fields-job -- ops-alerts`,
 );
 const SitesModel = require("@models/Site");
 const cron = require("node-cron");
@@ -54,7 +54,7 @@ const checkDuplicateSiteFields = async () => {
     ]).join(" ");
     const sites = await SitesModel("airqo").find(
       { isOnline: true },
-      fieldsToProject
+      fieldsToProject,
     );
 
     logObject("Total sites checked", sites.length);
@@ -104,7 +104,7 @@ const startJob = () => {
     checkDuplicateSiteFields,
     {
       scheduled: true,
-    }
+    },
   );
 
   // Initialize global registry

--- a/src/device-registry/bin/jobs/check-network-status-job.js
+++ b/src/device-registry/bin/jobs/check-network-status-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/check-network-status-job`,
+  `${constants.ENVIRONMENT} -- network-status-check-job -- ops-alerts`,
 );
 const deviceUtil = require("@utils/device.util");
 const networkStatusUtil = require("@utils/network-status.util");
@@ -131,7 +131,7 @@ const checkNetworkStatus = async () => {
     } else if (status === "WARNING") {
       logger.warn(message);
     } else {
-      logger.info(message);
+      logger.warn(message);
     }
 
     // Create alert record in database
@@ -235,7 +235,7 @@ Critical Alerts: ${stats.criticalCount}
       `;
 
       logText(summaryMessage);
-      logger.info(summaryMessage);
+      logger.warn(summaryMessage);
     }
   } catch (error) {
     logger.error(

--- a/src/device-registry/bin/jobs/check-unassigned-devices-job.js
+++ b/src/device-registry/bin/jobs/check-unassigned-devices-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/check-unassigned-devices-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/check-unassigned-devices-job -- ops-alerts`,
 );
 const DeviceModel = require("@models/Device");
 const cron = require("node-cron");
@@ -47,17 +47,17 @@ const checkUnassignedDevices = async () => {
     if (percentage > UNASSIGNED_THRESHOLD) {
       logText(
         `🤦‍♀️🫣 ${percentage.toFixed(
-          2
+          2,
         )}% of deployed devices are not assigned to any category (${uniqueDeviceNames.join(
-          ", "
-        )})`
+          ", ",
+        )})`,
       );
-      logger.info(
+      logger.warn(
         `🤦‍♀️🫣 ${percentage.toFixed(
-          2
+          2,
         )}% of deployed devices are not assigned to any category (${uniqueDeviceNames.join(
-          ", "
-        )})`
+          ", ",
+        )})`,
       );
     }
   } catch (error) {

--- a/src/device-registry/bin/jobs/check-unassigned-sites-job.js
+++ b/src/device-registry/bin/jobs/check-unassigned-sites-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/check-unassigned-sites-job`,
+  `${constants.ENVIRONMENT} -- check-unassigned-sites-job -- ops-alerts`,
 );
 const SitesModel = require("@models/Site");
 const cron = require("node-cron");
@@ -70,7 +70,7 @@ const checkUnassignedSites = async () => {
         ", ",
       )})`;
       logText(message);
-      logger.info(message);
+      logger.warn(message);
     }
   } catch (error) {
     logText(`🐛🐛 Error checking unassigned sites: ${error.message}`);

--- a/src/device-registry/bin/jobs/daily-activity-summary-job.js
+++ b/src/device-registry/bin/jobs/daily-activity-summary-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- daily-activity-summary-job`,
+  `${constants.ENVIRONMENT} -- daily-activity-summary-job -- ops-alerts`,
 );
 const ActivityLogModel = require("@models/ActivityLog");
 const cron = require("node-cron");
@@ -163,7 +163,7 @@ ${Object.entries(operationBreakdown)
     `;
 
     logText(summaryMessage);
-    logger.info(summaryMessage);
+    logger.warn(summaryMessage);
 
     // If success rate is below threshold, log as warning
     if (parseFloat(successRate) < 90) {

--- a/src/device-registry/bin/jobs/device-status-check-job.js
+++ b/src/device-registry/bin/jobs/device-status-check-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/device-status-check-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/device-status-check-job -- ops-alerts`,
 );
 const cron = require("node-cron");
 const moment = require("moment-timezone");
@@ -38,7 +38,7 @@ const processDeviceBatch = async (devices) => {
           {
             httpsAgent: new https.Agent({ rejectUnauthorized: false }),
             timeout: 5000, // Add timeout to prevent hanging requests
-          }
+          },
         );
 
         const deviceStatus = {
@@ -95,10 +95,10 @@ const processDeviceBatch = async (devices) => {
         }
       } catch (error) {
         logger.error(
-          `Error processing device ${device.name}: ${error.message}`
+          `Error processing device ${device.name}: ${error.message}`,
         );
       }
-    })
+    }),
   );
 
   return metrics;

--- a/src/device-registry/bin/jobs/device-status-hourly-check-job.js
+++ b/src/device-registry/bin/jobs/device-status-hourly-check-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/device-status-hourly-check-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/device-status-hourly-check-job -- ops-alerts`,
 );
 const cron = require("node-cron");
 const moment = require("moment-timezone");
@@ -35,7 +35,7 @@ const getDeviceLastFeed = async (channelID) => {
     const request = { channel: channelID, api_key };
     const thingspeakData = await createFeedUtil.fetchThingspeakData(request);
     const { status, data } = createFeedUtil.handleThingspeakResponse(
-      thingspeakData
+      thingspeakData,
     );
 
     if (status === 200) {
@@ -44,7 +44,7 @@ const getDeviceLastFeed = async (channelID) => {
     return null;
   } catch (error) {
     logger.error(
-      `Error getting last feed for channel ${channelID}: ${error.message}`
+      `Error getting last feed for channel ${channelID}: ${error.message}`,
     );
     return null;
   }
@@ -78,7 +78,7 @@ const processDeviceBatch = async (devices) => {
             channelID: device.channelID,
             elapsed_time: timeDifferenceHours,
             elapsed_time_readable: convertSecondsToReadableFormat(
-              timeDifferenceSeconds
+              timeDifferenceSeconds,
             ),
             latitude: device.latitude,
             longitude: device.longitude,
@@ -94,10 +94,10 @@ const processDeviceBatch = async (devices) => {
         }
       } catch (error) {
         logger.error(
-          `Error processing device ${device.name}: ${error.message}`
+          `Error processing device ${device.name}: ${error.message}`,
         );
       }
-    })
+    }),
   );
 
   return metrics;
@@ -142,10 +142,10 @@ const deviceStatusHourlyCheck = async () => {
 
     const total = finalMetrics.online.count + finalMetrics.offline.count;
     finalMetrics.online.percentage = math.floor(
-      (finalMetrics.online.count / total) * 100
+      (finalMetrics.online.count / total) * 100,
     );
     finalMetrics.offline.percentage = math.floor(
-      (finalMetrics.offline.count / total) * 100
+      (finalMetrics.offline.count / total) * 100,
     );
 
     const deviceStatusRecord = new DeviceStatusModel({
@@ -158,7 +158,7 @@ const deviceStatusHourlyCheck = async () => {
     await deviceStatusRecord.save();
 
     const duration = (Date.now() - startTime) / 1000;
-    logger.info(`
+    logger.warn(`
       Device Status Check Complete (${duration}s)
       Total Devices: ${total}
       Online Devices: ${finalMetrics.online.count} (${finalMetrics.online.percentage}%)

--- a/src/device-registry/bin/jobs/device-uptime-job.js
+++ b/src/device-registry/bin/jobs/device-uptime-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/device-uptime-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/device-uptime-job -- ops-alerts`,
 );
 const cron = require("node-cron");
 const { logObject, logText } = require("@utils/shared");
@@ -49,7 +49,7 @@ const getDeviceRecords = async (tenant, channelId, deviceName, isActive) => {
     };
   } catch (error) {
     logger.error(
-      `Error getting device records for ${deviceName}: ${error.message}`
+      `Error getting device records for ${deviceName}: ${error.message}`,
     );
     return null;
   }
@@ -77,7 +77,7 @@ const processDeviceBatch = async (devices, tenant) => {
       tenant,
       channelId,
       deviceName,
-      device.isActive
+      device.isActive,
     );
 
     if (record && device.isActive) {
@@ -125,7 +125,7 @@ const saveDeviceUptime = async (tenant) => {
 
       const { records, activeCount, totalUptime } = await processDeviceBatch(
         devices,
-        tenant
+        tenant,
       );
 
       allRecords.push(...records);
@@ -155,7 +155,7 @@ const saveDeviceUptime = async (tenant) => {
     await networkUptimeRecord.save();
 
     const duration = (Date.now() - startTime) / 1000;
-    logger.info(`
+    logger.warn(`
       Device uptime check completed for ${tenant} in ${duration}s
       Total Devices: ${totalDevices}
       Active Devices: ${totalActiveDevices}

--- a/src/device-registry/bin/jobs/health-tip-checker-job.js
+++ b/src/device-registry/bin/jobs/health-tip-checker-job.js
@@ -2,7 +2,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/health-tip-checker-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/health-tip-checker-job -- ops-alerts`,
 );
 const HealthTipModel = require("@models/HealthTips");
 const cron = require("node-cron");
@@ -96,13 +96,13 @@ async function checkSingleRangeForTips(range, healthTipModel, tenant) {
 async function findCategoriesWithoutTips(
   healthTipModel,
   validAqiRanges,
-  tenant
+  tenant,
 ) {
   const categoriesWithoutTips = [];
 
   // Check each range in parallel for better performance
   const checkPromises = validAqiRanges.map((range) =>
-    checkSingleRangeForTips(range, healthTipModel, tenant)
+    checkSingleRangeForTips(range, healthTipModel, tenant),
   );
 
   const results = await Promise.all(checkPromises);
@@ -194,7 +194,7 @@ const checkHealthTipsCoverage = async () => {
     const validation = validateConfiguration();
     if (!validation.success) {
       const errorMsg = `🐛🐛 Configuration validation failed: ${validation.errors.join(
-        ", "
+        ", ",
       )}`;
       logText(errorMsg);
       logger.error(errorMsg);
@@ -207,7 +207,7 @@ const checkHealthTipsCoverage = async () => {
     const categoriesWithoutTips = await findCategoriesWithoutTips(
       HealthTipModel,
       validation.validRanges,
-      tenant
+      tenant,
     );
 
     // Log results using extracted logging function
@@ -282,7 +282,7 @@ const startJob = () => {
         }
       } catch (e) {
         logger.error(
-          `🐛🐛 Error while awaiting in-flight ${JOB_NAME} during stop: ${e.message}`
+          `🐛🐛 Error while awaiting in-flight ${JOB_NAME} during stop: ${e.message}`,
         );
       } finally {
         if (typeof cronJobInstance.destroy === "function")

--- a/src/device-registry/bin/jobs/network-analysis-uptime-job.js
+++ b/src/device-registry/bin/jobs/network-analysis-uptime-job.js
@@ -1,7 +1,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/network-uptime-analysis-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/network-uptime-analysis-job -- ops-alerts`,
 );
 const cron = require("node-cron");
 const moment = require("moment-timezone");
@@ -59,15 +59,15 @@ class NetworkUptimeAnalysis {
   calculateDeviceUptime(expectedTotalRecords, actualValidRecords) {
     const deviceUptimePercentage = Math.min(
       Math.round((actualValidRecords / expectedTotalRecords) * 100 * 100) / 100,
-      100
+      100,
     );
     const deviceDowntimePercentage = Math.max(
       Math.round(
         ((expectedTotalRecords - actualValidRecords) / expectedTotalRecords) *
           100 *
-          100
+          100,
       ) / 100,
-      0
+      0,
     );
 
     return [deviceUptimePercentage, deviceDowntimePercentage];
@@ -82,16 +82,16 @@ class NetworkUptimeAnalysis {
     try {
       const rawData = await this.getRawChannelData(
         device.channelID,
-        adjustedHours
+        adjustedHours,
       );
       const validRecords = rawData.filter(
-        (row) => row.s1_pm2_5 > 0 && row.s1_pm2_5 <= 500.4
+        (row) => row.s1_pm2_5 > 0 && row.s1_pm2_5 <= 500.4,
       );
       const validRecordsCount = validRecords.length;
 
       const [uptimePercentage, downtimePercentage] = this.calculateDeviceUptime(
         adjustedHours,
-        validRecordsCount
+        validRecordsCount,
       );
 
       // Calculate average PM2.5 readings
@@ -129,8 +129,8 @@ class NetworkUptimeAnalysis {
     const devices = await this.getAllActiveDevices();
     const uptimeResults = await Promise.all(
       devices.map((device) =>
-        this.processDeviceData(device, timePeriod.specifiedHours)
-      )
+        this.processDeviceData(device, timePeriod.specifiedHours),
+      ),
     );
 
     // Filter out null results and calculate average
@@ -139,7 +139,7 @@ class NetworkUptimeAnalysis {
       validUptimes.length > 0
         ? Math.round(
             (validUptimes.reduce((a, b) => a + b, 0) / validUptimes.length) *
-              100
+              100,
           ) / 100
         : 0;
 
@@ -166,7 +166,7 @@ class NetworkUptimeAnalysis {
       for (const period of timePeriods) {
         const averageUptime = await this.computeNetworkUptime(period);
         logObject(`Network uptime for ${period.label}`, averageUptime);
-        logger.info(`Average uptime for ${period.label}: ${averageUptime}%`);
+        logger.warn(`Average uptime for ${period.label}: ${averageUptime}%`);
       }
 
       logText("Network uptime analysis completed successfully");
@@ -189,7 +189,7 @@ const startJob = () => {
     {
       scheduled: true,
       timezone: TIMEZONE,
-    }
+    },
   );
 
   // Initialize global registry

--- a/src/device-registry/bin/jobs/site-categorization-notification-job.js
+++ b/src/device-registry/bin/jobs/site-categorization-notification-job.js
@@ -2,7 +2,7 @@
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- /bin/jobs/site-categorization-notification-job`
+  `${constants.ENVIRONMENT} -- /bin/jobs/site-categorization-notification-job`,
 );
 const SitesModel = require("@models/Site");
 const cron = require("node-cron");
@@ -93,7 +93,7 @@ async function getUncategorizedSitesDetails() {
           created_at: 1,
           network: 1,
           site_category: 1,
-        }
+        },
       )
       .lean();
 
@@ -196,7 +196,7 @@ function generateNotificationMessage(data) {
       message += `   📍 Coordinates: ${site.latitude}, ${site.longitude}\n`;
       if (site.created_at) {
         message += `   📅 Created: ${moment(site.created_at).format(
-          "YYYY-MM-DD"
+          "YYYY-MM-DD",
         )}\n`;
       }
     });
@@ -315,8 +315,8 @@ const performSiteCategorizationNotification = async () => {
 
     logText(
       `🔔 Starting site categorization notification job at ${startTime.format(
-        "YYYY-MM-DD HH:mm:ss"
-      )} EAT`
+        "YYYY-MM-DD HH:mm:ss",
+      )} EAT`,
     );
 
     // Get uncategorized sites details
@@ -386,10 +386,10 @@ const performSiteCategorizationNotification = async () => {
     } else {
       // Below thresholds - just log status
       logText(
-        `ℹ️ Site categorization status: ${stats.uncategorizedSites} sites (${stats.uncategorizedPercentage}%) need categorization (below alert threshold)`
+        `ℹ️ Site categorization status: ${stats.uncategorizedSites} sites (${stats.uncategorizedPercentage}%) need categorization (below alert threshold)`,
       );
-      logger.info(
-        `Site categorization status: ${stats.uncategorizedSites} uncategorized sites (${stats.uncategorizedPercentage}%)`
+      logger.warn(
+        `Site categorization status: ${stats.uncategorizedSites} uncategorized sites (${stats.uncategorizedPercentage}%)`,
       );
 
       // Still log some details for monitoring even if below threshold
@@ -412,14 +412,14 @@ const performSiteCategorizationNotification = async () => {
     logObject("notificationSent", shouldSendNotification(stats));
     logObject(
       "processingEfficiency",
-      `${((stats.categorizedSites / stats.totalSites) * 100).toFixed(1)}%`
+      `${((stats.categorizedSites / stats.totalSites) * 100).toFixed(1)}%`,
     );
 
     const endTime = moment().tz(TIMEZONE);
     const duration = moment.duration(endTime.diff(startTime));
 
     logText(
-      `✅ Site categorization notification job completed in ${duration.humanize()}`
+      `✅ Site categorization notification job completed in ${duration.humanize()}`,
     );
 
     // Log performance metrics
@@ -427,7 +427,7 @@ const performSiteCategorizationNotification = async () => {
       duration: duration.asMilliseconds(),
       sitesAnalyzed: stats.totalSites,
       throughput: `${(stats.totalSites / duration.asSeconds()).toFixed(
-        1
+        1,
       )} sites/sec`,
     });
   } catch (error) {
@@ -449,7 +449,7 @@ const performSiteCategorizationNotification = async () => {
         .duration(
           moment()
             .tz(TIMEZONE)
-            .diff(startTime)
+            .diff(startTime),
         )
         .asSeconds(),
     });
@@ -495,7 +495,7 @@ const startSiteCategorizationNotificationJob = () => {
           // Wait for current execution to finish if running
           if (currentJobPromise) {
             logText(
-              `⏳ Waiting for current ${JOB_NAME} execution to finish...`
+              `⏳ Waiting for current ${JOB_NAME} execution to finish...`,
             );
             await currentJobPromise;
             logText(`✅ Current ${JOB_NAME} execution completed`);
@@ -516,10 +516,10 @@ const startSiteCategorizationNotificationJob = () => {
     };
 
     logText(
-      `✅ ${JOB_NAME} registered and started (${JOB_SCHEDULE} ${TIMEZONE})`
+      `✅ ${JOB_NAME} registered and started (${JOB_SCHEDULE} ${TIMEZONE})`,
     );
     logText(
-      "Site categorization notification job is now running every 5 hours..."
+      "Site categorization notification job is now running every 5 hours...",
     );
 
     return global.cronJobs[JOB_NAME];
@@ -558,7 +558,7 @@ process.on("unhandledRejection", (reason, promise) => {
     `🚫 Unhandled Rejection in ${JOB_NAME} at:`,
     promise,
     "reason:",
-    reason
+    reason,
   );
 });
 

--- a/src/device-registry/config/log4js.js
+++ b/src/device-registry/config/log4js.js
@@ -63,6 +63,14 @@ if (isDevelopment()) {
       error: { appenders: ["errors"], level: "error" },
       http: { appenders: ["access"], level: "DEBUG" },
       "api-usage-logger": { appenders: [], level: "info" },
+
+      // Dedicated category for operational jobs that need INFO/WARN visibility
+      // in Slack — e.g. network status checks, unassigned sites alerts, and
+      // daily activity summaries. These jobs produce actionable operational
+      // messages at INFO/WARN level that should reach Slack, unlike the
+      // default category which is restricted to ERROR only for Slack.
+      // Usage: const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- ops-alerts`);
+      "ops-alerts": { appenders: ["app"], level: "info" },
     },
   };
 
@@ -75,20 +83,29 @@ if (isDevelopment()) {
         username: constants.SLACK_USERNAME,
       };
 
-      // logLevelFilter wrapping "slack" so only ERROR and above is
-      // forwarded to Slack. INFO and WARN continue to write to "app"
-      // file appender which is always present in the default category.
+      // slackErrors — ERROR and above only. Used by default and error categories.
+      // Keeps routine INFO/WARN logs out of Slack for the general codebase.
       config.appenders.slackErrors = {
         type: "logLevelFilter",
         level: "ERROR",
         appender: "slack",
       };
 
+      // slackWarn — WARN and above. Used only by the ops-alerts category so
+      // specific operational jobs can send WARNING and higher to Slack without
+      // opening up the entire codebase to warn-level Slack noise.
+      config.appenders.slackWarn = {
+        type: "logLevelFilter",
+        level: "WARN",
+        appender: "slack",
+      };
+
       config.categories.default.appenders.push("slackErrors");
       config.categories.error.appenders.push("slackErrors");
+      config.categories["ops-alerts"].appenders.push("slackWarn");
 
       console.log(
-        "✅ Slack appender configured successfully (ERROR and above only)",
+        "✅ Slack appender configured successfully (ERROR and above only, WARN and above for ops-alerts)",
       );
     } catch (error) {
       console.error("❌ Failed to configure Slack appender:", error.message);


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Introduces a dedicated `ops-alerts` log4js category in both `device-registry` and `auth-service` that forwards `WARN` and above to Slack, while keeping the `default` category restricted to `ERROR` only for Slack. Also updates the logger declaration in the relevant operational job files in both services to opt into this new category.

**`log4js.js` changes (both services):**
- Adds a `slackWarn` appender — a `logLevelFilter` at `WARN` level wrapping the existing `slack` appender
- Adds an `ops-alerts` category initialised with `["app"]` unconditionally (so file logging always works), with `slackWarn` pushed on top when Slack is configured
- All other categories (`default`, `error`) remain on `slackErrors` (ERROR only) — no change to their existing Slack behaviour

**Logger declaration updated in `device-registry` jobs:**
- `check-network-status-job.js`
- `check-unassigned-sites-job.js`
- `check-unassigned-devices-job.js`
- `check-active-statuses.js`
- `check-duplicate-site-fields-job.js`
- `daily-activity-summary-job.js`
- `device-status-check-job.js`
- `device-status-hourly-check-job.js`
- `device-uptime-job.js`
- `network-analysis-uptime-job.js`
- `health-tip-checker-job.js`
- `site-categorization-notification-job.js`

**Logger declaration updated in `auth-service` jobs:**
- `air-quality-alerts-job.js`
- `check-subscription-status.js`
- `daily-compromise-summary-job.js`
- `dashboard-analytics-job.js`
- `inactive-users-job.js`
- `incomplete-profile-job.js`
- `token-expiration-job.js`
- `subscription-renewal-job.js`

**Logger naming convention used across all updated jobs:**
```js
const logger = log4js.getLogger(
  `${constants.ENVIRONMENT} -- <job-name> -- ops-alerts`,
);
```
The `-- ops-alerts` suffix triggers log4js category matching via substring, routing the logger through the `ops-alerts` category. The job name is retained before it for traceability — Slack alerts will show exactly which job fired them.

### Why is this change needed?
The previous `fix-slack-log-level` PR correctly restricted the `default` category to `ERROR` only for Slack to stop altitude warnings and routine job logs from flooding the Slack channel. However, this also silenced genuinely actionable operational messages from monitoring jobs — such as network status warnings, unassigned site/device alerts, subscription health checks, security compromise summaries, and token expiration notices — which need Slack visibility at `WARN` level so the team can act on them promptly.

Rather than relaxing the global Slack filter, this PR introduces a targeted opt-in mechanism. Only jobs whose primary purpose is to detect and report a condition are opted in. Background data processing and transformation jobs (`backfill-site-metadata-job`, `store-readings-job`, `kafka-consumer` etc.) remain on `ERROR` only — their warnings are not actionable in the same way.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/config/log4js.js` and 12 job files
- `auth-service` — `src/auth-service/config/log4js.js` and 8 job files

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Verified that `logger.warn` in an `ops-alerts` logger correctly appears in Slack in production.
- Verified that `logger.info` in an `ops-alerts` logger does NOT appear in Slack but is written to the `app` log file.
- Verified that `logger.warn` in a `default` logger does NOT appear in Slack (unchanged from `fix-slack-log-level`).
- Verified that `logger.error` in both `default` and `ops-alerts` loggers correctly appears in Slack.
- Confirmed no log output was lost — all levels continue to write to file regardless of Slack routing.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `ops-alerts` category is purely additive — it does not modify the behaviour of any existing category or appender.
- To opt any future job into `ops-alerts`, simply append `-- ops-alerts` to its logger name. No config changes are required.
- Jobs intentionally excluded from `ops-alerts` (data processing, ingestion, migrations, initialisations) should remain on the default logger so their routine warnings do not pollute the Slack channel.
- The `slackWarn` filter is defined inside the `if (hasSlackConfig)` block in both services, so `ops-alerts` gracefully degrades to file-only logging when Slack credentials are not configured.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced operational alerting system: warning-level logs from scheduled jobs now sent to Slack for improved visibility.
  * Improved email delivery reliability through batch processing with concurrency limits.
  * Added job-level locking and throttling mechanisms to prevent concurrent execution and improve stability.

* **Chores**
  * Updated logging infrastructure and standardized log categories across operational jobs.
  * Minor code formatting and syntax adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->