### PR TITLE
fix: fall back to raw pm2_5 for BAM devices in events aggregation

### DIFF
--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -825,6 +825,27 @@ function buildEarlyProjection(isHistorical) {
   };
 }
 
+/**
+ * Returns a MongoDB aggregation expression that resolves to the averaged/
+ * calibrated field when its nested `.value` is non-null, and falls back to the
+ * raw sensor field otherwise.  Used so BAM devices (which never populate
+ * average_pm2_5) surface their raw readings instead of being silently dropped
+ * by filterNullAndReportOffDevices.
+ *
+ * @param {string} averageFieldKey - e.g. "average_pm2_5"
+ * @param {string} rawFieldKey     - e.g. "pm2_5"
+ * @returns {object} MongoDB $cond aggregation expression
+ */
+function buildPreferredMeasurement(averageFieldKey, rawFieldKey) {
+  return {
+    $cond: {
+      if: { $ne: [{ $ifNull: [`$${averageFieldKey}.value`, null] }, null] },
+      then: `$${averageFieldKey}`,
+      else: `$${rawFieldKey}`,
+    },
+  };
+}
+
 function logSlowQuery(queryType, duration, metadata, isHistorical, limit) {
   if (duration > SLOW_QUERY_THRESHOLD_MS) {
     logger.warn(
@@ -959,20 +980,8 @@ async function fetchData(model, filter) {
     // fallback every BAM event is silently dropped by filterNullAndReportOffDevices.
     // Lowcost behavior is unchanged: average_pm2_5.value is always non-null for
     // them, so the $cond always resolves to "$average_pm2_5" as before.
-    pm2_5 = {
-      $cond: {
-        if: { $ne: [{ $ifNull: ["$average_pm2_5.value", null] }, null] },
-        then: "$average_pm2_5",
-        else: "$pm2_5",
-      },
-    };
-    pm10 = {
-      $cond: {
-        if: { $ne: [{ $ifNull: ["$average_pm10.value", null] }, null] },
-        then: "$average_pm10",
-        else: "$pm10",
-      },
-    };
+    pm2_5 = buildPreferredMeasurement("average_pm2_5", "pm2_5");
+    pm10 = buildPreferredMeasurement("average_pm10", "pm10");
   }
 
   // ── Projection setup (unchanged from original) ──────────────────────────
@@ -1735,20 +1744,8 @@ async function signalData(model, filter) {
   let as = "deviceDetails";
   // Prefer calibrated/averaged value; fall back to raw for BAM devices
   // that never populate average_pm2_5. Same rationale as fetchData.
-  let pm2_5 = {
-    $cond: {
-      if: { $ne: [{ $ifNull: ["$average_pm2_5.value", null] }, null] },
-      then: "$average_pm2_5",
-      else: "$pm2_5",
-    },
-  };
-  let pm10 = {
-    $cond: {
-      if: { $ne: [{ $ifNull: ["$average_pm10.value", null] }, null] },
-      then: "$average_pm10",
-      else: "$pm10",
-    },
-  };
+  let pm2_5 = buildPreferredMeasurement("average_pm2_5", "pm2_5");
+  let pm10 = buildPreferredMeasurement("average_pm10", "pm10");
   let s1_pm2_5 = "$pm2_5";
   let s1_pm10 = "$pm10";
   let elementAtIndex0 = elementAtIndexName(metadata, recent);

--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -950,6 +950,29 @@ async function fetchData(model, filter) {
   if (tenant !== "airqo") {
     pm2_5 = "$pm2_5";
     pm10 = "$pm10";
+  } else {
+    // For airqo tenant: prefer the calibrated/averaged value (populated by
+    // lowcost pipelines) but fall back to the raw sensor reading when the
+    // averaged field is absent or null.  BAM (Beta Attenuation Monitor)
+    // devices are reference-grade monitors that skip the ML calibration step,
+    // so their events never carry a non-null average_pm2_5.  Without this
+    // fallback every BAM event is silently dropped by filterNullAndReportOffDevices.
+    // Lowcost behavior is unchanged: average_pm2_5.value is always non-null for
+    // them, so the $cond always resolves to "$average_pm2_5" as before.
+    pm2_5 = {
+      $cond: {
+        if: { $ne: [{ $ifNull: ["$average_pm2_5.value", null] }, null] },
+        then: "$average_pm2_5",
+        else: "$pm2_5",
+      },
+    };
+    pm10 = {
+      $cond: {
+        if: { $ne: [{ $ifNull: ["$average_pm10.value", null] }, null] },
+        then: "$average_pm10",
+        else: "$pm10",
+      },
+    };
   }
 
   // ── Projection setup (unchanged from original) ──────────────────────────
@@ -1710,8 +1733,22 @@ async function signalData(model, filter) {
   let from = "devices";
   let _as = "_deviceDetails";
   let as = "deviceDetails";
-  let pm2_5 = "$average_pm2_5";
-  let pm10 = "$average_pm10";
+  // Prefer calibrated/averaged value; fall back to raw for BAM devices
+  // that never populate average_pm2_5. Same rationale as fetchData.
+  let pm2_5 = {
+    $cond: {
+      if: { $ne: [{ $ifNull: ["$average_pm2_5.value", null] }, null] },
+      then: "$average_pm2_5",
+      else: "$pm2_5",
+    },
+  };
+  let pm10 = {
+    $cond: {
+      if: { $ne: [{ $ifNull: ["$average_pm10.value", null] }, null] },
+      then: "$average_pm10",
+      else: "$pm10",
+    },
+  };
   let s1_pm2_5 = "$pm2_5";
   let s1_pm10 = "$pm10";
   let elementAtIndex0 = elementAtIndexName(metadata, recent);


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a `$cond` fallback in the MongoDB aggregation pipeline so that when `average_pm2_5.value` is `null`, the `pm2_5` output field resolves to the raw `pm2_5` sensor reading instead. The same fallback is applied to `pm10`. The fix is applied in both `fetchData` and `signalData` functions in `Event.js`.

### Why is this change needed?

BAM (Beta Attenuation Monitor) devices are reference-grade air quality monitors that skip the ML calibration step applied to lowcost devices. As a result, their events never carry a non-null `average_pm2_5` value.

For the AirQo network, device-registry's aggregation pipeline aliases the `pm2_5` output field to `average_pm2_5` (the calibrated/averaged value). This design was built around lowcost devices where `average_pm2_5` holds the display-ready calibrated reading. For BAM devices, `average_pm2_5` is always `null`, so `filterNullAndReportOffDevices` silently drops every BAM event from the API response — even when the raw `pm2_5` reading is a perfectly valid measurement (e.g. 14.8 µg/m³).

This also prevents `store-readings-job` from ever promoting BAM events to the `readings` collection, which means BAM devices never appear on the AirQo map.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/models/Event.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

- Confirmed that querying `GET /api/v2/devices/events?device=<bam_device>` with a BAM device previously returned `measurements: []` despite `meta.total` showing matching documents. After the fix, events with a valid raw `pm2_5.value` are correctly returned.
- Verified that lowcost device responses are unchanged — their `average_pm2_5.value` is always non-null, so the `$cond` always resolves to `"$average_pm2_5"`, preserving existing behaviour.
- Verified that non-airqo tenant behaviour is unchanged — those tenants use `"$pm2_5"` directly and are unaffected by this code path.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The output field names (`pm2_5`, `s1_pm2_5`, `average_pm2_5`) are identical to before. The only observable difference is that BAM devices now return a non-null `pm2_5` value instead of being silently dropped. All existing consumers receive the same field structure.

---

## :memo: Additional Notes

- The `$cond` logic is: if `average_pm2_5.value` is non-null → use `average_pm2_5` (existing behaviour for lowcost); else → use raw `pm2_5` (new behaviour for BAM).
- `pm10` receives the same fallback for consistency.
- A complementary fix is required in the `workflows` microservice (BAM Airflow DAG) to also populate `average_pm2_5` in the posted payload so that `store-readings-job` can promote BAM events to the `readings` collection and display them on the map.
- Investigation document: `src/device-registry/docs/v3-bam-devices-not-on-map-investigation.md`

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PM2.5 and PM10 measurement logic: for the AirQo tenant sensor readings now prefer averaged/calibrated values when available and fall back to raw sensors otherwise, producing more reliable aggregated and grouped PM metrics used in reporting and filtering. Non‑AirQo tenants continue to use raw PM values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->