### PR TITLE
fix: resolve bugs in device claiming and cohort assignment system

### DIFF
--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -542,7 +542,7 @@ const createCohort = {
               createdAt: {
                 $dateToString: {
                   format: "%Y-%m-%d %H:%M:%S",
-                  date: "$_id",
+                  date: "$createdAt",
                 },
               },
             },
@@ -606,7 +606,7 @@ const createCohort = {
               createdAt: {
                 $dateToString: {
                   format: "%Y-%m-%d %H:%M:%S",
-                  date: "$_id",
+                  date: "$createdAt",
                 },
               },
             },
@@ -655,75 +655,70 @@ const createCohort = {
         };
       }
 
-      const alreadyAssignedDevices = [];
+      // Batch fetch all devices at once to avoid N+1 queries
+      const existingDevices = await DeviceModel(tenant)
+        .find({ _id: { $in: device_ids } })
+        .select("_id cohorts")
+        .lean();
 
-      for (const device_id of device_ids) {
-        const device = await DeviceModel(tenant)
-          .findById(ObjectId(device_id))
-          .lean();
+      const foundIds = new Set(existingDevices.map((d) => d._id.toString()));
+      const notFoundIds = device_ids.filter(
+        (id) => !foundIds.has(id.toString()),
+      );
 
-        if (!device) {
-          return {
-            success: false,
-            message: "Bad Request Error",
-            errors: {
-              message: `Invalid Device ID ${device_id}, please crosscheck`,
-            },
-            status: httpStatus.BAD_REQUEST,
-          };
-        }
-
-        if (
-          device.cohorts &&
-          device.cohorts.map(String).includes(cohort_id.toString())
-        ) {
-          alreadyAssignedDevices.push(device_id);
-        }
-      }
-
-      if (alreadyAssignedDevices.length > 0) {
+      if (notFoundIds.length > 0) {
         return {
           success: false,
           message: "Bad Request Error",
           errors: {
-            message: `The following devices are already assigned to the Cohort ${cohort_id}: ${alreadyAssignedDevices.join(
-              ", ",
-            )}`,
+            message: `The following Device IDs were not found: ${notFoundIds.join(", ")}`,
           },
           status: httpStatus.BAD_REQUEST,
         };
       }
-      //
-      const totalDevices = device_ids.length;
-      const { nModified, n } = await DeviceModel(tenant).updateMany(
-        { _id: { $in: device_ids } },
+
+      // Split into already-assigned and new-to-assign; proceed with new ones
+      const cohortIdStr = cohort_id.toString();
+      const alreadyAssigned = existingDevices
+        .filter(
+          (d) =>
+            d.cohorts && d.cohorts.map(String).includes(cohortIdStr),
+        )
+        .map((d) => d._id);
+
+      const toAssign = existingDevices
+        .filter(
+          (d) =>
+            !d.cohorts || !d.cohorts.map(String).includes(cohortIdStr),
+        )
+        .map((d) => d._id);
+
+      if (toAssign.length === 0) {
+        return {
+          success: true,
+          message: "All provided devices are already assigned to this cohort",
+          status: httpStatus.OK,
+          data: { assigned: [], already_assigned: alreadyAssigned },
+        };
+      }
+
+      await DeviceModel(tenant).updateMany(
+        { _id: { $in: toAssign } },
         { $addToSet: { cohorts: cohort_id } },
       );
 
-      const notFoundCount = totalDevices - nModified;
-      if (nModified === 0) {
-        return {
-          success: false,
-          message: "Bad Request Error",
-          errors: { message: "No matching Device found in the system" },
-          status: httpStatus.BAD_REQUEST,
-        };
-      }
-
-      if (notFoundCount > 0) {
-        return {
-          success: true,
-          message: `Operation partially successful some ${notFoundCount} of the provided devices were not found in the system`,
-          status: httpStatus.OK,
-          data: cohort,
-        };
-      }
+      const partialMessage =
+        alreadyAssigned.length > 0
+          ? `${alreadyAssigned.length} device(s) were already assigned and skipped`
+          : null;
 
       return {
         success: true,
-        message: "successfully assigned all the provided devices to the Cohort",
+        message: partialMessage
+          ? `Partially successful: ${partialMessage}`
+          : "Successfully assigned all provided devices to the cohort",
         status: httpStatus.OK,
-        data: cohort,
+        data: { assigned: toAssign, already_assigned: alreadyAssigned },
       };
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
@@ -982,18 +977,14 @@ const createCohort = {
         };
       }
       // Fetch devices based on the provided Cohort ID
-      const devices = await DeviceModel(tenant).find({ cohorts: cohort_id });
+      const devices = await DeviceModel(tenant)
+        .find({ cohorts: cohort_id })
+        .select("_id site_id")
+        .lean();
 
-      // Extract device IDs from the fetched devices
+      // Extract device and site IDs directly from the fetched documents
       const device_ids = devices.map((device) => device._id);
-
-      // Fetch sites for each device concurrently
-      const site_ids_promises = device_ids.map(async (deviceId) => {
-        const device = await DeviceModel(tenant).findOne({ _id: deviceId });
-        return device.site_id;
-      });
-
-      const site_ids = await Promise.all(site_ids_promises);
+      const site_ids = devices.map((device) => device.site_id);
 
       logObject("device_ids:", device_ids);
       logObject("device_ids:", site_ids);

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -541,7 +541,7 @@ const createCohort = {
               description: 1,
               createdAt: {
                 $dateToString: {
-                  format: "%Y-%m-%d %H:%M:%S",
+                  format: "%Y-%m-%dT%H:%M:%SZ",
                   date: "$createdAt",
                 },
               },
@@ -605,7 +605,7 @@ const createCohort = {
               description: 1,
               createdAt: {
                 $dateToString: {
-                  format: "%Y-%m-%d %H:%M:%S",
+                  format: "%Y-%m-%dT%H:%M:%SZ",
                   date: "$createdAt",
                 },
               },
@@ -707,6 +707,14 @@ const createCohort = {
         { $addToSet: { cohorts: cohort_id } },
       );
 
+      // Re-query after the update to confirm which devices were actually assigned,
+      // guarding against concurrent requests that may have already written the same cohort_id.
+      const confirmedDocs = await DeviceModel(tenant)
+        .find({ _id: { $in: toAssign }, cohorts: cohort_id })
+        .select("_id")
+        .lean();
+      const confirmedAssigned = confirmedDocs.map((d) => d._id);
+
       const partialMessage =
         alreadyAssigned.length > 0
           ? `${alreadyAssigned.length} device(s) were already assigned and skipped`
@@ -718,7 +726,7 @@ const createCohort = {
           ? `Partially successful: ${partialMessage}`
           : "Successfully assigned all provided devices to the cohort",
         status: httpStatus.OK,
-        data: { assigned: toAssign, already_assigned: alreadyAssigned },
+        data: { assigned: confirmedAssigned, already_assigned: alreadyAssigned },
       };
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
@@ -987,7 +995,7 @@ const createCohort = {
       const site_ids = devices.map((device) => device.site_id);
 
       logObject("device_ids:", device_ids);
-      logObject("device_ids:", site_ids);
+      logObject("site_ids:", site_ids);
 
       return {
         success: true,

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -3075,11 +3075,11 @@ const deviceUtil = {
           return { success: false, ...groupObjectIdsResult };
         }
         groupObjectIds = groupObjectIdsResult.data;
-        const groups = await CohortModel(tenant)
-          .find({ groups: { $in: groupObjectIds } })
+        const groupLinkedCohorts = await CohortModel(tenant)
+          .find({ grp_id: { $in: groupObjectIds } })
           .select("_id")
           .lean();
-        groupCohorts = groups.map((g) => g._id);
+        groupCohorts = groupLinkedCohorts.map((g) => g._id);
       }
 
       // 2. Combine all cohort IDs: direct user cohorts and group cohorts

--- a/src/device-registry/utils/test/ut_cohort.util.js
+++ b/src/device-registry/utils/test/ut_cohort.util.js
@@ -1009,12 +1009,9 @@ describe("createCohort", () => {
     // Add more test cases as needed for different scenarios
   });
   describe("assignManyDevicesToCohort", () => {
-    it("should assign devices to a cohort successfully", async () => {
-      // Arrange
+    it("should assign all new devices to a cohort successfully", async () => {
       const request = {
-        params: {
-          cohort_id: "sample_cohort_id",
-        },
+        params: { cohort_id: "sample_cohort_id" },
         body: {
           device_ids: [
             "sample_device_id_1",
@@ -1022,65 +1019,110 @@ describe("createCohort", () => {
             "sample_device_id_3",
           ],
         },
-        query: {
-          tenant: "sample_tenant",
-        },
+        query: { tenant: "sample_tenant" },
       };
 
-      // Mock the CohortModel.findById function to return a valid cohort
-      const findByIdCohortStub = chai.spy.on(
+      chai.spy.on(
         createCohort.CohortModel("sample_tenant"),
         "findById",
-        () => ({
-          _id: "sample_cohort_id",
-          // Add any other cohort data here
-        })
+        () => ({ lean: () => ({ _id: "sample_cohort_id" }) })
       );
 
-      // Mock the DeviceModel.findById function to return valid devices
-      const findByIdDeviceStub = chai.spy.on(
+      let findCallCount = 0;
+      chai.spy.on(
         createCohort.DeviceModel("sample_tenant"),
-        "findById",
-        (deviceId) => ({
-          _id: deviceId,
-          cohorts: [], // Set the initial cohorts array to be empty
-          // Add any other device data here
-        })
+        "find",
+        () => {
+          findCallCount++;
+          const docs =
+            findCallCount === 1
+              ? [
+                  { _id: "sample_device_id_1", cohorts: [] },
+                  { _id: "sample_device_id_2", cohorts: [] },
+                  { _id: "sample_device_id_3", cohorts: [] },
+                ]
+              : [
+                  { _id: "sample_device_id_1" },
+                  { _id: "sample_device_id_2" },
+                  { _id: "sample_device_id_3" },
+                ];
+          return { select: () => ({ lean: () => Promise.resolve(docs) }) };
+        }
       );
 
-      // Mock the DeviceModel.updateMany function to return the number of modified documents
-      const updateManyStub = chai.spy.on(
+      chai.spy.on(
         createCohort.DeviceModel("sample_tenant"),
         "updateMany",
-        () => ({
-          nModified: 3, // Number of documents modified
-          n: 3, // Total number of matching documents
-        })
+        () => Promise.resolve({ nModified: 3, n: 3 })
       );
 
-      // Act
       const result = await createCohort.assignManyDevicesToCohort(request);
 
-      // Assert
       expect(result.success).to.be.true;
       expect(result.message).to.equal(
-        "successfully assigned all the provided devices to the Cohort"
+        "Successfully assigned all provided devices to the cohort"
       );
       expect(result.status).to.equal(httpStatus.OK);
-      // Add additional assertions based on the response data
+      expect(result.data).to.have.property("assigned");
+      expect(result.data).to.have.property("already_assigned");
+      expect(result.data.already_assigned).to.have.lengthOf(0);
 
-      // Restore the stubs
       createCohort.CohortModel("sample_tenant").findById.restore();
-      createCohort.DeviceModel("sample_tenant").findById.restore();
+      createCohort.DeviceModel("sample_tenant").find.restore();
+      createCohort.DeviceModel("sample_tenant").updateMany.restore();
+    });
+
+    it("should skip already-assigned devices and assign only new ones", async () => {
+      const request = {
+        params: { cohort_id: "sample_cohort_id" },
+        body: { device_ids: ["device_new_1", "device_already_1"] },
+        query: { tenant: "sample_tenant" },
+      };
+
+      chai.spy.on(
+        createCohort.CohortModel("sample_tenant"),
+        "findById",
+        () => ({ lean: () => ({ _id: "sample_cohort_id" }) })
+      );
+
+      let findCallCount = 0;
+      chai.spy.on(
+        createCohort.DeviceModel("sample_tenant"),
+        "find",
+        () => {
+          findCallCount++;
+          const docs =
+            findCallCount === 1
+              ? [
+                  { _id: "device_new_1", cohorts: [] },
+                  { _id: "device_already_1", cohorts: ["sample_cohort_id"] },
+                ]
+              : [{ _id: "device_new_1" }];
+          return { select: () => ({ lean: () => Promise.resolve(docs) }) };
+        }
+      );
+
+      chai.spy.on(
+        createCohort.DeviceModel("sample_tenant"),
+        "updateMany",
+        () => Promise.resolve({ nModified: 1, n: 1 })
+      );
+
+      const result = await createCohort.assignManyDevicesToCohort(request);
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.include("Partially successful");
+      expect(result.status).to.equal(httpStatus.OK);
+      expect(result.data.already_assigned).to.have.lengthOf(1);
+
+      createCohort.CohortModel("sample_tenant").findById.restore();
+      createCohort.DeviceModel("sample_tenant").find.restore();
       createCohort.DeviceModel("sample_tenant").updateMany.restore();
     });
 
     it("should handle invalid cohort ID", async () => {
-      // Arrange
       const request = {
-        params: {
-          cohort_id: "invalid_cohort_id",
-        },
+        params: { cohort_id: "invalid_cohort_id" },
         body: {
           device_ids: [
             "sample_device_id_1",
@@ -1088,22 +1130,17 @@ describe("createCohort", () => {
             "sample_device_id_3",
           ],
         },
-        query: {
-          tenant: "sample_tenant",
-        },
+        query: { tenant: "sample_tenant" },
       };
 
-      // Mock the CohortModel.findById function to return null (invalid cohort ID)
-      const findByIdCohortStub = chai.spy.on(
+      chai.spy.on(
         createCohort.CohortModel("sample_tenant"),
         "findById",
-        () => null
+        () => ({ lean: () => null })
       );
 
-      // Act
       const result = await createCohort.assignManyDevicesToCohort(request);
 
-      // Assert
       expect(result.success).to.be.false;
       expect(result.message).to.equal("Bad Request Error");
       expect(result.status).to.equal(httpStatus.BAD_REQUEST);
@@ -1111,62 +1148,39 @@ describe("createCohort", () => {
         "Invalid cohort ID invalid_cohort_id"
       );
 
-      // Restore the stubs
       createCohort.CohortModel("sample_tenant").findById.restore();
-      createCohort.DeviceModel("sample_tenant").findById.restore();
-      createCohort.DeviceModel("sample_tenant").updateMany.restore();
     });
 
-    it("should handle invalid device IDs", async () => {
-      // Arrange
+    it("should handle device IDs not found in the system", async () => {
       const request = {
-        params: {
-          cohort_id: "sample_cohort_id",
-        },
+        params: { cohort_id: "sample_cohort_id" },
         body: {
-          device_ids: [
-            "invalid_device_id_1",
-            "invalid_device_id_2",
-            "invalid_device_id_3",
-          ],
+          device_ids: ["invalid_device_id_1", "invalid_device_id_2"],
         },
-        query: {
-          tenant: "sample_tenant",
-        },
+        query: { tenant: "sample_tenant" },
       };
 
-      // Mock the CohortModel.findById function to return a valid cohort
-      const findByIdCohortStub = chai.spy.on(
+      chai.spy.on(
         createCohort.CohortModel("sample_tenant"),
         "findById",
-        () => ({
-          _id: "sample_cohort_id",
-          // Add any other cohort data here
-        })
+        () => ({ lean: () => ({ _id: "sample_cohort_id" }) })
       );
 
-      // Mock the DeviceModel.findById function to return null (invalid device ID)
-      const findByIdDeviceStub = chai.spy.on(
+      chai.spy.on(
         createCohort.DeviceModel("sample_tenant"),
-        "findById",
-        () => null
+        "find",
+        () => ({ select: () => ({ lean: () => Promise.resolve([]) }) })
       );
 
-      // Act
       const result = await createCohort.assignManyDevicesToCohort(request);
 
-      // Assert
       expect(result.success).to.be.false;
       expect(result.message).to.equal("Bad Request Error");
       expect(result.status).to.equal(httpStatus.BAD_REQUEST);
-      expect(result.errors.message).to.equal(
-        "Invalid Device ID invalid_device_id_1, please crosscheck"
-      );
+      expect(result.errors.message).to.include("not found");
 
-      // Restore the stubs
       createCohort.CohortModel("sample_tenant").findById.restore();
-      createCohort.DeviceModel("sample_tenant").findById.restore();
-      createCohort.DeviceModel("sample_tenant").updateMany.restore();
+      createCohort.DeviceModel("sample_tenant").find.restore();
     });
 
     // Add more test cases as needed for different scenarios


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes four bugs across the device claiming and cohort assignment system in the `device-registry` service:

1. **`listAssignedDevices`** — `createdAt` was built using `$_id` (an ObjectId) as the date source in a `$dateToString` aggregation stage, producing garbage timestamps. Fixed to use `$createdAt`.

2. **`assignManyDevicesToCohort`** — The bulk assignment operation used a serial N+1 loop (one DB query per device) to validate inputs, then failed the entire operation if even one device was already assigned to the cohort. Replaced with a single batch query; already-assigned devices are now skipped gracefully. Response now returns `{ assigned, already_assigned }` instead of the stale cohort document.

3. **`getSiteAndDeviceIds`** — After fetching all devices for a cohort in one query, the function immediately re-fetched each device individually (N+1) just to read `site_id`. The redundant re-fetch is eliminated; site IDs are now extracted from the initial query result.

4. **`getMyDevices`** — When resolving which cohorts belong to a user's groups, the filter queried `groups` (a `[String]` field on the Cohort model) using ObjectId instances, which never matched. Fixed to query `grp_id` (the ObjectId reference field), so group-linked cohorts are now correctly resolved.

### Why is this change needed?
These bugs collectively broke the "My Devices" view for users whose devices were assigned via group cohorts (Fix 4 — group cohort lookup never returned results), produced incorrect `createdAt` timestamps in assigned-device listings (Fix 1), caused bulk cohort assignments to fail entirely if any device was already assigned (Fix 2), and introduced unnecessary N+1 database queries under load (Fixes 2 & 3).

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/utils/cohort.util.js`
- `device-registry` — `src/device-registry/utils/device.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Verified `listAssignedDevices` returns correct ISO-formatted `createdAt` timestamps.
- Verified `assignManyDevicesToCohort` with a mix of new and already-assigned devices — already-assigned entries are skipped and reported in `already_assigned`; new ones are written correctly.
- Verified `getMyDevices` with `group_ids` now returns devices belonging to cohorts linked via `grp_id`, which previously returned empty results.
- Confirmed `getSiteAndDeviceIds` returns identical `device_ids` and `site_ids` arrays with no redundant queries.

---

## :boom: Breaking Changes

- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

**`assignManyDevicesToCohort` response shape changed:**
- **Before:** `data` contained the raw cohort document.
- **After:** `data` is `{ assigned: [...deviceIds], already_assigned: [...deviceIds] }`.

Consumers of `POST /cohorts/:cohort_id/assign-devices` should update to read `data.assigned` instead of `data`. The behaviour change (skip instead of reject on already-assigned devices) is intentional and backwards-compatible for callers that were not handling the previous 400 error.

---

## :memo: Additional Notes

- Fix 4 (`grp_id` vs `groups`) is the most impactful: it caused `GET /devices/my-devices` to silently return no group-cohort-linked devices for any user passing `group_ids`, regardless of their actual cohort membership.
- Fixes 2 & 3 also reduce DB load for large cohorts — the previous implementation issued up to 2× N queries for N devices in a cohort.
- A companion frontend bug report has been shared with the Vertex frontend team covering the cohort import flow not calling the device claiming endpoints.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized device assignment operations to process multiple devices in a single batch query instead of individual lookups.
  * Improved device and site ID retrieval by reducing database calls.

* **Enhancements**
  * Enhanced assignment responses with clearer distinction between newly assigned and previously assigned devices.
  * Corrected timestamp formatting accuracy in device lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->