### PR TITLE
fix(readings): resolve empty measurements array on /readings/map endpoint

### DIFF
--- a/src/device-registry/controllers/event.controller.js
+++ b/src/device-registry/controllers/event.controller.js
@@ -1136,6 +1136,8 @@ const createEvent = {
         },
       };
 
+      delete request.query.internal;
+
       const { cohort_id } = { ...req.query, ...req.params };
 
       if (cohort_id) {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
This PR fixes a regression on the `/api/v2/devices/readings/map` endpoint that was causing it to return an empty `measurements` array.

### Why is this change needed?
The endpoint was recently updated to use a new utility function (`createEventUtil.listForMap`) that returns data in a paginated format (`{ data: { measurements: [...] } }`). However, the controller's response handler was not updated to handle this new nested data structure and was expecting a flat array of measurements directly. This mismatch caused the endpoint to fail silently and return an empty array.

This change reverts the data fetching logic in the `readingsForMap` controller to use the `createEventUtil.readRecentWithFilter` utility, which returns data in the correct format and immediately restores the endpoint's functionality.

---

## :link: Related Issues
- [ ] Closes #<ISSUE_NUMBER>
- [ ] Fixes #<ISSUE_NUMBER>
- [ ] Related to #<ISSUE_NUMBER>

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- device-registry

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually tested the `/api/v2/devices/readings/map` endpoint using Postman. Verified that the `measurements` array in the JSON response is now correctly populated with the latest readings for each site, whereas it was returning empty on the `staging` branch.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
This fix is targeted and ensures that the new `listForMap` utility remains available for other endpoints that are designed to handle its paginated response structure.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation flow for the map readings endpoint to terminate early on invalid requests.
  * Standardized error responses with explicit status handling and consistent formatting.

* **Changes**
  * Map readings now default the tenant to "airqo" when omitted.
  * Optimized data retrieval and inlined response shaping for clearer success/error payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->