### PR TITLE
fix: reduce map endpoint latency via index and scan window optimisation

### DIFF
--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -55,22 +55,35 @@ const createSafePollutantLookup = (
 // SHARED HELPER — clampMapTimeWindow
 //
 // Single source of truth for the time-window clamping rules used by both
-// listForMap and latestForMap. Extracted to eliminate the duplicated
-// fortyEightHoursAgo / fourteenDaysAgo / effectiveGte blocks (finding 2).
+// listForMap and latestForMap. Accepts the raw filter.time value directly
+// (either a { $gte: Date, ... } object or a bare Date instance) and
+// normalises it internally so both callers behave identically regardless
+// of how filter.time was passed.
 //
-//   • No callerGte              → 48 h default (fast path, partial index hit)
-//   • callerGte within 48 h    → honour as-is
-//   • callerGte within 14 d    → honour as-is
-//   • callerGte older than 14 d → clamp to fourteenDaysAgo (TTL boundary),
-//                                  NOT fortyEightHoursAgo so data between
-//                                  48 h–14 d is never silently discarded
+//   • No callerTime / no resolvable $gte → 48 h default (partial index hit)
+//   • resolved $gte within 48 h          → honour as-is
+//   • resolved $gte within 14 d          → honour as-is
+//   • resolved $gte older than 14 d      → clamp to fourteenDaysAgo (TTL),
+//                                           NOT fortyEightHoursAgo so data
+//                                           between 48 h–14 d is preserved
 //
-// @param {Date|undefined} callerGte
+// @param {Date|{ $gte?: Date, $lte?: Date, $lt?: Date }|undefined} callerTime
+//   The raw filter.time value — pass filter.time (listForMap) or callerTime
+//   (latestForMap after destructuring) directly; no pre-extraction needed.
 // @returns {{ effectiveGte: Date, fourteenDaysAgo: Date }}
 // ═══════════════════════════════════════════════════════════════════════════════
-const clampMapTimeWindow = (callerGte) => {
+const clampMapTimeWindow = (callerTime) => {
   const fortyEightHoursAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
   const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+
+  // Normalise: a plain Date is treated as a lower bound; an object may carry
+  // $gte; anything else (null/undefined) resolves to undefined → default 48 h.
+  const callerGte =
+    callerTime instanceof Date
+      ? callerTime
+      : callerTime?.$gte instanceof Date
+      ? callerTime.$gte
+      : undefined;
 
   let effectiveGte;
   if (!callerGte) {
@@ -789,12 +802,10 @@ ReadingsSchema.statics.latestForMap = async function(
       ...safeFilterForMatch
     } = filter;
 
-    // Resolve callerGte — handle both { $gte: Date } and a bare Date instance.
-    const callerGte =
-      callerTime?.$gte ?? (callerTime instanceof Date ? callerTime : undefined);
-
-    // Delegate to shared helper — eliminates duplication with listForMap.
-    const { effectiveGte } = clampMapTimeWindow(callerGte);
+    // Delegate to shared helper — pass callerTime directly; normalisation of
+    // bare Date vs { $gte } object is handled inside clampMapTimeWindow,
+    // making this identical to the listForMap call path.
+    const { effectiveGte } = clampMapTimeWindow(callerTime);
 
     // Preserve any caller-supplied upper bound ($lte / $lt) while enforcing
     // the clamped lower bound. Mirror the listForMap timeConstraint pattern:
@@ -1823,8 +1834,9 @@ ReadingsSchema.statics.listForMap = async function(
         ? 0
         : parsedSkip;
 
-    // Delegate to shared helper — see clampMapTimeWindow defined above.
-    const { effectiveGte } = clampMapTimeWindow(filter.time?.$gte);
+    // Delegate to shared helper — pass filter.time directly; the helper
+    // normalises bare Date vs { $gte } object identically to latestForMap.
+    const { effectiveGte } = clampMapTimeWindow(filter.time);
 
     const timeConstraint = {
       ...(filter.time || {}),


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes 18+ second load times on `GET /api/v2/devices/readings/map` and `GET /api/v2/devices/readings/map/test` by correcting a partial index predicate mismatch and reducing the default aggregation scan window from 14 days to 48 hours.

**Three targeted changes in `Reading.js`:**

1. **Fix partial index partial filter** — The existing `{ time: -1, "pm2_5.value": 1 }` index had `partialFilterExpression: { "pm2_5.value": { $exists: true, $ne: null } }`. MongoDB's query planner does **not** recognise `{ $gt: 0 }` as a superset of `{ $ne: null }`, so every `listForMap` and `latestForMap` call silently fell back to a full collection scan. The partial filter is updated to `{ "pm2_5.value": { $gt: 0 } }` to exactly match the query predicate.

2. **Reduce scan window from 14 days → 48 hours** in both `listForMap` and `latestForMap`. A map view only needs the most recent reading per site/device. With 474+ active devices reporting every 5–15 minutes, 14 days ≈ 1.93 M documents before deduplication; 48 hours ≈ 274 K — a **~7× reduction** in documents scanned, sorted, and grouped. The 14-day outer bound is preserved as a hard cap so the TTL and existing behaviour are unchanged.

3. **Simplify `pm2_5` query predicate** from `{ $exists: true, $gt: 0 }` → `{ $gt: 0 }`. The `$exists: true` clause is redundant (implied by `$gt: 0`) and was the second reason the query planner could not match the partial index.

### Why is this change needed?

Both map endpoints regressed to 18+ seconds after recent deployment. The root cause is not the deployment itself but the fact that `listForMap` was a new aggregation pipeline with no validated "before" baseline — it was always hitting millions of documents without the partial index being usable. The fix makes the index work as intended and shrinks the input dataset by 7×.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :wrench: Enhancement/improvement
- [ ] :sparkles: New feature
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `device-registry` — `src/device-registry/models/Reading.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

After deploying, verify with:
```bash
# Both should respond in under 3 seconds
curl -w "\nTime: %{time_total}s\n" "https://<host>/api/v2/devices/readings/map?tenant=airqo"
curl -w "\nTime: %{time_total}s\n" "https://<host>/api/v2/devices/readings/map/test?tenant=airqo"
```

Run the one-time index migration in the mongo shell **before or immediately after deploy**:
```js
// Check the exact current index name first
db.readings.getIndexes().filter(i => i.key["pm2_5.value"])

// Drop the old partial index
db.readings.dropIndex("time_-1_pm2_5.value_1")   // adjust name if different

// Recreate with correct partial filter (Mongoose will also do this on app restart)
db.readings.createIndex(
  { time: -1, "pm2_5.value": 1 },
  {
    name: "time_pm25_map_idx",
    partialFilterExpression: { "pm2_5.value": { $gt: 0 } },
    background: true
  }
)
```

Confirm the index is being used:
```js
db.readings.explain("executionStats").aggregate([
  { $match: { time: { $gte: new Date(Date.now() - 48*60*60*1000) }, "pm2_5.value": { $gt: 0 } } },
  { $sort: { time: -1 } }
])
// Look for: winningPlan.stage === "IXSCAN" using "time_pm25_map_idx"
```

---

## :boom: Breaking Changes

- [x] **No breaking changes**

The 48-hour window only affects the default lower bound for `listForMap` and `latestForMap` when no explicit `time.$gte` filter is provided by the caller. Any caller passing a tighter time window is unaffected. Any caller relying on data older than 48 hours from these two map-specific statics should not exist — but if it does, the caller can pass an explicit `filter.time.$gte`.

---

## :memo: Additional Notes

- The partial index drop-and-recreate is a **one-time manual step**. MongoDB does not automatically replace a partial index whose partial filter changes — it creates a second index alongside the old one, which wastes memory and does not fix the query plan. Drop the old index first.
- `createIndex` with `{ background: true }` on the live Readings collection should complete in a few minutes without blocking reads or writes.
- The `$exists: true` clause was not causing a correctness bug — it was simply redundant and contributed to the planner skipping the index. Removing it is safe.
- `pm2_5.value` is correctly accessed via dot notation (`"pm2_5.value"`) because the schema defines `pm2_5: { value: Number }` — a nested object, not a flat field. This was verified against the schema before confirming the index key path.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added top-level public schemas exposing latest PM2.5 raw and calibrated values.

* **Bug Fixes / Improvements**
  * Unified and enforced map time-window (48-hour minimum, 14-day maximum) across queries.
  * Tightened map queries to require PM2.5 > 0 and reordered aggregation to apply safe filters earlier, improving accuracy and pagination.
  * Simplified outputs, adjusted diagnostics and non-fatal zero-result warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->