### PR TITLE
Prefer cached location metadata to incoming location data

### DIFF
--- a/src/workflows/airqo_etl_utils/datautils.py
+++ b/src/workflows/airqo_etl_utils/datautils.py
@@ -819,8 +819,8 @@ class DataUtils:
             lat_fallback = device.get("latitude")
             lon_fallback = device.get("longitude")
         else:
-            lat_fallback = meta_data.get("latitude") or device.get("latitude")
-            lon_fallback = meta_data.get("longitude") or device.get("longitude")
+            lat_fallback = device.get("latitude") or meta_data.get("latitude")
+            lon_fallback = device.get("longitude") or meta_data.get("longitude")
 
         data = DataValidationUtils.fill_missing_columns(data=data, cols=data_columns)
         data["device_category"] = device.get("device_category")


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
Prefers cached location data to incoming location data when processing device data

### Why is this change needed?
To ensure location data is almost always picked from cached data

---

## 🔗 Related Issues
- [ ] OPS-445

---

## 🔄 Type of Change
- [ ] 🔧 Enhancement/improvement
- [ ] ♻️ Refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected coordinate resolution logic to prioritize device-specific values over metadata values, ensuring accurate location data assignment for devices with explicit coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->