### PR TITLE
fix: harden Kafka consumer to handle all sensor manufacturer measurements

### DIFF
--- a/src/device-registry/bin/jobs/kafka-consumer.js
+++ b/src/device-registry/bin/jobs/kafka-consumer.js
@@ -46,6 +46,9 @@ const eventSchema = Joi.object({
   device_id: Joi.string()
     .empty("")
     .required(),
+  device_name: Joi.string()
+    .empty("")
+    .optional(),
   site_id: Joi.string().optional(),
   device_number: Joi.number().optional(),
   atmospheric_pressure: Joi.number().optional(),
@@ -62,6 +65,10 @@ const eventSchema = Joi.object({
     .optional(),
   pm2_5_calibrated_value: Joi.number().optional(),
   pm10_calibrated_value: Joi.number().optional(),
+  no2_raw_value: Joi.number().optional(),
+  no2_calibrated_value: Joi.number().optional(),
+  pm1_raw_value: Joi.number().optional(),
+  pm1_calibrated_value: Joi.number().optional(),
   tvoc: Joi.number().optional(),
   hcho: Joi.number().optional(),
   co2: Joi.number().optional(),
@@ -185,6 +192,40 @@ const consumeHourlyMeasurements = async (messageData) => {
 
     // Normalize location data to ensure backward compatibility
     cleanedMeasurements = normalizeLocationData(cleanedMeasurements);
+
+    // Normalize device_name → device_id.
+    // process_data_for_message_broker in workflows renames device_id to
+    // device_name before publishing; map it back so Joi validation, device
+    // context checks, and EVENT_MAPPINGS all receive the expected field name.
+    cleanedMeasurements = cleanedMeasurements.map((m) =>
+      m.device_id || !m.device_name ? m : { ...m, device_id: m.device_name }
+    );
+
+    // Normalize raw pollutant fields.
+    // EVENT_MAPPINGS reads pm2_5_raw_value / pm10_raw_value / no2_raw_value /
+    // pm1_raw_value to populate the stored pm2_5.value etc. fields.
+    // Manufacturers that do not run a calibration pipeline (e.g. NASA/PurpleAir,
+    // Urban Better) only send the flat pm2_5 / pm10 / no2 / pm1 fields.
+    // Fall back to the flat field so their measurements are stored correctly.
+    // Manufacturers that already supply the _raw_value fields are unaffected.
+    cleanedMeasurements = cleanedMeasurements.map((m) => {
+      const patch = {};
+      if (m.pm2_5_raw_value === undefined && m.pm2_5 !== undefined)
+        patch.pm2_5_raw_value = m.pm2_5;
+      if (m.pm10_raw_value === undefined && m.pm10 !== undefined)
+        patch.pm10_raw_value = m.pm10;
+      if (m.no2_raw_value === undefined && m.no2 !== undefined)
+        patch.no2_raw_value = m.no2;
+      if (m.pm1_raw_value === undefined && m.pm1 !== undefined)
+        patch.pm1_raw_value = m.pm1;
+      if (Object.keys(patch).length) {
+        logger.debug(
+          `KAFKA: backfilled raw_value fields ${Object.keys(patch).join(", ")} for device ${m.device_id || m.device_name} (network: ${m.network || "unknown"})`
+        );
+        return { ...m, ...patch };
+      }
+      return m;
+    });
 
     const options = {
       abortEarly: false,
@@ -555,7 +596,8 @@ const kafkaConsumer = async () => {
 
     // Define topic-to-operation function mapping
     const topicOperations = {
-      "hourly-measurements-topic": consumeHourlyMeasurements,
+      [constants.HOURLY_MEASUREMENTS_TOPIC ||
+      "hourly-measurements-topic"]: consumeHourlyMeasurements,
       "airqo.forecasts": consumeForecasts,
       [constants.GROUPS_TOPIC]: handleGroupCreated,
       [constants.NETWORK_EVENTS_TOPIC]: handleNetworkEvents,

--- a/src/device-registry/bin/jobs/kafka-consumer.js
+++ b/src/device-registry/bin/jobs/kafka-consumer.js
@@ -598,8 +598,7 @@ const kafkaConsumer = async () => {
 
     // Define topic-to-operation function mapping
     const topicOperations = {
-      [constants.HOURLY_MEASUREMENTS_TOPIC ||
-      "hourly-measurements-topic"]: consumeHourlyMeasurements,
+      [constants.HOURLY_MEASUREMENTS_TOPIC]: consumeHourlyMeasurements,
       "airqo.forecasts": consumeForecasts,
       [constants.GROUPS_TOPIC]: handleGroupCreated,
       [constants.NETWORK_EVENTS_TOPIC]: handleNetworkEvents,

--- a/src/device-registry/bin/jobs/kafka-consumer.js
+++ b/src/device-registry/bin/jobs/kafka-consumer.js
@@ -40,6 +40,8 @@ const eventSchema = Joi.object({
   pm2_5: Joi.number().optional(),
   pm10_raw_value: Joi.number().optional(),
   pm10: Joi.number().optional(),
+  no2: Joi.number().optional(),
+  pm1: Joi.number().optional(),
   timestamp: Joi.date()
     .iso()
     .required(),

--- a/src/device-registry/bin/jobs/test/ut_kafka-consumer.js
+++ b/src/device-registry/bin/jobs/test/ut_kafka-consumer.js
@@ -230,6 +230,20 @@ describe("kafkaConsumer", () => {
       expect(body[0].device_id).to.equal("bam-device-001");
     });
 
+    it("should preserve existing device_id when both device_id and device_name are present", async () => {
+      const body = await sendMessage([
+        {
+          device_id: "original-id",
+          device_name: "workflow-name",
+          site_id: "site1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          pm2_5: 10,
+        },
+      ]);
+      expect(body).to.not.be.null;
+      expect(body[0].device_id).to.equal("original-id");
+    });
+
     it("should backfill _raw_value fields from flat pollutant fields when absent", async () => {
       const body = await sendMessage([
         {

--- a/src/device-registry/bin/jobs/test/ut_kafka-consumer.js
+++ b/src/device-registry/bin/jobs/test/ut_kafka-consumer.js
@@ -5,6 +5,7 @@ const { Kafka } = require("kafkajs");
 const log4js = require("log4js");
 const constants = require("@config/constants");
 const createEvent = require("@utils/create-event");
+const createEventUtil = require("@utils/event.util");
 const kafkaConsumer = require("@bin/jobs/kafka-consumer");
 
 describe("kafkaConsumer", () => {
@@ -181,6 +182,88 @@ describe("kafkaConsumer", () => {
 
       expect(console.log.calledWith("KAFKA: failed to store the measurements"))
         .to.be.true;
+    });
+  });
+
+  describe("normalisation logic in consumeHourlyMeasurements", () => {
+    let storeStub;
+    let validateDeviceContextStub;
+    let eachMessageHandler;
+
+    beforeEach(async () => {
+      // Capture the eachMessage handler passed to consumer.run
+      consumerMock.run.callsFake(async ({ eachMessage }) => {
+        eachMessageHandler = eachMessage;
+      });
+
+      storeStub = sinon.stub(createEventUtil, "store").resolves({
+        success: true,
+      });
+      validateDeviceContextStub = sinon
+        .stub(createEventUtil, "validateDeviceContext")
+        .resolves({ success: true });
+
+      await kafkaConsumer();
+    });
+
+    const sendMessage = async (data) => {
+      await eachMessageHandler({
+        topic: constants.HOURLY_MEASUREMENTS_TOPIC || "hourly-measurements-topic",
+        partition: 0,
+        message: {
+          value: Buffer.from(JSON.stringify({ data })),
+        },
+      });
+      return storeStub.firstCall?.args[0]?.body ?? null;
+    };
+
+    it("should map device_name to device_id when device_id is absent", async () => {
+      const body = await sendMessage([
+        {
+          device_name: "bam-device-001",
+          site_id: "site1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          pm2_5: 10,
+        },
+      ]);
+      expect(body).to.not.be.null;
+      expect(body[0].device_id).to.equal("bam-device-001");
+    });
+
+    it("should backfill _raw_value fields from flat pollutant fields when absent", async () => {
+      const body = await sendMessage([
+        {
+          device_id: "dev-001",
+          site_id: "site1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          pm2_5: 15,
+          pm10: 25,
+          no2: 5,
+          pm1: 8,
+        },
+      ]);
+      expect(body).to.not.be.null;
+      expect(body[0].pm2_5_raw_value).to.equal(15);
+      expect(body[0].pm10_raw_value).to.equal(25);
+      expect(body[0].no2_raw_value).to.equal(5);
+      expect(body[0].pm1_raw_value).to.equal(8);
+    });
+
+    it("should preserve existing _raw_value fields and not overwrite with flat pollutant values", async () => {
+      const body = await sendMessage([
+        {
+          device_id: "dev-001",
+          site_id: "site1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          pm2_5: 15,
+          pm2_5_raw_value: 14.5,
+          pm10: 25,
+          pm10_raw_value: 24,
+        },
+      ]);
+      expect(body).to.not.be.null;
+      expect(body[0].pm2_5_raw_value).to.equal(14.5);
+      expect(body[0].pm10_raw_value).to.equal(24);
     });
   });
 

--- a/src/device-registry/config/global/envs.js
+++ b/src/device-registry/config/global/envs.js
@@ -65,7 +65,8 @@ const envs = {
   DEPLOY_TOPIC: process.env.DEPLOY_TOPIC,
   RECALL_TOPIC: process.env.RECALL_TOPIC,
   COHORT_TOPIC: process.env.COHORT_TOPIC,
-  HOURLY_MEASUREMENTS_TOPIC: process.env.HOURLY_MEASUREMENTS_TOPIC,
+  HOURLY_MEASUREMENTS_TOPIC:
+    process.env.HOURLY_MEASUREMENTS_TOPIC || "hourly-measurements-topic",
   NETWORK_EVENTS_TOPIC:
     process.env.NETWORK_EVENTS_TOPIC || "network-events-topic",
   NETWORK_CREATION_REQUESTS_TOPIC:


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Hardens the Kafka `hourly-measurements-topic` consumer in device-registry to correctly handle measurements from all sensor manufacturers. Four targeted normalisation steps are added to `consumeHourlyMeasurements` before Joi validation runs:

1. **Topic env var** — `HOURLY_MEASUREMENTS_TOPIC` constant is now used instead of a hardcoded string, so the env var actually takes effect across environments.
2. **`device_name` → `device_id` normalisation** — `process_data_for_message_broker` in workflows renames `device_id` to `device_name` before every publish. The consumer now maps it back so Joi validation, device context checks, and `EVENT_MAPPINGS` all receive the expected field.
3. **`pm2_5_raw_value` backfill** — `EVENT_MAPPINGS` reads `pm2_5_raw_value` (not `pm2_5`) to store `pm2_5.value` in MongoDB. Manufacturers without a calibration pipeline (e.g. NASA/PurpleAir, Urban Better) only produce a flat `pm2_5` field. The consumer now backfills `pm2_5_raw_value = pm2_5` (and equivalently for `pm10`, `no2`, `pm1`) when the `_raw_value` field is absent. A debug log line is emitted when the backfill fires, identifying the device and network — useful for verifying new publishers.
4. **Joi schema additions** — `device_name`, `no2_raw_value`, `no2_calibrated_value`, `pm1_raw_value`, and `pm1_calibrated_value` added explicitly to the schema for consistency; previously these passed silently through `.unknown(true)`.

### Why is this change needed?

As part of a strategic migration from REST API to Kafka for all hourly measurement ingestion, a review of the pipeline revealed several silent failures in the consumer:

- The hardcoded topic name meant the `HOURLY_MEASUREMENTS_TOPIC` env var was ignored, making topic configuration ineffective across environments.
- Every Kafka message from workflows arrived without a `device_id` (renamed by `process_data_for_message_broker`), causing validation errors on every message, skipped device context checks, and events stored without a device link.
- Manufacturers that don't run a calibration pipeline sent only `pm2_5` (flat), which passed Joi validation but was silently discarded by `EVENT_MAPPINGS` — their measurements were never stored.

These fixes make the consumer manufacturer-agnostic so any publisher sending to `HOURLY_MEASUREMENTS_TOPIC` is correctly ingested without requiring per-manufacturer changes in device-registry.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/bin/jobs/kafka-consumer.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

- Verified that existing lowcost (AirQo) and AirNow measurements continue to be stored correctly after the normalisation steps — both already supply `device_id` and `pm2_5_raw_value` so the backfill and `device_name` normalisation are no-ops for them.
- Verified that a manually constructed Kafka message using `device_name` (no `device_id`) and flat `pm2_5` (no `pm2_5_raw_value`) is correctly normalised and stored with `pm2_5.value` populated.
- Confirmed the debug log line fires correctly when the backfill is applied.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All normalisation steps are additive and conditional — existing publishers that already send the correct field names are unaffected. No schema changes, no API changes, no changes to stored document structure.

---

## :memo: Additional Notes

- This is part of a broader initiative to migrate all hourly measurement ingestion from REST API to Kafka (`HOURLY_MEASUREMENTS_TOPIC`). The companion document covering the full pipeline, workflows action items, and design recommendations is at `src/device-registry/docs/kafka-hourly-measurements-pipeline.md`.
- Corresponding workflows-side changes (BAM DAG topic fix, NASA/PurpleAir and Urban Better Kafka publish tasks) are tracked separately and are the responsibility of the workflows microservice maintainer.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for additional air-quality fields (NO2, PM1) including raw and calibrated values.
  * Optional device name accepted and used when device ID is missing to improve ingest reliability.
  * Missing raw measurement values are auto-filled from available values; a debug log is emitted when backfilling occurs.

* **Tests**
  * Added tests covering normalization and backfill behaviors.

* **Chores**
  * Hourly measurements topic now uses the configurable environment key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->