### PR TITLE
Improve token expiry emails and add opt-in client secret enforcement

### DIFF
--- a/src/auth-service/bin/jobs/token-expiration-job.js
+++ b/src/auth-service/bin/jobs/token-expiration-job.js
@@ -15,11 +15,14 @@ async function sendEmailsInBatches(tokens, batchSize = 100) {
       logObject("the expiring token", token);
       const {
         user: { email, firstName, lastName },
+        token: tokenValue,
+        name: tokenName,
+        expires,
       } = token;
 
       logObject("the email to be used", email);
       return mailer
-        .expiringToken({ email, firstName, lastName })
+        .expiringToken({ email, firstName, lastName, token: tokenValue, tokenName, expires })
         .then((response) => {
           if (response && response.success === false) {
             logger.error(

--- a/src/auth-service/config/global/db-projections.js
+++ b/src/auth-service/config/global/db-projections.js
@@ -940,6 +940,7 @@ const dbProjections = {
     description: 1,
     networks: "$networks",
     access_token: { $arrayElemAt: ["$access_token", 0] },
+    requireClientSecret: 1,
   },
   CLIENTS_EXCLUSION_PROJECTION: function (category) {
     const initialProjection = {

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -6,6 +6,7 @@ const httpStatus = require("http-status");
 const Validator = require("validator");
 const UserModel = require("@models/User");
 const AccessTokenModel = require("@models/AccessToken");
+const ClientModel = require("@models/Client");
 const constants = require("@config/constants");
 const PermissionModel = require("@models/Permission");
 const { mailer, stringify, winstonLogger } = require("@utils/common");
@@ -1015,28 +1016,56 @@ const useAuthTokenStrategy = (tenant, req, res, next) =>
           return done(null, false);
         }
 
-        UserModel(tenant.toLowerCase()).findOne(
-          { id: accessToken.user_id },
-          function (error, user) {
+        const proceedWithUserLookup = () => {
+          UserModel(tenant.toLowerCase()).findOne(
+            { id: accessToken.user_id },
+            function (error, user) {
+              if (error) {
+                return done(error);
+              }
+
+              if (!user) {
+                return done(null, false);
+              }
+
+              winstonLogger.info(
+                `successful login through ${
+                  service ? service : "unknown"
+                } service`,
+                {
+                  username: user.userName,
+                  email: user.email,
+                  service: service ? service : "unknown",
+                },
+              );
+              return done(null, user);
+            },
+          );
+        };
+
+        // If the client has opted into client-secret enforcement, validate the
+        // X-Client-Secret header before allowing the request through.
+        // This is user-triggered and opt-in — clients where requireClientSecret
+        // is false (the default) are completely unaffected.
+        if (!accessToken.client_id) {
+          return proceedWithUserLookup();
+        }
+
+        ClientModel(tenant.toLowerCase()).findOne(
+          { _id: accessToken.client_id },
+          function (error, client) {
             if (error) {
               return done(error);
             }
 
-            if (!user) {
-              return done(null, false);
+            if (client && client.requireClientSecret === true) {
+              const providedSecret = req.headers["x-client-secret"];
+              if (!providedSecret || providedSecret !== client.client_secret) {
+                return done(null, false);
+              }
             }
 
-            winstonLogger.info(
-              `successful login through ${
-                service ? service : "unknown"
-              } service`,
-              {
-                username: user.userName,
-                email: user.email,
-                service: service ? service : "unknown",
-              },
-            );
-            return done(null, user);
+            return proceedWithUserLookup();
           },
         );
       },

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1058,7 +1058,13 @@ const useAuthTokenStrategy = (tenant, req, res, next) =>
               return done(error);
             }
 
-            if (client && client.requireClientSecret === true) {
+            // Fail closed: if the token references a client that no longer exists,
+            // reject the request rather than silently proceeding.
+            if (!client) {
+              return done(null, false);
+            }
+
+            if (client.requireClientSecret === true) {
               const providedSecret = req.headers["x-client-secret"];
               if (!providedSecret || providedSecret !== client.client_secret) {
                 return done(null, false);

--- a/src/auth-service/models/Client.js
+++ b/src/auth-service/models/Client.js
@@ -30,6 +30,7 @@ const ClientSchema = new Schema(
     ip_addresses: [{ type: String }],
     description: { type: String },
     rateLimit: { type: Number },
+    requireClientSecret: { type: Boolean, default: false },
   },
   { timestamps: true }
 );

--- a/src/auth-service/models/Client.js
+++ b/src/auth-service/models/Client.js
@@ -250,6 +250,7 @@ ClientSchema.methods = {
       rateLimit: this.rateLimit,
       ip_address: this.ip_address,
       ip_addresses: this.ip_addresses,
+      requireClientSecret: this.requireClientSecret,
     };
   },
 };

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -14,6 +14,51 @@ const processString = (inputString) => {
   return uppercasedString;
 };
 
+/**
+ * Builds the shared token-identification and security-tip HTML segments used
+ * in both token-expiry email templates. Centralises masking, HTML-escaping,
+ * date validation, and the security-tip callout so neither template diverges.
+ *
+ * @param {object} opts
+ * @param {string}  opts.token       - Raw or pre-masked token value
+ * @param {string}  opts.tokenName   - Human-readable token name (may contain HTML)
+ * @param {*}       opts.expires     - Expiry value (Date, ISO string, timestamp, …)
+ * @param {boolean} opts.expiredMode - true → past-tense copy; false → future-tense
+ * @returns {{ maskedToken: string, tokenLabel: string, expiryLine: string, securityTip: string }}
+ */
+const buildTokenEmailSegment = ({
+  token = "",
+  tokenName = "",
+  expires = null,
+  expiredMode = false,
+} = {}) => {
+  const maskedToken = escapeHtml(
+    token && token.length > 12
+      ? `${token.slice(0, 8)}...${token.slice(-4)}`
+      : token || "N/A",
+  );
+
+  const tokenLabel = tokenName
+    ? ` (<strong>${escapeHtml(tokenName)}</strong>)`
+    : "";
+
+  let expiryLine = expiredMode
+    ? ""
+    : "<p>This token will expire in less than 1 month from today.</p>";
+  if (expires !== null && expires !== undefined) {
+    const expiryDate = new Date(expires);
+    if (!isNaN(expiryDate.getTime())) {
+      expiryLine = expiredMode
+        ? `<p>This token expired on <strong>${expiryDate.toDateString()}</strong>.</p>`
+        : `<p>This token will expire on <strong>${expiryDate.toDateString()}</strong>.</p>`;
+    }
+  }
+
+  const securityTip = `<p style="margin-top:16px; padding:12px; background:#F0F4FF; border-left:4px solid #4A6CF7; border-radius:4px;"><strong>Security tip:</strong> You can now require your client secret on every API request for an extra layer of protection. Once enabled, requests using your token must also include your client secret via the <code>X-Client-Secret</code> header. Enable this under <strong>Settings &rsaquo; API</strong> in <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>.</p>`;
+
+  return { maskedToken, tokenLabel, expiryLine, securityTip };
+};
+
 module.exports = {
   confirm: "Email sent, please check your inbox to confirm",
   confirmed: "Your email is confirmed!",
@@ -600,16 +645,8 @@ module.exports = {
     expires = null,
   } = {}) => {
     const name = firstName + " " + lastName;
-    const maskedToken =
-      token && token.length > 12
-        ? `${token.slice(0, 8)}...${token.slice(-4)}`
-        : token || "N/A";
-    const tokenLabel = tokenName
-      ? ` (<strong>${escapeHtml(tokenName)}</strong>)`
-      : "";
-    const expiryLine = expires
-      ? `<p>This token expired on <strong>${new Date(expires).toDateString()}</strong>.</p>`
-      : "";
+    const { maskedToken, tokenLabel, expiryLine, securityTip } =
+      buildTokenEmailSegment({ token, tokenName, expires, expiredMode: true });
     const content = `
     <tr>
       <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
@@ -617,11 +654,7 @@ module.exports = {
         ${expiryLine}
         <p>To continue accessing our services, you can refresh your token directly — no need to create a new API client. Simply log in to <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>, go to <strong>Settings &rsaquo; API</strong>, and regenerate your token from your existing client.</p>
         <p>If you are using the AirQo mobile app, you can manage your API token settings directly within the app.</p>
-        <p style="margin-top:16px; padding:12px; background:#F0F4FF; border-left:4px solid #4A6CF7; border-radius:4px;">
-          <strong>Security tip:</strong> You can now require your client secret on every API request for an extra layer of protection.
-          Once enabled, requests using your token must also include your client secret via the <code>X-Client-Secret</code> header.
-          Enable this under <strong>Settings &rsaquo; API</strong> in <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>.
-        </p>
+        ${securityTip}
       </td>
     </tr>
     `;
@@ -666,16 +699,8 @@ module.exports = {
     expires = null,
   } = {}) => {
     const name = firstName + " " + lastName;
-    const maskedToken =
-      token && token.length > 12
-        ? `${token.slice(0, 8)}...${token.slice(-4)}`
-        : token || "N/A";
-    const tokenLabel = tokenName
-      ? ` (<strong>${escapeHtml(tokenName)}</strong>)`
-      : "";
-    const expiryLine = expires
-      ? `<p>This token will expire on <strong>${new Date(expires).toDateString()}</strong>.</p>`
-      : "<p>This token will expire in less than 1 month from today.</p>";
+    const { maskedToken, tokenLabel, expiryLine, securityTip } =
+      buildTokenEmailSegment({ token, tokenName, expires, expiredMode: false });
     const content = `
       <tr>
         <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
@@ -684,11 +709,7 @@ module.exports = {
           <p>You can refresh your token directly — no need to create a new API client. Simply log in to <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>, go to <strong>Settings &rsaquo; API</strong>, and regenerate your token from your existing client.</p>
           <p>If you have already refreshed your token, please ignore this message.</p>
           <p>If you are using the AirQo mobile app, you can manage your API token settings directly within the app.</p>
-          <p style="margin-top:16px; padding:12px; background:#F0F4FF; border-left:4px solid #4A6CF7; border-radius:4px;">
-            <strong>Security tip:</strong> You can now require your client secret on every API request for an extra layer of protection.
-            Once enabled, requests using your token must also include your client secret via the <code>X-Client-Secret</code> header.
-            Enable this under <strong>Settings &rsaquo; API</strong> in <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>.
-          </p>
+          ${securityTip}
         </td>
       </tr>
     `;

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -604,14 +604,16 @@ module.exports = {
       token && token.length > 12
         ? `${token.slice(0, 8)}...${token.slice(-4)}`
         : token || "N/A";
-    const tokenLabel = tokenName ? ` (<strong>${tokenName}</strong>)` : "";
+    const tokenLabel = tokenName
+      ? ` (<strong>${escapeHtml(tokenName)}</strong>)`
+      : "";
     const expiryLine = expires
       ? `<p>This token expired on <strong>${new Date(expires).toDateString()}</strong>.</p>`
       : "";
     const content = `
     <tr>
       <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-        <p>Your AirQo API token ending in <strong>...${maskedToken.slice(-4)}</strong>${tokenLabel} has expired.</p>
+        <p>Your AirQo API token <strong>${maskedToken}</strong>${tokenLabel} has expired.</p>
         ${expiryLine}
         <p>To continue accessing our services, you can refresh your token directly — no need to create a new API client. Simply log in to <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>, go to <strong>Settings &rsaquo; API</strong>, and regenerate your token from your existing client.</p>
         <p>If you are using the AirQo mobile app, you can manage your API token settings directly within the app.</p>
@@ -668,14 +670,16 @@ module.exports = {
       token && token.length > 12
         ? `${token.slice(0, 8)}...${token.slice(-4)}`
         : token || "N/A";
-    const tokenLabel = tokenName ? ` (<strong>${tokenName}</strong>)` : "";
+    const tokenLabel = tokenName
+      ? ` (<strong>${escapeHtml(tokenName)}</strong>)`
+      : "";
     const expiryLine = expires
       ? `<p>This token will expire on <strong>${new Date(expires).toDateString()}</strong>.</p>`
       : "<p>This token will expire in less than 1 month from today.</p>";
     const content = `
       <tr>
         <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-          <p>Your AirQo API token ending in <strong>...${maskedToken.slice(-4)}</strong>${tokenLabel} is expiring soon.</p>
+          <p>Your AirQo API token <strong>${maskedToken}</strong>${tokenLabel} is expiring soon.</p>
           ${expiryLine}
           <p>You can refresh your token directly — no need to create a new API client. Simply log in to <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>, go to <strong>Settings &rsaquo; API</strong>, and regenerate your token from your existing client.</p>
           <p>If you have already refreshed your token, please ignore this message.</p>

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -596,15 +596,30 @@ module.exports = {
     lastName = "",
     email = "",
     token = "",
+    tokenName = "",
+    expires = null,
   } = {}) => {
     const name = firstName + " " + lastName;
+    const maskedToken =
+      token && token.length > 12
+        ? `${token.slice(0, 8)}...${token.slice(-4)}`
+        : token || "N/A";
+    const tokenLabel = tokenName ? ` (<strong>${tokenName}</strong>)` : "";
+    const expiryLine = expires
+      ? `<p>This token expired on <strong>${new Date(expires).toDateString()}</strong>.</p>`
+      : "";
     const content = `
     <tr>
       <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-        <p>Your AIRQO API token <strong>${token}</strong> has expired.</p>
-        <p>Please create a new token to continue accessing our services. You can do so by logging into your account and navigating to the API section under settings.</p>
-        <p>If you are using the AirQo web platform, <a href="${constants.LOGIN_PAGE}">Click here</a> to log in to your AirQo account.</p>
+        <p>Your AirQo API token ending in <strong>...${maskedToken.slice(-4)}</strong>${tokenLabel} has expired.</p>
+        ${expiryLine}
+        <p>To continue accessing our services, you can refresh your token directly — no need to create a new API client. Simply log in to <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>, go to <strong>Settings &rsaquo; API</strong>, and regenerate your token from your existing client.</p>
         <p>If you are using the AirQo mobile app, you can manage your API token settings directly within the app.</p>
+        <p style="margin-top:16px; padding:12px; background:#F0F4FF; border-left:4px solid #4A6CF7; border-radius:4px;">
+          <strong>Security tip:</strong> You can now require your client secret on every API request for an extra layer of protection.
+          Once enabled, requests using your token must also include your client secret via the <code>X-Client-Secret</code> header.
+          Enable this under <strong>Settings &rsaquo; API</strong> in <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>.
+        </p>
       </td>
     </tr>
     `;
@@ -640,16 +655,36 @@ module.exports = {
     `;
     return constants.EMAIL_BODY({ email, content, name });
   },
-  tokenExpiringSoon: ({ firstName = "", lastName = "", email = "" }) => {
+  tokenExpiringSoon: ({
+    firstName = "",
+    lastName = "",
+    email = "",
+    token = "",
+    tokenName = "",
+    expires = null,
+  } = {}) => {
     const name = firstName + " " + lastName;
-    let content = "";
-    content = `
+    const maskedToken =
+      token && token.length > 12
+        ? `${token.slice(0, 8)}...${token.slice(-4)}`
+        : token || "N/A";
+    const tokenLabel = tokenName ? ` (<strong>${tokenName}</strong>)` : "";
+    const expiryLine = expires
+      ? `<p>This token will expire on <strong>${new Date(expires).toDateString()}</strong>.</p>`
+      : "<p>This token will expire in less than 1 month from today.</p>";
+    const content = `
       <tr>
         <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-          <p>Your AIRQO API token is set to expire soon, in less than 1 month from today.</p>
-          <p>Please generate a new token to continue accessing our services.</p>
-          <p>If you have already done so, please ignore this message.</p>
-          <p>You can manage your API token settings through the AirQo web platform or directly within the mobile app.</p>
+          <p>Your AirQo API token ending in <strong>...${maskedToken.slice(-4)}</strong>${tokenLabel} is expiring soon.</p>
+          ${expiryLine}
+          <p>You can refresh your token directly — no need to create a new API client. Simply log in to <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>, go to <strong>Settings &rsaquo; API</strong>, and regenerate your token from your existing client.</p>
+          <p>If you have already refreshed your token, please ignore this message.</p>
+          <p>If you are using the AirQo mobile app, you can manage your API token settings directly within the app.</p>
+          <p style="margin-top:16px; padding:12px; background:#F0F4FF; border-left:4px solid #4A6CF7; border-radius:4px;">
+            <strong>Security tip:</strong> You can now require your client secret on every API request for an extra layer of protection.
+            Once enabled, requests using your token must also include your client secret via the <code>X-Client-Secret</code> header.
+            Enable this under <strong>Settings &rsaquo; API</strong> in <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>.
+          </p>
         </td>
       </tr>
     `;

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -707,8 +707,8 @@ const getEmailSubject = (functionName, params) => {
       "Urgent Security Alert - Potential Compromise of Your AIRQO API Token",
     newDeviceLogin: "Security Alert: New Sign-In to Your AirQo Account",
     sendBotAlert: "🚨 Security Alert: Automated Bot Activity Detected",
-    expiredToken: "Action Required: Your AirQo API Token is expired",
-    expiringToken: "AirQo API Token Expiry: Create New Token Urgently",
+    expiredToken: "Action Required: Your AirQo API Token Has Expired",
+    expiringToken: "Action Required: Your AirQo API Token is Expiring Soon",
 
     // ===== SENSOR MANUFACTURER (NETWORK) REQUEST FUNCTIONS =====
     notifyAdminOfSensorManufacturerRequest: `New Sensor Manufacturer Request: ${sanitizeEmailString(
@@ -2310,6 +2310,8 @@ const mailer = {
         lastName: params.lastName,
         email: params.email,
         token: params.token,
+        tokenName: params.tokenName,
+        expires: params.expires,
       }),
     {
       cooldownDays: constants.COMPROMISED_TOKEN_COOLDOWN_DAYS,
@@ -2323,6 +2325,9 @@ const mailer = {
         firstName: params.firstName,
         lastName: params.lastName,
         email: params.email,
+        token: params.token,
+        tokenName: params.tokenName,
+        expires: params.expires,
       }),
     {
       cooldownDays: constants.EXPIRING_TOKEN_REMINDER_DAYS,

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -2304,15 +2304,20 @@ const mailer = {
   ),
   expiredToken: createSecurityEmailFunction(
     "expiredToken", //
-    (params) =>
-      msgs.tokenExpired({
+    (params) => {
+      const maskedToken =
+        params.token && params.token.length > 12
+          ? `${params.token.slice(0, 8)}...${params.token.slice(-4)}`
+          : params.token || "";
+      return msgs.tokenExpired({
         firstName: params.firstName,
         lastName: params.lastName,
         email: params.email,
-        token: params.token,
+        token: maskedToken,
         tokenName: params.tokenName,
         expires: params.expires,
-      }),
+      });
+    },
     {
       cooldownDays: constants.COMPROMISED_TOKEN_COOLDOWN_DAYS,
       enableCooldown: true,
@@ -2320,15 +2325,20 @@ const mailer = {
   ),
   expiringToken: createSecurityEmailFunction(
     "expiringToken", //
-    (params) =>
-      msgs.tokenExpiringSoon({
+    (params) => {
+      const maskedToken =
+        params.token && params.token.length > 12
+          ? `${params.token.slice(0, 8)}...${params.token.slice(-4)}`
+          : params.token || "";
+      return msgs.tokenExpiringSoon({
         firstName: params.firstName,
         lastName: params.lastName,
         email: params.email,
-        token: params.token,
+        token: maskedToken,
         tokenName: params.tokenName,
         expires: params.expires,
-      }),
+      });
+    },
     {
       cooldownDays: constants.EXPIRING_TOKEN_REMINDER_DAYS,
       enableCooldown: true,

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -502,6 +502,7 @@ const isIPBlacklistedHelper = async (
               user: { email, firstName, lastName },
               token,
               name,
+              expires,
               expiredEmailSent,
             } = tokenDetails;
 
@@ -515,6 +516,8 @@ const isIPBlacklistedHelper = async (
                   firstName,
                   lastName,
                   token,
+                  tokenName: name,
+                  expires,
                 },
                 next,
               );

--- a/src/auth-service/validators/clients.validators.js
+++ b/src/auth-service/validators/clients.validators.js
@@ -3,6 +3,7 @@ const { query, body, param, oneOf } = require("express-validator");
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 const constants = require("@config/constants");
+const ClientModel = require("@models/Client");
 
 const validateTenant = oneOf([
   query("tenant")
@@ -142,7 +143,24 @@ const update = [
       .optional()
       .isBoolean()
       .withMessage("requireClientSecret must be a boolean value")
-      .toBoolean(),
+      .toBoolean()
+      .custom(async (value, { req }) => {
+        if (value !== true) return true;
+        const tenant =
+          (req.query && req.query.tenant) || constants.DEFAULT_TENANT;
+        const client_id = req.params && req.params.client_id;
+        if (!client_id) throw new Error("client_id param is required");
+        const client = await ClientModel(tenant).findOne(
+          { _id: client_id },
+          { client_secret: 1 },
+        );
+        if (!client || !client.client_secret) {
+          throw new Error(
+            "A client_secret must exist before enabling requireClientSecret — call PATCH /:client_id/secret first",
+          );
+        }
+        return true;
+      }),
   ],
 ];
 

--- a/src/auth-service/validators/clients.validators.js
+++ b/src/auth-service/validators/clients.validators.js
@@ -138,6 +138,11 @@ const update = [
       .isURL()
       .withMessage("the redirect_url is not a valid URL")
       .trim(),
+    body("requireClientSecret")
+      .optional()
+      .isBoolean()
+      .withMessage("requireClientSecret must be a boolean value")
+      .toBoolean(),
   ],
 ];
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

- Updates **token expiry and expiring-soon emails** to reflect the current UX: users can now refresh their token directly under **Settings › API** in AirQo Analytics — no need to create a new client first
- Each email now displays the **masked token** (first 8 + last 4 characters) and its **human-readable expiry date** so users can immediately identify which token the alert is about, without exposing the full token value
- Adds a soft-launch **"Security tip" callout** to both token expiry emails, introducing the new opt-in client secret enforcement feature
- Implements a **user-triggered `requireClientSecret` flag** on API clients: when a user sets `requireClientSecret: true` on their client, every inbound API request using that client's token must also include the correct `client_secret` via the `X-Client-Secret` request header — requests missing or presenting an incorrect secret are rejected

### Why is this change needed?

- The previous email copy instructed users to *create a new API client and then generate a new token from it* — a flow that was superseded when token refresh from an existing client was introduced; the emails were never updated to reflect this
- Showing a masked token + exact expiry date gives users enough context to act without requiring them to log in first just to identify which token is affected
- `client_secret` has been stored on every API client since the initial OAuth implementation but was never validated at request time, leaving it unused from a security standpoint; this PR closes that gap in a fully backward-compatible, user-controlled way
- Making enforcement opt-in (default `false`) ensures zero disruption to any existing integration in production

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

- Verified token masking logic (first 8 + last 4 chars) handles short tokens and missing values gracefully
- Confirmed email copy reflects new "refresh from Settings › API" flow
- Validated that `requireClientSecret: false` (the default) leaves all existing client authentication completely unchanged — no header required, no new errors
- Confirmed opt-in path: setting `requireClientSecret: true` then calling the API without `X-Client-Secret` returns 401; with the correct header returns 200
- `token-expiration-job` correctly forwards `token`, `tokenName`, and `expires` to the mailer

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`requireClientSecret` defaults to `false` on all existing and new clients. No existing API consumer needs to change anything unless they explicitly opt in. The `X-Client-Secret` header is ignored entirely for clients where `requireClientSecret` is `false`.

---

## :memo: Additional Notes

**Files changed:**

| File | Change |
|---|---|
| `models/Client.js` | Added `requireClientSecret: Boolean, default: false` field |
| `validators/clients.validators.js` | Permitted `requireClientSecret` as optional boolean in `update` validator |
| `middleware/passport.js` | Added `ClientModel` import; injected client secret check in `useAuthTokenStrategy` |
| `utils/common/email.msgs.util.js` | Updated `tokenExpired` and `tokenExpiringSoon` — masked token, expiry date, refreshed copy, security tip callout |
| `utils/common/mailer.util.js` | Updated email subjects; forwarded `token`, `tokenName`, `expires` to both email functions |
| `bin/jobs/token-expiration-job.js` | Destructures and passes `token`, `tokenName`, `expires` from each token record to the mailer |

**How a user opts in:**
1. `PATCH /clients/:client_id/secret` — ensure a current `client_secret` is set
2. `PUT /clients/:client_id` with `{ "requireClientSecret": true }` — enforcement is now live
3. All subsequent API requests must include `X-Client-Secret: <secret>` or they will be rejected

To opt back out: `PUT /clients/:client_id` with `{ "requireClientSecret": false }`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients can opt in to require a client-secret for token-based API requests; auth flow enforces it when enabled.
  * Admin updates now validate a client has a secret before enabling that requirement.

* **Bug Fixes / Improvements**
  * Token expiration emails and subjects updated: masked token display, optional token name, explicit expiration dates when available, clearer wording, and a security tip about X-Client-Secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->