### PR TITLE
Fix 504 on cohorts/devices: replace $expr/$or with indexed lookups

### DIFF
--- a/src/device-registry/models/Activity.js
+++ b/src/device-registry/models/Activity.js
@@ -128,6 +128,8 @@ activitySchema.index({ site_id: 1, createdAt: -1 });
 activitySchema.index({ site_id: 1, activityType: 1, createdAt: -1 });
 activitySchema.index({ device_id: 1, createdAt: -1 });
 activitySchema.index({ device: 1, createdAt: -1 });
+activitySchema.index({ device_id: 1, activityType: 1, createdAt: -1 });
+activitySchema.index({ device: 1, activityType: 1, createdAt: -1 });
 activitySchema.index({ status: 1 });
 
 activitySchema.methods = {

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1455,7 +1455,9 @@ const createCohort = {
             from: "activities",
             let: { deviceName: "$name" },
             pipeline: [
-              { $match: { $expr: { $eq: ["$device", "$$deviceName"] } } },
+              // device_id: null restricts to legacy name-only records, preventing
+              // overlap with the device_id branch and avoiding duplicate fetches.
+              { $match: { device_id: null, $expr: { $eq: ["$device", "$$deviceName"] } } },
               { $sort: { createdAt: -1 } },
               {
                 $project: {
@@ -1472,14 +1474,13 @@ const createCohort = {
         },
         {
           $addFields: {
+            // Both branches are disjoint after the device_id:null constraint above,
+            // so $concatArrays is safe (no duplicates). $sortArray requires MongoDB
+            // 5.2+ which cannot be guaranteed; JS post-processing sorts the merged
+            // array instead.
             activities: {
               $slice: [
-                {
-                  $sortArray: {
-                    input: { $setUnion: ["$_activities_by_id", "$_activities_by_name"] },
-                    sortBy: { createdAt: -1 },
-                  },
-                },
+                { $concatArrays: ["$_activities_by_id", "$_activities_by_name"] },
                 activitiesLimit,
               ],
             },
@@ -1504,7 +1505,7 @@ const createCohort = {
             from: "activities",
             let: { deviceName: "$name" },
             pipeline: [
-              { $match: { activityType: "deployment", $expr: { $eq: ["$device", "$$deviceName"] } } },
+              { $match: { activityType: "deployment", device_id: null, $expr: { $eq: ["$device", "$$deviceName"] } } },
               { $sort: { createdAt: -1 } },
               { $limit: 1 },
             ],
@@ -1513,11 +1514,29 @@ const createCohort = {
         },
         {
           $addFields: {
+            // $sortArray requires MongoDB 5.2+. Since each branch returns ≤1 item,
+            // use nested $cond to pick the branch with the later createdAt instead.
             latest_deployment_activity: {
-              $sortArray: {
-                input: { $setUnion: ["$_deploy_by_id", "$_deploy_by_name"] },
-                sortBy: { createdAt: -1 },
-              },
+              $cond: [
+                { $eq: [{ $size: "$_deploy_by_id" }, 0] },
+                "$_deploy_by_name",
+                {
+                  $cond: [
+                    { $eq: [{ $size: "$_deploy_by_name" }, 0] },
+                    "$_deploy_by_id",
+                    {
+                      $cond: [
+                        { $gte: [
+                          { $arrayElemAt: ["$_deploy_by_id.createdAt", 0] },
+                          { $arrayElemAt: ["$_deploy_by_name.createdAt", 0] },
+                        ]},
+                        "$_deploy_by_id",
+                        "$_deploy_by_name",
+                      ],
+                    },
+                  ],
+                },
+              ],
             },
           },
         },
@@ -1540,7 +1559,7 @@ const createCohort = {
             from: "activities",
             let: { deviceName: "$name" },
             pipeline: [
-              { $match: { activityType: "maintenance", $expr: { $eq: ["$device", "$$deviceName"] } } },
+              { $match: { activityType: "maintenance", device_id: null, $expr: { $eq: ["$device", "$$deviceName"] } } },
               { $sort: { createdAt: -1 } },
               { $limit: 1 },
             ],
@@ -1550,10 +1569,26 @@ const createCohort = {
         {
           $addFields: {
             latest_maintenance_activity: {
-              $sortArray: {
-                input: { $setUnion: ["$_maint_by_id", "$_maint_by_name"] },
-                sortBy: { createdAt: -1 },
-              },
+              $cond: [
+                { $eq: [{ $size: "$_maint_by_id" }, 0] },
+                "$_maint_by_name",
+                {
+                  $cond: [
+                    { $eq: [{ $size: "$_maint_by_name" }, 0] },
+                    "$_maint_by_id",
+                    {
+                      $cond: [
+                        { $gte: [
+                          { $arrayElemAt: ["$_maint_by_id.createdAt", 0] },
+                          { $arrayElemAt: ["$_maint_by_name.createdAt", 0] },
+                        ]},
+                        "$_maint_by_id",
+                        "$_maint_by_name",
+                      ],
+                    },
+                  ],
+                },
+              ],
             },
           },
         },
@@ -1576,7 +1611,7 @@ const createCohort = {
             from: "activities",
             let: { deviceName: "$name" },
             pipeline: [
-              { $match: { activityType: { $in: ["recall", "recallment"] }, $expr: { $eq: ["$device", "$$deviceName"] } } },
+              { $match: { activityType: { $in: ["recall", "recallment"] }, device_id: null, $expr: { $eq: ["$device", "$$deviceName"] } } },
               { $sort: { createdAt: -1 } },
               { $limit: 1 },
             ],
@@ -1586,10 +1621,26 @@ const createCohort = {
         {
           $addFields: {
             latest_recall_activity: {
-              $sortArray: {
-                input: { $setUnion: ["$_recall_by_id", "$_recall_by_name"] },
-                sortBy: { createdAt: -1 },
-              },
+              $cond: [
+                { $eq: [{ $size: "$_recall_by_id" }, 0] },
+                "$_recall_by_name",
+                {
+                  $cond: [
+                    { $eq: [{ $size: "$_recall_by_name" }, 0] },
+                    "$_recall_by_id",
+                    {
+                      $cond: [
+                        { $gte: [
+                          { $arrayElemAt: ["$_recall_by_id.createdAt", 0] },
+                          { $arrayElemAt: ["$_recall_by_name.createdAt", 0] },
+                        ]},
+                        "$_recall_by_id",
+                        "$_recall_by_name",
+                      ],
+                    },
+                  ],
+                },
+              ],
             },
           },
         },
@@ -1665,6 +1716,15 @@ const createCohort = {
           device.latest_recall_activity.length > 0
             ? device.latest_recall_activity[0]
             : null;
+
+        // Sort the merged activities array by most recent first.
+        // $sortArray (MongoDB 5.2+) was removed for version compatibility;
+        // the two disjoint branches are sorted here in JS instead.
+        if (device.activities && device.activities.length > 1) {
+          device.activities.sort(
+            (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
+          );
+        }
 
         // Create activities by type mapping
         if (device.activities && device.activities.length > 0) {

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1426,153 +1426,209 @@ const createCohort = {
             as: "assigned_grid",
           },
         },
+        // ── Main activities — split by device_id / device-name to allow index use ─
+        // A single $expr/$or on two fields prevents MongoDB from using either
+        // { device_id, createdAt } or { device, createdAt } index. Two targeted
+        // single-field lookups let MongoDB use an index for each branch.
         {
           $lookup: {
             from: "activities",
-            let: { deviceName: "$name", deviceId: "$_id" },
+            let: { deviceId: "$_id" },
             pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $or: [
-                      { $eq: ["$device", "$$deviceName"] },
-                      { $eq: ["$device_id", "$$deviceId"] },
-                    ],
-                  },
-                },
-              },
+              { $match: { $expr: { $eq: ["$device_id", "$$deviceId"] } } },
               { $sort: { createdAt: -1 } },
               {
                 $project: {
-                  _id: 1,
-                  site_id: 1,
-                  device_id: 1,
-                  device: 1,
-                  activityType: 1,
-                  maintenanceType: 1,
-                  recallType: 1,
-                  date: 1,
-                  description: 1,
-                  nextMaintenance: 1,
-                  createdAt: 1,
-                  tags: 1,
+                  _id: 1, site_id: 1, device_id: 1, device: 1,
+                  activityType: 1, maintenanceType: 1, recallType: 1,
+                  date: 1, description: 1, nextMaintenance: 1,
+                  createdAt: 1, tags: 1,
                 },
               },
               { $limit: activitiesLimit },
             ],
-            as: "activities",
+            as: "_activities_by_id",
           },
         },
         {
           $lookup: {
             from: "activities",
-            let: { deviceName: "$name", deviceId: "$_id" },
+            let: { deviceName: "$name" },
             pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $and: [
-                      {
-                        $or: [
-                          { $eq: ["$device", "$$deviceName"] },
-                          { $eq: ["$device_id", "$$deviceId"] },
-                        ],
-                      },
-                      { $eq: ["$activityType", "deployment"] },
-                    ],
-                  },
-                },
-              },
+              { $match: { $expr: { $eq: ["$device", "$$deviceName"] } } },
               { $sort: { createdAt: -1 } },
-              { $limit: 1 },
-            ],
-            as: "latest_deployment_activity",
-          },
-        },
-        {
-          $lookup: {
-            from: "activities",
-            let: { deviceName: "$name", deviceId: "$_id" },
-            pipeline: [
               {
-                $match: {
-                  $expr: {
-                    $and: [
-                      {
-                        $or: [
-                          { $eq: ["$device", "$$deviceName"] },
-                          { $eq: ["$device_id", "$$deviceId"] },
-                        ],
-                      },
-                      { $eq: ["$activityType", "maintenance"] },
-                    ],
-                  },
+                $project: {
+                  _id: 1, site_id: 1, device_id: 1, device: 1,
+                  activityType: 1, maintenanceType: 1, recallType: 1,
+                  date: 1, description: 1, nextMaintenance: 1,
+                  createdAt: 1, tags: 1,
                 },
               },
-              { $sort: { createdAt: -1 } },
-              { $limit: 1 },
+              { $limit: activitiesLimit },
             ],
-            as: "latest_maintenance_activity",
-          },
-        },
-        {
-          $lookup: {
-            from: "activities",
-            let: { deviceName: "$name", deviceId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $and: [
-                      {
-                        $or: [
-                          { $eq: ["$device", "$$deviceName"] },
-                          { $eq: ["$device_id", "$$deviceId"] },
-                        ],
-                      },
-                      {
-                        $or: [
-                          { $eq: ["$activityType", "recall"] },
-                          { $eq: ["$activityType", "recallment"] },
-                        ],
-                      },
-                    ],
-                  },
-                },
-              },
-              { $sort: { createdAt: -1 } },
-              { $limit: 1 },
-            ],
-            as: "latest_recall_activity",
-          },
-        },
-        {
-          // Separate count lookup so total_activities reflects the true
-          // activity count, not the capped activitiesLimit window.
-          $lookup: {
-            from: "activities",
-            let: { deviceName: "$name", deviceId: "$_id" },
-            pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $or: [
-                      { $eq: ["$device", "$$deviceName"] },
-                      { $eq: ["$device_id", "$$deviceId"] },
-                    ],
-                  },
-                },
-              },
-              { $count: "count" },
-            ],
-            as: "activity_count",
+            as: "_activities_by_name",
           },
         },
         {
           $addFields: {
-            // True total — not capped by activitiesLimit
+            activities: {
+              $slice: [
+                {
+                  $sortArray: {
+                    input: { $setUnion: ["$_activities_by_id", "$_activities_by_name"] },
+                    sortBy: { createdAt: -1 },
+                  },
+                },
+                activitiesLimit,
+              ],
+            },
+          },
+        },
+        { $unset: ["_activities_by_id", "_activities_by_name"] },
+        // ── Latest deployment activity — indexed split lookups ─────────────────
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceId: "$_id" },
+            pipeline: [
+              { $match: { activityType: "deployment", $expr: { $eq: ["$device_id", "$$deviceId"] } } },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "_deploy_by_id",
+          },
+        },
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceName: "$name" },
+            pipeline: [
+              { $match: { activityType: "deployment", $expr: { $eq: ["$device", "$$deviceName"] } } },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "_deploy_by_name",
+          },
+        },
+        {
+          $addFields: {
+            latest_deployment_activity: {
+              $sortArray: {
+                input: { $setUnion: ["$_deploy_by_id", "$_deploy_by_name"] },
+                sortBy: { createdAt: -1 },
+              },
+            },
+          },
+        },
+        { $unset: ["_deploy_by_id", "_deploy_by_name"] },
+        // ── Latest maintenance activity — indexed split lookups ────────────────
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceId: "$_id" },
+            pipeline: [
+              { $match: { activityType: "maintenance", $expr: { $eq: ["$device_id", "$$deviceId"] } } },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "_maint_by_id",
+          },
+        },
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceName: "$name" },
+            pipeline: [
+              { $match: { activityType: "maintenance", $expr: { $eq: ["$device", "$$deviceName"] } } },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "_maint_by_name",
+          },
+        },
+        {
+          $addFields: {
+            latest_maintenance_activity: {
+              $sortArray: {
+                input: { $setUnion: ["$_maint_by_id", "$_maint_by_name"] },
+                sortBy: { createdAt: -1 },
+              },
+            },
+          },
+        },
+        { $unset: ["_maint_by_id", "_maint_by_name"] },
+        // ── Latest recall activity — indexed split lookups ─────────────────────
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceId: "$_id" },
+            pipeline: [
+              { $match: { activityType: { $in: ["recall", "recallment"] }, $expr: { $eq: ["$device_id", "$$deviceId"] } } },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "_recall_by_id",
+          },
+        },
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceName: "$name" },
+            pipeline: [
+              { $match: { activityType: { $in: ["recall", "recallment"] }, $expr: { $eq: ["$device", "$$deviceName"] } } },
+              { $sort: { createdAt: -1 } },
+              { $limit: 1 },
+            ],
+            as: "_recall_by_name",
+          },
+        },
+        {
+          $addFields: {
+            latest_recall_activity: {
+              $sortArray: {
+                input: { $setUnion: ["$_recall_by_id", "$_recall_by_name"] },
+                sortBy: { createdAt: -1 },
+              },
+            },
+          },
+        },
+        { $unset: ["_recall_by_id", "_recall_by_name"] },
+        // ── True activity count — split to avoid double-counting ──────────────
+        // (a) All activities matched by ObjectId reference.
+        // (b) Legacy name-only activities (device_id absent) matched by device name.
+        // Summing (a) + (b) gives the true total with no overlap.
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceId: "$_id" },
+            pipeline: [
+              { $match: { $expr: { $eq: ["$device_id", "$$deviceId"] } } },
+              { $count: "count" },
+            ],
+            as: "_count_by_id",
+          },
+        },
+        {
+          $lookup: {
+            from: "activities",
+            let: { deviceName: "$name" },
+            pipeline: [
+              // Only legacy records where device_id is not set — prevents double-counting
+              { $match: { device_id: null, $expr: { $eq: ["$device", "$$deviceName"] } } },
+              { $count: "count" },
+            ],
+            as: "_count_by_name",
+          },
+        },
+        {
+          $addFields: {
+            // True total — not capped by activitiesLimit, no double-counting
             total_activities: {
-              $ifNull: [{ $arrayElemAt: ["$activity_count.count", 0] }, 0],
+              $add: [
+                { $ifNull: [{ $arrayElemAt: ["$_count_by_id.count", 0] }, 0] },
+                { $ifNull: [{ $arrayElemAt: ["$_count_by_name.count", 0] }, 0] },
+              ],
             },
             // How many activity documents were actually returned in this response
             activities_loaded: {
@@ -1580,6 +1636,7 @@ const createCohort = {
             },
           },
         },
+        { $unset: ["_count_by_id", "_count_by_name"] },
         { $project: inclusionProjection },
         { $project: exclusionProjection },
       ];


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes 504 gateway timeouts on `POST /api/v2/devices/cohorts/devices` by replacing five `$expr/$or` activity `$lookup` stages in `listDevices` with indexed split lookups, and adds two compound indexes to the Activity model to cover device-based typed-activity queries.

