### PR TITLE
Fix auth-service memory spikes and re-enable token verify rate limiting

### DIFF
--- a/src/auth-service/config/global/envs.js
+++ b/src/auth-service/config/global/envs.js
@@ -121,6 +121,10 @@ const envs = {
   // logins across 3 replicas (each login uses ~3-5 pool slots).
   // Tune via MONGODB_POOL_SIZE env var without a code change.
   MONGODB_POOL_SIZE: parseNumber(process.env.MONGODB_POOL_SIZE, 100),
+  // Maximum concurrent background IP analysis operations per pod.
+  // Shedding work above this threshold prevents OOM during DB slowness.
+  // Tune via IP_ANALYSIS_CONCURRENCY env var without a code change.
+  IP_ANALYSIS_CONCURRENCY: parseNumber(process.env.IP_ANALYSIS_CONCURRENCY, 50),
 
   // ── Feedback domain constants ──────────────────────────────────────────────
   // Single source of truth shared between the Feedback model and validators.

--- a/src/auth-service/config/global/envs.js
+++ b/src/auth-service/config/global/envs.js
@@ -124,7 +124,10 @@ const envs = {
   // Maximum concurrent background IP analysis operations per pod.
   // Shedding work above this threshold prevents OOM during DB slowness.
   // Tune via IP_ANALYSIS_CONCURRENCY env var without a code change.
-  IP_ANALYSIS_CONCURRENCY: parseNumber(process.env.IP_ANALYSIS_CONCURRENCY, 50),
+  IP_ANALYSIS_CONCURRENCY: (() => {
+    const val = Math.floor(parseNumber(process.env.IP_ANALYSIS_CONCURRENCY, 50));
+    return Number.isFinite(val) && val >= 1 ? val : 50;
+  })(),
 
   // ── Feedback domain constants ──────────────────────────────────────────────
   // Single source of truth shared between the Feedback model and validators.

--- a/src/auth-service/middleware/ip-pattern-analysis.middleware.js
+++ b/src/auth-service/middleware/ip-pattern-analysis.middleware.js
@@ -7,12 +7,16 @@ const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- ip-pattern-analysis.middleware`,
 );
 
-// Cap the number of concurrent background analysis operations.
-// When the DB is slow, fire-and-forget promises accumulate in the event loop
-// and drive up memory. Shedding work above this threshold prevents the OOM
-// spiral seen during DB reconnect windows.
-const MAX_CONCURRENT_ANALYSIS = 50;
+// Read from constants so the limit can be tuned per deployment via
+// the IP_ANALYSIS_CONCURRENCY environment variable without a code change.
+const MAX_CONCURRENT_ANALYSIS =
+  constants.IP_ANALYSIS_CONCURRENCY || 50;
 let _pendingAnalysis = 0;
+
+// Only log the backpressure warning on the transition into the overloaded
+// state, not on every subsequent request. This avoids flooding logs with
+// warn-level noise right when the service is already degraded.
+let _atCapacity = false;
 
 const analyzeIP = async (req, res, next) => {
   try {
@@ -27,26 +31,34 @@ const analyzeIP = async (req, res, next) => {
 
     if (ip) {
       if (_pendingAnalysis >= MAX_CONCURRENT_ANALYSIS) {
-        logger.warn(
-          `analyzeIP: backpressure limit reached (${_pendingAnalysis} pending), skipping background analysis for ${ip}`,
-        );
+        if (!_atCapacity) {
+          _atCapacity = true;
+          logger.warn(
+            `analyzeIP: backpressure limit reached (${_pendingAnalysis} pending), shedding background analysis until load reduces`,
+          );
+        }
       } else {
+        if (_atCapacity) {
+          _atCapacity = false;
+          logger.info(
+            `analyzeIP: backpressure recovered (${_pendingAnalysis} pending), resuming background analysis`,
+          );
+        }
         _pendingAnalysis++;
 
-        // Log the request without waiting for it to complete
-        IPRequestLogModel(tenant)
-          .recordRequest({ ip, endpoint, token })
-          .catch((err) => logObject("Error in background IP recording", err))
-          .finally(() => {
-            _pendingAnalysis--;
-          });
-
-        // Asynchronously analyze the IP patterns
-        tokenUtil
-          .analyzeIPRequestPatterns({ ip, tenant, endpoint })
-          .catch((err) => {
-            logObject("Error in background IP analysis", err);
-          });
+        // Account for both background operations in the concurrency counter
+        // so that a slow analyzeIPRequestPatterns cannot accumulate unbounded
+        // promises independently of recordRequest.
+        Promise.allSettled([
+          IPRequestLogModel(tenant)
+            .recordRequest({ ip, endpoint, token })
+            .catch((err) => logObject("Error in background IP recording", err)),
+          tokenUtil
+            .analyzeIPRequestPatterns({ ip, tenant, endpoint })
+            .catch((err) => logObject("Error in background IP analysis", err)),
+        ]).finally(() => {
+          _pendingAnalysis--;
+        });
       }
     }
   } catch (error) {

--- a/src/auth-service/middleware/ip-pattern-analysis.middleware.js
+++ b/src/auth-service/middleware/ip-pattern-analysis.middleware.js
@@ -1,6 +1,18 @@
 const IPRequestLogModel = require("@models/IPRequestLog");
 const tokenUtil = require("@utils/token.util");
 const { logObject } = require("@utils/shared");
+const log4js = require("log4js");
+const constants = require("@config/constants");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- ip-pattern-analysis.middleware`,
+);
+
+// Cap the number of concurrent background analysis operations.
+// When the DB is slow, fire-and-forget promises accumulate in the event loop
+// and drive up memory. Shedding work above this threshold prevents the OOM
+// spiral seen during DB reconnect windows.
+const MAX_CONCURRENT_ANALYSIS = 50;
+let _pendingAnalysis = 0;
 
 const analyzeIP = async (req, res, next) => {
   try {
@@ -14,17 +26,28 @@ const analyzeIP = async (req, res, next) => {
     const tenant = req.query.tenant || "airqo";
 
     if (ip) {
-      // Log the request without waiting for it to complete
-      IPRequestLogModel(tenant)
-        .recordRequest({ ip, endpoint, token })
-        .catch((err) => logObject("Error in background IP recording", err));
+      if (_pendingAnalysis >= MAX_CONCURRENT_ANALYSIS) {
+        logger.warn(
+          `analyzeIP: backpressure limit reached (${_pendingAnalysis} pending), skipping background analysis for ${ip}`,
+        );
+      } else {
+        _pendingAnalysis++;
 
-      // Asynchronously analyze the IP patterns
-      tokenUtil
-        .analyzeIPRequestPatterns({ ip, tenant, endpoint })
-        .catch((err) => {
-          logObject("Error in background IP analysis", err);
-        });
+        // Log the request without waiting for it to complete
+        IPRequestLogModel(tenant)
+          .recordRequest({ ip, endpoint, token })
+          .catch((err) => logObject("Error in background IP recording", err))
+          .finally(() => {
+            _pendingAnalysis--;
+          });
+
+        // Asynchronously analyze the IP patterns
+        tokenUtil
+          .analyzeIPRequestPatterns({ ip, tenant, endpoint })
+          .catch((err) => {
+            logObject("Error in background IP analysis", err);
+          });
+      }
     }
   } catch (error) {
     logObject("Error in IP analysis middleware", error);

--- a/src/auth-service/middleware/rate-limit.middleware.js
+++ b/src/auth-service/middleware/rate-limit.middleware.js
@@ -270,13 +270,18 @@ const onRateLimitError = (error, req, res, next) => {
  * Create a safe rate limiter with error handling
  */
 const createSafeRateLimiter = (config) => {
+  // Extract keyGenerator separately so callers can override the default
+  // IP-based key. Placing ...config last would let callers override store,
+  // skip, and handler too, which is undesirable — so we only allow
+  // keyGenerator to be customised.
+  const { keyGenerator: configKeyGenerator, ...restConfig } = config;
   try {
     return rateLimit({
-      ...config,
+      ...restConfig,
       store: rateStore,
       skip: skipFunction,
       handler: rateLimitHandler,
-      keyGenerator,
+      keyGenerator: configKeyGenerator || keyGenerator,
       // Suppress the trust-proxy validation error — we use custom x-client-ip
       // headers via keyGenerator so req.ip trustworthiness is irrelevant here.
       validate: { trustProxy: false },

--- a/src/auth-service/middleware/rate-limit.middleware.js
+++ b/src/auth-service/middleware/rate-limit.middleware.js
@@ -1,5 +1,6 @@
 const constants = require("@config/constants");
 const rateLimit = require("express-rate-limit");
+const crypto = require("crypto");
 const { logObject, logText } = require("@utils/shared");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
@@ -376,7 +377,18 @@ const tokenVerifyRateLimiter = createSafeRateLimiter({
   message: "Too many verification requests for this token. Please try again later.",
   keyGenerator: (req) => {
     const token = req.params.token;
-    if (token) return `token_verify_rl:${token}`;
+    if (token) {
+      // Hash the token so raw credentials are never stored in Redis keys or
+      // visible in datastore inspection/metrics. A 16-char hex prefix of
+      // SHA-256 gives 64 bits of collision resistance — sufficient for a
+      // rate-limit key while keeping key size small.
+      const hashed = crypto
+        .createHash("sha256")
+        .update(token)
+        .digest("hex")
+        .slice(0, 16);
+      return `token_verify_rl:${hashed}`;
+    }
     return `token_verify_rl:ip:${extractIp(req)}`;
   },
 });

--- a/src/auth-service/middleware/rate-limit.middleware.js
+++ b/src/auth-service/middleware/rate-limit.middleware.js
@@ -352,6 +352,31 @@ const readRateLimiter = createSafeRateLimiter({
 });
 
 /**
+ * Token-keyed rate limiter for the /:token/verify endpoint.
+ *
+ * Keyed by the token value from req.params.token rather than IP so that:
+ * - Each API client gets its own independent bucket regardless of the IP they
+ *   call from (internal services sharing a cluster IP won't collide).
+ * - External abuse of a single token is still capped.
+ *
+ * Limit: 2000 requests per hour per token — generous enough for busy
+ * service-to-service callers (~33/min) but low enough to cap runaway callers.
+ * Falls back to IP key if the token param is absent for any reason.
+ */
+const tokenVerifyRateLimiter = createSafeRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 2000,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: "Too many verification requests for this token. Please try again later.",
+  keyGenerator: (req) => {
+    const token = req.params.token;
+    if (token) return `token_verify_rl:${token}`;
+    return `token_verify_rl:ip:${extractIp(req)}`;
+  },
+});
+
+/**
  * Custom rate limiter factory
  */
 const createCustomRateLimiter = ({ windowMs, max, message }) => {
@@ -483,6 +508,7 @@ module.exports = {
   authRateLimiter,
   writeRateLimiter,
   readRateLimiter,
+  tokenVerifyRateLimiter,
 
   // Subscription tier-aware limiter (apply after JWT auth)
   tierBasedRateLimiter,

--- a/src/auth-service/middleware/rate-limit.middleware.js
+++ b/src/auth-service/middleware/rate-limit.middleware.js
@@ -358,6 +358,23 @@ const readRateLimiter = createSafeRateLimiter({
 });
 
 /**
+ * Coarse IP-based guard for the /:token/verify endpoint.
+ *
+ * Applied before the per-token limiter to prevent high-cardinality bypass
+ * attacks where an abuser rotates many unique (invalid) tokens from the same
+ * IP, each getting its own fresh per-token bucket. 5000 req/hr per IP allows
+ * a legitimate internal service running ~2-3 tokens at up to 2000 req/hr
+ * each, while blocking any single IP that hammers the endpoint indiscriminately.
+ */
+const tokenVerifyIpRateLimiter = createSafeRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 5000,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: "Too many verification requests from this IP. Please try again later.",
+});
+
+/**
  * Token-keyed rate limiter for the /:token/verify endpoint.
  *
  * Keyed by the token value from req.params.token rather than IP so that:
@@ -525,6 +542,7 @@ module.exports = {
   authRateLimiter,
   writeRateLimiter,
   readRateLimiter,
+  tokenVerifyIpRateLimiter,
   tokenVerifyRateLimiter,
 
   // Subscription tier-aware limiter (apply after JWT auth)

--- a/src/auth-service/middleware/rate-limiter.js
+++ b/src/auth-service/middleware/rate-limiter.js
@@ -157,11 +157,15 @@ const createDynamicLimiter = (options) => {
       // unique limiter config produces at most 3 keys (redis/memory/fallback),
       // so this supports ~33 distinct rate-limit configs before evicting the
       // oldest. Prevents unbounded growth when Redis availability flips often.
-      if (!limiterCache.has(limiterKey)) {
+      const evictIfNeeded = () => {
         if (limiterCache.size >= 100) {
           const oldestKey = limiterCache.keys().next().value;
           limiterCache.delete(oldestKey);
         }
+      };
+
+      if (!limiterCache.has(limiterKey)) {
+        evictIfNeeded();
         const config = createLimiterConfig(options, useRedis);
         const limiter = rateLimit(config);
 
@@ -189,6 +193,7 @@ const createDynamicLimiter = (options) => {
       const fallbackKey = `fallback_${cacheKey}`;
 
       if (!limiterCache.has(fallbackKey)) {
+        evictIfNeeded();
         const fallbackConfig = createLimiterConfig(options, false);
         const fallbackLimiter = rateLimit(fallbackConfig);
 

--- a/src/auth-service/middleware/rate-limiter.js
+++ b/src/auth-service/middleware/rate-limiter.js
@@ -153,8 +153,15 @@ const createDynamicLimiter = (options) => {
 
       const limiterKey = useRedis ? `redis_${cacheKey}` : `memory_${cacheKey}`;
 
-      // Create or get cached limiter
+      // Create or get cached limiter. Cap the cache at 100 entries — each
+      // unique limiter config produces at most 3 keys (redis/memory/fallback),
+      // so this supports ~33 distinct rate-limit configs before evicting the
+      // oldest. Prevents unbounded growth when Redis availability flips often.
       if (!limiterCache.has(limiterKey)) {
+        if (limiterCache.size >= 100) {
+          const oldestKey = limiterCache.keys().next().value;
+          limiterCache.delete(oldestKey);
+        }
         const config = createLimiterConfig(options, useRedis);
         const limiter = rateLimit(config);
 

--- a/src/auth-service/routes/v2/tokens.routes.js
+++ b/src/auth-service/routes/v2/tokens.routes.js
@@ -25,7 +25,7 @@ const {
 
 const { validate, headers, pagination } = require("@validators/common");
 
-const { strictRateLimiter } = require("@middleware/rate-limit.middleware");
+const { strictRateLimiter, tokenVerifyRateLimiter } = require("@middleware/rate-limit.middleware");
 
 const domainBlockingMiddleware = require("@middleware/domain-blocking.middleware");
 // Apply common middleware
@@ -105,7 +105,7 @@ router.get(
   validateTenant,
   // domainBlockingMiddleware, // Temporarily disabled for performance monitoring
   validateTokenParam,
-  // strictRateLimiter,
+  tokenVerifyRateLimiter,
   createTokenController.verify,
 );
 

--- a/src/auth-service/routes/v2/tokens.routes.js
+++ b/src/auth-service/routes/v2/tokens.routes.js
@@ -25,7 +25,7 @@ const {
 
 const { validate, headers, pagination } = require("@validators/common");
 
-const { tokenVerifyRateLimiter } = require("@middleware/rate-limit.middleware");
+const { tokenVerifyIpRateLimiter, tokenVerifyRateLimiter } = require("@middleware/rate-limit.middleware");
 
 const domainBlockingMiddleware = require("@middleware/domain-blocking.middleware");
 // Apply common middleware
@@ -105,6 +105,7 @@ router.get(
   validateTenant,
   // domainBlockingMiddleware, // Temporarily disabled for performance monitoring
   validateTokenParam,
+  tokenVerifyIpRateLimiter,
   tokenVerifyRateLimiter,
   createTokenController.verify,
 );

--- a/src/auth-service/routes/v2/tokens.routes.js
+++ b/src/auth-service/routes/v2/tokens.routes.js
@@ -25,7 +25,7 @@ const {
 
 const { validate, headers, pagination } = require("@validators/common");
 
-const { strictRateLimiter, tokenVerifyRateLimiter } = require("@middleware/rate-limit.middleware");
+const { tokenVerifyRateLimiter } = require("@middleware/rate-limit.middleware");
 
 const domainBlockingMiddleware = require("@middleware/domain-blocking.middleware");
 // Apply common middleware

--- a/src/auth-service/utils/common/log-winston.util.js
+++ b/src/auth-service/utils/common/log-winston.util.js
@@ -53,6 +53,9 @@ const pollInterval = setInterval(() => {
     addMongoTransport();
   }
 }, 2000);
+// Prevent these timers from keeping the event loop alive if the process is
+// otherwise idle (e.g. during DB reconnect windows or test teardown).
+pollInterval.unref();
 
 // Cap polling so it doesn't run forever if the DB never comes up.
 // mongoTimeout is named so the success path above can cancel it.
@@ -64,5 +67,6 @@ const mongoTimeout = setTimeout(() => {
     );
   }
 }, 60000);
+mongoTimeout.unref();
 
 module.exports = winstonLogger;

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -87,14 +87,15 @@ const TOKEN_VERIFY_TIER_LIMITS = { Free: 100, Standard: 500, Premium: 2000 };
 // { key: { count: number, expiry: number } }
 const _rlMemoryStore = new Map();
 
-// Prune expired entries once per hour so the Map doesn't grow indefinitely
-// in long-running processes where Redis stays unavailable.
+// Prune expired entries every 5 minutes so the Map doesn't grow significantly
+// during high-traffic windows where Redis stays unavailable. The previous 1-hour
+// cadence allowed a full hour of unique IPs to accumulate before cleanup.
 setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of _rlMemoryStore) {
     if (entry.expiry < now) _rlMemoryStore.delete(key);
   }
-}, 3600000).unref();
+}, 300000).unref();
 
 /**
  * Check and increment the hourly rate limit counter for a user.


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds a concurrency cap (50 pending operations) to the `analyzeIP` background middleware so that unresolved DB promises are shed under backpressure instead of accumulating in the event loop
- Introduces a token-keyed rate limiter (`tokenVerifyRateLimiter`) for the `/:token/verify` endpoint — keyed by token value rather than IP — and re-enables it on that route
- Exports the new limiter alongside existing ones in `rate-limit.middleware.js`

### Why is this change needed?
Auth pods were being OOM-killed during DB load spikes. Investigation revealed two compounding causes:

1. `analyzeIP` is called fire-and-forget on every token verify request. Under DB load, `IPRequestLogModel.recordRequest()` and `analyzeIPRequestPatterns()` promises accumulate without bound in the Node.js event loop, driving memory up until the pod is killed.

2. The original `strictRateLimiter` on `/:token/verify` was removed in October 2025 (commit `dd84e62`) because it was IP-keyed — internal services sharing cluster IPs collectively exhausted the 200 req/hr bucket and started receiving 429s within hours of deployment. A token-keyed limiter fixes the key collision while still providing DB protection.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/auth-service` — `middleware/ip-pattern-analysis.middleware.js`, `middleware/rate-limit.middleware.js`, `routes/v2/tokens.routes.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified locally that the `_pendingAnalysis` counter correctly increments/decrements and that the backpressure warning fires when the cap is reached. Verified that `tokenVerifyRateLimiter` buckets correctly by token param — two different tokens each get their own 2000/hr window and do not interfere. Confirmed internal service calls with separate tokens are no longer affected by shared-IP bucket exhaustion.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `MAX_CONCURRENT_ANALYSIS` cap of 50 is a module-level constant in `ip-pattern-analysis.middleware.js` and can be adjusted without other code changes.
- `tokenVerifyRateLimiter` allows 2000 requests per hour per token (~33/min), which is generous for legitimate service-to-service callers but caps runaway clients. The limit can be tuned via `createCustomRateLimiter` if specific callers need more headroom.
- The old `strictRateLimiter` import is retained in `tokens.routes.js` for use on other routes — only the verify route has been switched to the token-keyed limiter.
- Samantha's memory limit increase (PR #6389, merged 2026-04-13) provides headroom during the rollout of this fix. Once this is stable in production, the limits can be re-evaluated downward.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated rate limiting for the token verification endpoint (high-capacity hourly limit).

* **Improvements**
  * Concurrency backpressure for IP pattern analysis to reduce overload and dropped background work.
  * Bounded cache for rate limiter instances to limit memory growth.
  * Polling/timer behavior adjusted so background timers no longer prevent process shutdown.
  * In-memory fallback now prunes expired entries more frequently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->