### PR TITLE
feat: add sensor manufacturer creation request workflow with Kafka email notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ env/
 __pycache__/
 .DS_Store
 .nyc_output
+.claude
 
 # global vscode gitignore
 .vscode/*

--- a/k8s/kafka/topics/kafka-topics.yaml
+++ b/k8s/kafka/topics/kafka-topics.yaml
@@ -363,6 +363,7 @@ spec:
   replicas: 2
   config:
     retention.ms: 86400000
+    min.insync.replicas: 2
 
 ---
 apiVersion: kafka.strimzi.io/v1beta2
@@ -377,3 +378,19 @@ spec:
   replicas: 2
   config:
     retention.ms: 86400000
+    min.insync.replicas: 2
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: network-creation-denied-topic
+  namespace: message-broker
+  labels:
+    strimzi.io/cluster: kafka-cluster
+spec:
+  partitions: 2
+  replicas: 2
+  config:
+    retention.ms: 86400000
+    min.insync.replicas: 2

--- a/k8s/kafka/topics/kafka-topics.yaml
+++ b/k8s/kafka/topics/kafka-topics.yaml
@@ -349,3 +349,31 @@ spec:
   replicas: 2
   config:
     retention.ms: 18000000
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: network-creation-requests-topic
+  namespace: message-broker
+  labels:
+    strimzi.io/cluster: kafka-cluster
+spec:
+  partitions: 2
+  replicas: 2
+  config:
+    retention.ms: 86400000
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: network-creation-approved-topic
+  namespace: message-broker
+  labels:
+    strimzi.io/cluster: kafka-cluster
+spec:
+  partitions: 2
+  replicas: 2
+  config:
+    retention.ms: 86400000

--- a/src/auth-service/bin/jobs/kafka-consumer.js
+++ b/src/auth-service/bin/jobs/kafka-consumer.js
@@ -357,6 +357,23 @@ const emailsForRecalledDevices = async (messageData) => {
 //
 // Topic: network-creation-approved-topic
 //   action "approved"         → notify the requester that their request was approved
+//
+// Topic: network-creation-denied-topic
+//   action "denied"           → notify the requester that their request was denied
+
+/**
+ * Return a copy of the payload with PII fields redacted so it is safe to log.
+ * Only the fields introduced by the sensor manufacturer request workflow are
+ * masked here; add more fields as the payload schema evolves.
+ */
+const maskSensorManufacturerPayload = (obj) => {
+  if (!obj || typeof obj !== "object") return obj;
+  const masked = { ...obj };
+  if (masked.requester_email) masked.requester_email = "***@***.***";
+  if (masked.net_email) masked.net_email = "***@***.***";
+  if (masked.requester_name) masked.requester_name = "[REDACTED]";
+  return masked;
+};
 
 const operationForSensorManufacturerRequest = async (messageData) => {
   let parsed;
@@ -364,9 +381,7 @@ const operationForSensorManufacturerRequest = async (messageData) => {
     parsed = JSON.parse(messageData);
   } catch (error) {
     logger.error(
-      `🐛🐛 KAFKA: Invalid JSON in network-creation-requests-topic -- ${stringify(
-        error,
-      )}`,
+      `🐛🐛 KAFKA: Invalid JSON in network-creation-requests-topic -- ${error.message}`,
     );
     return;
   }
@@ -385,7 +400,7 @@ const operationForSensorManufacturerRequest = async (messageData) => {
   if (!action || !requester_email || !net_name) {
     logger.error(
       `🤦🤦 KAFKA: Missing required fields in network-creation-requests-topic payload -- ${stringify(
-        parsed,
+        maskSensorManufacturerPayload(parsed),
       )}`,
     );
     return;
@@ -408,16 +423,14 @@ const operationForSensorManufacturerRequest = async (messageData) => {
       );
 
       if (emailResponse && emailResponse.success === false) {
-        logger.error(
-          `🐛🐛 KAFKA: Failed to send admin sensor manufacturer request email -- ${stringify(
-            emailResponse,
-          )}`,
-        );
-      } else {
-        logger.info(
-          `📧 KAFKA: Admin notified of sensor manufacturer request for "${net_name}"`,
+        throw new Error(
+          `Admin notification email failed for sensor manufacturer request (net_name="${net_name}"): ${emailResponse.message}`,
         );
       }
+
+      logger.info(
+        `📧 KAFKA: Admin notified of sensor manufacturer request for "${net_name}"`,
+      );
     } else if (action === "request_received") {
       // Acknowledge to the requester that we received their request
       const emailResponse =
@@ -429,27 +442,26 @@ const operationForSensorManufacturerRequest = async (messageData) => {
         });
 
       if (emailResponse && emailResponse.success === false) {
-        logger.error(
-          `🐛🐛 KAFKA: Failed to send request-received email to ${requester_email} -- ${stringify(
-            emailResponse,
-          )}`,
-        );
-      } else {
-        logger.info(
-          `📧 KAFKA: Request-received acknowledgement sent to ${requester_email} for "${net_name}"`,
+        throw new Error(
+          `Requester acknowledgement email failed for sensor manufacturer request (net_name="${net_name}"): ${emailResponse.message}`,
         );
       }
+
+      logger.info(
+        `📧 KAFKA: Request-received acknowledgement sent for "${net_name}"`,
+      );
     } else {
       logger.warn(
         `KAFKA: Unknown action "${action}" on network-creation-requests-topic`,
       );
     }
   } catch (error) {
+    // Log without PII, then re-throw so eachMessage/Kafka sees the failure
+    // and can retry or route to a DLQ.
     logger.error(
-      `🐛🐛 KAFKA: Internal Server Error -- operationForSensorManufacturerRequest() -- ${stringify(
-        error,
-      )}`,
+      `🐛🐛 KAFKA: operationForSensorManufacturerRequest() failed -- ${error.message}`,
     );
+    throw error;
   }
 };
 
@@ -459,9 +471,7 @@ const operationForSensorManufacturerApproved = async (messageData) => {
     parsed = JSON.parse(messageData);
   } catch (error) {
     logger.error(
-      `🐛🐛 KAFKA: Invalid JSON in network-creation-approved-topic -- ${stringify(
-        error,
-      )}`,
+      `🐛🐛 KAFKA: Invalid JSON in network-creation-approved-topic -- ${error.message}`,
     );
     return;
   }
@@ -471,7 +481,7 @@ const operationForSensorManufacturerApproved = async (messageData) => {
   if (action !== "approved" || !requester_email || !net_name) {
     logger.error(
       `🤦🤦 KAFKA: Missing or unexpected fields in network-creation-approved-topic payload -- ${stringify(
-        parsed,
+        maskSensorManufacturerPayload(parsed),
       )}`,
     );
     return;
@@ -486,22 +496,68 @@ const operationForSensorManufacturerApproved = async (messageData) => {
     });
 
     if (emailResponse && emailResponse.success === false) {
-      logger.error(
-        `🐛🐛 KAFKA: Failed to send approval email to ${requester_email} -- ${stringify(
-          emailResponse,
-        )}`,
-      );
-    } else {
-      logger.info(
-        `📧 KAFKA: Approval email sent to ${requester_email} for "${net_name}"`,
+      throw new Error(
+        `Approval email failed for sensor manufacturer request (net_name="${net_name}"): ${emailResponse.message}`,
       );
     }
+
+    logger.info(
+      `📧 KAFKA: Approval email sent for "${net_name}"`,
+    );
   } catch (error) {
     logger.error(
-      `🐛🐛 KAFKA: Internal Server Error -- operationForSensorManufacturerApproved() -- ${stringify(
-        error,
+      `🐛🐛 KAFKA: operationForSensorManufacturerApproved() failed -- ${error.message}`,
+    );
+    throw error;
+  }
+};
+
+const operationForSensorManufacturerDenied = async (messageData) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(messageData);
+  } catch (error) {
+    logger.error(
+      `🐛🐛 KAFKA: Invalid JSON in network-creation-denied-topic -- ${error.message}`,
+    );
+    return;
+  }
+
+  const { action, requester_name, requester_email, net_name, reviewer_notes } =
+    parsed;
+
+  if (action !== "denied" || !requester_email || !net_name) {
+    logger.error(
+      `🤦🤦 KAFKA: Missing or unexpected fields in network-creation-denied-topic payload -- ${stringify(
+        maskSensorManufacturerPayload(parsed),
       )}`,
     );
+    return;
+  }
+
+  try {
+    const emailResponse = await mailer.notifySensorManufacturerRequestDenied({
+      email: requester_email,
+      requester_name,
+      requester_email,
+      net_name,
+      reviewer_notes,
+    });
+
+    if (emailResponse && emailResponse.success === false) {
+      throw new Error(
+        `Denial email failed for sensor manufacturer request (net_name="${net_name}"): ${emailResponse.message}`,
+      );
+    }
+
+    logger.info(
+      `📧 KAFKA: Denial email sent for "${net_name}"`,
+    );
+  } catch (error) {
+    logger.error(
+      `🐛🐛 KAFKA: operationForSensorManufacturerDenied() failed -- ${error.message}`,
+    );
+    throw error;
   }
 };
 
@@ -579,14 +635,31 @@ const kafkaConsumer = async () => {
       "network-creation-requests-topic"]: operationForSensorManufacturerRequest,
       [constants.NETWORK_CREATION_APPROVED_TOPIC ||
       "network-creation-approved-topic"]: operationForSensorManufacturerApproved,
+      [constants.NETWORK_CREATION_DENIED_TOPIC ||
+      "network-creation-denied-topic"]: operationForSensorManufacturerDenied,
     };
 
     await consumer.connect();
 
+    // Notification-only topics must start from the latest offset so a fresh
+    // deploy does not replay the entire history and re-send emails for requests
+    // that were already processed before this consumer group existed.
+    const latestOffsetTopics = new Set([
+      constants.NETWORK_CREATION_REQUESTS_TOPIC ||
+        "network-creation-requests-topic",
+      constants.NETWORK_CREATION_APPROVED_TOPIC ||
+        "network-creation-approved-topic",
+      constants.NETWORK_CREATION_DENIED_TOPIC ||
+        "network-creation-denied-topic",
+    ]);
+
     // First, subscribe to all topics
     await Promise.all(
       Object.keys(topicOperations).map((topic) =>
-        consumer.subscribe({ topic, fromBeginning: true })
+        consumer.subscribe({
+          topic,
+          fromBeginning: !latestOffsetTopics.has(topic),
+        })
       )
     );
 

--- a/src/auth-service/bin/jobs/kafka-consumer.js
+++ b/src/auth-service/bin/jobs/kafka-consumer.js
@@ -347,6 +347,164 @@ const emailsForRecalledDevices = async (messageData) => {
     logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
   }
 };
+// ── Sensor manufacturer (network) creation request handlers ──────────────────
+//
+// Terminology: internally "networks"; in all user-facing copy "sensor manufacturers".
+//
+// Topic: network-creation-requests-topic
+//   action "new_request"      → email the AirQo admin
+//   action "request_received" → send acknowledgement to the requester
+//
+// Topic: network-creation-approved-topic
+//   action "approved"         → notify the requester that their request was approved
+
+const operationForSensorManufacturerRequest = async (messageData) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(messageData);
+  } catch (error) {
+    logger.error(
+      `🐛🐛 KAFKA: Invalid JSON in network-creation-requests-topic -- ${stringify(
+        error,
+      )}`,
+    );
+    return;
+  }
+
+  const {
+    action,
+    requester_name,
+    requester_email,
+    net_name,
+    net_email,
+    net_website,
+    net_category,
+    net_description,
+  } = parsed;
+
+  if (!action || !requester_email || !net_name) {
+    logger.error(
+      `🤦🤦 KAFKA: Missing required fields in network-creation-requests-topic payload -- ${stringify(
+        parsed,
+      )}`,
+    );
+    return;
+  }
+
+  try {
+    if (action === "new_request") {
+      // Notify the AirQo admin team about the new sensor manufacturer request
+      const emailResponse = await mailer.notifyAdminOfSensorManufacturerRequest(
+        {
+          email: constants.SUPPORT_EMAIL || "support@airqo.net",
+          requester_name,
+          requester_email,
+          net_name,
+          net_email,
+          net_website,
+          net_category,
+          net_description,
+        },
+      );
+
+      if (emailResponse && emailResponse.success === false) {
+        logger.error(
+          `🐛🐛 KAFKA: Failed to send admin sensor manufacturer request email -- ${stringify(
+            emailResponse,
+          )}`,
+        );
+      } else {
+        logger.info(
+          `📧 KAFKA: Admin notified of sensor manufacturer request for "${net_name}"`,
+        );
+      }
+    } else if (action === "request_received") {
+      // Acknowledge to the requester that we received their request
+      const emailResponse =
+        await mailer.confirmSensorManufacturerRequestReceived({
+          email: requester_email,
+          requester_name,
+          requester_email,
+          net_name,
+        });
+
+      if (emailResponse && emailResponse.success === false) {
+        logger.error(
+          `🐛🐛 KAFKA: Failed to send request-received email to ${requester_email} -- ${stringify(
+            emailResponse,
+          )}`,
+        );
+      } else {
+        logger.info(
+          `📧 KAFKA: Request-received acknowledgement sent to ${requester_email} for "${net_name}"`,
+        );
+      }
+    } else {
+      logger.warn(
+        `KAFKA: Unknown action "${action}" on network-creation-requests-topic`,
+      );
+    }
+  } catch (error) {
+    logger.error(
+      `🐛🐛 KAFKA: Internal Server Error -- operationForSensorManufacturerRequest() -- ${stringify(
+        error,
+      )}`,
+    );
+  }
+};
+
+const operationForSensorManufacturerApproved = async (messageData) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(messageData);
+  } catch (error) {
+    logger.error(
+      `🐛🐛 KAFKA: Invalid JSON in network-creation-approved-topic -- ${stringify(
+        error,
+      )}`,
+    );
+    return;
+  }
+
+  const { action, requester_name, requester_email, net_name } = parsed;
+
+  if (action !== "approved" || !requester_email || !net_name) {
+    logger.error(
+      `🤦🤦 KAFKA: Missing or unexpected fields in network-creation-approved-topic payload -- ${stringify(
+        parsed,
+      )}`,
+    );
+    return;
+  }
+
+  try {
+    const emailResponse = await mailer.notifySensorManufacturerRequestApproved({
+      email: requester_email,
+      requester_name,
+      requester_email,
+      net_name,
+    });
+
+    if (emailResponse && emailResponse.success === false) {
+      logger.error(
+        `🐛🐛 KAFKA: Failed to send approval email to ${requester_email} -- ${stringify(
+          emailResponse,
+        )}`,
+      );
+    } else {
+      logger.info(
+        `📧 KAFKA: Approval email sent to ${requester_email} for "${net_name}"`,
+      );
+    }
+  } catch (error) {
+    logger.error(
+      `🐛🐛 KAFKA: Internal Server Error -- operationForSensorManufacturerApproved() -- ${stringify(
+        error,
+      )}`,
+    );
+  }
+};
+
 const operationForSiteCreated = async (messageData) => {
   try {
     const event = JSON.parse(messageData);
@@ -417,6 +575,10 @@ const kafkaConsumer = async () => {
       ["recall-topic"]: emailsForRecalledDevices,
       ["sites-topic"]: operationForSiteCreated,
       [constants.GROUPS_TOPIC]: () => {}, // No-op for auth-service, just acknowledging the topic
+      [constants.NETWORK_CREATION_REQUESTS_TOPIC ||
+      "network-creation-requests-topic"]: operationForSensorManufacturerRequest,
+      [constants.NETWORK_CREATION_APPROVED_TOPIC ||
+      "network-creation-approved-topic"]: operationForSensorManufacturerApproved,
     };
 
     await consumer.connect();

--- a/src/auth-service/config/global/envs.js
+++ b/src/auth-service/config/global/envs.js
@@ -69,6 +69,9 @@ const envs = {
   NETWORK_CREATION_APPROVED_TOPIC:
     process.env.NETWORK_CREATION_APPROVED_TOPIC ||
     "network-creation-approved-topic",
+  NETWORK_CREATION_DENIED_TOPIC:
+    process.env.NETWORK_CREATION_DENIED_TOPIC ||
+    "network-creation-denied-topic",
   UNIQUE_CONSUMER_GROUP: process.env.UNIQUE_CONSUMER_GROUP,
   UNIQUE_PRODUCER_GROUP: process.env.UNIQUE_PRODUCER_GROUP,
   NEW_MOBILE_APP_USER_TOPIC: process.env.NEW_MOBILE_APP_USER_TOPIC,

--- a/src/auth-service/config/global/envs.js
+++ b/src/auth-service/config/global/envs.js
@@ -63,6 +63,12 @@ const envs = {
   RECALL_TOPIC: process.env.RECALL_TOPIC,
   NETWORK_EVENTS_TOPIC:
     process.env.NETWORK_EVENTS_TOPIC || "network-events-topic",
+  NETWORK_CREATION_REQUESTS_TOPIC:
+    process.env.NETWORK_CREATION_REQUESTS_TOPIC ||
+    "network-creation-requests-topic",
+  NETWORK_CREATION_APPROVED_TOPIC:
+    process.env.NETWORK_CREATION_APPROVED_TOPIC ||
+    "network-creation-approved-topic",
   UNIQUE_CONSUMER_GROUP: process.env.UNIQUE_CONSUMER_GROUP,
   UNIQUE_PRODUCER_GROUP: process.env.UNIQUE_PRODUCER_GROUP,
   NEW_MOBILE_APP_USER_TOPIC: process.env.NEW_MOBILE_APP_USER_TOPIC,

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -1472,6 +1472,102 @@ module.exports = {
     return constants.EMAIL_BODY({ email: userEmail, content, name: "Admin" });
   },
 
+  // ── Sensor manufacturer (network) creation request emails ──────────────────
+  //
+  // Terminology: internally "networks"; in all user-facing copy "sensor manufacturers".
+  //
+  // Three emails in the workflow:
+  //   1. notifyAdminOfSensorManufacturerRequest  → sent to the AirQo admin
+  //   2. confirmSensorManufacturerRequestReceived → sent to the requester
+  //   3. notifySensorManufacturerRequestApproved  → sent to the requester on approval
+
+  notifyAdminOfSensorManufacturerRequest: ({
+    requester_name,
+    requester_email,
+    net_name,
+    net_email,
+    net_website,
+    net_category,
+    net_description,
+  }) => {
+    const content = `
+    <tr>
+      <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>A new sensor manufacturer onboarding request has been submitted and is awaiting your review.</p>
+        <table style="width: 100%; border-collapse: collapse; margin: 12px 0;">
+          <tr>
+            <td style="padding: 6px 0; font-weight: 600; width: 40%;">Sensor Manufacturer Name:</td>
+            <td style="padding: 6px 0;">${escapeHtml(net_name)}</td>
+          </tr>
+          <tr>
+            <td style="padding: 6px 0; font-weight: 600;">Contact Email:</td>
+            <td style="padding: 6px 0;">${escapeHtml(net_email)}</td>
+          </tr>
+          ${net_website ? `<tr><td style="padding: 6px 0; font-weight: 600;">Website:</td><td style="padding: 6px 0;">${escapeHtml(net_website)}</td></tr>` : ""}
+          ${net_category ? `<tr><td style="padding: 6px 0; font-weight: 600;">Category:</td><td style="padding: 6px 0;">${escapeHtml(net_category)}</td></tr>` : ""}
+          ${net_description ? `<tr><td style="padding: 6px 0; font-weight: 600;">Description:</td><td style="padding: 6px 0;">${escapeHtml(net_description)}</td></tr>` : ""}
+          <tr>
+            <td style="padding: 6px 0; font-weight: 600;">Submitted By:</td>
+            <td style="padding: 6px 0;">${escapeHtml(requester_name)} (${escapeHtml(requester_email)})</td>
+          </tr>
+        </table>
+        <p>Please review and process this request in the admin dashboard.</p>
+      </td>
+    </tr>
+  `;
+
+    return constants.EMAIL_BODY({
+      email: constants.SUPPORT_EMAIL || "support@airqo.net",
+      content,
+    });
+  },
+
+  confirmSensorManufacturerRequestReceived: ({
+    requester_name,
+    requester_email,
+    net_name,
+  }) => {
+    const content = `
+    <tr>
+      <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>Thank you for submitting a request to onboard <strong>${escapeHtml(net_name)}</strong> as a sensor manufacturer on the AirQo platform.</p>
+        <p>We have received your request and our team will review it shortly. You will receive a follow-up email once your request has been processed.</p>
+        <p>If you have any questions in the meantime, please contact our support team at <a href="mailto:support@airqo.net">support@airqo.net</a>.</p>
+        <p>Thank you for contributing to cleaner air across Africa.</p>
+      </td>
+    </tr>
+  `;
+
+    return constants.EMAIL_BODY({
+      email: requester_email,
+      content,
+      name: requester_name,
+    });
+  },
+
+  notifySensorManufacturerRequestApproved: ({
+    requester_name,
+    requester_email,
+    net_name,
+  }) => {
+    const content = `
+    <tr>
+      <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>Great news! Your request to onboard <strong>${escapeHtml(net_name)}</strong> as a sensor manufacturer on the AirQo platform has been <strong>approved</strong>.</p>
+        <p>The sensor manufacturer profile has been created and is now available in the AirQo system. Our team will be in touch to guide you through the next steps of the integration process.</p>
+        <p>If you have any questions, please contact our support team at <a href="mailto:support@airqo.net">support@airqo.net</a>.</p>
+        <p>Welcome to the AirQo network!</p>
+      </td>
+    </tr>
+  `;
+
+    return constants.EMAIL_BODY({
+      email: requester_email,
+      content,
+      name: requester_name,
+    });
+  },
+
   // Sent to all group members and the manager when an admin changes group status.
   // Deactivation (INACTIVE/SUSPENDED/ARCHIVED) always triggers this regardless
   // of the notify_members flag. Activation also sends to the manager.

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -1476,10 +1476,11 @@ module.exports = {
   //
   // Terminology: internally "networks"; in all user-facing copy "sensor manufacturers".
   //
-  // Three emails in the workflow:
+  // Four emails in the workflow:
   //   1. notifyAdminOfSensorManufacturerRequest  → sent to the AirQo admin
   //   2. confirmSensorManufacturerRequestReceived → sent to the requester
   //   3. notifySensorManufacturerRequestApproved  → sent to the requester on approval
+  //   4. notifySensorManufacturerRequestDenied    → sent to the requester on denial
 
   notifyAdminOfSensorManufacturerRequest: ({
     requester_name,
@@ -1557,6 +1558,35 @@ module.exports = {
         <p>The sensor manufacturer profile has been created and is now available in the AirQo system. Our team will be in touch to guide you through the next steps of the integration process.</p>
         <p>If you have any questions, please contact our support team at <a href="mailto:support@airqo.net">support@airqo.net</a>.</p>
         <p>Welcome to the AirQo network!</p>
+      </td>
+    </tr>
+  `;
+
+    return constants.EMAIL_BODY({
+      email: requester_email,
+      content,
+      name: requester_name,
+    });
+  },
+
+  notifySensorManufacturerRequestDenied: ({
+    requester_name,
+    requester_email,
+    net_name,
+    reviewer_notes,
+  }) => {
+    const notesRow = reviewer_notes
+      ? `<p><strong>Reason:</strong> ${escapeHtml(reviewer_notes)}</p>`
+      : "";
+
+    const content = `
+    <tr>
+      <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>Thank you for your interest in partnering with AirQo as a sensor manufacturer.</p>
+        <p>After careful review, we regret to inform you that your request to onboard <strong>${escapeHtml(net_name)}</strong> has not been approved at this time.</p>
+        ${notesRow}
+        <p>If you believe this decision was made in error, or if you would like to provide additional information, please contact us at <a href="mailto:support@airqo.net">support@airqo.net</a>.</p>
+        <p>We appreciate your interest in the AirQo network and encourage you to reach out if your circumstances change.</p>
       </td>
     </tr>
   `;

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -710,6 +710,17 @@ const getEmailSubject = (functionName, params) => {
     expiredToken: "Action Required: Your AirQo API Token is expired",
     expiringToken: "AirQo API Token Expiry: Create New Token Urgently",
 
+    // ===== SENSOR MANUFACTURER (NETWORK) REQUEST FUNCTIONS =====
+    notifyAdminOfSensorManufacturerRequest: `New Sensor Manufacturer Request: ${sanitizeEmailString(
+      params.net_name || "",
+    )}`,
+    confirmSensorManufacturerRequestReceived: `We Have Received Your Sensor Manufacturer Request: ${sanitizeEmailString(
+      params.net_name || "",
+    )}`,
+    notifySensorManufacturerRequestApproved: `Your Sensor Manufacturer Request Has Been Approved: ${sanitizeEmailString(
+      params.net_name || "",
+    )}`,
+
     // ===== ORG MANAGEMENT FUNCTIONS =====
     notifyAdminsOfNewOrgRequest: `New Organization Request: ${sanitizeEmailString(
       params.organization_name || "",
@@ -827,6 +838,12 @@ const EMAIL_CATEGORIES = {
     "expiringToken",
     "onboardingAccountSetup",
     "notifyGroupStatusChanged",
+  ],
+
+  SENSOR_MANUFACTURER_MANAGEMENT: [
+    "notifyAdminOfSensorManufacturerRequest",
+    "confirmSensorManufacturerRequestReceived",
+    "notifySensorManufacturerRequestApproved",
   ],
 
   ORG_MANAGEMENT: [
@@ -2524,6 +2541,54 @@ const mailer = {
       };
     },
   ),
+  // ── Sensor manufacturer (network) creation request emails ──────────────────
+  //
+  // 1. Admin notification — sent to AirQo support when a new request is submitted
+  notifyAdminOfSensorManufacturerRequest: createMailerFunction(
+    "notifyAdminOfSensorManufacturerRequest",
+    "SENSOR_MANUFACTURER_MANAGEMENT",
+    (params) =>
+      msgs.notifyAdminOfSensorManufacturerRequest({
+        requester_name: params.requester_name,
+        requester_email: params.requester_email,
+        net_name: params.net_name,
+        net_email: params.net_email,
+        net_website: params.net_website,
+        net_category: params.net_category,
+        net_description: params.net_description,
+      }),
+    // Route this email to the support inbox rather than the requester's address
+    (baseMailOptions, _params) => ({
+      ...baseMailOptions,
+      to: constants.SUPPORT_EMAIL || "support@airqo.net",
+      bcc: constants.REQUEST_ACCESS_EMAILS || undefined,
+    }),
+  ),
+
+  // 2. Requester acknowledgement — confirms the request has been received
+  confirmSensorManufacturerRequestReceived: createMailerFunction(
+    "confirmSensorManufacturerRequestReceived",
+    "SENSOR_MANUFACTURER_MANAGEMENT",
+    (params) =>
+      msgs.confirmSensorManufacturerRequestReceived({
+        requester_name: params.requester_name,
+        requester_email: params.requester_email,
+        net_name: params.net_name,
+      }),
+  ),
+
+  // 3. Requester approval — informs the requester that the request was approved
+  notifySensorManufacturerRequestApproved: createMailerFunction(
+    "notifySensorManufacturerRequestApproved",
+    "SENSOR_MANUFACTURER_MANAGEMENT",
+    (params) =>
+      msgs.notifySensorManufacturerRequestApproved({
+        requester_name: params.requester_name,
+        requester_email: params.requester_email,
+        net_name: params.net_name,
+      }),
+  ),
+
   // Mandatory lifecycle notification — sent to the group manager and all members
   // when an admin changes group status. Deactivation always triggers this;
   // activation also notifies the manager. Bypasses unsubscribe checks (CORE_CRITICAL)

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -720,6 +720,9 @@ const getEmailSubject = (functionName, params) => {
     notifySensorManufacturerRequestApproved: `Your Sensor Manufacturer Request Has Been Approved: ${sanitizeEmailString(
       params.net_name || "",
     )}`,
+    notifySensorManufacturerRequestDenied: `Update on Your Sensor Manufacturer Request: ${sanitizeEmailString(
+      params.net_name || "",
+    )}`,
 
     // ===== ORG MANAGEMENT FUNCTIONS =====
     notifyAdminsOfNewOrgRequest: `New Organization Request: ${sanitizeEmailString(
@@ -844,6 +847,7 @@ const EMAIL_CATEGORIES = {
     "notifyAdminOfSensorManufacturerRequest",
     "confirmSensorManufacturerRequestReceived",
     "notifySensorManufacturerRequestApproved",
+    "notifySensorManufacturerRequestDenied",
   ],
 
   ORG_MANAGEMENT: [
@@ -2586,6 +2590,18 @@ const mailer = {
         requester_name: params.requester_name,
         requester_email: params.requester_email,
         net_name: params.net_name,
+      }),
+  ),
+
+  notifySensorManufacturerRequestDenied: createMailerFunction(
+    "notifySensorManufacturerRequestDenied",
+    "SENSOR_MANUFACTURER_MANAGEMENT",
+    (params) =>
+      msgs.notifySensorManufacturerRequestDenied({
+        requester_name: params.requester_name,
+        requester_email: params.requester_email,
+        net_name: params.net_name,
+        reviewer_notes: params.reviewer_notes,
       }),
   ),
 

--- a/src/device-registry/config/global/envs.js
+++ b/src/device-registry/config/global/envs.js
@@ -74,6 +74,9 @@ const envs = {
   NETWORK_CREATION_APPROVED_TOPIC:
     process.env.NETWORK_CREATION_APPROVED_TOPIC ||
     "network-creation-approved-topic",
+  NETWORK_CREATION_DENIED_TOPIC:
+    process.env.NETWORK_CREATION_DENIED_TOPIC ||
+    "network-creation-denied-topic",
   PORT: process.env.PORT || 3000,
   TAHMO_API_GET_STATIONS_URL: process.env.TAHMO_API_GET_STATIONS_URL,
   TAHMO_API_CREDENTIALS_USERNAME: process.env.TAHMO_API_CREDENTIALS_USERNAME,

--- a/src/device-registry/config/global/envs.js
+++ b/src/device-registry/config/global/envs.js
@@ -68,6 +68,12 @@ const envs = {
   HOURLY_MEASUREMENTS_TOPIC: process.env.HOURLY_MEASUREMENTS_TOPIC,
   NETWORK_EVENTS_TOPIC:
     process.env.NETWORK_EVENTS_TOPIC || "network-events-topic",
+  NETWORK_CREATION_REQUESTS_TOPIC:
+    process.env.NETWORK_CREATION_REQUESTS_TOPIC ||
+    "network-creation-requests-topic",
+  NETWORK_CREATION_APPROVED_TOPIC:
+    process.env.NETWORK_CREATION_APPROVED_TOPIC ||
+    "network-creation-approved-topic",
   PORT: process.env.PORT || 3000,
   TAHMO_API_GET_STATIONS_URL: process.env.TAHMO_API_GET_STATIONS_URL,
   TAHMO_API_CREDENTIALS_USERNAME: process.env.TAHMO_API_CREDENTIALS_USERNAME,

--- a/src/device-registry/controllers/network-creation-request.controller.js
+++ b/src/device-registry/controllers/network-creation-request.controller.js
@@ -1,0 +1,168 @@
+"use strict";
+const httpStatus = require("http-status");
+const {
+  logObject,
+  HttpError,
+  extractErrorsFromRequest,
+} = require("@utils/shared");
+const networkCreationRequestUtil = require("@utils/network-creation-request.util");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- network-creation-request-controller`
+);
+const isEmpty = require("is-empty");
+
+// ── Shared request/response helpers ──────────────────────────────────────────
+
+const handleRequest = (req, next) => {
+  const errors = extractErrorsFromRequest(req);
+  if (errors) {
+    next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+    return null;
+  }
+  const request = req;
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  request.query.tenant = isEmpty(req.query.tenant)
+    ? defaultTenant
+    : req.query.tenant;
+  return request;
+};
+
+const handleError = (error, next) => {
+  logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+  next(
+    new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+      message: error.message,
+    })
+  );
+};
+
+function handleResponse({ res, result, key = "data" }) {
+  if (!result || res.headersSent) return;
+
+  const { success, status, data, message, errors, ...rest } = result;
+  const responseStatus =
+    status || (success ? httpStatus.OK : httpStatus.INTERNAL_SERVER_ERROR);
+
+  if (success) {
+    const responseBody = {
+      success: true,
+      message: message || "Operation Successful",
+      ...rest,
+    };
+    if (data !== undefined) responseBody[key] = data;
+    return res.status(responseStatus).json(responseBody);
+  }
+
+  return res.status(responseStatus).json({
+    success: false,
+    message: message || "An unexpected error occurred.",
+    errors: errors || { message: "An unexpected error occurred." },
+  });
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+const createRequest = async (req, res, next) => {
+  try {
+    const request = handleRequest(req, next);
+    if (!request) return;
+
+    const result =
+      await networkCreationRequestUtil.createNetworkCreationRequest(
+        request,
+        next
+      );
+    handleResponse({
+      res,
+      result,
+      key: "network_creation_request",
+    });
+  } catch (error) {
+    handleError(error, next);
+  }
+};
+
+const listRequests = async (req, res, next) => {
+  try {
+    const request = handleRequest(req, next);
+    if (!request) return;
+
+    const result =
+      await networkCreationRequestUtil.listNetworkCreationRequests(
+        request,
+        next
+      );
+    handleResponse({ res, result, key: "network_creation_requests" });
+  } catch (error) {
+    handleError(error, next);
+  }
+};
+
+const getRequest = async (req, res, next) => {
+  try {
+    const request = handleRequest(req, next);
+    if (!request) return;
+
+    const result =
+      await networkCreationRequestUtil.getNetworkCreationRequest(request, next);
+    handleResponse({ res, result, key: "network_creation_request" });
+  } catch (error) {
+    handleError(error, next);
+  }
+};
+
+const approveRequest = async (req, res, next) => {
+  try {
+    const request = handleRequest(req, next);
+    if (!request) return;
+
+    const result =
+      await networkCreationRequestUtil.approveNetworkCreationRequest(
+        request,
+        next
+      );
+    handleResponse({ res, result, key: "approval" });
+  } catch (error) {
+    handleError(error, next);
+  }
+};
+
+const denyRequest = async (req, res, next) => {
+  try {
+    const request = handleRequest(req, next);
+    if (!request) return;
+
+    const result =
+      await networkCreationRequestUtil.denyNetworkCreationRequest(request, next);
+    handleResponse({ res, result, key: "denied_request" });
+  } catch (error) {
+    handleError(error, next);
+  }
+};
+
+const reviewRequest = async (req, res, next) => {
+  try {
+    const request = handleRequest(req, next);
+    if (!request) return;
+
+    const result =
+      await networkCreationRequestUtil.reviewNetworkCreationRequest(
+        request,
+        next
+      );
+    handleResponse({ res, result, key: "reviewed_request" });
+  } catch (error) {
+    handleError(error, next);
+  }
+};
+
+module.exports = {
+  createRequest,
+  listRequests,
+  getRequest,
+  approveRequest,
+  denyRequest,
+  reviewRequest,
+};

--- a/src/device-registry/controllers/network-creation-request.controller.js
+++ b/src/device-registry/controllers/network-creation-request.controller.js
@@ -1,7 +1,6 @@
 "use strict";
 const httpStatus = require("http-status");
 const {
-  logObject,
   HttpError,
   extractErrorsFromRequest,
 } = require("@utils/shared");

--- a/src/device-registry/models/NetworkCreationRequest.js
+++ b/src/device-registry/models/NetworkCreationRequest.js
@@ -112,6 +112,9 @@ NetworkCreationRequestSchema.methods.toJSON = function() {
     reviewer_notes,
     reviewed_by,
     reviewed_at,
+    // Truncated to "YYYY-MM-DDTHH:mm:ss" (no trailing Z/timezone) intentionally:
+    // API consumers display these as local times; the raw UTC offset is dropped
+    // to avoid confusion in the dashboard UI.
     createdAt: createdAt ? new Date(createdAt).toISOString().slice(0, 19) : null,
     updatedAt: updatedAt ? new Date(updatedAt).toISOString().slice(0, 19) : null,
   };
@@ -130,7 +133,7 @@ NetworkCreationRequestSchema.statics.register = async function(args, next) {
       };
     }
 
-    next(
+    return next(
       new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
         message:
           "request not created despite successful operation",

--- a/src/device-registry/models/NetworkCreationRequest.js
+++ b/src/device-registry/models/NetworkCreationRequest.js
@@ -2,7 +2,6 @@
 const mongoose = require("mongoose");
 const { Schema } = mongoose;
 const isEmpty = require("is-empty");
-const uniqueValidator = require("mongoose-unique-validator");
 const { logObject, HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
 const constants = require("@config/constants");
@@ -79,10 +78,6 @@ const NetworkCreationRequestSchema = new Schema(
     timestamps: true,
   }
 );
-
-NetworkCreationRequestSchema.plugin(uniqueValidator, {
-  message: `{VALUE} is a duplicate value!`,
-});
 
 NetworkCreationRequestSchema.methods.toJSON = function() {
   const {

--- a/src/device-registry/models/NetworkCreationRequest.js
+++ b/src/device-registry/models/NetworkCreationRequest.js
@@ -112,11 +112,8 @@ NetworkCreationRequestSchema.methods.toJSON = function() {
     reviewer_notes,
     reviewed_by,
     reviewed_at,
-    // Truncated to "YYYY-MM-DDTHH:mm:ss" (no trailing Z/timezone) intentionally:
-    // API consumers display these as local times; the raw UTC offset is dropped
-    // to avoid confusion in the dashboard UI.
-    createdAt: createdAt ? new Date(createdAt).toISOString().slice(0, 19) : null,
-    updatedAt: updatedAt ? new Date(updatedAt).toISOString().slice(0, 19) : null,
+    createdAt: createdAt ? new Date(createdAt).toISOString() : null,
+    updatedAt: updatedAt ? new Date(updatedAt).toISOString() : null,
   };
 };
 
@@ -133,32 +130,35 @@ NetworkCreationRequestSchema.statics.register = async function(args, next) {
       };
     }
 
-    return next(
-      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
-        message:
-          "request not created despite successful operation",
-      })
-    );
+    return {
+      success: false,
+      message: "request not created despite successful operation",
+      errors: { message: "request not created despite successful operation" },
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+    };
   } catch (error) {
     logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
 
-    const response = {
-      message: "validation errors for some of the provided fields",
-      success: false,
-      status: httpStatus.CONFLICT,
-      errors: {},
-    };
-
     if (!isEmpty(error.errors)) {
+      const errors = {};
       Object.entries(error.errors).forEach(([key, value]) => {
-        response.errors.message = value.message;
-        response.errors[value.path] = value.message;
+        errors.message = value.message;
+        errors[value.path] = value.message;
       });
-    } else {
-      response.errors = { message: error.message };
+      return {
+        success: false,
+        message: "validation errors for some of the provided fields",
+        errors,
+        status: httpStatus.CONFLICT,
+      };
     }
 
-    next(new HttpError(response.message, response.status, response.errors));
+    return {
+      success: false,
+      message: error.message,
+      errors: { message: error.message },
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+    };
   }
 };
 

--- a/src/device-registry/models/NetworkCreationRequest.js
+++ b/src/device-registry/models/NetworkCreationRequest.js
@@ -1,0 +1,248 @@
+"use strict";
+const mongoose = require("mongoose");
+const { Schema } = mongoose;
+const isEmpty = require("is-empty");
+const uniqueValidator = require("mongoose-unique-validator");
+const { logObject, HttpError } = require("@utils/shared");
+const httpStatus = require("http-status");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- network-creation-request-model`
+);
+const { getModelByTenant } = require("@config/database");
+
+const NetworkCreationRequestSchema = new Schema(
+  {
+    requester_name: {
+      type: String,
+      required: [true, "requester_name is required"],
+      trim: true,
+    },
+    requester_email: {
+      type: String,
+      required: [true, "requester_email is required"],
+      match: [/\S+@\S+\.\S+/, "is invalid"],
+      trim: true,
+      lowercase: true,
+    },
+    net_name: {
+      type: String,
+      required: [true, "net_name is required"],
+      trim: true,
+    },
+    net_email: {
+      type: String,
+      required: [true, "net_email is required"],
+      match: [/\S+@\S+\.\S+/, "is invalid"],
+      trim: true,
+      lowercase: true,
+    },
+    net_website: {
+      type: String,
+      trim: true,
+    },
+    net_category: {
+      type: String,
+      trim: true,
+    },
+    net_description: {
+      type: String,
+      trim: true,
+    },
+    net_acronym: {
+      type: String,
+      trim: true,
+    },
+    // Current lifecycle state of the request
+    status: {
+      type: String,
+      enum: ["pending", "approved", "denied", "under_review"],
+      default: "pending",
+      index: true,
+    },
+    // Optional notes left by the reviewer on approval, denial, or review
+    reviewer_notes: {
+      type: String,
+      trim: true,
+    },
+    // Username or identifier of the admin who acted on the request
+    reviewed_by: {
+      type: String,
+      trim: true,
+    },
+    reviewed_at: {
+      type: Date,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+NetworkCreationRequestSchema.plugin(uniqueValidator, {
+  message: `{VALUE} is a duplicate value!`,
+});
+
+NetworkCreationRequestSchema.methods.toJSON = function() {
+  const {
+    _id,
+    requester_name,
+    requester_email,
+    net_name,
+    net_email,
+    net_website,
+    net_category,
+    net_description,
+    net_acronym,
+    status,
+    reviewer_notes,
+    reviewed_by,
+    reviewed_at,
+    createdAt,
+    updatedAt,
+  } = this.toObject();
+
+  return {
+    _id,
+    requester_name,
+    requester_email,
+    net_name,
+    net_email,
+    net_website,
+    net_category,
+    net_description,
+    net_acronym,
+    status,
+    reviewer_notes,
+    reviewed_by,
+    reviewed_at,
+    createdAt: createdAt ? new Date(createdAt).toISOString().slice(0, 19) : null,
+    updatedAt: updatedAt ? new Date(updatedAt).toISOString().slice(0, 19) : null,
+  };
+};
+
+NetworkCreationRequestSchema.statics.register = async function(args, next) {
+  try {
+    const created = await this.create({ ...args });
+
+    if (!isEmpty(created)) {
+      return {
+        success: true,
+        data: created,
+        message: "sensor manufacturer creation request submitted successfully",
+        status: httpStatus.CREATED,
+      };
+    }
+
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message:
+          "request not created despite successful operation",
+      })
+    );
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+
+    const response = {
+      message: "validation errors for some of the provided fields",
+      success: false,
+      status: httpStatus.CONFLICT,
+      errors: {},
+    };
+
+    if (!isEmpty(error.errors)) {
+      Object.entries(error.errors).forEach(([key, value]) => {
+        response.errors.message = value.message;
+        response.errors[value.path] = value.message;
+      });
+    } else {
+      response.errors = { message: error.message };
+    }
+
+    next(new HttpError(response.message, response.status, response.errors));
+  }
+};
+
+NetworkCreationRequestSchema.statics.list = async function(
+  { filter = {}, limit = 100, skip = 0 } = {},
+  next
+) {
+  try {
+    const data = await this.find(filter)
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .lean();
+
+    return {
+      success: true,
+      message: isEmpty(data)
+        ? "No records found for this search"
+        : "Successfully retrieved sensor manufacturer creation requests",
+      data: data || [],
+      status: httpStatus.OK,
+    };
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+NetworkCreationRequestSchema.statics.modify = async function(
+  { filter = {}, update = {} } = {},
+  next
+) {
+  try {
+    const updated = await this.findOneAndUpdate(filter, update, {
+      new: true,
+      lean: true,
+      runValidators: true,
+    });
+
+    if (!isEmpty(updated)) {
+      return {
+        success: true,
+        message: "request updated successfully",
+        data: updated,
+        status: httpStatus.OK,
+      };
+    }
+
+    return {
+      success: false,
+      message: "request not found",
+      errors: { message: "No matching request found" },
+      status: httpStatus.NOT_FOUND,
+    };
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+const NetworkCreationRequestModel = (tenant) => {
+  const modelName = "NetworkCreationRequest";
+  try {
+    return getModelByTenant(
+      tenant,
+      modelName,
+      NetworkCreationRequestSchema
+    );
+  } catch (error) {
+    logger.error(
+      `getModelByTenant failed for tenant "${tenant}": ${error.message}`
+    );
+    throw error;
+  }
+};
+
+module.exports = NetworkCreationRequestModel;

--- a/src/device-registry/routes/v2/index.js
+++ b/src/device-registry/routes/v2/index.js
@@ -150,6 +150,12 @@ const routes = [
   // Canonical Network CRUD endpoints — /api/v2/devices/networks/...
   // The legacy /cohorts/networks/... paths remain fully operational.
   { path: "/networks", route: "@routes/v2/networks.routes", name: "networks" },
+  // Sensor manufacturer (network) creation request workflow
+  {
+    path: "/network-creation-requests",
+    route: "@routes/v2/network-creation-requests.routes",
+    name: "network-creation-requests",
+  },
   {
     path: "/network-coverage",
     route: "@routes/v2/network-coverage.routes",

--- a/src/device-registry/routes/v2/network-creation-requests.routes.js
+++ b/src/device-registry/routes/v2/network-creation-requests.routes.js
@@ -1,0 +1,65 @@
+// network-creation-requests.routes.js
+// Mounted at /api/v2/devices/network-creation-requests
+//
+// Terminology note: internally these are "networks", but in all user-facing
+// surfaces (emails, docs, frontend) they are called "sensor manufacturers".
+//
+// Workflow:
+//   POST   /                          — submit a new sensor manufacturer creation request (public)
+//   GET    /                          — list all requests (admin only, requires admin_secret in query)
+//   GET    /:request_id               — retrieve a single request
+//   PUT    /:request_id/approve       — approve the request and create the network (admin only)
+//   PUT    /:request_id/deny          — deny the request (admin only)
+//   PUT    /:request_id/review        — mark the request as under review (admin only)
+const express = require("express");
+const router = express.Router();
+const networkCreationRequestController = require("@controllers/network-creation-request.controller");
+const networkCreationRequestValidators = require("@validators/network-creation-request.validators");
+const { headers, pagination } = require("@validators/common");
+
+router.use(headers);
+
+// Submit a new sensor manufacturer creation request
+router.post(
+  "/",
+  networkCreationRequestValidators.createRequest,
+  networkCreationRequestController.createRequest
+);
+
+// List all requests (admin)
+router.get(
+  "/",
+  networkCreationRequestValidators.listRequests,
+  pagination(),
+  networkCreationRequestController.listRequests
+);
+
+// Get a single request
+router.get(
+  "/:request_id",
+  networkCreationRequestValidators.getRequest,
+  networkCreationRequestController.getRequest
+);
+
+// Approve a request (creates the network)
+router.put(
+  "/:request_id/approve",
+  networkCreationRequestValidators.approveRequest,
+  networkCreationRequestController.approveRequest
+);
+
+// Deny a request
+router.put(
+  "/:request_id/deny",
+  networkCreationRequestValidators.denyRequest,
+  networkCreationRequestController.denyRequest
+);
+
+// Mark a request as under review
+router.put(
+  "/:request_id/review",
+  networkCreationRequestValidators.reviewRequest,
+  networkCreationRequestController.reviewRequest
+);
+
+module.exports = router;

--- a/src/device-registry/utils/network-creation-request.util.js
+++ b/src/device-registry/utils/network-creation-request.util.js
@@ -403,6 +403,18 @@ const reviewNetworkCreationRequest = async (request, next) => {
       };
     }
 
+    const reviewableStates = ["pending"];
+    if (!reviewableStates.includes(existing.status)) {
+      return {
+        success: false,
+        message: "Request cannot be marked under review",
+        errors: {
+          message: `Only requests in 'pending' state can be moved to under_review. Current status: '${existing.status}'`,
+        },
+        status: httpStatus.CONFLICT,
+      };
+    }
+
     return await NetworkCreationRequestModel(tenant).modify(
       {
         filter: { _id: new ObjectId(request_id) },

--- a/src/device-registry/utils/network-creation-request.util.js
+++ b/src/device-registry/utils/network-creation-request.util.js
@@ -27,7 +27,7 @@ const NetworkModel = require("@models/Network");
 const isEmpty = require("is-empty");
 const httpStatus = require("http-status");
 const mongoose = require("mongoose");
-const ObjectId = mongoose.Types.ObjectId;
+const { ObjectId } = mongoose.Types;
 const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- network-creation-request-util`
@@ -38,29 +38,36 @@ const { HttpError } = require("@utils/shared");
 // Internal Kafka helper
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Kafka client is created once at module scope and reused across calls to avoid
+// repeated TCP connection setup on every publish.
+const kafka = new Kafka({
+  clientId: constants.KAFKA_CLIENT_ID,
+  brokers: constants.KAFKA_BOOTSTRAP_SERVERS,
+});
+
 /**
- * Publish a single message to a Kafka topic.
- * Creates a transient producer (connect → send → disconnect) to stay consistent
- * with the pattern already used elsewhere in device-registry.
+ * Publish one or more messages to a Kafka topic in a single producer.send()
+ * call.  Accepts an array of payloads so callers can batch multiple events
+ * without paying the connect/disconnect overhead more than once.
+ *
+ * Failures are non-fatal: they are logged but never bubble up to the caller so
+ * the HTTP response is unaffected.
  */
-const publishToKafka = async (topic, payload) => {
-  const kafka = new Kafka({
-    clientId: constants.KAFKA_CLIENT_ID,
-    brokers: constants.KAFKA_BOOTSTRAP_SERVERS,
-  });
+const publishToKafka = async (topic, payloads) => {
+  const messages = (Array.isArray(payloads) ? payloads : [payloads]).map(
+    (p) => ({ value: JSON.stringify(p) })
+  );
 
   const producer = kafka.producer();
   try {
     await producer.connect();
-    await producer.send({
-      topic,
-      messages: [{ value: JSON.stringify(payload) }],
-    });
-    logger.info(`Published Kafka event to topic "${topic}"`);
+    await producer.send({ topic, messages });
+    logger.info(
+      `Published ${messages.length} Kafka event(s) to topic "${topic}"`
+    );
   } catch (error) {
-    // Non-fatal: log and continue so the HTTP response still succeeds.
     logger.error(
-      `Failed to publish Kafka event to topic "${topic}": ${error.message}`
+      `Failed to publish Kafka event(s) to topic "${topic}": ${error.message}`
     );
   } finally {
     try {
@@ -104,17 +111,13 @@ const createNetworkCreationRequest = async (request, next) => {
       request_id: created.data._id,
     };
 
-    // Event consumed by auth-service to email the admin
-    await publishToKafka(requestTopic, {
-      action: "new_request",
-      ...eventPayload,
-    });
-
-    // Event consumed by auth-service to send acknowledgement to requester
-    await publishToKafka(requestTopic, {
-      action: "request_received",
-      ...eventPayload,
-    });
+    // Both events go to the same topic in one producer.send() call:
+    //   • "new_request"      → auth-service emails the admin
+    //   • "request_received" → auth-service sends acknowledgement to requester
+    await publishToKafka(requestTopic, [
+      { action: "new_request", ...eventPayload },
+      { action: "request_received", ...eventPayload },
+    ]);
 
     return created;
   } catch (error) {
@@ -159,7 +162,7 @@ const getNetworkCreationRequest = async (request, next) => {
     const { request_id } = params;
 
     const found = await NetworkCreationRequestModel(tenant)
-      .findById(ObjectId(request_id))
+      .findById(new ObjectId(request_id))
       .lean();
 
     if (!found) {
@@ -196,7 +199,7 @@ const approveNetworkCreationRequest = async (request, next) => {
 
     // 1. Load the pending request
     const pendingRequest = await NetworkCreationRequestModel(tenant)
-      .findById(ObjectId(request_id))
+      .findById(new ObjectId(request_id))
       .lean();
 
     if (!pendingRequest) {
@@ -208,11 +211,14 @@ const approveNetworkCreationRequest = async (request, next) => {
       };
     }
 
-    if (pendingRequest.status === "approved") {
+    const approvableStates = ["pending", "under_review"];
+    if (!approvableStates.includes(pendingRequest.status)) {
       return {
         success: false,
-        message: "Request has already been approved",
-        errors: { message: "This request was already approved" },
+        message: "Request cannot be approved",
+        errors: {
+          message: `Only requests in 'pending' or 'under_review' state can be approved. Current status: '${pendingRequest.status}'`,
+        },
         status: httpStatus.CONFLICT,
       };
     }
@@ -241,7 +247,7 @@ const approveNetworkCreationRequest = async (request, next) => {
     // 3. Mark request as approved
     const updatedRequest = await NetworkCreationRequestModel(tenant).modify(
       {
-        filter: { _id: ObjectId(request_id) },
+        filter: { _id: new ObjectId(request_id) },
         update: {
           status: "approved",
           reviewer_notes: reviewer_notes || null,
@@ -251,6 +257,25 @@ const approveNetworkCreationRequest = async (request, next) => {
       },
       next
     );
+
+    if (!updatedRequest || updatedRequest.success === false) {
+      // The network was created but the request record could not be marked
+      // approved. Log and surface the error so the caller can retry rather than
+      // leaving the system in an inconsistent state.
+      logger.error(
+        `approveNetworkCreationRequest: network created (id=${createdNetwork.data._id}) but request status update failed for request_id=${request_id}`
+      );
+      return {
+        success: false,
+        message: "Network created but failed to update request status to approved",
+        errors: {
+          message: updatedRequest
+            ? updatedRequest.errors?.message
+            : "Status update returned no result",
+        },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
 
     // 4. Publish Kafka event for approval email
     const approvedTopic =
@@ -293,7 +318,7 @@ const denyNetworkCreationRequest = async (request, next) => {
     const { reviewer_notes, reviewed_by } = body;
 
     const existing = await NetworkCreationRequestModel(tenant)
-      .findById(ObjectId(request_id))
+      .findById(new ObjectId(request_id))
       .lean();
 
     if (!existing) {
@@ -305,18 +330,21 @@ const denyNetworkCreationRequest = async (request, next) => {
       };
     }
 
-    if (existing.status === "denied") {
+    const deniableStates = ["pending", "under_review"];
+    if (!deniableStates.includes(existing.status)) {
       return {
         success: false,
-        message: "Request has already been denied",
-        errors: { message: "This request was already denied" },
+        message: "Request cannot be denied",
+        errors: {
+          message: `Only requests in 'pending' or 'under_review' state can be denied. Current status: '${existing.status}'`,
+        },
         status: httpStatus.CONFLICT,
       };
     }
 
-    return await NetworkCreationRequestModel(tenant).modify(
+    const result = await NetworkCreationRequestModel(tenant).modify(
       {
-        filter: { _id: ObjectId(request_id) },
+        filter: { _id: new ObjectId(request_id) },
         update: {
           status: "denied",
           reviewer_notes: reviewer_notes || null,
@@ -326,6 +354,25 @@ const denyNetworkCreationRequest = async (request, next) => {
       },
       next
     );
+
+    if (!result || result.success === false) return result;
+
+    // Publish Kafka event so auth-service can send a denial email to the requester
+    const deniedTopic =
+      constants.NETWORK_CREATION_DENIED_TOPIC ||
+      "network-creation-denied-topic";
+
+    await publishToKafka(deniedTopic, {
+      action: "denied",
+      requester_name: existing.requester_name,
+      requester_email: existing.requester_email,
+      net_name: existing.net_name,
+      request_id: existing._id,
+      reviewer_notes: reviewer_notes || null,
+      reviewed_by: reviewed_by || null,
+    });
+
+    return result;
   } catch (error) {
     logger.error(`🐛🐛 Internal Server Error ${error.message}`);
     next(
@@ -344,7 +391,7 @@ const reviewNetworkCreationRequest = async (request, next) => {
     const { reviewer_notes, reviewed_by } = body;
 
     const existing = await NetworkCreationRequestModel(tenant)
-      .findById(ObjectId(request_id))
+      .findById(new ObjectId(request_id))
       .lean();
 
     if (!existing) {
@@ -358,7 +405,7 @@ const reviewNetworkCreationRequest = async (request, next) => {
 
     return await NetworkCreationRequestModel(tenant).modify(
       {
-        filter: { _id: ObjectId(request_id) },
+        filter: { _id: new ObjectId(request_id) },
         update: {
           status: "under_review",
           reviewer_notes: reviewer_notes || null,

--- a/src/device-registry/utils/network-creation-request.util.js
+++ b/src/device-registry/utils/network-creation-request.util.js
@@ -1,0 +1,388 @@
+"use strict";
+/**
+ * network-creation-request.util.js
+ *
+ * Business logic for the sensor manufacturer (network) creation request workflow:
+ *
+ *   1. A requester submits a new request via POST /network-creation-requests.
+ *      The request is persisted with status "pending" and two Kafka events are
+ *      published to `network-creation-requests-topic`:
+ *        • An admin notification (action: "new_request")
+ *        • A requester acknowledgement (action: "request_received")
+ *
+ *   2. An admin reviews the request and may:
+ *        • Approve  → network is created in device-registry + Kafka event to
+ *                     `network-creation-approved-topic` (action: "approved")
+ *        • Deny     → status updated to "denied"
+ *        • Review   → status updated to "under_review"
+ *
+ * Terminology note: internally these are "networks"; in all user-facing copy
+ * (emails, response messages) they are called "sensor manufacturers".
+ */
+
+const { Kafka } = require("kafkajs");
+const constants = require("@config/constants");
+const NetworkCreationRequestModel = require("@models/NetworkCreationRequest");
+const NetworkModel = require("@models/Network");
+const isEmpty = require("is-empty");
+const httpStatus = require("http-status");
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Types.ObjectId;
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- network-creation-request-util`
+);
+const { HttpError } = require("@utils/shared");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal Kafka helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Publish a single message to a Kafka topic.
+ * Creates a transient producer (connect → send → disconnect) to stay consistent
+ * with the pattern already used elsewhere in device-registry.
+ */
+const publishToKafka = async (topic, payload) => {
+  const kafka = new Kafka({
+    clientId: constants.KAFKA_CLIENT_ID,
+    brokers: constants.KAFKA_BOOTSTRAP_SERVERS,
+  });
+
+  const producer = kafka.producer();
+  try {
+    await producer.connect();
+    await producer.send({
+      topic,
+      messages: [{ value: JSON.stringify(payload) }],
+    });
+    logger.info(`Published Kafka event to topic "${topic}"`);
+  } catch (error) {
+    // Non-fatal: log and continue so the HTTP response still succeeds.
+    logger.error(
+      `Failed to publish Kafka event to topic "${topic}": ${error.message}`
+    );
+  } finally {
+    try {
+      await producer.disconnect();
+    } catch (_) {
+      /* ignore disconnect errors */
+    }
+  }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CRUD helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const createNetworkCreationRequest = async (request, next) => {
+  try {
+    const { query, body } = request;
+    const tenant = query.tenant || constants.DEFAULT_TENANT || "airqo";
+
+    const created = await NetworkCreationRequestModel(tenant).register(
+      body,
+      next
+    );
+
+    if (!created || created.success === false) return created;
+
+    // Publish Kafka events (fire-and-forget; failures do not affect the HTTP response)
+    const requestTopic =
+      constants.NETWORK_CREATION_REQUESTS_TOPIC ||
+      "network-creation-requests-topic";
+
+    const eventPayload = {
+      requester_name: created.data.requester_name,
+      requester_email: created.data.requester_email,
+      net_name: created.data.net_name,
+      net_email: created.data.net_email,
+      net_website: created.data.net_website,
+      net_category: created.data.net_category,
+      net_description: created.data.net_description,
+      net_acronym: created.data.net_acronym,
+      request_id: created.data._id,
+    };
+
+    // Event consumed by auth-service to email the admin
+    await publishToKafka(requestTopic, {
+      action: "new_request",
+      ...eventPayload,
+    });
+
+    // Event consumed by auth-service to send acknowledgement to requester
+    await publishToKafka(requestTopic, {
+      action: "request_received",
+      ...eventPayload,
+    });
+
+    return created;
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+const listNetworkCreationRequests = async (request, next) => {
+  try {
+    const { query } = request;
+    const tenant = query.tenant || constants.DEFAULT_TENANT || "airqo";
+    const limit = parseInt(query.limit) || 100;
+    const skip = parseInt(query.skip) || 0;
+
+    const filter = {};
+    if (query.status) filter.status = query.status;
+    if (query.requester_email) filter.requester_email = query.requester_email.toLowerCase();
+
+    return await NetworkCreationRequestModel(tenant).list(
+      { filter, limit, skip },
+      next
+    );
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+const getNetworkCreationRequest = async (request, next) => {
+  try {
+    const { query, params } = request;
+    const tenant = query.tenant || constants.DEFAULT_TENANT || "airqo";
+    const { request_id } = params;
+
+    const found = await NetworkCreationRequestModel(tenant)
+      .findById(ObjectId(request_id))
+      .lean();
+
+    if (!found) {
+      return {
+        success: false,
+        message: "Sensor manufacturer creation request not found",
+        errors: { message: "No request found with the provided ID" },
+        status: httpStatus.NOT_FOUND,
+      };
+    }
+
+    return {
+      success: true,
+      message: "Successfully retrieved request",
+      data: found,
+      status: httpStatus.OK,
+    };
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+const approveNetworkCreationRequest = async (request, next) => {
+  try {
+    const { query, body, params } = request;
+    const tenant = query.tenant || constants.DEFAULT_TENANT || "airqo";
+    const { request_id } = params;
+    const { reviewer_notes, reviewed_by } = body;
+
+    // 1. Load the pending request
+    const pendingRequest = await NetworkCreationRequestModel(tenant)
+      .findById(ObjectId(request_id))
+      .lean();
+
+    if (!pendingRequest) {
+      return {
+        success: false,
+        message: "Request not found",
+        errors: { message: "No request found with the provided ID" },
+        status: httpStatus.NOT_FOUND,
+      };
+    }
+
+    if (pendingRequest.status === "approved") {
+      return {
+        success: false,
+        message: "Request has already been approved",
+        errors: { message: "This request was already approved" },
+        status: httpStatus.CONFLICT,
+      };
+    }
+
+    // 2. Create the network in device-registry
+    const networkBody = {
+      net_name: pendingRequest.net_name,
+      net_email: pendingRequest.net_email,
+      net_website: pendingRequest.net_website,
+      net_category: pendingRequest.net_category,
+      net_description: pendingRequest.net_description,
+      net_acronym: pendingRequest.net_acronym || pendingRequest.net_name,
+      name: pendingRequest.net_name,
+      net_status: "inactive",
+    };
+
+    const createdNetwork = await NetworkModel(tenant).register(
+      networkBody,
+      next
+    );
+
+    if (!createdNetwork || createdNetwork.success === false) {
+      return createdNetwork;
+    }
+
+    // 3. Mark request as approved
+    const updatedRequest = await NetworkCreationRequestModel(tenant).modify(
+      {
+        filter: { _id: ObjectId(request_id) },
+        update: {
+          status: "approved",
+          reviewer_notes: reviewer_notes || null,
+          reviewed_by: reviewed_by || null,
+          reviewed_at: new Date(),
+        },
+      },
+      next
+    );
+
+    // 4. Publish Kafka event for approval email
+    const approvedTopic =
+      constants.NETWORK_CREATION_APPROVED_TOPIC ||
+      "network-creation-approved-topic";
+
+    await publishToKafka(approvedTopic, {
+      action: "approved",
+      requester_name: pendingRequest.requester_name,
+      requester_email: pendingRequest.requester_email,
+      net_name: pendingRequest.net_name,
+      request_id: pendingRequest._id,
+      network_id: createdNetwork.data._id,
+    });
+
+    return {
+      success: true,
+      message: "Sensor manufacturer creation request approved and network created",
+      status: httpStatus.OK,
+      data: {
+        request: updatedRequest ? updatedRequest.data : null,
+        network: createdNetwork.data,
+      },
+    };
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+const denyNetworkCreationRequest = async (request, next) => {
+  try {
+    const { query, body, params } = request;
+    const tenant = query.tenant || constants.DEFAULT_TENANT || "airqo";
+    const { request_id } = params;
+    const { reviewer_notes, reviewed_by } = body;
+
+    const existing = await NetworkCreationRequestModel(tenant)
+      .findById(ObjectId(request_id))
+      .lean();
+
+    if (!existing) {
+      return {
+        success: false,
+        message: "Request not found",
+        errors: { message: "No request found with the provided ID" },
+        status: httpStatus.NOT_FOUND,
+      };
+    }
+
+    if (existing.status === "denied") {
+      return {
+        success: false,
+        message: "Request has already been denied",
+        errors: { message: "This request was already denied" },
+        status: httpStatus.CONFLICT,
+      };
+    }
+
+    return await NetworkCreationRequestModel(tenant).modify(
+      {
+        filter: { _id: ObjectId(request_id) },
+        update: {
+          status: "denied",
+          reviewer_notes: reviewer_notes || null,
+          reviewed_by: reviewed_by || null,
+          reviewed_at: new Date(),
+        },
+      },
+      next
+    );
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+const reviewNetworkCreationRequest = async (request, next) => {
+  try {
+    const { query, body, params } = request;
+    const tenant = query.tenant || constants.DEFAULT_TENANT || "airqo";
+    const { request_id } = params;
+    const { reviewer_notes, reviewed_by } = body;
+
+    const existing = await NetworkCreationRequestModel(tenant)
+      .findById(ObjectId(request_id))
+      .lean();
+
+    if (!existing) {
+      return {
+        success: false,
+        message: "Request not found",
+        errors: { message: "No request found with the provided ID" },
+        status: httpStatus.NOT_FOUND,
+      };
+    }
+
+    return await NetworkCreationRequestModel(tenant).modify(
+      {
+        filter: { _id: ObjectId(request_id) },
+        update: {
+          status: "under_review",
+          reviewer_notes: reviewer_notes || null,
+          reviewed_by: reviewed_by || null,
+          reviewed_at: new Date(),
+        },
+      },
+      next
+    );
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+module.exports = {
+  createNetworkCreationRequest,
+  listNetworkCreationRequests,
+  getNetworkCreationRequest,
+  approveNetworkCreationRequest,
+  denyNetworkCreationRequest,
+  reviewNetworkCreationRequest,
+};

--- a/src/device-registry/utils/test/ut_network-creation-request.util.js
+++ b/src/device-registry/utils/test/ut_network-creation-request.util.js
@@ -5,12 +5,21 @@ const chai = require("chai");
 const httpStatus = require("http-status");
 const { expect } = chai;
 
-// ── Module under test ────────────────────────────────────────────────────────
-// We require the module once; individual model/Kafka internals are stubbed via
-// sinon.stub on the required modules before each test.
-const NetworkCreationRequestModel = require("@models/NetworkCreationRequest");
-const NetworkModel = require("@models/Network");
-const util = require("@utils/network-creation-request.util");
+// ── Paths (resolved once; used for require.cache patching) ────────────────────
+const utilPath = require.resolve("@utils/network-creation-request.util");
+const reqModelPath = require.resolve("@models/NetworkCreationRequest");
+const netModelPath = require.resolve("@models/Network");
+const kafkaJsPath = require.resolve("kafkajs");
+
+/**
+ * Re-require the util fresh so it captures whatever is currently in
+ * require.cache for its dependencies (models, kafkajs).
+ * Call this AFTER patching the relevant cache entries.
+ */
+const loadUtil = () => {
+  delete require.cache[utilPath];
+  return require("@utils/network-creation-request.util");
+};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -39,22 +48,14 @@ const fakeRequestDoc = {
 describe("network-creation-request.util", () => {
   afterEach(() => {
     sinon.restore();
+    // Evict the util from cache so each test group starts fresh
+    delete require.cache[utilPath];
   });
 
   // ── createNetworkCreationRequest ────────────────────────────────────────────
 
   describe("createNetworkCreationRequest", () => {
-    it("returns the created record and publishes 2 batched Kafka events", async () => {
-      const request = makeRequest({
-        body: {
-          requester_name: "Jane Doe",
-          requester_email: "jane@example.com",
-          net_name: "AirSense",
-          net_email: "contact@airsense.io",
-        },
-      });
-
-      // Build a fake model instance that register resolves successfully
+    it("returns the created record on success", async () => {
       const fakeModel = {
         register: sinon.stub().resolves({
           success: true,
@@ -62,27 +63,31 @@ describe("network-creation-request.util", () => {
           data: fakeRequestDoc,
         }),
       };
-      const modelFnStub = sinon
-        .stub()
-        .withArgs("airqo")
-        .returns(fakeModel);
+      const modelFnStub = sinon.stub().returns(fakeModel);
 
-      // Patch the require cache entry so the util uses our stub
-      const NetworkCreationRequestModelPath = require.resolve(
-        "@models/NetworkCreationRequest"
-      );
-      const original = require.cache[NetworkCreationRequestModelPath].exports;
-      require.cache[NetworkCreationRequestModelPath].exports = modelFnStub;
+      const origReqModel = require.cache[reqModelPath].exports;
+      require.cache[reqModelPath].exports = modelFnStub;
 
       try {
+        const util = loadUtil();
         const next = sinon.stub();
-        const result = await util.createNetworkCreationRequest(request, next);
+        const result = await util.createNetworkCreationRequest(
+          makeRequest({
+            body: {
+              requester_name: "Jane Doe",
+              requester_email: "jane@example.com",
+              net_name: "AirSense",
+              net_email: "contact@airsense.io",
+            },
+          }),
+          next
+        );
 
         expect(result.success).to.be.true;
         expect(fakeModel.register.calledOnce).to.be.true;
         expect(next.called).to.be.false;
       } finally {
-        require.cache[NetworkCreationRequestModelPath].exports = original;
+        require.cache[reqModelPath].exports = origReqModel;
       }
     });
 
@@ -96,23 +101,28 @@ describe("network-creation-request.util", () => {
       };
       const modelFnStub = sinon.stub().returns(fakeModel);
 
-      const NetworkCreationRequestModelPath = require.resolve(
-        "@models/NetworkCreationRequest"
-      );
-      const original = require.cache[NetworkCreationRequestModelPath].exports;
-      require.cache[NetworkCreationRequestModelPath].exports = modelFnStub;
+      const origReqModel = require.cache[reqModelPath].exports;
+      require.cache[reqModelPath].exports = modelFnStub;
 
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.createNetworkCreationRequest(
-          makeRequest({ body: { requester_name: "X", requester_email: "x@x.com", net_name: "Y", net_email: "y@y.com" } }),
+          makeRequest({
+            body: {
+              requester_name: "X",
+              requester_email: "x@x.com",
+              net_name: "Y",
+              net_email: "y@y.com",
+            },
+          }),
           next
         );
 
         expect(result.success).to.be.false;
         expect(next.called).to.be.false;
       } finally {
-        require.cache[NetworkCreationRequestModelPath].exports = original;
+        require.cache[reqModelPath].exports = origReqModel;
       }
     });
   });
@@ -121,24 +131,19 @@ describe("network-creation-request.util", () => {
 
   describe("approveNetworkCreationRequest", () => {
     const patchModels = (requestModelFn, networkModelFn) => {
-      const reqPath = require.resolve("@models/NetworkCreationRequest");
-      const netPath = require.resolve("@models/Network");
-      const origReq = require.cache[reqPath].exports;
-      const origNet = require.cache[netPath].exports;
-      require.cache[reqPath].exports = requestModelFn;
-      require.cache[netPath].exports = networkModelFn;
+      const origReq = require.cache[reqModelPath].exports;
+      const origNet = require.cache[netModelPath].exports;
+      require.cache[reqModelPath].exports = requestModelFn;
+      require.cache[netModelPath].exports = networkModelFn;
       return () => {
-        require.cache[reqPath].exports = origReq;
-        require.cache[netPath].exports = origNet;
+        require.cache[reqModelPath].exports = origReq;
+        require.cache[netModelPath].exports = origNet;
       };
     };
 
     it("creates the network, updates request status, and returns success", async () => {
       const pendingDoc = { ...fakeRequestDoc, status: "pending" };
-      const fakeNetwork = {
-        _id: "6642f1e2c3a4b5d6e7f80099",
-        net_name: "AirSense",
-      };
+      const fakeNetwork = { _id: "6642f1e2c3a4b5d6e7f80099", net_name: "AirSense" };
 
       const requestModel = {
         findById: sinon.stub().returns({
@@ -150,10 +155,7 @@ describe("network-creation-request.util", () => {
         }),
       };
       const networkModel = {
-        register: sinon.stub().resolves({
-          success: true,
-          data: fakeNetwork,
-        }),
+        register: sinon.stub().resolves({ success: true, data: fakeNetwork }),
       };
 
       const restore = patchModels(
@@ -162,6 +164,7 @@ describe("network-creation-request.util", () => {
       );
 
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.approveNetworkCreationRequest(
           makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
@@ -193,6 +196,7 @@ describe("network-creation-request.util", () => {
       );
 
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.approveNetworkCreationRequest(
           makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
@@ -223,6 +227,7 @@ describe("network-creation-request.util", () => {
       );
 
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.approveNetworkCreationRequest(
           makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
@@ -250,10 +255,7 @@ describe("network-creation-request.util", () => {
         }),
       };
       const networkModel = {
-        register: sinon.stub().resolves({
-          success: true,
-          data: fakeNetwork,
-        }),
+        register: sinon.stub().resolves({ success: true, data: fakeNetwork }),
       };
 
       const restore = patchModels(
@@ -262,6 +264,7 @@ describe("network-creation-request.util", () => {
       );
 
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.approveNetworkCreationRequest(
           makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
@@ -281,11 +284,10 @@ describe("network-creation-request.util", () => {
 
   describe("denyNetworkCreationRequest", () => {
     const patchRequestModel = (modelFn) => {
-      const reqPath = require.resolve("@models/NetworkCreationRequest");
-      const orig = require.cache[reqPath].exports;
-      require.cache[reqPath].exports = modelFn;
+      const orig = require.cache[reqModelPath].exports;
+      require.cache[reqModelPath].exports = modelFn;
       return () => {
-        require.cache[reqPath].exports = orig;
+        require.cache[reqModelPath].exports = orig;
       };
     };
 
@@ -303,6 +305,7 @@ describe("network-creation-request.util", () => {
 
       const restore = patchRequestModel(sinon.stub().returns(requestModel));
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.denyNetworkCreationRequest(
           makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
@@ -328,6 +331,7 @@ describe("network-creation-request.util", () => {
 
       const restore = patchRequestModel(sinon.stub().returns(requestModel));
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.denyNetworkCreationRequest(
           makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
@@ -353,6 +357,7 @@ describe("network-creation-request.util", () => {
 
       const restore = patchRequestModel(sinon.stub().returns(requestModel));
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.denyNetworkCreationRequest(
           makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
@@ -376,6 +381,7 @@ describe("network-creation-request.util", () => {
 
       const restore = patchRequestModel(sinon.stub().returns(requestModel));
       try {
+        const util = loadUtil();
         const next = sinon.stub();
         const result = await util.denyNetworkCreationRequest(
           makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
@@ -406,15 +412,14 @@ describe("network-creation-request.util", () => {
       };
       const modelFnStub = sinon.stub().returns(fakeModel);
 
-      // Patch the KafkaJS Kafka class so that producer.send always rejects
-      const kafkaJsPath = require.resolve("kafkajs");
-      const origKafkaJs = require.cache[kafkaJsPath].exports;
-
       const fakeProducer = {
         connect: sinon.stub().resolves(),
         send: sinon.stub().rejects(new Error("broker unavailable")),
         disconnect: sinon.stub().resolves(),
       };
+      const origKafkaJs = require.cache[kafkaJsPath].exports;
+      const origReqModel = require.cache[reqModelPath].exports;
+
       require.cache[kafkaJsPath].exports = {
         Kafka: class {
           producer() {
@@ -422,25 +427,12 @@ describe("network-creation-request.util", () => {
           }
         },
       };
-
-      const NetworkCreationRequestModelPath = require.resolve(
-        "@models/NetworkCreationRequest"
-      );
-      const origModel = require.cache[NetworkCreationRequestModelPath].exports;
-      require.cache[NetworkCreationRequestModelPath].exports = modelFnStub;
-
-      // Re-require the util so it picks up the patched KafkaJS
-      // (module cache holds the old instance, so we delete and re-require)
-      const utilPath = require.resolve(
-        "@utils/network-creation-request.util"
-      );
-      delete require.cache[utilPath];
+      require.cache[reqModelPath].exports = modelFnStub;
 
       try {
-        const freshUtil = require("@utils/network-creation-request.util");
+        const util = loadUtil();
         const next = sinon.stub();
-
-        const result = await freshUtil.createNetworkCreationRequest(
+        const result = await util.createNetworkCreationRequest(
           makeRequest({
             body: {
               requester_name: "Jane",
@@ -456,10 +448,7 @@ describe("network-creation-request.util", () => {
         expect(next.called).to.be.false;
       } finally {
         require.cache[kafkaJsPath].exports = origKafkaJs;
-        require.cache[NetworkCreationRequestModelPath].exports = origModel;
-        // Restore the util module to its original cached version
-        delete require.cache[utilPath];
-        require("@utils/network-creation-request.util");
+        require.cache[reqModelPath].exports = origReqModel;
       }
     });
   });

--- a/src/device-registry/utils/test/ut_network-creation-request.util.js
+++ b/src/device-registry/utils/test/ut_network-creation-request.util.js
@@ -1,0 +1,488 @@
+"use strict";
+require("module-alias/register");
+const sinon = require("sinon");
+const chai = require("chai");
+const httpStatus = require("http-status");
+const { expect } = chai;
+
+// ── Module under test ────────────────────────────────────────────────────────
+// We require the module once; individual model/Kafka internals are stubbed via
+// sinon.stub on the required modules before each test.
+const NetworkCreationRequestModel = require("@models/NetworkCreationRequest");
+const NetworkModel = require("@models/Network");
+const util = require("@utils/network-creation-request.util");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeRequest = (overrides = {}) => ({
+  query: { tenant: "airqo" },
+  params: {},
+  body: {},
+  ...overrides,
+});
+
+const fakeRequestDoc = {
+  _id: "6642f1e2c3a4b5d6e7f80001",
+  requester_name: "Jane Doe",
+  requester_email: "jane@example.com",
+  net_name: "AirSense",
+  net_email: "contact@airsense.io",
+  net_website: "https://airsense.io",
+  net_category: "research",
+  net_description: "Air quality sensors",
+  net_acronym: "AS",
+  status: "pending",
+};
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+describe("network-creation-request.util", () => {
+  let modelStub;
+  let networkModelStub;
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // ── createNetworkCreationRequest ────────────────────────────────────────────
+
+  describe("createNetworkCreationRequest", () => {
+    it("returns the created record and publishes 2 batched Kafka events", async () => {
+      const registerStub = sinon.stub().resolves({
+        success: true,
+        status: httpStatus.CREATED,
+        message: "sensor manufacturer creation request submitted successfully",
+        data: fakeRequestDoc,
+      });
+
+      modelStub = sinon.stub(NetworkCreationRequestModel, "call").returns({
+        register: registerStub,
+      });
+      // Stub the function itself (it is called as NetworkCreationRequestModel(tenant))
+      // The module uses NetworkCreationRequestModel(tenant) which invokes the exported function.
+      // We need to replace the export with a stub that returns a model-like object.
+      // Since require caches the module, we stub the returned model object methods.
+
+      // Re-require with proxyquire is not available; instead we stub internal kafka
+      // publish by stubbing the producer at module level via a spy on the model.
+      // This test validates the success path returns the created record.
+
+      const request = makeRequest({
+        body: {
+          requester_name: "Jane Doe",
+          requester_email: "jane@example.com",
+          net_name: "AirSense",
+          net_email: "contact@airsense.io",
+        },
+      });
+
+      // Build a fake model instance that register resolves successfully
+      const fakeModel = {
+        register: sinon.stub().resolves({
+          success: true,
+          status: httpStatus.CREATED,
+          data: fakeRequestDoc,
+        }),
+      };
+      const modelFnStub = sinon
+        .stub()
+        .withArgs("airqo")
+        .returns(fakeModel);
+
+      // Patch the require cache entry so the util uses our stub
+      const NetworkCreationRequestModelPath = require.resolve(
+        "@models/NetworkCreationRequest"
+      );
+      const original = require.cache[NetworkCreationRequestModelPath].exports;
+      require.cache[NetworkCreationRequestModelPath].exports = modelFnStub;
+
+      try {
+        const next = sinon.stub();
+        const result = await util.createNetworkCreationRequest(request, next);
+
+        expect(result.success).to.be.true;
+        expect(fakeModel.register.calledOnce).to.be.true;
+        expect(next.called).to.be.false;
+      } finally {
+        require.cache[NetworkCreationRequestModelPath].exports = original;
+      }
+    });
+
+    it("returns early when register reports success:false", async () => {
+      const fakeModel = {
+        register: sinon.stub().resolves({
+          success: false,
+          status: httpStatus.CONFLICT,
+          message: "Duplicate",
+        }),
+      };
+      const modelFnStub = sinon.stub().returns(fakeModel);
+
+      const NetworkCreationRequestModelPath = require.resolve(
+        "@models/NetworkCreationRequest"
+      );
+      const original = require.cache[NetworkCreationRequestModelPath].exports;
+      require.cache[NetworkCreationRequestModelPath].exports = modelFnStub;
+
+      try {
+        const next = sinon.stub();
+        const result = await util.createNetworkCreationRequest(
+          makeRequest({ body: { requester_name: "X", requester_email: "x@x.com", net_name: "Y", net_email: "y@y.com" } }),
+          next
+        );
+
+        expect(result.success).to.be.false;
+        expect(next.called).to.be.false;
+      } finally {
+        require.cache[NetworkCreationRequestModelPath].exports = original;
+      }
+    });
+  });
+
+  // ── approveNetworkCreationRequest ───────────────────────────────────────────
+
+  describe("approveNetworkCreationRequest", () => {
+    const patchModels = (requestModelFn, networkModelFn) => {
+      const reqPath = require.resolve("@models/NetworkCreationRequest");
+      const netPath = require.resolve("@models/Network");
+      const origReq = require.cache[reqPath].exports;
+      const origNet = require.cache[netPath].exports;
+      require.cache[reqPath].exports = requestModelFn;
+      require.cache[netPath].exports = networkModelFn;
+      return () => {
+        require.cache[reqPath].exports = origReq;
+        require.cache[netPath].exports = origNet;
+      };
+    };
+
+    it("creates the network, updates request status, and returns success", async () => {
+      const pendingDoc = { ...fakeRequestDoc, status: "pending" };
+      const fakeNetwork = {
+        _id: "6642f1e2c3a4b5d6e7f80099",
+        net_name: "AirSense",
+      };
+
+      const requestModel = {
+        findById: sinon.stub().returns({
+          lean: sinon.stub().resolves(pendingDoc),
+        }),
+        modify: sinon.stub().resolves({
+          success: true,
+          data: { ...pendingDoc, status: "approved" },
+        }),
+      };
+      const networkModel = {
+        register: sinon.stub().resolves({
+          success: true,
+          data: fakeNetwork,
+        }),
+      };
+
+      const restore = patchModels(
+        sinon.stub().returns(requestModel),
+        sinon.stub().returns(networkModel)
+      );
+
+      try {
+        const next = sinon.stub();
+        const result = await util.approveNetworkCreationRequest(
+          makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
+          next
+        );
+
+        expect(result.success).to.be.true;
+        expect(networkModel.register.calledOnce).to.be.true;
+        expect(requestModel.modify.calledOnce).to.be.true;
+        expect(next.called).to.be.false;
+      } finally {
+        restore();
+      }
+    });
+
+    it("rejects approval when status is 'approved'", async () => {
+      const approvedDoc = { ...fakeRequestDoc, status: "approved" };
+
+      const requestModel = {
+        findById: sinon.stub().returns({
+          lean: sinon.stub().resolves(approvedDoc),
+        }),
+        modify: sinon.stub(),
+      };
+
+      const restore = patchModels(
+        sinon.stub().returns(requestModel),
+        sinon.stub().returns({})
+      );
+
+      try {
+        const next = sinon.stub();
+        const result = await util.approveNetworkCreationRequest(
+          makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
+          next
+        );
+
+        expect(result.success).to.be.false;
+        expect(result.status).to.equal(httpStatus.CONFLICT);
+        expect(requestModel.modify.called).to.be.false;
+      } finally {
+        restore();
+      }
+    });
+
+    it("rejects approval when status is 'denied'", async () => {
+      const deniedDoc = { ...fakeRequestDoc, status: "denied" };
+
+      const requestModel = {
+        findById: sinon.stub().returns({
+          lean: sinon.stub().resolves(deniedDoc),
+        }),
+        modify: sinon.stub(),
+      };
+
+      const restore = patchModels(
+        sinon.stub().returns(requestModel),
+        sinon.stub().returns({})
+      );
+
+      try {
+        const next = sinon.stub();
+        const result = await util.approveNetworkCreationRequest(
+          makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
+          next
+        );
+
+        expect(result.success).to.be.false;
+        expect(result.status).to.equal(httpStatus.CONFLICT);
+      } finally {
+        restore();
+      }
+    });
+
+    it("surfaces error when status update fails after network is created", async () => {
+      const pendingDoc = { ...fakeRequestDoc, status: "pending" };
+      const fakeNetwork = { _id: "6642f1e2c3a4b5d6e7f80099", net_name: "AirSense" };
+
+      const requestModel = {
+        findById: sinon.stub().returns({
+          lean: sinon.stub().resolves(pendingDoc),
+        }),
+        modify: sinon.stub().resolves({
+          success: false,
+          errors: { message: "DB write failed" },
+        }),
+      };
+      const networkModel = {
+        register: sinon.stub().resolves({
+          success: true,
+          data: fakeNetwork,
+        }),
+      };
+
+      const restore = patchModels(
+        sinon.stub().returns(requestModel),
+        sinon.stub().returns(networkModel)
+      );
+
+      try {
+        const next = sinon.stub();
+        const result = await util.approveNetworkCreationRequest(
+          makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
+          next
+        );
+
+        expect(result.success).to.be.false;
+        expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+        expect(result.message).to.include("failed to update request status");
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  // ── denyNetworkCreationRequest ──────────────────────────────────────────────
+
+  describe("denyNetworkCreationRequest", () => {
+    const patchRequestModel = (modelFn) => {
+      const reqPath = require.resolve("@models/NetworkCreationRequest");
+      const orig = require.cache[reqPath].exports;
+      require.cache[reqPath].exports = modelFn;
+      return () => {
+        require.cache[reqPath].exports = orig;
+      };
+    };
+
+    it("denies a pending request and returns success", async () => {
+      const pendingDoc = { ...fakeRequestDoc, status: "pending" };
+      const requestModel = {
+        findById: sinon.stub().returns({
+          lean: sinon.stub().resolves(pendingDoc),
+        }),
+        modify: sinon.stub().resolves({
+          success: true,
+          data: { ...pendingDoc, status: "denied" },
+        }),
+      };
+
+      const restore = patchRequestModel(sinon.stub().returns(requestModel));
+      try {
+        const next = sinon.stub();
+        const result = await util.denyNetworkCreationRequest(
+          makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
+          next
+        );
+
+        expect(result.success).to.be.true;
+        expect(requestModel.modify.calledOnce).to.be.true;
+        expect(next.called).to.be.false;
+      } finally {
+        restore();
+      }
+    });
+
+    it("rejects denial when status is 'approved'", async () => {
+      const approvedDoc = { ...fakeRequestDoc, status: "approved" };
+      const requestModel = {
+        findById: sinon.stub().returns({
+          lean: sinon.stub().resolves(approvedDoc),
+        }),
+        modify: sinon.stub(),
+      };
+
+      const restore = patchRequestModel(sinon.stub().returns(requestModel));
+      try {
+        const next = sinon.stub();
+        const result = await util.denyNetworkCreationRequest(
+          makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
+          next
+        );
+
+        expect(result.success).to.be.false;
+        expect(result.status).to.equal(httpStatus.CONFLICT);
+        expect(requestModel.modify.called).to.be.false;
+      } finally {
+        restore();
+      }
+    });
+
+    it("rejects denial when status is already 'denied'", async () => {
+      const deniedDoc = { ...fakeRequestDoc, status: "denied" };
+      const requestModel = {
+        findById: sinon.stub().returns({
+          lean: sinon.stub().resolves(deniedDoc),
+        }),
+        modify: sinon.stub(),
+      };
+
+      const restore = patchRequestModel(sinon.stub().returns(requestModel));
+      try {
+        const next = sinon.stub();
+        const result = await util.denyNetworkCreationRequest(
+          makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
+          next
+        );
+
+        expect(result.success).to.be.false;
+        expect(result.status).to.equal(httpStatus.CONFLICT);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns NOT_FOUND when the request does not exist", async () => {
+      const requestModel = {
+        findById: sinon.stub().returns({
+          lean: sinon.stub().resolves(null),
+        }),
+        modify: sinon.stub(),
+      };
+
+      const restore = patchRequestModel(sinon.stub().returns(requestModel));
+      try {
+        const next = sinon.stub();
+        const result = await util.denyNetworkCreationRequest(
+          makeRequest({ params: { request_id: fakeRequestDoc._id }, body: {} }),
+          next
+        );
+
+        expect(result.success).to.be.false;
+        expect(result.status).to.equal(httpStatus.NOT_FOUND);
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  // ── Kafka failure isolation ─────────────────────────────────────────────────
+  // publishToKafka is fire-and-forget: a Kafka error must NOT propagate to the
+  // caller. We verify this by making the underlying KafkaJS producer.send throw
+  // and asserting the util still returns a success response.
+
+  describe("Kafka publish failure does not affect HTTP response", () => {
+    it("createNetworkCreationRequest succeeds even when Kafka publish throws", async () => {
+      const fakeModel = {
+        register: sinon.stub().resolves({
+          success: true,
+          status: httpStatus.CREATED,
+          data: fakeRequestDoc,
+        }),
+      };
+      const modelFnStub = sinon.stub().returns(fakeModel);
+
+      // Patch the KafkaJS Kafka class so that producer.send always rejects
+      const kafkaJsPath = require.resolve("kafkajs");
+      const origKafkaJs = require.cache[kafkaJsPath].exports;
+
+      const fakeProducer = {
+        connect: sinon.stub().resolves(),
+        send: sinon.stub().rejects(new Error("broker unavailable")),
+        disconnect: sinon.stub().resolves(),
+      };
+      require.cache[kafkaJsPath].exports = {
+        Kafka: class {
+          producer() {
+            return fakeProducer;
+          }
+        },
+      };
+
+      const NetworkCreationRequestModelPath = require.resolve(
+        "@models/NetworkCreationRequest"
+      );
+      const origModel = require.cache[NetworkCreationRequestModelPath].exports;
+      require.cache[NetworkCreationRequestModelPath].exports = modelFnStub;
+
+      // Re-require the util so it picks up the patched KafkaJS
+      // (module cache holds the old instance, so we delete and re-require)
+      const utilPath = require.resolve(
+        "@utils/network-creation-request.util"
+      );
+      delete require.cache[utilPath];
+
+      try {
+        const freshUtil = require("@utils/network-creation-request.util");
+        const next = sinon.stub();
+
+        const result = await freshUtil.createNetworkCreationRequest(
+          makeRequest({
+            body: {
+              requester_name: "Jane",
+              requester_email: "jane@example.com",
+              net_name: "AirSense",
+              net_email: "contact@airsense.io",
+            },
+          }),
+          next
+        );
+
+        expect(result.success).to.be.true;
+        expect(next.called).to.be.false;
+      } finally {
+        require.cache[kafkaJsPath].exports = origKafkaJs;
+        require.cache[NetworkCreationRequestModelPath].exports = origModel;
+        // Restore the util module to its original cached version
+        delete require.cache[utilPath];
+        require("@utils/network-creation-request.util");
+      }
+    });
+  });
+});

--- a/src/device-registry/utils/test/ut_network-creation-request.util.js
+++ b/src/device-registry/utils/test/ut_network-creation-request.util.js
@@ -37,9 +37,6 @@ const fakeRequestDoc = {
 // ── Test suite ────────────────────────────────────────────────────────────────
 
 describe("network-creation-request.util", () => {
-  let modelStub;
-  let networkModelStub;
-
   afterEach(() => {
     sinon.restore();
   });
@@ -48,25 +45,6 @@ describe("network-creation-request.util", () => {
 
   describe("createNetworkCreationRequest", () => {
     it("returns the created record and publishes 2 batched Kafka events", async () => {
-      const registerStub = sinon.stub().resolves({
-        success: true,
-        status: httpStatus.CREATED,
-        message: "sensor manufacturer creation request submitted successfully",
-        data: fakeRequestDoc,
-      });
-
-      modelStub = sinon.stub(NetworkCreationRequestModel, "call").returns({
-        register: registerStub,
-      });
-      // Stub the function itself (it is called as NetworkCreationRequestModel(tenant))
-      // The module uses NetworkCreationRequestModel(tenant) which invokes the exported function.
-      // We need to replace the export with a stub that returns a model-like object.
-      // Since require caches the module, we stub the returned model object methods.
-
-      // Re-require with proxyquire is not available; instead we stub internal kafka
-      // publish by stubbing the producer at module level via a spy on the model.
-      // This test validates the success path returns the created record.
-
       const request = makeRequest({
         body: {
           requester_name: "Jane Doe",

--- a/src/device-registry/validators/network-creation-request.validators.js
+++ b/src/device-registry/validators/network-creation-request.validators.js
@@ -38,7 +38,7 @@ const paramObjectId = (field) =>
     .isMongoId()
     .withMessage(`${field} must be an object ID`)
     .bail()
-    .customSanitizer((value) => ObjectId(value));
+    .customSanitizer((value) => new ObjectId(value));
 
 // Middleware that validates the admin_secret in the request body using
 // constant-time comparison to prevent timing attacks.
@@ -51,7 +51,9 @@ const requireAdminSecret = (req, res, next) => {
     );
   }
 
-  const provided = Buffer.from(req.body.admin_secret || "");
+  const provided = Buffer.from(
+    req.body.admin_secret || req.query.admin_secret || ""
+  );
   const expected = Buffer.from(constants.ADMIN_SETUP_SECRET);
 
   if (
@@ -134,6 +136,15 @@ const createRequest = [
 // Admin: list all requests
 const listRequests = [
   ...tenant,
+  query("admin_secret")
+    .exists()
+    .withMessage("admin_secret is required")
+    .bail()
+    .isString()
+    .withMessage("admin_secret must be a string")
+    .bail()
+    .notEmpty()
+    .withMessage("admin_secret must not be empty"),
   query("status")
     .optional()
     .trim()
@@ -147,13 +158,24 @@ const listRequests = [
     .isEmail()
     .withMessage("requester_email must be a valid email address"),
   handleValidationErrors,
+  requireAdminSecret,
 ];
 
-// Anyone can view a single request by ID
+// Admin: get a single request by ID
 const getRequest = [
   ...tenant,
   paramObjectId("request_id"),
+  query("admin_secret")
+    .exists()
+    .withMessage("admin_secret is required")
+    .bail()
+    .isString()
+    .withMessage("admin_secret must be a string")
+    .bail()
+    .notEmpty()
+    .withMessage("admin_secret must not be empty"),
   handleValidationErrors,
+  requireAdminSecret,
 ];
 
 // Admin: approve a request

--- a/src/device-registry/validators/network-creation-request.validators.js
+++ b/src/device-registry/validators/network-creation-request.validators.js
@@ -1,0 +1,247 @@
+// network-creation-request.validators.js
+const { query, body, param, validationResult } = require("express-validator");
+const { ObjectId } = require("mongoose").Types;
+const constants = require("@config/constants");
+const { HttpError } = require("@utils/shared");
+const httpStatus = require("http-status");
+const crypto = require("crypto");
+
+const handleValidationErrors = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return next(
+      new HttpError("Validation error", httpStatus.BAD_REQUEST, errors.mapped())
+    );
+  }
+  next();
+};
+
+// Reusable building blocks
+const tenant = [
+  query("tenant")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("tenant cannot be empty if provided")
+    .bail()
+    .toLowerCase()
+    .isIn(constants.TENANTS)
+    .withMessage("the tenant value is not among the expected ones"),
+];
+
+const paramObjectId = (field) =>
+  param(field)
+    .exists()
+    .withMessage(`${field} is missing in request`)
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage(`${field} must be an object ID`)
+    .bail()
+    .customSanitizer((value) => ObjectId(value));
+
+// Middleware that validates the admin_secret in the request body using
+// constant-time comparison to prevent timing attacks.
+const requireAdminSecret = (req, res, next) => {
+  if (!constants.ADMIN_SETUP_SECRET) {
+    return next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: "Admin secret not configured on server",
+      })
+    );
+  }
+
+  const provided = Buffer.from(req.body.admin_secret || "");
+  const expected = Buffer.from(constants.ADMIN_SETUP_SECRET);
+
+  if (
+    provided.length !== expected.length ||
+    !crypto.timingSafeEqual(provided, expected)
+  ) {
+    return next(
+      new HttpError("Forbidden", httpStatus.FORBIDDEN, {
+        message: "Invalid admin secret provided",
+      })
+    );
+  }
+
+  next();
+};
+
+// ── Validators ────────────────────────────────────────────────────────────────
+
+// Public: anyone can submit a sensor manufacturer creation request
+const createRequest = [
+  ...tenant,
+  body("requester_name")
+    .exists()
+    .withMessage("requester_name is required")
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage("requester_name must not be empty"),
+  body("requester_email")
+    .exists()
+    .withMessage("requester_email is required")
+    .bail()
+    .trim()
+    .isEmail()
+    .withMessage("requester_email is not a valid email address")
+    .bail()
+    .normalizeEmail(),
+  body("net_name")
+    .exists()
+    .withMessage("net_name (sensor manufacturer name) is required")
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage("net_name must not be empty"),
+  body("net_email")
+    .exists()
+    .withMessage("net_email is required")
+    .bail()
+    .trim()
+    .isEmail()
+    .withMessage("net_email is not a valid email address")
+    .bail()
+    .normalizeEmail(),
+  body("net_website")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("net_website must not be empty if provided")
+    .bail()
+    .isURL()
+    .withMessage("net_website is not a valid URL"),
+  body("net_category")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("net_category must not be empty if provided"),
+  body("net_description")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("net_description must not be empty if provided"),
+  body("net_acronym")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("net_acronym must not be empty if provided"),
+  handleValidationErrors,
+];
+
+// Admin: list all requests
+const listRequests = [
+  ...tenant,
+  query("status")
+    .optional()
+    .trim()
+    .isIn(["pending", "approved", "denied", "under_review"])
+    .withMessage(
+      "status must be one of: pending, approved, denied, under_review"
+    ),
+  query("requester_email")
+    .optional()
+    .trim()
+    .isEmail()
+    .withMessage("requester_email must be a valid email address"),
+  handleValidationErrors,
+];
+
+// Anyone can view a single request by ID
+const getRequest = [
+  ...tenant,
+  paramObjectId("request_id"),
+  handleValidationErrors,
+];
+
+// Admin: approve a request
+const approveRequest = [
+  ...tenant,
+  paramObjectId("request_id"),
+  body("admin_secret")
+    .exists()
+    .withMessage("admin_secret is required")
+    .bail()
+    .isString()
+    .withMessage("admin_secret must be a string")
+    .bail()
+    .notEmpty()
+    .withMessage("admin_secret must not be empty"),
+  body("reviewer_notes")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("reviewer_notes must not be empty if provided"),
+  body("reviewed_by")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("reviewed_by must not be empty if provided"),
+  handleValidationErrors,
+  requireAdminSecret,
+];
+
+// Admin: deny a request
+const denyRequest = [
+  ...tenant,
+  paramObjectId("request_id"),
+  body("admin_secret")
+    .exists()
+    .withMessage("admin_secret is required")
+    .bail()
+    .isString()
+    .withMessage("admin_secret must be a string")
+    .bail()
+    .notEmpty()
+    .withMessage("admin_secret must not be empty"),
+  body("reviewer_notes")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("reviewer_notes must not be empty if provided"),
+  body("reviewed_by")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("reviewed_by must not be empty if provided"),
+  handleValidationErrors,
+  requireAdminSecret,
+];
+
+// Admin: mark a request as under review
+const reviewRequest = [
+  ...tenant,
+  paramObjectId("request_id"),
+  body("admin_secret")
+    .exists()
+    .withMessage("admin_secret is required")
+    .bail()
+    .isString()
+    .withMessage("admin_secret must be a string")
+    .bail()
+    .notEmpty()
+    .withMessage("admin_secret must not be empty"),
+  body("reviewer_notes")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("reviewer_notes must not be empty if provided"),
+  body("reviewed_by")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("reviewed_by must not be empty if provided"),
+  handleValidationErrors,
+  requireAdminSecret,
+];
+
+module.exports = {
+  createRequest,
+  listRequests,
+  getRequest,
+  approveRequest,
+  denyRequest,
+  reviewRequest,
+};


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Introduces a full sensor manufacturer (network) onboarding request workflow in `device-registry`. Requesters can submit a new sensor manufacturer creation request via a public endpoint. Admins can then approve, deny, or mark requests as under review. On submission, two emails are triggered via Kafka: an admin notification and a requester acknowledgement. On approval, the network is created directly in `device-registry` and the requester is notified by email.

### Why is this change needed?
Previously, network (sensor manufacturer) creation was a direct admin-only operation with no structured intake process. This change adds a formal request-and-review workflow that supports the ongoing migration of the networks use case from `auth-service` into `device-registry`, while also improving the onboarding experience for new sensor manufacturers through automated email notifications.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — new model, util, controller, validators, and routes for the creation request workflow
- `auth-service` — new Kafka topic handlers and email templates/mailer functions for the 3 notification emails
- `k8s/kafka` — 2 new Kafka topic definitions registered in the cluster config

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually tested all 6 endpoints via Postman: request submission (returns `201` and publishes Kafka events), list/get requests, approve (creates network + fires approval email event), deny, and mark as under review. Admin secret rejection tested with an invalid value (returns `403`). Missing required fields tested (returns `400`).

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- Internally the entities are called **networks**; all user-facing copy (emails, response messages, frontend) uses the term **sensor manufacturers** — this distinction is preserved throughout.
- The `ADMIN_SETUP_SECRET` environment variable required for admin endpoints (`approve`, `deny`, `review`) is the same one already used by the existing `POST /networks` endpoint — no new secret needs to be provisioned.
- Kafka publishing in `network-creation-request.util.js` is fire-and-forget: a Kafka failure does not cause the HTTP request to fail, consistent with the existing pattern in `device-registry`.
- The two new Kafka topics (`network-creation-requests-topic`, `network-creation-approved-topic`) have been added to `k8s/kafka/topics/kafka-topics.yaml` and the corresponding constants added to both `device-registry` and `auth-service` `envs.js` files with safe fallback defaults.
- This PR is intentionally scoped to the request/approval workflow only. Denial email notifications are not included in this iteration but can be added as a follow-up.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API endpoints to submit, list, retrieve, review, approve, and deny network-creation requests (admin-protected).
  * Automated emails for submission, acknowledgement, approval, and denial.
  * Background processing: publish/consume network-creation events to/from Kafka with notification handlers.

* **Chores**
  * Added Kafka topics and environment variable support for network-creation events.
  * Added .claude to .gitignore.

* **Tests**
  * Unit tests covering create/approve/deny flows and resilience to Kafka publish failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->