### PR TITLE
fix: normalize all_categories array before storing readings to prevent character-split corruption

### DIFF
--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -12,6 +12,7 @@ const { stringify, generateFilter } = require("@utils/common");
 const cron = require("node-cron");
 const moment = require("moment-timezone");
 const NodeCache = require("node-cache");
+const TIMEZONE = moment.tz.guess();
 
 // Cache manager for storing site averages
 const siteAveragesCache = new NodeCache({ stdTTL: 3600 }); // 1 hour TTL
@@ -377,7 +378,6 @@ async function fetchAndStoreReadings() {
   }
 }
 
-const TIMEZONE = moment.tz.guess();
 const JOB_NAME = "store-readings-job";
 const JOB_SCHEDULE = "30 * * * *"; // At minute 30 of every hour
 

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -252,7 +252,24 @@ const DeviceCategorySchema = new Schema(
     deployment_category: { type: String, default: null },
     mobile_category: { type: String, default: null },
     ownership_category: { type: String, default: null },
-    all_categories: { type: [String], default: [] },
+    all_categories: {
+      type: [String],
+      default: [],
+      set(value) {
+        // Setter runs BEFORE Mongoose's own [String] casting on .save()/.create(),
+        // intercepting the value while it is still in its original form.
+        // Mongoose coerces [String] paths before pre("validate") fires, so a setter
+        // is the only reliable hook for .save() paths.
+        if (Array.isArray(value)) return value;
+        if (typeof value === "string" && value.length > 0) {
+          return value
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+        }
+        return [];
+      },
+    },
     is_mobile: { type: Boolean, default: null },
     is_static: { type: Boolean, default: null },
     is_lowcost: { type: Boolean, default: null },
@@ -458,21 +475,65 @@ ReadingsSchema.pre("save", function(next) {
   next();
 });
 
-ReadingsSchema.pre("validate", function(next) {
-  if (
-    this.device_categories &&
-    this.device_categories.all_categories !== undefined &&
-    !Array.isArray(this.device_categories.all_categories)
-  ) {
-    const raw = this.device_categories.all_categories;
-    this.device_categories.all_categories =
-      typeof raw === "string" && raw.length > 0
-        ? raw
-            .split(",")
-            .map((s) => s.trim())
-            .filter(Boolean)
-        : [];
+function _normalizeAllCategoriesInUpdate(update) {
+  const payload = update.$set || update;
+
+  // Flat path: { "device_categories.all_categories": <value> }
+  const flatKey = "device_categories.all_categories";
+  if (Object.prototype.hasOwnProperty.call(payload, flatKey)) {
+    const raw = payload[flatKey];
+    if (!Array.isArray(raw)) {
+      payload[flatKey] =
+        typeof raw === "string" && raw.length > 0
+          ? raw
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : [];
+    }
   }
+
+  // Nested path: { device_categories: { all_categories: <value> } }
+  if (
+    payload.device_categories &&
+    typeof payload.device_categories === "object" &&
+    !Array.isArray(payload.device_categories) &&
+    Object.prototype.hasOwnProperty.call(
+      payload.device_categories,
+      "all_categories",
+    )
+  ) {
+    const raw = payload.device_categories.all_categories;
+    if (!Array.isArray(raw)) {
+      payload.device_categories.all_categories =
+        typeof raw === "string" && raw.length > 0
+          ? raw
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : [];
+    }
+  }
+}
+
+ReadingsSchema.pre("updateOne", function(next) {
+  try {
+    _normalizeAllCategoriesInUpdate(this.getUpdate());
+  } catch (_) {}
+  next();
+});
+
+ReadingsSchema.pre("updateMany", function(next) {
+  try {
+    _normalizeAllCategoriesInUpdate(this.getUpdate());
+  } catch (_) {}
+  next();
+});
+
+ReadingsSchema.pre("findOneAndUpdate", function(next) {
+  try {
+    _normalizeAllCategoriesInUpdate(this.getUpdate());
+  } catch (_) {}
   next();
 });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Normalizes `device_categories.all_categories` to a proper array before writing
to the Readings collection in `store-readings-job.js`. Instead of a direct
assignment, the field is now shallow-copied and guarded so that any non-array
value (e.g. a bare string) is coerced into an array before the `$set` upsert
is executed.

### Why is this change needed?
Mongoose defines `all_categories` in `DeviceCategorySchema` as `{ type: [String] }`.
When a plain string (e.g. `"airqo"`) is assigned to a `[String]` field, Mongoose
splits it character by character, producing `["a", "i", "r", "q", "o"]` instead
of `["airqo", "lowcost", "static"]`. This caused the `/api/v2/devices/readings/map`
endpoint (which reads from the Readings collection) to return malformed
`all_categories` arrays, while the `/map/test` endpoint (live aggregation) remained
correct. The fix ensures a properly formed array always reaches the database
regardless of what shape the upstream Events pipeline delivers.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/bin/jobs/store-readings-job.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified by comparing responses from `/api/v2/devices/readings/map` (Readings
collection) and `/api/v2/devices/readings/map/test` (live aggregation) before
and after the fix. Post-fix, `all_categories` in both endpoints returns
consistent full-string arrays (e.g. `["airqo", "lowcost", "static"]`) instead
of the corrupted single-character arrays previously observed on the `/map`
endpoint.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The fix only touches the `processDocument` method in `ReadingsBatchProcessor`.
  No schema changes, no route changes, no other job files affected.
- A defense-in-depth `pre("validate")` hook can be added to `Reading.js`
  (`DeviceCategorySchema`) as a follow-up to prevent any future writes of
  malformed `all_categories` values at the model level, regardless of call site.
- Existing documents in the Readings collection that were written with the
  corrupted character-split arrays will remain corrupted until the next cron
  run overwrites them via the upsert. No backfill migration is required;
  documents are refreshed automatically on the next `:30` cron tick.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized device category input so category lists are validated and stored as arrays, converting comma-separated strings when needed.
  * Prevented improper splitting of category strings into individual characters, ensuring consistent category data when readings are saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->