### Why is this change needed?
The Analytics web app fires concurrent requests to the `cohorts/devices` endpoint on page load. Each request ran five MongoDB `$lookup` stages per device that matched activities using `$expr: { $or: [{ device_id }, { device }] }`. A two-field `$or` inside `$expr` prevents MongoDB from using either the `{ device_id, createdAt }` or `{ device, createdAt }` index, forcing a full collection scan of the activities collection for every device on every page. With 10 devices × 5 lookups × multiple concurrent requests, the DB connection pool saturated and responses exceeded the proxy's 60-second timeout.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/device-registry` — `utils/cohort.util.js`, `models/Activity.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified locally that `POST /cohorts/devices` returns the correct response shape with all activity fields (`activities`, `latest_deployment_activity`, `latest_maintenance_activity`, `latest_recall_activity`, `total_activities`, `activities_loaded`) populated. Confirmed `total_activities` is a true count and not double-counted for devices that have both `device_id` and `device` name set on their activity records.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All response field names, types, and pagination structures are unchanged. The `activities_loaded` and `total_activities` fields were already present; `total_activities` now reflects the true count rather than the capped array size, which is a correctness fix.

---

## :memo: Additional Notes

**Root cause — why Postman passes but staging times out:**
The endpoint works fine in isolation (single request, no contention). The 504 only manifests under the concurrent load the Analytics app generates on page load. Each full activities collection scan takes hundreds of milliseconds; multiple concurrent scans exhaust the MongoDB connection pool, pushing the last requests past the 60-second proxy timeout.

