### PR TITLE
Fix token verify crash and improve MongoDB reconnect resilience

### DIFF
--- a/src/auth-service/config/database.js
+++ b/src/auth-service/config/database.js
@@ -36,7 +36,10 @@ const options = {
   // failing every in-flight request. Operations now buffer for up to 10s
   // before surfacing an error, matching the typical reconnect window.
   // Long outages still surface as errors — just not on the first 200ms blip.
-  bufferTimeoutMS: parseInt(constants.MONGODB_BUFFER_TIMEOUT_MS || "10000", 10),
+  bufferTimeoutMS: (() => {
+    const val = parseInt(constants.MONGODB_BUFFER_TIMEOUT_MS, 10);
+    return Number.isFinite(val) && val > 0 ? val : 10000;
+  })(),
   connectTimeoutMS: 30000,
   socketTimeoutMS: 60000,
   serverSelectionTimeoutMS: 30000,

--- a/src/auth-service/config/database.js
+++ b/src/auth-service/config/database.js
@@ -31,7 +31,12 @@ const options = {
   // Default 100 supports ~1000 concurrent logins (each login uses ~3-5 pool
   // slots across auth + session + stats queries).
   poolSize: parseInt(constants.MONGODB_POOL_SIZE || "100", 10),
-  bufferMaxEntries: 0,
+  // bufferMaxEntries: 0 was removed to allow brief connection-loss windows
+  // (e.g. replica-set elections, TCP keepalive resets) to recover without
+  // failing every in-flight request. Operations now buffer for up to 10s
+  // before surfacing an error, matching the typical reconnect window.
+  // Long outages still surface as errors — just not on the first 200ms blip.
+  bufferTimeoutMS: parseInt(constants.MONGODB_BUFFER_TIMEOUT_MS || "10000", 10),
   connectTimeoutMS: 30000,
   socketTimeoutMS: 60000,
   serverSelectionTimeoutMS: 30000,

--- a/src/auth-service/controllers/token.controller.js
+++ b/src/auth-service/controllers/token.controller.js
@@ -268,6 +268,10 @@ const createAccessToken = {
       analyzeIP(request, res, () => {});
       const result = await tokenUtil.verifyToken(request, next);
 
+      if (result == null) {
+        // verifyToken threw and the error is being handled by the catch block
+        return;
+      }
       const status = result.status;
       if (!res.headersSent) {
         res.status(status).send(result.message);

--- a/src/auth-service/controllers/token.controller.js
+++ b/src/auth-service/controllers/token.controller.js
@@ -269,7 +269,7 @@ const createAccessToken = {
       const result = await tokenUtil.verifyToken(request, next);
 
       if (result == null) {
-        // verifyToken threw and the error is being handled by the catch block
+        next(new Error("Token verification returned no result"));
         return;
       }
       const status = result.status;

--- a/src/auth-service/controllers/token.controller.js
+++ b/src/auth-service/controllers/token.controller.js
@@ -269,6 +269,7 @@ const createAccessToken = {
       const result = await tokenUtil.verifyToken(request, next);
 
       if (result == null) {
+        if (res.headersSent) return;
         next(
           new HttpError(
             "Internal Server Error",

--- a/src/auth-service/controllers/token.controller.js
+++ b/src/auth-service/controllers/token.controller.js
@@ -269,7 +269,13 @@ const createAccessToken = {
       const result = await tokenUtil.verifyToken(request, next);
 
       if (result == null) {
-        next(new Error("Token verification returned no result"));
+        next(
+          new HttpError(
+            "Internal Server Error",
+            httpStatus.INTERNAL_SERVER_ERROR,
+            { message: "Token verification returned no result" },
+          ),
+        );
         return;
       }
       const status = result.status;

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1010,14 +1010,7 @@ const token = {
       }
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message },
-        ),
-      );
-      return;
+      throw error;
     }
   },
   listAccessToken: async (request, next) => {

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1009,7 +1009,6 @@ const token = {
         }
       }
     } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       throw error;
     }
   },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Fixes a crash in the token verification controller where accessing `.status` on an `undefined` result caused a `TypeError`, which also triggered a double `next()` call on every DB failure
- Adds a `null` guard in the controller as defence-in-depth against any future undefined return from the util
- Replaces `bufferMaxEntries: 0` in the MongoDB connection config with a `bufferTimeoutMS` of 10 seconds so that brief connection interruptions (e.g. replica set elections, TCP keepalive resets) no longer immediately fail every in-flight request

### Why is this change needed?
During a production incident on 2026-04-10, the auth-service experienced repeated bursts of `"Query database connection not established or not ready"` errors followed immediately by `"Cannot read properties of undefined (reading 'status')"`. These two errors always appeared together because a single DB failure triggered two separate error paths: the util called `next(error)` and returned `undefined`, then the controller crashed reading `.status` on that `undefined` and called `next(error)` a second time. The `bufferMaxEntries: 0` config amplified the issue by failing every in-flight operation the instant MongoDB readyState dropped — even for sub-second reconnects — producing a log storm and 500s to callers until the connection self-recovered.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/auth-service` — `utils/token.util.js`, `controllers/token.controller.js`, `config/database.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified locally that a simulated DB connection failure during token verification now produces a single clean error response with no TypeError and no double `next()` call. Verified that the controller correctly short-circuits when `verifyToken` throws. The `bufferTimeoutMS` change was confirmed against Mongoose docs — operations now queue for up to 10 seconds during a reconnect window before surfacing an error, matching the typical replica set election window.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `bufferTimeoutMS` can be tuned via the `MONGODB_BUFFER_TIMEOUT_MS` environment variable without a code change. Default is `10000` (10 seconds).
- A token-verify rate limiter exists in the codebase (`strictRateLimiter`) but was intentionally left disabled — it is IP-keyed and does not work correctly for internal service-to-service calls. A follow-up is needed to re-key it by token value before it can be safely re-enabled.
- Infrastructure-side recommendations (NGINX rate limiting, NetworkPolicy for auth-service) have been shared separately with the infrastructure team.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection resilience: operations now buffer briefly during short connectivity interruptions instead of failing immediately.
  * Enhanced token verification handling: added safeguards for missing verification results to prevent runtime errors.
  * Refined authentication error behavior: internal errors are now propagated differently to preserve original error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->