### PR TITLE
feat: include co-located devices list in site details response

### DIFF
--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1119,7 +1119,26 @@ const deviceUtil = {
               foreignField: "_id",
               as: "site",
               pipeline: [
-                { $project: { _id: 1, name: 1, district: 1, country: 1 } },
+                {
+                  $lookup: {
+                    from: "devices",
+                    localField: "_id",
+                    foreignField: "site_id",
+                    as: "devices",
+                    pipeline: [
+                      { $project: { _id: 1, name: 1, long_name: 1 } },
+                    ],
+                  },
+                },
+                {
+                  $project: {
+                    _id: 1,
+                    name: 1,
+                    district: 1,
+                    country: 1,
+                    devices: 1,
+                  },
+                },
               ],
             },
           },
@@ -1167,6 +1186,27 @@ const deviceUtil = {
               preserveNullAndEmptyArrays: true,
             },
           },
+          {
+            $lookup: {
+              from: "devices",
+              let: { siteId: "$site_id" },
+              pipeline: [
+                {
+                  $match: {
+                    $expr: { $eq: ["$site_id", "$$siteId"] },
+                  },
+                },
+                { $project: { _id: 1, name: 1, long_name: 1 } },
+              ],
+              as: "_site_devices",
+            },
+          },
+          {
+            $addFields: {
+              "site.devices": "$_site_devices",
+            },
+          },
+          { $unset: "_site_devices" },
           {
             $lookup: {
               from: "hosts",

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1069,6 +1069,7 @@ const deviceUtil = {
         skip,
         useCache = "true",
         detailLevel = "full",
+        includeSiteDevices = "false",
         sortBy,
         order,
       } = request.query;
@@ -1118,28 +1119,40 @@ const deviceUtil = {
               localField: "site_id",
               foreignField: "_id",
               as: "site",
-              pipeline: [
-                {
-                  $lookup: {
-                    from: "devices",
-                    localField: "_id",
-                    foreignField: "site_id",
-                    as: "devices",
-                    pipeline: [
-                      { $project: { _id: 1, name: 1, long_name: 1 } },
+              pipeline:
+                includeSiteDevices === "true"
+                  ? [
+                      {
+                        $lookup: {
+                          from: "devices",
+                          localField: "_id",
+                          foreignField: "site_id",
+                          as: "devices",
+                          pipeline: [
+                            { $project: { _id: 1, name: 1, long_name: 1 } },
+                          ],
+                        },
+                      },
+                      {
+                        $project: {
+                          _id: 1,
+                          name: 1,
+                          district: 1,
+                          country: 1,
+                          devices: 1,
+                        },
+                      },
+                    ]
+                  : [
+                      {
+                        $project: {
+                          _id: 1,
+                          name: 1,
+                          district: 1,
+                          country: 1,
+                        },
+                      },
                     ],
-                  },
-                },
-                {
-                  $project: {
-                    _id: 1,
-                    name: 1,
-                    district: 1,
-                    country: 1,
-                    devices: 1,
-                  },
-                },
-              ],
             },
           },
           {
@@ -1186,38 +1199,47 @@ const deviceUtil = {
               preserveNullAndEmptyArrays: true,
             },
           },
-          {
-            $lookup: {
-              from: "devices",
-              let: { siteId: "$site_id" },
-              pipeline: [
+          ...(includeSiteDevices === "true"
+            ? [
                 {
-                  $match: {
-                    $expr: {
-                      $and: [
-                        { $ne: ["$$siteId", null] },
-                        { $eq: ["$site_id", "$$siteId"] },
-                      ],
+                  $lookup: {
+                    from: "devices",
+                    let: { siteId: "$site_id" },
+                    pipeline: [
+                      {
+                        $match: {
+                          $expr: {
+                            $and: [
+                              { $ne: ["$$siteId", null] },
+                              { $eq: ["$site_id", "$$siteId"] },
+                            ],
+                          },
+                        },
+                      },
+                      { $project: { _id: 1, name: 1, long_name: 1 } },
+                    ],
+                    as: "_site_devices",
+                  },
+                },
+                {
+                  $addFields: {
+                    "site.devices": {
+                      $cond: {
+                        if: {
+                          $and: [
+                            { $ne: ["$site", null] },
+                            { $gt: [{ $size: "$_site_devices" }, 0] },
+                          ],
+                        },
+                        then: "$_site_devices",
+                        else: "$$REMOVE",
+                      },
                     },
                   },
                 },
-                { $project: { _id: 1, name: 1, long_name: 1 } },
-              ],
-              as: "_site_devices",
-            },
-          },
-          {
-            $addFields: {
-              "site.devices": {
-                $cond: {
-                  if: { $and: [{ $ne: ["$site", null] }, { $gt: [{ $size: "$_site_devices" }, 0] }] },
-                  then: "$_site_devices",
-                  else: "$$REMOVE",
-                },
-              },
-            },
-          },
-          { $unset: "_site_devices" },
+                { $unset: "_site_devices" },
+              ]
+            : []),
           {
             $lookup: {
               from: "hosts",

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1193,7 +1193,12 @@ const deviceUtil = {
               pipeline: [
                 {
                   $match: {
-                    $expr: { $eq: ["$site_id", "$$siteId"] },
+                    $expr: {
+                      $and: [
+                        { $ne: ["$$siteId", null] },
+                        { $eq: ["$site_id", "$$siteId"] },
+                      ],
+                    },
                   },
                 },
                 { $project: { _id: 1, name: 1, long_name: 1 } },
@@ -1203,7 +1208,13 @@ const deviceUtil = {
           },
           {
             $addFields: {
-              "site.devices": "$_site_devices",
+              "site.devices": {
+                $cond: {
+                  if: { $and: [{ $ne: ["$site", null] }, { $gt: [{ $size: "$_site_devices" }, 0] }] },
+                  then: "$_site_devices",
+                  else: "$$REMOVE",
+                },
+              },
             },
           },
           { $unset: "_site_devices" },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Extends the device listing endpoint (`GET /devices`) to include a `devices` array inside the `site` object in the response. Each entry contains only the essential identifiers: `_id`, `name`, and `long_name`. This applies to both the `summary` and `full` detail levels.

### Why is this change needed?
Consumers of the device listing endpoint needed a way to discover all devices co-located at the same site without making a separate API call. Previously, the `site` field only returned high-level metadata (`name`, `district`, `country`). This change enriches that context with a lightweight list of sibling devices at the site.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/utils/device.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually verified that the `GET /devices` endpoint (both `summary` and `full` detail levels) returns a `site.devices` array with `_id`, `name`, and `long_name` for each co-located device. Confirmed that devices with no assigned site still return correctly with `site` as `null`/absent (no regression).

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`site.devices` is a purely additive field. All existing `site` fields (`_id`, `name`, `district`, `country`, etc.) remain unchanged. Existing consumers that do not reference `site.devices` are unaffected.

---

## :memo: Additional Notes

- The nested `$lookup` in the `summary` pipeline fetches devices directly from within the site sub-pipeline, keeping the aggregation self-contained.
- The `full` detail level uses a `let`/`$expr` match after the site `$unwind`, writing to a temporary `_site_devices` field that is merged into `site.devices` via `$addFields` and then removed with `$unset`.
- Only `_id`, `name`, and `long_name` are projected to keep the payload lightweight and avoid exposing sensitive device fields.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device listings are now properly included with site information in both summary and detailed views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->