### PR TITLE
Enforce device and site visibility for private cohorts and grids

### DIFF
--- a/src/device-registry/controllers/cohort.controller.js
+++ b/src/device-registry/controllers/cohort.controller.js
@@ -377,6 +377,17 @@ const createCohort = {
       handleError(error, next);
     }
   },
+  promoteCohorts: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await createCohortUtil.promoteCohorts(request, next);
+      handleResponse({ res, result, key: "promotion" });
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
 };
 
 module.exports = createCohort;

--- a/src/device-registry/controllers/reading.controller.js
+++ b/src/device-registry/controllers/reading.controller.js
@@ -85,10 +85,10 @@ const getSitesFromGrid = async ({ tenant = "airqo", grid_id } = {}) => {
     };
   }
 };
-const getDevicesFromCohort = async ({ tenant = "airqo", cohort_id } = {}) => {
+const getDevicesFromCohort = async ({ tenant = "airqo", cohort_id, user_id } = {}) => {
   try {
     const responseFromGetDevicesOfCohort = await createEventUtil.getDevicesFromCohort(
-      { cohort_id, tenant }
+      { cohort_id, tenant, user_id }
     );
     return responseFromGetDevicesOfCohort;
   } catch (error) {
@@ -119,7 +119,7 @@ const processGridIds = async (grid_ids, request) => {
         return responseFromGetSitesOfGrid;
       } else if (responseFromGetSitesOfGrid.suppressed) {
         // Grid is private — treat as empty site set, not an error
-        return [];
+        return null;
       } else if (isEmpty(responseFromGetSitesOfGrid.data)) {
         logger.error(
           `🐛🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`
@@ -186,6 +186,7 @@ const processCohortIds = async (cohort_ids, request) => {
       const responseFromGetDevicesOfCohort = await getDevicesFromCohort({
         cohort_id,
         user_id,
+        tenant: request.query.tenant,
       });
 
       logObject(
@@ -202,7 +203,7 @@ const processCohortIds = async (cohort_ids, request) => {
         return responseFromGetDevicesOfCohort;
       } else if (responseFromGetDevicesOfCohort.suppressed) {
         // Cohort is private — treat as empty device set, not an error
-        return [];
+        return null;
       } else if (isEmpty(responseFromGetDevicesOfCohort.data)) {
         logger.error(
           `🐛🐛 The provided Cohort ID ${cohort_id} does not have any associated Device IDs`

--- a/src/device-registry/controllers/reading.controller.js
+++ b/src/device-registry/controllers/reading.controller.js
@@ -40,6 +40,17 @@ const getSitesFromGrid = async ({ tenant = "airqo", grid_id } = {}) => {
       };
     }
 
+    // Privacy gate: private grids do not expose their sites
+    if (gridDetails.visibility === false) {
+      return {
+        success: true,
+        message: "Grid is private; site data is not publicly accessible",
+        data: null,
+        suppressed: true,
+        status: httpStatus.OK,
+      };
+    }
+
     const sites = gridDetails.sites || [];
 
     if (sites.length === 0) {
@@ -106,6 +117,9 @@ const processGridIds = async (grid_ids, request) => {
           )}`
         );
         return responseFromGetSitesOfGrid;
+      } else if (responseFromGetSitesOfGrid.suppressed) {
+        // Grid is private — treat as empty site set, not an error
+        return [];
       } else if (isEmpty(responseFromGetSitesOfGrid.data)) {
         logger.error(
           `🐛🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`
@@ -163,11 +177,15 @@ const processCohortIds = async (cohort_ids, request) => {
     ? cohort_ids
     : cohort_ids.toString().split(",");
 
+  // Pass through requester identity so private cohorts can apply owner bypass
+  const user_id = request.query.user_id;
+
   // Use Promise.all to concurrently process each cohort_id
   const deviceIdsPromises = cohortIdArray.map(async (cohort_id) => {
     if (!isEmpty(cohort_id)) {
       const responseFromGetDevicesOfCohort = await getDevicesFromCohort({
         cohort_id,
+        user_id,
       });
 
       logObject(
@@ -182,6 +200,9 @@ const processCohortIds = async (cohort_ids, request) => {
           )}`
         );
         return responseFromGetDevicesOfCohort;
+      } else if (responseFromGetDevicesOfCohort.suppressed) {
+        // Cohort is private — treat as empty device set, not an error
+        return [];
       } else if (isEmpty(responseFromGetDevicesOfCohort.data)) {
         logger.error(
           `🐛🐛 The provided Cohort ID ${cohort_id} does not have any associated Device IDs`

--- a/src/device-registry/routes/v2/cohorts.routes.js
+++ b/src/device-registry/routes/v2/cohorts.routes.js
@@ -106,6 +106,12 @@ router.post(
   createCohortController.filterOutPrivateDevices,
 );
 
+router.post(
+  "/promote",
+  cohortValidations.promoteCohorts,
+  createCohortController.promoteCohorts,
+);
+
 router.get(
   "/:cohort_id/generate",
   cohortValidations.getSiteAndDeviceIds,

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1016,22 +1016,27 @@ const createCohort = {
   },
   filterOutPrivateDevices: async (request, next) => {
     try {
-      const { tenant, devices, device_ids, device_names } = {
+      const { tenant, devices, device_ids, device_names, user_id } = {
         ...request.body,
         ...request.query,
         ...request.params,
       };
       const privateCohorts = await CohortModel(tenant)
-        .find({
-          visibility: false,
-        })
+        .find({ visibility: false })
         .select("_id")
         .lean();
 
       const privateCohortIds = privateCohorts.map((cohort) => cohort._id);
-      const privateDevices = await DeviceModel(tenant).find({
-        cohorts: { $in: privateCohortIds },
-      });
+
+      // When a user_id is provided, exclude devices owned by that user from the
+      // "private" set so owners can always access their own device data.
+      const privateDevicesQuery = { cohorts: { $in: privateCohortIds } };
+      if (user_id) {
+        privateDevicesQuery.owner_id = { $ne: new ObjectId(user_id) };
+      }
+      const privateDevices = await DeviceModel(tenant).find(
+        privateDevicesQuery,
+      );
 
       const privateDeviceIds = privateDevices.map((device) =>
         device._id.toString(),

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1078,10 +1078,8 @@ const createCohort = {
   },
   promoteCohorts: async (request, next) => {
     try {
-      const { tenant, cohort_ids } = {
-        ...request.body,
-        ...request.query,
-      };
+      const { cohort_ids } = request.body;
+      const tenant = request.query.tenant || request.body.tenant;
 
       const objectIds = cohort_ids.map((id) => new ObjectId(id));
 
@@ -1112,10 +1110,18 @@ const createCohort = {
       return {
         success: true,
         status: httpStatus.OK,
-        message:
-          toPromote.length > 0
-            ? `Successfully promoted ${toPromote.length} cohort(s) to public`
-            : "All provided cohorts are already public",
+        message: (() => {
+          if (toPromote.length > 0 && notFound.length > 0) {
+            return `Promoted ${toPromote.length} cohort(s) to public; ${notFound.length} ID(s) not found`;
+          }
+          if (toPromote.length > 0) {
+            return `Successfully promoted ${toPromote.length} cohort(s) to public`;
+          }
+          if (notFound.length > 0) {
+            return `No cohorts promoted; the following ID(s) were not found: ${notFound.join(", ")}`;
+          }
+          return "All provided cohorts are already public";
+        })(),
         data: {
           promoted: toPromote.map((id) => id.toString()),
           already_public: alreadyPublic,

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1031,7 +1031,7 @@ const createCohort = {
       // When a user_id is provided, exclude devices owned by that user from the
       // "private" set so owners can always access their own device data.
       const privateDevicesQuery = { cohorts: { $in: privateCohortIds } };
-      if (user_id) {
+      if (user_id && ObjectId.isValid(user_id)) {
         privateDevicesQuery.owner_id = { $ne: new ObjectId(user_id) };
       }
       const privateDevices = await DeviceModel(tenant).find(

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1076,6 +1076,63 @@ const createCohort = {
       );
     }
   },
+  promoteCohorts: async (request, next) => {
+    try {
+      const { tenant, cohort_ids } = {
+        ...request.body,
+        ...request.query,
+      };
+
+      const objectIds = cohort_ids.map((id) => new ObjectId(id));
+
+      // Identify which IDs exist in the DB
+      const existingCohorts = await CohortModel(tenant)
+        .find({ _id: { $in: objectIds } })
+        .select("_id visibility")
+        .lean();
+
+      const existingIds = new Set(
+        existingCohorts.map((c) => c._id.toString()),
+      );
+      const notFound = cohort_ids.filter((id) => !existingIds.has(id));
+      const alreadyPublic = existingCohorts
+        .filter((c) => c.visibility === true)
+        .map((c) => c._id.toString());
+      const toPromote = existingCohorts
+        .filter((c) => c.visibility !== true)
+        .map((c) => c._id);
+
+      if (toPromote.length > 0) {
+        await CohortModel(tenant).updateMany(
+          { _id: { $in: toPromote } },
+          { $set: { visibility: true } },
+        );
+      }
+
+      return {
+        success: true,
+        status: httpStatus.OK,
+        message:
+          toPromote.length > 0
+            ? `Successfully promoted ${toPromote.length} cohort(s) to public`
+            : "All provided cohorts are already public",
+        data: {
+          promoted: toPromote.map((id) => id.toString()),
+          already_public: alreadyPublic,
+          not_found: notFound,
+        },
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
   createCohortFromCohortIDs: async (request, next) => {
     try {
       const { body, query } = request;

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -840,12 +840,19 @@ const getDevicesFromCohort = async ({
         .find({ cohorts: cohort_id, owner_id: new ObjectId(user_id) })
         .select("_id")
         .lean();
+      if (ownedDevices.length === 0) {
+        return {
+          success: true,
+          message: "No owned devices found in this private cohort",
+          data: null,
+          suppressed: true,
+          status: httpStatus.OK,
+        };
+      }
       const ownedIds = ownedDevices.map((d) => d._id.toString()).join(",");
       return {
         success: true,
-        message: ownedIds
-          ? "Successfully retrieved owned devices from private cohort"
-          : "No owned devices found in this private cohort",
+        message: "Successfully retrieved owned devices from private cohort",
         data: ownedIds,
         status: httpStatus.OK,
       };
@@ -894,7 +901,7 @@ const processGridIds = async (grid_ids, request) => {
         return responseFromGetSitesOfGrid;
       } else if (responseFromGetSitesOfGrid.suppressed) {
         // Grid is private — treat as empty site set, not an error
-        return [];
+        return null;
       } else if (isEmpty(responseFromGetSitesOfGrid.data)) {
         logger.error(
           `🐛🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`,
@@ -924,7 +931,7 @@ const processGridIds = async (grid_ids, request) => {
   logObject("siteIdResults", siteIdResults);
 
   const invalidSiteIdResults = siteIdResults.filter(
-    (result) => result.success === false,
+    (result) => result != null && result.success === false,
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
@@ -935,7 +942,7 @@ const processGridIds = async (grid_ids, request) => {
   logObject("invalidSiteIdResults", invalidSiteIdResults);
 
   const validSiteIdResults = siteIdResults.filter(
-    (result) => !(result.success === false),
+    (result) => result != null && !(result.success === false),
   );
 
   logObject("validSiteIdResults", validSiteIdResults);
@@ -975,7 +982,7 @@ const processCohortIds = async (cohort_ids, request) => {
         return responseFromGetDevicesOfCohort;
       } else if (responseFromGetDevicesOfCohort.suppressed) {
         // Cohort is private — treat as empty device set, not an error
-        return [];
+        return null;
       } else if (isEmpty(responseFromGetDevicesOfCohort.data)) {
         logger.error(
           `🐛🐛 The provided Cohort ID ${cohort_id} does not have any associated Device IDs`,
@@ -997,7 +1004,7 @@ const processCohortIds = async (cohort_ids, request) => {
   const deviceIdsResults = await Promise.all(deviceIdsPromises);
 
   const invalidDeviceIdResults = deviceIdsResults.filter(
-    (result) => result.success === false,
+    (result) => result != null && result.success === false,
   );
 
   // Return the first error found to the controller

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -1098,7 +1098,7 @@ const processAirQloudIds = async (airqloud_ids, request) => {
   logObject("siteIdResults", siteIdResults);
 
   const invalidSiteIdResults = siteIdResults.filter(
-    (result) => result.success === false,
+    (result) => result != null && result.success === false,
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
@@ -1109,7 +1109,7 @@ const processAirQloudIds = async (airqloud_ids, request) => {
   logObject("invalidSiteIdResults", invalidSiteIdResults);
 
   const validSiteIdResults = siteIdResults.filter(
-    (result) => !(result.success === false),
+    (result) => result != null && !(result.success === false),
   );
 
   logObject("validSiteIdResults", validSiteIdResults);

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -965,6 +965,7 @@ const processCohortIds = async (cohort_ids, request) => {
       const responseFromGetDevicesOfCohort = await getDevicesFromCohort({
         cohort_id,
         user_id,
+        tenant: request.query.tenant,
       });
 
       logObject(
@@ -1015,8 +1016,11 @@ const processCohortIds = async (cohort_ids, request) => {
     return invalidDeviceIdResults[0];
   }
 
+  // null entries are cohorts that were suppressed (private, no bypass)
+  const suppressedCount = deviceIdsResults.filter((r) => r === null).length;
+
   const validDeviceIdResults = deviceIdsResults.filter(
-    (result) => !(result.success === false),
+    (result) => result != null && !(result.success === false),
   );
 
   const flattened = [].concat(...validDeviceIdResults);
@@ -1026,7 +1030,9 @@ const processCohortIds = async (cohort_ids, request) => {
     // The use of a Set handles potential duplicates if a device is in multiple cohorts.
     const uniqueDeviceIds = [...new Set(flattened)];
     request.query.device_id = uniqueDeviceIds.join(",");
-  } else if (isEmpty(flattened)) {
+  } else if (isEmpty(flattened) && suppressedCount === 0) {
+    // Only return an error if the empty result is not due to privacy suppression.
+    // When all cohorts are private, silently resolve to no devices.
     return {
       success: false,
       status: httpStatus.BAD_REQUEST,

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -47,6 +47,8 @@ const {
   redisExpireAsync,
 } = require("@config/redis");
 const asyncRetry = require("async-retry");
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Types.ObjectId;
 const CACHE_TIMEOUT_PERIOD = constants.CACHE_TIMEOUT_PERIOD || 10000;
 let lastRedisWarning = 0;
 const REDIS_WARNING_THROTTLE = 30 * 60 * 1000; // 30 minutes throttle (30 minutes * 60 seconds * 1000 milliseconds)
@@ -739,7 +741,8 @@ const getSitesFromGrid = async ({ tenant = "airqo", grid_id } = {}) => {
       return {
         success: true,
         message: "Grid is private; site data is not publicly accessible",
-        data: "",
+        data: null,
+        suppressed: true,
         status: httpStatus.OK,
       };
     }
@@ -819,13 +822,22 @@ const getDevicesFromCohort = async ({
           success: true,
           message:
             "Cohort is private; device data is not publicly accessible",
-          data: "",
+          data: null,
+          suppressed: true,
           status: httpStatus.OK,
         };
       }
       // User context present — return only devices owned by this user
+      if (!ObjectId.isValid(user_id)) {
+        return {
+          success: false,
+          message: "Bad Request Error",
+          errors: { message: "Invalid user_id format" },
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
       const ownedDevices = await DeviceModel(tenant)
-        .find({ cohorts: cohort_id, owner_id: user_id })
+        .find({ cohorts: cohort_id, owner_id: new ObjectId(user_id) })
         .select("_id")
         .lean();
       const ownedIds = ownedDevices.map((d) => d._id.toString()).join(",");
@@ -880,6 +892,9 @@ const processGridIds = async (grid_ids, request) => {
           )}`,
         );
         return responseFromGetSitesOfGrid;
+      } else if (responseFromGetSitesOfGrid.suppressed) {
+        // Grid is private — treat as empty site set, not an error
+        return [];
       } else if (isEmpty(responseFromGetSitesOfGrid.data)) {
         logger.error(
           `🐛🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`,
@@ -958,6 +973,9 @@ const processCohortIds = async (cohort_ids, request) => {
         );
         // Return the error response to the caller
         return responseFromGetDevicesOfCohort;
+      } else if (responseFromGetDevicesOfCohort.suppressed) {
+        // Cohort is private — treat as empty device set, not an error
+        return [];
       } else if (isEmpty(responseFromGetDevicesOfCohort.data)) {
         logger.error(
           `🐛🐛 The provided Cohort ID ${cohort_id} does not have any associated Device IDs`,

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -734,6 +734,16 @@ const getSitesFromGrid = async ({ tenant = "airqo", grid_id } = {}) => {
       };
     }
 
+    // Privacy gate: private grids do not expose their sites
+    if (gridDetails.visibility === false) {
+      return {
+        success: true,
+        message: "Grid is private; site data is not publicly accessible",
+        data: "",
+        status: httpStatus.OK,
+      };
+    }
+
     const sites = gridDetails.sites || [];
 
     if (sites.length === 0) {
@@ -766,7 +776,11 @@ const getSitesFromGrid = async ({ tenant = "airqo", grid_id } = {}) => {
     };
   }
 };
-const getDevicesFromCohort = async ({ tenant = "airqo", cohort_id } = {}) => {
+const getDevicesFromCohort = async ({
+  tenant = "airqo",
+  cohort_id,
+  user_id,
+} = {}) => {
   try {
     const request = {
       query: {
@@ -796,6 +810,35 @@ const getDevicesFromCohort = async ({ tenant = "airqo", cohort_id } = {}) => {
         status: httpStatus.INTERNAL_SERVER_ERROR,
       };
     }
+    // Privacy gate: private cohorts restrict access to recent measurements
+    const isPrivate = cohortDetails.visibility === false;
+    if (isPrivate) {
+      if (!user_id) {
+        // No user context — suppress all devices from this private cohort
+        return {
+          success: true,
+          message:
+            "Cohort is private; device data is not publicly accessible",
+          data: "",
+          status: httpStatus.OK,
+        };
+      }
+      // User context present — return only devices owned by this user
+      const ownedDevices = await DeviceModel(tenant)
+        .find({ cohorts: cohort_id, owner_id: user_id })
+        .select("_id")
+        .lean();
+      const ownedIds = ownedDevices.map((d) => d._id.toString()).join(",");
+      return {
+        success: true,
+        message: ownedIds
+          ? "Successfully retrieved owned devices from private cohort"
+          : "No owned devices found in this private cohort",
+        data: ownedIds,
+        status: httpStatus.OK,
+      };
+    }
+
     const assignedDevices = cohortDetails.devices || [];
     const deviceIds = assignedDevices.map((device) => device._id.toString());
 
@@ -892,10 +935,14 @@ const processCohortIds = async (cohort_ids, request) => {
     ? cohort_ids
     : cohort_ids.toString().split(",");
 
+  // Pass through requester identity so private cohorts can apply owner bypass
+  const user_id = request.query.user_id;
+
   const deviceIdsPromises = cohortIdArray.map(async (cohort_id) => {
     if (!isEmpty(cohort_id)) {
       const responseFromGetDevicesOfCohort = await getDevicesFromCohort({
         cohort_id,
+        user_id,
       });
 
       logObject(

--- a/src/device-registry/validators/cohorts.validators.js
+++ b/src/device-registry/validators/cohorts.validators.js
@@ -13,6 +13,32 @@ const constants = require("@config/constants");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
 const { validateNetwork, validateAdminLevels } = require("@validators/common");
+const crypto = require("crypto");
+
+const requireAdminSecret = (req, res, next) => {
+  if (!constants.ADMIN_SETUP_SECRET) {
+    return next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: "Admin secret not configured on server",
+      }),
+    );
+  }
+  const provided = Buffer.from(
+    req.body.admin_secret || req.query.admin_secret || "",
+  );
+  const expected = Buffer.from(constants.ADMIN_SETUP_SECRET);
+  if (
+    provided.length !== expected.length ||
+    !crypto.timingSafeEqual(provided, expected)
+  ) {
+    return next(
+      new HttpError("Forbidden", httpStatus.FORBIDDEN, {
+        message: "Invalid admin secret",
+      }),
+    );
+  }
+  next();
+};
 
 const handleValidationErrors = (req, res, next) => {
   const errors = validationResult(req);
@@ -752,7 +778,35 @@ const cohortValidations = {
   ],
 };
 
+const promoteCohorts = [
+  ...commonValidations.tenant,
+  body("admin_secret")
+    .exists()
+    .withMessage("admin_secret is required")
+    .bail()
+    .isString()
+    .withMessage("admin_secret must be a string")
+    .bail()
+    .notEmpty()
+    .withMessage("admin_secret must not be empty"),
+  body("cohort_ids")
+    .exists()
+    .withMessage("cohort_ids is required")
+    .bail()
+    .isArray({ min: 1 })
+    .withMessage("cohort_ids must be a non-empty array"),
+  body("cohort_ids.*")
+    .isString()
+    .withMessage("each cohort_id must be a string")
+    .bail()
+    .custom((id) => isValidObjectId(id))
+    .withMessage("each cohort_id must be a valid MongoDB ObjectId"),
+  handleValidationErrors,
+  requireAdminSecret,
+];
+
 module.exports = {
   ...cohortValidations,
+  promoteCohorts,
   pagination: commonValidations.pagination,
 };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

- **Private cohort gate** (`event.util.js` — `getDevicesFromCohort`): If a cohort has `visibility: false`, the function now returns `{ data: null, suppressed: true }` for unauthenticated callers. Callers who pass `?user_id=<mongo_id>` receive only devices they own within that cohort (`owner_id` match). The `user_id` is validated with `ObjectId.isValid` before use; an invalid value returns a 400 rather than a 500.
- **Private grid gate** (`event.util.js` — `getSitesFromGrid`): If a grid has `visibility: false`, site resolution returns `{ data: null, suppressed: true }`. Grid sites have no `owner_id` so there is no user bypass for grids.
- **`processGridIds` / `processCohortIds` suppression handling** (`event.util.js`): Both callers now check `suppressed === true` before the `isEmpty(data)` branch, so a private entity is treated as an empty result set rather than a BAD_REQUEST error.
- **`processCohortIds` threads `user_id`** (`event.util.js`): Reads the optional `request.query.user_id` and passes it through to `getDevicesFromCohort` so the owner bypass works end-to-end.
- **`filterOutPrivateDevices` owner bypass** (`cohort.util.js`): Re-enables the previously suspended endpoint. When `user_id` is provided and passes `ObjectId.isValid`, devices owned by that user are excluded from the private suppression set. Invalid `user_id` values silently skip the owner bypass rather than throwing.

### Why is this change needed?

Private cohorts (`visibility: false`) had no runtime enforcement — their devices were visible to any caller via the resolution and events endpoints. This change ensures private cohort devices are suppressed for public callers while preserving access for device owners via an optional `user_id` parameter.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/device-registry` — `utils/cohort.util.js`, `utils/event.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

Manually verified against staging:
- Public cohort/grid resolution is unchanged — IDs are returned as before.
- Private cohort resolution without `user_id` returns an empty device set (no BAD_REQUEST).
- Private cohort resolution with a valid `?user_id` returns only devices owned by that user.
- Private cohort resolution with a malformed `user_id` returns a 400 (not a 500).
- Private grid resolution returns an empty site set (no BAD_REQUEST).

Unit tests for `getDevicesFromCohort` privacy paths (private/public cohort, with/without valid `user_id`) are tracked as a follow-up task.

---

## :boom: Breaking Changes

- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

> **Intentional transition change:** Cohorts default to `visibility: false` by design to protect partner data. Before this PR, the privacy field existed but was never enforced — all cohort data was accessible regardless of its value. With enforcement now active, any cohort with `visibility: false` will have its devices suppressed from public event and readings queries.
>
> **Pre-deploy requirement:** Before deploying, identify all cohorts whose data should remain publicly accessible and promote them using the operator script at `migrations/set-cohort-visibility-true.js`. Any cohort NOT promoted will correctly become private. Cohorts that have already been explicitly approved by their partner should be promoted; all others remain private as intended.

---

## :memo: Additional Notes

- **New admin endpoint — `POST /devices/cohorts/promote`:** Takes `admin_secret` and a `cohort_ids` array. Promotes the specified cohorts to `visibility: true` (publicly accessible). Returns `{ promoted, already_public, not_found }`. Requires `ADMIN_SETUP_SECRET` to be set in the environment. This replaces the need for a manual DB migration script when deploying.
- Implementation guides for the Analytics (`impl-notes-analytics-nicholas.md`) and Spatial (`impl-notes-spatial-raja.md`) microservice maintainers are included in `src/device-registry/` to document the `/generate` endpoint pattern. No code changes were made to those services.
- **Pre-deploy step required:** Before deploying, use the new `POST /devices/cohorts/promote` endpoint to promote only the cohorts that have been approved for public access. Cohorts not promoted remain private. See endpoint details below.
- The `user_id` owner bypass currently reads from `request.query`. A reviewer noted this allows callers to spoof another user's identity on public endpoints. Full mitigation (sourcing `user_id` from authenticated middleware, e.g. `request.user`) requires knowing which auth middleware is attached to these routes and is tracked as a follow-up security hardening task.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin endpoint to promote cohorts from private to public visibility, returning promoted/already-public/not-found summary.
  * Validation and admin-secret check added for cohort promotion.

* **Bug Fixes**
  * Privacy gating for grids and cohorts to avoid exposing suppressed site/device lists.
  * Device filtering refined so private-device lists exclude the requesting user's own devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->