### PR TITLE
feat: add MongoDB-backed two-level cache to survive Kubernetes pod restarts

### DIFF
--- a/src/device-registry/models/Activity.js
+++ b/src/device-registry/models/Activity.js
@@ -125,6 +125,7 @@ activitySchema.pre("save", function(next) {
 });
 
 activitySchema.index({ site_id: 1, createdAt: -1 });
+activitySchema.index({ site_id: 1, activityType: 1, createdAt: -1 });
 activitySchema.index({ device_id: 1, createdAt: -1 });
 activitySchema.index({ device: 1, createdAt: -1 });
 activitySchema.index({ status: 1 });

--- a/src/device-registry/models/ComputedCache.js
+++ b/src/device-registry/models/ComputedCache.js
@@ -1,0 +1,78 @@
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+
+/**
+ * ComputedCache — lightweight MongoDB-backed key/value store for
+ * expensive aggregation results that need to survive pod restarts and be
+ * shared across all Kubernetes replicas.
+ *
+ * Why MongoDB instead of in-memory?
+ *   - In-memory caches are pod-local: each replica maintains its own copy,
+ *     so every pod independently pays the aggregation cost on its first miss.
+ *   - Pod restarts (rolling deploys, OOM kills, evictions) reset in-memory
+ *     caches, causing a cold-start spike on every replacement pod.
+ *   - A single MongoDB document is shared by all replicas. Once any one pod
+ *     writes it, all other pods benefit immediately on their next L2 read.
+ *
+ * Usage pattern (two-level cache):
+ *   1. Check L1 (in-memory)  → hit: return instantly
+ *   2. Check L2 (this model) → hit: populate L1, return
+ *   3. Both miss             → run expensive query, write to L2 + L1, return
+ *
+ * TTL: the `expiresAt` field carries a MongoDB TTL index so expired documents
+ * are cleaned up automatically. The application also checks `expiresAt` before
+ * trusting a document, so the effective TTL is controlled at the call site.
+ */
+const computedCacheSchema = new mongoose.Schema(
+  {
+    // Logical name of the cached computation, e.g. "private_site_ids"
+    key: {
+      type: String,
+      required: true,
+    },
+    // Tenant this cache entry belongs to
+    tenant: {
+      type: String,
+      required: true,
+    },
+    // The cached payload — any serialisable value
+    data: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true,
+    },
+    // When the computation was last run
+    computedAt: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+    // MongoDB TTL index field — document is automatically deleted after this
+    // timestamp. Acts as a server-side safety net so stale entries never
+    // accumulate even if the application logic skips a recompute cycle.
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+  },
+  { timestamps: false }
+);
+
+// One document per (key, tenant) pair
+computedCacheSchema.index({ key: 1, tenant: 1 }, { unique: true });
+
+// MongoDB removes the document automatically once expiresAt is in the past
+computedCacheSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+const ComputedCacheModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("computedcaches");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "computedcache", computedCacheSchema);
+  }
+};
+
+module.exports = ComputedCacheModel;

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1547,11 +1547,34 @@ const createCohort = {
           },
         },
         {
+          // Separate count lookup so total_activities reflects the true
+          // activity count, not the capped activitiesLimit window.
+          $lookup: {
+            from: "activities",
+            let: { deviceName: "$name", deviceId: "$_id" },
+            pipeline: [
+              {
+                $match: {
+                  $expr: {
+                    $or: [
+                      { $eq: ["$device", "$$deviceName"] },
+                      { $eq: ["$device_id", "$$deviceId"] },
+                    ],
+                  },
+                },
+              },
+              { $count: "count" },
+            ],
+            as: "activity_count",
+          },
+        },
+        {
           $addFields: {
+            // True total — not capped by activitiesLimit
             total_activities: {
-              $cond: [{ $isArray: "$activities" }, { $size: "$activities" }, 0],
+              $ifNull: [{ $arrayElemAt: ["$activity_count.count", 0] }, 0],
             },
-            // explicit metric for the truncated activities array we actually returned
+            // How many activity documents were actually returned in this response
             activities_loaded: {
               $cond: [{ $isArray: "$activities" }, { $size: "$activities" }, 0],
             },

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1845,55 +1845,79 @@ const createCohort = {
             as: "activities",
           },
         },
-        // Derive typed-activity arrays from the already-fetched activities
-        // array rather than issuing 3 separate collection lookups per site.
-        // The activities array is already sorted by createdAt desc, so
-        // $slice after $filter gives us the most-recent item of each type.
-        // Shape: array of 0 or 1 elements — matches the post-processing
-        // expectations below (checks .length > 0 then takes [0]).
+        // Dedicated lookups for the most-recent activity of each type.
+        // These cannot be derived from the capped activities array above
+        // because that array is limited to the 100 most-recent activities
+        // overall — the latest deployment/maintenance/recall could be older
+        // than position 100.  The compound index on Activity
+        // { site_id, activityType, createdAt } makes each of these an
+        // index-range scan + limit 1, so the cost is negligible.
         {
-          $addFields: {
-            latest_deployment_activity: {
-              $slice: [
-                {
-                  $filter: {
-                    input: { $ifNull: ["$activities", []] },
-                    as: "act",
-                    cond: { $eq: ["$$act.activityType", "deployment"] },
+          $lookup: {
+            from: "activities",
+            let: { siteId: "$_id" },
+            pipeline: [
+              {
+                $match: {
+                  $expr: {
+                    $and: [
+                      { $eq: ["$site_id", "$$siteId"] },
+                      { $eq: ["$activityType", "deployment"] },
+                    ],
                   },
                 },
-                1,
-              ],
-            },
-            latest_maintenance_activity: {
-              $slice: [
-                {
-                  $filter: {
-                    input: { $ifNull: ["$activities", []] },
-                    as: "act",
-                    cond: { $eq: ["$$act.activityType", "maintenance"] },
+              },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "latest_deployment_activity",
+          },
+        },
+        {
+          $lookup: {
+            from: "activities",
+            let: { siteId: "$_id" },
+            pipeline: [
+              {
+                $match: {
+                  $expr: {
+                    $and: [
+                      { $eq: ["$site_id", "$$siteId"] },
+                      { $eq: ["$activityType", "maintenance"] },
+                    ],
                   },
                 },
-                1,
-              ],
-            },
-            latest_recall_activity: {
-              $slice: [
-                {
-                  $filter: {
-                    input: { $ifNull: ["$activities", []] },
-                    as: "act",
-                    cond: {
-                      $or: [
-                        { $eq: ["$$act.activityType", "recall"] },
-                        { $eq: ["$$act.activityType", "recallment"] },
-                      ],
-                    },
+              },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "latest_maintenance_activity",
+          },
+        },
+        {
+          $lookup: {
+            from: "activities",
+            let: { siteId: "$_id" },
+            pipeline: [
+              {
+                $match: {
+                  $expr: {
+                    $and: [
+                      { $eq: ["$site_id", "$$siteId"] },
+                      {
+                        $or: [
+                          { $eq: ["$activityType", "recall"] },
+                          { $eq: ["$activityType", "recallment"] },
+                        ],
+                      },
+                    ],
                   },
                 },
-                1,
-              ],
-            },
+              },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "latest_recall_activity",
           },
         },
         {

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -323,8 +323,36 @@ const createCohort = {
         {
           $lookup: {
             from: "devices",
-            localField: "_id",
-            foreignField: "cohorts",
+            let: { cohortId: "$_id" },
+            // Project only the fields consumed by COHORTS_INCLUSION_PROJECTION
+            // so MongoDB transfers minimal data per device document.
+            pipeline: [
+              {
+                $match: {
+                  $expr: { $in: ["$$cohortId", { $ifNull: ["$cohorts", []] }] },
+                },
+              },
+              {
+                $project: {
+                  _id: 1,
+                  name: 1,
+                  long_name: 1,
+                  description: 1,
+                  latitude: 1,
+                  longitude: 1,
+                  device_number: 1,
+                  isActive: 1,
+                  isOnline: 1,
+                  rawOnlineStatus: 1,
+                  lastRawData: 1,
+                  lastActive: 1,
+                  status: 1,
+                  network: 1,
+                  createdAt: 1,
+                  deployment_date: 1,
+                },
+              },
+            ],
             as: "devices",
           },
         },
@@ -1817,72 +1845,55 @@ const createCohort = {
             as: "activities",
           },
         },
+        // Derive typed-activity arrays from the already-fetched activities
+        // array rather than issuing 3 separate collection lookups per site.
+        // The activities array is already sorted by createdAt desc, so
+        // $slice after $filter gives us the most-recent item of each type.
+        // Shape: array of 0 or 1 elements — matches the post-processing
+        // expectations below (checks .length > 0 then takes [0]).
         {
-          $lookup: {
-            from: "activities",
-            let: { siteId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $and: [
-                      { $eq: ["$site_id", "$$siteId"] },
-                      { $eq: ["$activityType", "deployment"] },
-                    ],
+          $addFields: {
+            latest_deployment_activity: {
+              $slice: [
+                {
+                  $filter: {
+                    input: { $ifNull: ["$activities", []] },
+                    as: "act",
+                    cond: { $eq: ["$$act.activityType", "deployment"] },
                   },
                 },
-              },
-              { $sort: { createdAt: -1 } },
-              { $limit: 1 },
-            ],
-            as: "latest_deployment_activity",
-          },
-        },
-        {
-          $lookup: {
-            from: "activities",
-            let: { siteId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $and: [
-                      { $eq: ["$site_id", "$$siteId"] },
-                      { $eq: ["$activityType", "maintenance"] },
-                    ],
+                1,
+              ],
+            },
+            latest_maintenance_activity: {
+              $slice: [
+                {
+                  $filter: {
+                    input: { $ifNull: ["$activities", []] },
+                    as: "act",
+                    cond: { $eq: ["$$act.activityType", "maintenance"] },
                   },
                 },
-              },
-              { $sort: { createdAt: -1 } },
-              { $limit: 1 },
-            ],
-            as: "latest_maintenance_activity",
-          },
-        },
-        {
-          $lookup: {
-            from: "activities",
-            let: { siteId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $and: [
-                      { $eq: ["$site_id", "$$siteId"] },
-                      {
-                        $or: [
-                          { $eq: ["$activityType", "recall"] },
-                          { $eq: ["$activityType", "recallment"] },
-                        ],
-                      },
-                    ],
+                1,
+              ],
+            },
+            latest_recall_activity: {
+              $slice: [
+                {
+                  $filter: {
+                    input: { $ifNull: ["$activities", []] },
+                    as: "act",
+                    cond: {
+                      $or: [
+                        { $eq: ["$$act.activityType", "recall"] },
+                        { $eq: ["$$act.activityType", "recallment"] },
+                      ],
+                    },
                   },
                 },
-              },
-              { $sort: { createdAt: -1 } },
-              { $limit: 1 },
-            ],
-            as: "latest_recall_activity",
+                1,
+              ],
+            },
           },
         },
         {

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -321,38 +321,14 @@ const createCohort = {
       const pipeline = [
         { $match: filter },
         {
+          // Simple array-membership join: MongoDB can use a multikey index on
+          // devices.cohorts with this form, unlike the correlated $expr/$in
+          // pipeline approach. Field trimming is handled downstream by the
+          // $map in COHORTS_INCLUSION_PROJECTION.
           $lookup: {
             from: "devices",
-            let: { cohortId: "$_id" },
-            // Project only the fields consumed by COHORTS_INCLUSION_PROJECTION
-            // so MongoDB transfers minimal data per device document.
-            pipeline: [
-              {
-                $match: {
-                  $expr: { $in: ["$$cohortId", { $ifNull: ["$cohorts", []] }] },
-                },
-              },
-              {
-                $project: {
-                  _id: 1,
-                  name: 1,
-                  long_name: 1,
-                  description: 1,
-                  latitude: 1,
-                  longitude: 1,
-                  device_number: 1,
-                  isActive: 1,
-                  isOnline: 1,
-                  rawOnlineStatus: 1,
-                  lastRawData: 1,
-                  lastActive: 1,
-                  status: 1,
-                  network: 1,
-                  createdAt: 1,
-                  deployment_date: 1,
-                },
-              },
-            ],
+            localField: "_id",
+            foreignField: "cohorts",
             as: "devices",
           },
         },
@@ -1852,6 +1828,8 @@ const createCohort = {
         // than position 100.  The compound index on Activity
         // { site_id, activityType, createdAt } makes each of these an
         // index-range scan + limit 1, so the cost is negligible.
+        // $project is placed after $match and before $sort/$limit to keep
+        // field parity with the main activities lookup and reduce sort memory.
         {
           $lookup: {
             from: "activities",
@@ -1865,6 +1843,22 @@ const createCohort = {
                       { $eq: ["$activityType", "deployment"] },
                     ],
                   },
+                },
+              },
+              {
+                $project: {
+                  _id: 1,
+                  site_id: 1,
+                  device_id: 1,
+                  device: 1,
+                  activityType: 1,
+                  maintenanceType: 1,
+                  recallType: 1,
+                  date: 1,
+                  description: 1,
+                  nextMaintenance: 1,
+                  createdAt: 1,
+                  tags: 1,
                 },
               },
               { $sort: { createdAt: -1 } },
@@ -1886,6 +1880,22 @@ const createCohort = {
                       { $eq: ["$activityType", "maintenance"] },
                     ],
                   },
+                },
+              },
+              {
+                $project: {
+                  _id: 1,
+                  site_id: 1,
+                  device_id: 1,
+                  device: 1,
+                  activityType: 1,
+                  maintenanceType: 1,
+                  recallType: 1,
+                  date: 1,
+                  description: 1,
+                  nextMaintenance: 1,
+                  createdAt: 1,
+                  tags: 1,
                 },
               },
               { $sort: { createdAt: -1 } },
@@ -1914,15 +1924,52 @@ const createCohort = {
                   },
                 },
               },
+              {
+                $project: {
+                  _id: 1,
+                  site_id: 1,
+                  device_id: 1,
+                  device: 1,
+                  activityType: 1,
+                  maintenanceType: 1,
+                  recallType: 1,
+                  date: 1,
+                  description: 1,
+                  nextMaintenance: 1,
+                  createdAt: 1,
+                  tags: 1,
+                },
+              },
               { $sort: { createdAt: -1 } },
               { $limit: 1 },
             ],
             as: "latest_recall_activity",
           },
         },
+        // Dedicated count lookup so total_activities reflects all activities
+        // for the site, not just the 100-document cap in the activities array.
+        // The { site_id, createdAt } index makes this an efficient count-scan.
+        // activity_count is an intermediate field; the inclusion $project
+        // below removes it from the final output automatically.
+        {
+          $lookup: {
+            from: "activities",
+            let: { siteId: "$_id" },
+            pipeline: [
+              { $match: { $expr: { $eq: ["$site_id", "$$siteId"] } } },
+              { $count: "count" },
+            ],
+            as: "activity_count",
+          },
+        },
         {
           $addFields: {
+            // True total across all activities for this site
             total_activities: {
+              $ifNull: [{ $arrayElemAt: ["$activity_count.count", 0] }, 0],
+            },
+            // Count of activities returned in the capped array (max 100)
+            recent_activities_count: {
               $cond: [{ $isArray: "$activities" }, { $size: "$activities" }, 0],
             },
           },

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -1,6 +1,7 @@
 const GridModel = require("@models/Grid");
 const SiteModel = require("@models/Site");
 const CohortModel = require("@models/Cohort");
+const ComputedCacheModel = require("@models/ComputedCache");
 const qs = require("qs");
 const DeviceModel = require("@models/Device");
 const AdminLevelModel = require("@models/AdminLevel");
@@ -21,6 +22,97 @@ const kafka = new Kafka({
   clientId: constants.KAFKA_CLIENT_ID,
   brokers: constants.KAFKA_BOOTSTRAP_SERVERS,
 });
+
+// ---------------------------------------------------------------------------
+// Two-level cache for the private-site-IDs aggregation.
+//
+// Why two levels?
+//   L1 (in-memory): pod-local, sub-millisecond reads, lost on pod restart.
+//   L2 (MongoDB):   shared across all Kubernetes replicas, survives restarts.
+//
+// Flow on each request:
+//   1. L1 hit  → return immediately (nanoseconds).
+//   2. L1 miss → check MongoDB document (one indexed findOne, ~1 ms).
+//      2a. L2 hit  → populate L1, return.
+//      2b. L2 miss → run full Cohort→Device aggregation, write to both
+//                    L2 and L1, then return.
+//
+// This means only ONE pod pays the aggregation cost after each TTL expiry;
+// every other replica immediately benefits from the shared L2 document on
+// its next request — including brand-new pods that Kubernetes just started.
+// ---------------------------------------------------------------------------
+const _privateSiteIdsCache = {};
+const PRIVATE_SITE_IDS_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const PRIVATE_SITE_IDS_CACHE_KEY = "private_site_ids";
+
+async function computePrivateSiteIds(tenant) {
+  const result = await CohortModel(tenant).aggregate([
+    { $match: { visibility: false } },
+    {
+      $lookup: {
+        from: "devices",
+        localField: "_id",
+        foreignField: "cohorts",
+        as: "devices",
+      },
+    },
+    { $unwind: "$devices" },
+    { $match: { "devices.site_id": { $ne: null } } },
+    { $group: { _id: null, site_ids: { $addToSet: "$devices.site_id" } } },
+  ]);
+  return result.length > 0 ? result[0].site_ids : [];
+}
+
+async function getPrivateSiteIds(tenant) {
+  const now = Date.now();
+
+  // ── L1: in-memory (pod-local) ──────────────────────────────────────────
+  const l1 = _privateSiteIdsCache[tenant];
+  if (l1 && now - l1.timestamp < PRIVATE_SITE_IDS_TTL_MS) {
+    return l1.data;
+  }
+
+  // ── L2: MongoDB (shared across all pods) ──────────────────────────────
+  try {
+    const l2 = await ComputedCacheModel(tenant)
+      .findOne({ key: PRIVATE_SITE_IDS_CACHE_KEY, tenant })
+      .lean();
+
+    if (l2 && l2.expiresAt > new Date()) {
+      // Fresh L2 hit — warm L1 and return
+      _privateSiteIdsCache[tenant] = { data: l2.data, timestamp: now };
+      return l2.data;
+    }
+  } catch (err) {
+    // L2 read failure is non-fatal: fall through to full recompute
+    logger.warn(
+      `ComputedCache L2 read failed for ${PRIVATE_SITE_IDS_CACHE_KEY}/${tenant}: ${err.message}`
+    );
+  }
+
+  // ── Full recompute (both levels missed or L2 unavailable) ─────────────
+  const data = await computePrivateSiteIds(tenant);
+  const expiresAt = new Date(now + PRIVATE_SITE_IDS_TTL_MS);
+
+  // Write L1
+  _privateSiteIdsCache[tenant] = { data, timestamp: now };
+
+  // Write L2 — fire-and-forget so a cache write failure never blocks the
+  // actual API response. The next request will simply recompute again.
+  ComputedCacheModel(tenant)
+    .findOneAndUpdate(
+      { key: PRIVATE_SITE_IDS_CACHE_KEY, tenant },
+      { $set: { data, computedAt: new Date(now), expiresAt } },
+      { upsert: true, new: false }
+    )
+    .catch((err) =>
+      logger.warn(
+        `ComputedCache L2 write failed for ${PRIVATE_SITE_IDS_CACHE_KEY}/${tenant}: ${err.message}`
+      )
+    );
+
+  return data;
+}
 
 function filterOutPrivateIDs(privateIds, randomIds) {
   // Create a Set from the privateIds array
@@ -573,26 +665,9 @@ const createGrid = {
         };
       }
 
-      // Optimized query to get all private site IDs in one go
-      const privateSiteIdsResponse = await CohortModel(tenant).aggregate([
-        { $match: { visibility: false } },
-        {
-          $lookup: {
-            from: "devices",
-            localField: "_id",
-            foreignField: "cohorts",
-            as: "devices",
-          },
-        },
-        { $unwind: "$devices" },
-        { $match: { "devices.site_id": { $ne: null } } },
-        { $group: { _id: null, site_ids: { $addToSet: "$devices.site_id" } } },
-      ]);
-
-      const privateSiteIds =
-        privateSiteIdsResponse.length > 0
-          ? privateSiteIdsResponse[0].site_ids
-          : [];
+      // Use cached helper — avoids a full Cohort→Device join on every request.
+      // Cache is per-tenant with a 5-minute TTL (see getPrivateSiteIds above).
+      const privateSiteIds = await getPrivateSiteIds(tenant);
 
       const exclusionProjection = constants.GRIDS_EXCLUSION_PROJECTION(
         detailLevel
@@ -1323,26 +1398,9 @@ const createGrid = {
   listCountries: async (request, next) => {
     try {
       const { tenant, cohort_id } = request.query;
-      // Optimized query to get all private site IDs in one go
-      const privateSiteIdsResponse = await CohortModel(tenant).aggregate([
-        { $match: { visibility: false } },
-        {
-          $lookup: {
-            from: "devices",
-            localField: "_id",
-            foreignField: "cohorts",
-            as: "devices",
-          },
-        },
-        { $unwind: "$devices" },
-        { $match: { "devices.site_id": { $ne: null } } },
-        { $group: { _id: null, site_ids: { $addToSet: "$devices.site_id" } } },
-      ]);
-
-      const privateSiteIds =
-        privateSiteIdsResponse.length > 0
-          ? privateSiteIdsResponse[0].site_ids
-          : [];
+      // Use cached helper — avoids a full Cohort→Device join on every request.
+      // Cache is per-tenant with a 5-minute TTL (see getPrivateSiteIds above).
+      const privateSiteIds = await getPrivateSiteIds(tenant);
 
       let cohortSiteIds = [];
       if (cohort_id) {
@@ -1411,7 +1469,7 @@ const createGrid = {
         },
       ];
 
-      const results = await GridModel(tenant).aggregate(pipeline);
+      const results = await GridModel(tenant).aggregate(pipeline).allowDiskUse(true);
 
       const countriesWithFlags = results.map((countryData) => {
         // Safely handle null or undefined country names

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -33,17 +33,56 @@ const kafka = new Kafka({
 // Flow on each request:
 //   1. L1 hit  → return immediately (nanoseconds).
 //   2. L1 miss → check MongoDB document (one indexed findOne, ~1 ms).
-//      2a. L2 hit  → populate L1, return.
-//      2b. L2 miss → run full Cohort→Device aggregation, write to both
-//                    L2 and L1, then return.
+//      2a. L2 hit  → populate L1 (TTL aligned to L2's absolute expiresAt), return.
+//      2b. L2 miss → try to acquire a cross-pod lease.
+//          Lease acquired   → run aggregation, write L2 + L1, release lease.
+//          Lease not held   → back off 500 ms, re-read L2; if still empty,
+//                             fall through to a local recompute so the
+//                             request never stalls indefinitely.
 //
-// This means only ONE pod pays the aggregation cost after each TTL expiry;
-// every other replica immediately benefits from the shared L2 document on
-// its next request — including brand-new pods that Kubernetes just started.
+// Within-pod concurrency: concurrent callers share a single in-flight
+// Promise (_inflight map) so only one goroutine-equivalent pays the DB cost.
 // ---------------------------------------------------------------------------
-const _privateSiteIdsCache = {};
+const _privateSiteIdsCache = new Map(); // Map prevents prototype-pollution attacks
+const _inflight = new Map(); // per-tenant in-flight recompute promises
 const PRIVATE_SITE_IDS_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const LOCK_TTL_MS = 30 * 1000; // 30-second lease; TTL index cleans stale locks
 const PRIVATE_SITE_IDS_CACHE_KEY = "private_site_ids";
+const PRIVATE_SITE_IDS_LOCK_KEY = "private_site_ids_lock";
+
+// Attempt to insert a lock document. Returns true when this pod holds the
+// lease, false when another pod already has it (duplicate-key error 11000).
+// Any other DB error is treated as "lease acquired" to avoid starvation.
+async function acquireComputeLease(tenant) {
+  try {
+    await ComputedCacheModel(tenant).create({
+      key: PRIVATE_SITE_IDS_LOCK_KEY,
+      tenant,
+      data: 1,
+      computedAt: new Date(),
+      expiresAt: new Date(Date.now() + LOCK_TTL_MS),
+    });
+    return true;
+  } catch (err) {
+    if (err.code === 11000) {
+      return false; // another pod holds the lease
+    }
+    return true; // allow recompute on unexpected errors to avoid starvation
+  }
+}
+
+// Delete the lock document so the next TTL cycle can start immediately.
+// Fire-and-forget; the TTL index on expiresAt is the safety net.
+async function releaseComputeLease(tenant) {
+  try {
+    await ComputedCacheModel(tenant).deleteOne({
+      key: PRIVATE_SITE_IDS_LOCK_KEY,
+      tenant,
+    });
+  } catch (_err) {
+    // best-effort; TTL index will clean it up within LOCK_TTL_MS
+  }
+}
 
 async function computePrivateSiteIds(tenant) {
   const result = await CohortModel(tenant).aggregate([
@@ -74,21 +113,26 @@ async function getPrivateSiteIds(tenant) {
 
   const now = Date.now();
 
-  // ── L1: in-memory (pod-local) ──────────────────────────────────────────
-  const l1 = _privateSiteIdsCache[normalizedTenant];
-  if (l1 && now - l1.timestamp < PRIVATE_SITE_IDS_TTL_MS) {
+  // ── L1: in-memory (pod-local, sub-millisecond) ────────────────────────
+  // L1 entry stores the absolute expiresAt (ms) taken from L2, so its
+  // effective lifetime tracks L2's expiry rather than resetting on warm.
+  const l1 = _privateSiteIdsCache.get(normalizedTenant);
+  if (l1 && now < l1.expiresAt) {
     return l1.data;
   }
 
-  // ── L2: MongoDB (shared across all pods) ──────────────────────────────
+  // ── L2: MongoDB (shared across all pods, ~1 ms) ───────────────────────
   try {
     const l2 = await ComputedCacheModel(normalizedTenant)
       .findOne({ key: PRIVATE_SITE_IDS_CACHE_KEY, tenant: normalizedTenant })
       .lean();
 
     if (l2 && l2.expiresAt > new Date()) {
-      // Fresh L2 hit — warm L1 and return
-      _privateSiteIdsCache[normalizedTenant] = { data: l2.data, timestamp: now };
+      // Fresh L2 hit — align L1 TTL to L2's absolute expiry timestamp
+      _privateSiteIdsCache.set(normalizedTenant, {
+        data: l2.data,
+        expiresAt: l2.expiresAt.getTime(),
+      });
       return l2.data;
     }
   } catch (err) {
@@ -98,36 +142,87 @@ async function getPrivateSiteIds(tenant) {
     );
   }
 
-  // ── Full recompute (both levels missed or L2 unavailable) ─────────────
-  const data = await computePrivateSiteIds(normalizedTenant);
-  const expiresAt = new Date(now + PRIVATE_SITE_IDS_TTL_MS);
+  // ── Within-pod deduplication ──────────────────────────────────────────
+  // If a recompute is already in-flight on this pod, piggyback on its
+  // promise rather than spawning a second concurrent aggregation.
+  const inflight = _inflight.get(normalizedTenant);
+  if (inflight) {
+    return inflight;
+  }
 
-  // Write L1
-  _privateSiteIdsCache[normalizedTenant] = { data, timestamp: now };
+  // ── Cross-pod deduplication (lease) + full recompute ─────────────────
+  // Store the promise BEFORE the first await so that any concurrent caller
+  // reaching this point on the same event-loop tick gets the same promise.
+  const promise = (async () => {
+    // hasLease is declared here so the finally block can see it.
+    let hasLease = false;
+    try {
+      hasLease = await acquireComputeLease(normalizedTenant);
 
-  // Write L2 — fire-and-forget so a cache write failure never blocks the
-  // actual API response. The next request will simply recompute again.
-  // $setOnInsert makes tenant and key explicit on document creation so the
-  // unique index filter is never the only source of those field values.
-  ComputedCacheModel(normalizedTenant)
-    .findOneAndUpdate(
-      { key: PRIVATE_SITE_IDS_CACHE_KEY, tenant: normalizedTenant },
-      {
-        $set: { data, computedAt: new Date(now), expiresAt },
-        $setOnInsert: {
-          key: PRIVATE_SITE_IDS_CACHE_KEY,
-          tenant: normalizedTenant,
-        },
-      },
-      { upsert: true, new: false }
-    )
-    .catch((err) =>
-      logger.warn(
-        `ComputedCache L2 write failed for ${PRIVATE_SITE_IDS_CACHE_KEY}/${normalizedTenant}: ${err.message}`
-      )
-    );
+      if (!hasLease) {
+        // Another pod is already computing. Back off and re-read L2.
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        try {
+          const l2Retry = await ComputedCacheModel(normalizedTenant)
+            .findOne({
+              key: PRIVATE_SITE_IDS_CACHE_KEY,
+              tenant: normalizedTenant,
+            })
+            .lean();
+          if (l2Retry && l2Retry.expiresAt > new Date()) {
+            _privateSiteIdsCache.set(normalizedTenant, {
+              data: l2Retry.data,
+              expiresAt: l2Retry.expiresAt.getTime(),
+            });
+            return l2Retry.data;
+          }
+        } catch (_err) {
+          // fall through to local recompute so the request never stalls
+        }
+      }
 
-  return data;
+      // ── Full aggregation ─────────────────────────────────────────────
+      const data = await computePrivateSiteIds(normalizedTenant);
+      const expiresAt = new Date(now + PRIVATE_SITE_IDS_TTL_MS);
+
+      // Write L1 (aligned to L2's expiresAt)
+      _privateSiteIdsCache.set(normalizedTenant, {
+        data,
+        expiresAt: expiresAt.getTime(),
+      });
+
+      // Write L2 — fire-and-forget so a cache write failure never blocks
+      // the API response. $setOnInsert keeps key/tenant explicit on insert
+      // so the unique-index filter is never the sole source of those fields.
+      ComputedCacheModel(normalizedTenant)
+        .findOneAndUpdate(
+          { key: PRIVATE_SITE_IDS_CACHE_KEY, tenant: normalizedTenant },
+          {
+            $set: { data, computedAt: new Date(now), expiresAt },
+            $setOnInsert: {
+              key: PRIVATE_SITE_IDS_CACHE_KEY,
+              tenant: normalizedTenant,
+            },
+          },
+          { upsert: true, new: false }
+        )
+        .catch((err) =>
+          logger.warn(
+            `ComputedCache L2 write failed for ${PRIVATE_SITE_IDS_CACHE_KEY}/${normalizedTenant}: ${err.message}`
+          )
+        );
+
+      return data;
+    } finally {
+      _inflight.delete(normalizedTenant);
+      if (hasLease) {
+        releaseComputeLease(normalizedTenant); // fire-and-forget, TTL is safety net
+      }
+    }
+  })();
+
+  _inflight.set(normalizedTenant, promise);
+  return promise;
 }
 
 function filterOutPrivateIDs(privateIds, randomIds) {
@@ -1540,9 +1635,8 @@ const createGrid = {
 // Not intended for use outside of tests.
 createGrid._getPrivateSiteIds = getPrivateSiteIds;
 createGrid._clearPrivateSiteIdsCache = () => {
-  Object.keys(_privateSiteIdsCache).forEach(
-    (k) => delete _privateSiteIdsCache[k]
-  );
+  _privateSiteIdsCache.clear();
+  _inflight.clear();
 };
 
 module.exports = createGrid;

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -64,50 +64,66 @@ async function computePrivateSiteIds(tenant) {
 }
 
 async function getPrivateSiteIds(tenant) {
+  // Normalise to the same effective tenant the models use, so L1 keys,
+  // L2 filter values, and upsert documents are always consistent even when
+  // the caller omits or passes an empty tenant.
+  const normalizedTenant =
+    (tenant && tenant.toString().trim().toLowerCase()) ||
+    constants.DEFAULT_TENANT ||
+    "airqo";
+
   const now = Date.now();
 
   // ── L1: in-memory (pod-local) ──────────────────────────────────────────
-  const l1 = _privateSiteIdsCache[tenant];
+  const l1 = _privateSiteIdsCache[normalizedTenant];
   if (l1 && now - l1.timestamp < PRIVATE_SITE_IDS_TTL_MS) {
     return l1.data;
   }
 
   // ── L2: MongoDB (shared across all pods) ──────────────────────────────
   try {
-    const l2 = await ComputedCacheModel(tenant)
-      .findOne({ key: PRIVATE_SITE_IDS_CACHE_KEY, tenant })
+    const l2 = await ComputedCacheModel(normalizedTenant)
+      .findOne({ key: PRIVATE_SITE_IDS_CACHE_KEY, tenant: normalizedTenant })
       .lean();
 
     if (l2 && l2.expiresAt > new Date()) {
       // Fresh L2 hit — warm L1 and return
-      _privateSiteIdsCache[tenant] = { data: l2.data, timestamp: now };
+      _privateSiteIdsCache[normalizedTenant] = { data: l2.data, timestamp: now };
       return l2.data;
     }
   } catch (err) {
     // L2 read failure is non-fatal: fall through to full recompute
     logger.warn(
-      `ComputedCache L2 read failed for ${PRIVATE_SITE_IDS_CACHE_KEY}/${tenant}: ${err.message}`
+      `ComputedCache L2 read failed for ${PRIVATE_SITE_IDS_CACHE_KEY}/${normalizedTenant}: ${err.message}`
     );
   }
 
   // ── Full recompute (both levels missed or L2 unavailable) ─────────────
-  const data = await computePrivateSiteIds(tenant);
+  const data = await computePrivateSiteIds(normalizedTenant);
   const expiresAt = new Date(now + PRIVATE_SITE_IDS_TTL_MS);
 
   // Write L1
-  _privateSiteIdsCache[tenant] = { data, timestamp: now };
+  _privateSiteIdsCache[normalizedTenant] = { data, timestamp: now };
 
   // Write L2 — fire-and-forget so a cache write failure never blocks the
   // actual API response. The next request will simply recompute again.
-  ComputedCacheModel(tenant)
+  // $setOnInsert makes tenant and key explicit on document creation so the
+  // unique index filter is never the only source of those field values.
+  ComputedCacheModel(normalizedTenant)
     .findOneAndUpdate(
-      { key: PRIVATE_SITE_IDS_CACHE_KEY, tenant },
-      { $set: { data, computedAt: new Date(now), expiresAt } },
+      { key: PRIVATE_SITE_IDS_CACHE_KEY, tenant: normalizedTenant },
+      {
+        $set: { data, computedAt: new Date(now), expiresAt },
+        $setOnInsert: {
+          key: PRIVATE_SITE_IDS_CACHE_KEY,
+          tenant: normalizedTenant,
+        },
+      },
       { upsert: true, new: false }
     )
     .catch((err) =>
       logger.warn(
-        `ComputedCache L2 write failed for ${PRIVATE_SITE_IDS_CACHE_KEY}/${tenant}: ${err.message}`
+        `ComputedCache L2 write failed for ${PRIVATE_SITE_IDS_CACHE_KEY}/${normalizedTenant}: ${err.message}`
       )
     );
 
@@ -1518,5 +1534,10 @@ const createGrid = {
     }
   },
 };
+
+// Exported under a private-convention name so unit tests can exercise the
+// two-level cache logic directly without going through a full HTTP request.
+// Not intended for use outside of tests.
+createGrid._getPrivateSiteIds = getPrivateSiteIds;
 
 module.exports = createGrid;

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -1535,9 +1535,14 @@ const createGrid = {
   },
 };
 
-// Exported under a private-convention name so unit tests can exercise the
+// Exported under private-convention names so unit tests can exercise the
 // two-level cache logic directly without going through a full HTTP request.
 // Not intended for use outside of tests.
 createGrid._getPrivateSiteIds = getPrivateSiteIds;
+createGrid._clearPrivateSiteIdsCache = () => {
+  Object.keys(_privateSiteIdsCache).forEach(
+    (k) => delete _privateSiteIdsCache[k]
+  );
+};
 
 module.exports = createGrid;

--- a/src/device-registry/utils/test/ut_grid.util.js
+++ b/src/device-registry/utils/test/ut_grid.util.js
@@ -461,9 +461,13 @@ describe("Grid Util", () => {
     let cohortAggregateStub;
     let computedCacheFindOneStub;
     let computedCacheFindOneAndUpdateStub;
-    let computedCacheModelStub;
 
     beforeEach(() => {
+      // Reset the module-level L1 cache before every test so no state leaks
+      // between cases (e.g. an L2-hit test warming L1 would cause the next
+      // test to skip both L2 and recompute, producing false passes).
+      gridUtil._clearPrivateSiteIdsCache();
+
       // Stub CohortModel aggregate (the full recompute path)
       cohortAggregateStub = sandbox.stub().resolves([{ site_ids: SITE_IDS }]);
       sandbox.stub(CohortModel, "default").returns({
@@ -473,7 +477,7 @@ describe("Grid Util", () => {
       // Stub ComputedCacheModel findOne and findOneAndUpdate
       computedCacheFindOneStub = sandbox.stub();
       computedCacheFindOneAndUpdateStub = sandbox.stub().resolves();
-      computedCacheModelStub = sandbox.stub(ComputedCacheModel, "default").returns({
+      sandbox.stub(ComputedCacheModel, "default").returns({
         findOne: computedCacheFindOneStub,
         findOneAndUpdate: computedCacheFindOneAndUpdateStub,
       });
@@ -545,15 +549,27 @@ describe("Grid Util", () => {
       });
       computedCacheFindOneAndUpdateStub.resolves();
 
-      // Call with no tenant / empty string
+      // Clear L1 between calls so both are forced through L2, allowing us to
+      // verify that undefined and "" normalise to the same canonical tenant.
       await gridUtil._getPrivateSiteIds(undefined);
+      gridUtil._clearPrivateSiteIdsCache();
       await gridUtil._getPrivateSiteIds("");
 
-      // Both calls must query L2 with the default tenant, not undefined/""
-      computedCacheFindOneAndUpdateStub.args.forEach(([filter, update]) => {
-        expect(filter.tenant).to.be.a("string").and.not.be.empty;
-        expect(filter.tenant).to.not.equal("undefined");
-        expect(update.$setOnInsert.tenant).to.equal(filter.tenant);
+      // Both calls must have hit L2 (findOne called twice)
+      expect(computedCacheFindOneStub.callCount).to.equal(2);
+      expect(computedCacheFindOneAndUpdateStub.callCount).to.equal(2);
+
+      // For each invocation, the read tenant must be a valid non-empty string
+      // and must exactly match the tenant written in the upsert — ensuring
+      // the normalisation is applied consistently end-to-end.
+      computedCacheFindOneStub.args.forEach(([readFilter], i) => {
+        const [writeFilter, writeUpdate] =
+          computedCacheFindOneAndUpdateStub.args[i];
+
+        expect(readFilter.tenant).to.be.a("string").and.not.be.empty;
+        expect(readFilter.tenant).to.not.equal("undefined");
+        expect(readFilter.tenant).to.equal(writeFilter.tenant);
+        expect(writeUpdate.$setOnInsert.tenant).to.equal(readFilter.tenant);
       });
     });
 

--- a/src/device-registry/utils/test/ut_grid.util.js
+++ b/src/device-registry/utils/test/ut_grid.util.js
@@ -8,6 +8,7 @@ const gridUtil = require("@utils/grid.util");
 const GridModel = require("@models/Grid");
 const SiteModel = require("@models/Site");
 const CohortModel = require("@models/Cohort");
+const ComputedCacheModel = require("@models/ComputedCache");
 const DeviceModel = require("@models/Device");
 const AdminLevelModel = require("@models/AdminLevel");
 const { generateFilter } = require("@utils/common");
@@ -443,6 +444,143 @@ describe("Grid Util", () => {
       const result = await gridUtil.deleteAdminLevel({});
       expect(result.success).to.be.false;
       expect(result.status).to.equal(httpStatus.SERVICE_UNAVAILABLE);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPrivateSiteIds — two-level cache (L1 in-memory + L2 MongoDB)
+  // ---------------------------------------------------------------------------
+  describe("getPrivateSiteIds", () => {
+    const SITE_IDS = [
+      new mongoose.Types.ObjectId(),
+      new mongoose.Types.ObjectId(),
+    ];
+    const FUTURE_EXPIRES = new Date(Date.now() + 10 * 60 * 1000); // 10 min from now
+    const PAST_EXPIRES = new Date(Date.now() - 1000); // already expired
+
+    let cohortAggregateStub;
+    let computedCacheFindOneStub;
+    let computedCacheFindOneAndUpdateStub;
+    let computedCacheModelStub;
+
+    beforeEach(() => {
+      // Stub CohortModel aggregate (the full recompute path)
+      cohortAggregateStub = sandbox.stub().resolves([{ site_ids: SITE_IDS }]);
+      sandbox.stub(CohortModel, "default").returns({
+        aggregate: cohortAggregateStub,
+      });
+
+      // Stub ComputedCacheModel findOne and findOneAndUpdate
+      computedCacheFindOneStub = sandbox.stub();
+      computedCacheFindOneAndUpdateStub = sandbox.stub().resolves();
+      computedCacheModelStub = sandbox.stub(ComputedCacheModel, "default").returns({
+        findOne: computedCacheFindOneStub,
+        findOneAndUpdate: computedCacheFindOneAndUpdateStub,
+      });
+    });
+
+    it("L2 hit: warms L1 and returns cached data without triggering recompute", async () => {
+      // L2 returns a fresh cached document
+      computedCacheFindOneStub.returns({
+        lean: sandbox.stub().resolves({
+          data: SITE_IDS,
+          expiresAt: FUTURE_EXPIRES,
+        }),
+      });
+
+      const result = await gridUtil._getPrivateSiteIds("airqo");
+
+      expect(result).to.deep.equal(SITE_IDS);
+      // Full recompute (CohortModel aggregate) must NOT have been called
+      expect(cohortAggregateStub.called).to.be.false;
+      // L2 findOne must have been called with normalised tenant
+      expect(
+        computedCacheFindOneStub.calledWith({
+          key: "private_site_ids",
+          tenant: "airqo",
+        })
+      ).to.be.true;
+    });
+
+    it("L2 miss (expired document): triggers recompute and attempts upsert", async () => {
+      // L2 returns an expired document
+      computedCacheFindOneStub.returns({
+        lean: sandbox.stub().resolves({
+          data: SITE_IDS,
+          expiresAt: PAST_EXPIRES,
+        }),
+      });
+      computedCacheFindOneAndUpdateStub.resolves();
+
+      const result = await gridUtil._getPrivateSiteIds("airqo");
+
+      expect(result).to.deep.equal(SITE_IDS);
+      // Full recompute must have run
+      expect(cohortAggregateStub.calledOnce).to.be.true;
+      // Upsert must have been attempted with correct key and tenant
+      expect(computedCacheFindOneAndUpdateStub.calledOnce).to.be.true;
+      const [filter, update] = computedCacheFindOneAndUpdateStub.firstCall.args;
+      expect(filter).to.deep.equal({ key: "private_site_ids", tenant: "airqo" });
+      expect(update.$set.data).to.deep.equal(SITE_IDS);
+      expect(update.$setOnInsert.tenant).to.equal("airqo");
+      expect(update.$setOnInsert.key).to.equal("private_site_ids");
+    });
+
+    it("L2 miss (no document): triggers recompute and attempts upsert", async () => {
+      computedCacheFindOneStub.returns({
+        lean: sandbox.stub().resolves(null),
+      });
+      computedCacheFindOneAndUpdateStub.resolves();
+
+      const result = await gridUtil._getPrivateSiteIds("airqo");
+
+      expect(result).to.deep.equal(SITE_IDS);
+      expect(cohortAggregateStub.calledOnce).to.be.true;
+      expect(computedCacheFindOneAndUpdateStub.calledOnce).to.be.true;
+    });
+
+    it("missing tenant falls back to default and uses it consistently for L1 key, L2 filter, and upsert", async () => {
+      computedCacheFindOneStub.returns({
+        lean: sandbox.stub().resolves(null),
+      });
+      computedCacheFindOneAndUpdateStub.resolves();
+
+      // Call with no tenant / empty string
+      await gridUtil._getPrivateSiteIds(undefined);
+      await gridUtil._getPrivateSiteIds("");
+
+      // Both calls must query L2 with the default tenant, not undefined/""
+      computedCacheFindOneAndUpdateStub.args.forEach(([filter, update]) => {
+        expect(filter.tenant).to.be.a("string").and.not.be.empty;
+        expect(filter.tenant).to.not.equal("undefined");
+        expect(update.$setOnInsert.tenant).to.equal(filter.tenant);
+      });
+    });
+
+    it("L2 read failure is non-fatal: falls through to recompute and still returns data", async () => {
+      // L2 findOne throws
+      computedCacheFindOneStub.returns({
+        lean: sandbox.stub().rejects(new Error("MongoDB connection lost")),
+      });
+      computedCacheFindOneAndUpdateStub.resolves();
+
+      const result = await gridUtil._getPrivateSiteIds("airqo");
+
+      // Must still return freshly computed data
+      expect(result).to.deep.equal(SITE_IDS);
+      expect(cohortAggregateStub.calledOnce).to.be.true;
+    });
+
+    it("L2 write failure is non-fatal: result is still returned correctly", async () => {
+      computedCacheFindOneStub.returns({
+        lean: sandbox.stub().resolves(null),
+      });
+      // Upsert rejects
+      computedCacheFindOneAndUpdateStub.rejects(new Error("write timeout"));
+
+      // Should not throw
+      const result = await gridUtil._getPrivateSiteIds("airqo");
+      expect(result).to.deep.equal(SITE_IDS);
     });
   });
 });

--- a/src/device-registry/utils/test/ut_grid.util.js
+++ b/src/device-registry/utils/test/ut_grid.util.js
@@ -463,9 +463,8 @@ describe("Grid Util", () => {
     let computedCacheFindOneAndUpdateStub;
 
     beforeEach(() => {
-      // Reset the module-level L1 cache before every test so no state leaks
-      // between cases (e.g. an L2-hit test warming L1 would cause the next
-      // test to skip both L2 and recompute, producing false passes).
+      // Reset the module-level L1 cache and any in-flight promises before
+      // every test so no state leaks between cases.
       gridUtil._clearPrivateSiteIdsCache();
 
       // Stub CohortModel aggregate (the full recompute path)
@@ -474,12 +473,18 @@ describe("Grid Util", () => {
         aggregate: cohortAggregateStub,
       });
 
-      // Stub ComputedCacheModel findOne and findOneAndUpdate
+      // Stub ComputedCacheModel — all methods used by the two-level cache:
+      //   findOne            : L2 read
+      //   findOneAndUpdate   : L2 upsert (write)
+      //   create             : acquireComputeLease (insert lock document)
+      //   deleteOne          : releaseComputeLease (delete lock document)
       computedCacheFindOneStub = sandbox.stub();
       computedCacheFindOneAndUpdateStub = sandbox.stub().resolves();
       sandbox.stub(ComputedCacheModel, "default").returns({
         findOne: computedCacheFindOneStub,
         findOneAndUpdate: computedCacheFindOneAndUpdateStub,
+        create: sandbox.stub().resolves(), // lease acquired by default
+        deleteOne: sandbox.stub().resolves(), // lease released by default
       });
     });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces the pod-local in-memory cache for the `privateSiteIds` aggregation in
`grid.util.js` with a **two-level cache** (L1 in-memory + L2 MongoDB) backed by
a new `ComputedCache` model. This makes the cache durable across pod restarts
and shared across all Kubernetes replicas.

**Changes:**
- **`models/ComputedCache.js`** *(new file)* — lightweight MongoDB key/value
  store for expensive aggregation results. Schema holds `key`, `tenant`, `data`,
  `computedAt`, and `expiresAt`. Carries a unique compound index on
  `{ key, tenant }` and a MongoDB TTL index on `expiresAt` for automatic
  document cleanup.
- **`utils/grid.util.js`** — `getPrivateSiteIds(tenant)` now follows a
  two-level lookup strategy:
  1. **L1** (in-memory, pod-local, nanoseconds) — same as before; serves the
     majority of requests within a pod's lifetime.
  2. **L2** (MongoDB `ComputedCache` document, ~1–2 ms) — checked on L1 miss;
     shared by all replicas. On hit, L1 is warmed for subsequent requests.
  3. **Full recompute** — only runs when both levels miss or on first boot; result
     is written to both L2 (fire-and-forget) and L1.

### Why is this change needed?
The previous pure in-memory cache had three critical weaknesses in the
Kubernetes deployment environment:

1. **Pod-local** — each replica independently cached the result, so every pod
   paid the full expensive `Cohort → $lookup devices → $unwind → $group`
   aggregation on its own first request. With N replicas only 1/N requests
   benefited from the cache.
2. **Lost on pod restart** — Kubernetes kills and replaces pods constantly
   (rolling deploys, OOM kills, node evictions). Every restart caused a cold
   cache and a full aggregation hit, often during peak traffic.
3. **Thundering herd on scale-out** — when Kubernetes spun up new pods in
   response to traffic spikes, all new pods started cold simultaneously —
   exactly when the database was already under load.

Redis is not yet stable in this environment and MongoDB is the only reliable
shared store, making a MongoDB-backed L2 the correct solution.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/device-registry`
  - `models/ComputedCache.js` *(new)*
  - `utils/grid.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

1. **Cold L1, cold L2 (first request after deploy):** confirmed full recompute
   runs and writes to both levels. Subsequent request within TTL window returned
   immediately from L1 without hitting MongoDB.
2. **Cold L1, warm L2 (pod restart simulation):** cleared `_privateSiteIdsCache`
   in-process; confirmed next request hit MongoDB `findOne` and returned the
   cached document without running the full aggregation, then populated L1.
3. **L2 write failure resilience:** confirmed that a failed `findOneAndUpdate`
   only logs a warning — the function still returned correct freshly-computed
   data and the endpoint responded successfully.
4. **Concurrent upsert safety:** MongoDB unique index on `{ key, tenant }`
   ensures concurrent `findOneAndUpdate` with `upsert: true` from multiple pods
   is atomic and produces exactly one document.
5. **`GET /api/v2/devices/grids/countries`** and **`GET /api/v2/devices/grids`**
   (both call `getPrivateSiteIds`) verified to return correct `countries` /
   grid responses with identical shape before and after the change.

---

## :boom: Breaking Changes

- [x] **No breaking changes**

`getPrivateSiteIds` returns the same array of site ObjectIds that both call
sites consumed before. All API response shapes, field names, and pagination
metadata are unchanged. The L2 write is fire-and-forget and a failure never
propagates to the caller.

---

## :memo: Additional Notes

- The `ComputedCache` collection will be created automatically by Mongoose on
  first write (standard behaviour). No manual migration or schema change script
  is required.
- The MongoDB TTL daemon runs every ~60 seconds, so expired documents may
  survive up to 60 seconds past `expiresAt`. The application-level
  `l2.expiresAt > new Date()` check is the authoritative freshness guard; the
  TTL index exists purely to prevent stale document accumulation.
- TTL is currently set to **5 minutes** (`PRIVATE_SITE_IDS_TTL_MS`). This can
  be adjusted if private cohort membership is expected to change more frequently.
- The `ComputedCache` model follows the same `try/catch` registration pattern
  used by `JobLock`, `JobState`, and other utility models in this service.
- Once Redis is stabilised, the L2 layer can be swapped to Redis with no changes
  to callers — only `getPrivateSiteIds` needs updating.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-tier persistent computed cache with an in-memory fast tier and cross-pod coordination to avoid duplicate recompute.
  * Site listings now surface latest deployment, maintenance, and recall activities.

* **Performance Improvements**
  * New activity index to speed site/time queries.
  * Aggregations allow disk use for large queries; uncapped activity counts added for accurate totals.

* **Tests**
  * Added tests for caching behavior, tenant normalization, and error-resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->