**What changed in `cohort.util.js` (`listDevices`):**

| Lookup | Before | After |
|---|---|---|
| Main activities | 1 `$expr/$or` — collection scan | 2 indexed `$eq` lookups → `$setUnion` + `$sortArray` + `$slice` |
| Deployment / Maintenance / Recall | 1 `$expr/$and/$or` per type — collection scan | 2 indexed `$eq` lookups per type → `$setUnion` + `$sortArray` |
| Activity count | 1 `$expr/$or` + `$count` — collection scan | 2 indexed `$eq` lookups with non-overlapping partitions: `device_id` match + `device`-name-only match (`device_id: null`), summed to avoid double-counting |

**New indexes in `Activity.js`:**
- `{ device_id: 1, activityType: 1, createdAt: -1 }` — covers typed activity lookups by ObjectId reference
- `{ device: 1, activityType: 1, createdAt: -1 }` — covers typed activity lookups by legacy device-name string

With these indexes, each typed lookup (`$limit: 1`) becomes an O(log n) index range scan returning 1 document, instead of a full collection scan.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster aggregation and retrieval of device activities with capped merging.

* **Bug Fixes**
  * Corrected total activity counts and ensured latest activity selection is accurate across legacy and current references.

* **Refactor**
  * Simplified activity aggregation and merging logic for clearer behavior and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->