### PR TITLE
fix: return user-friendly errors object on HttpError responses

### DIFF
--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -289,7 +289,7 @@ app.use(function (err, req, res, next) {
       res.status(err.statusCode).json({
         success: false,
         message: err.message,
-        errors: err.errors,
+        errors: err.errors ?? { message: err.message },
       });
     } else if (err instanceof SyntaxError) {
       res.status(400).json({


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Changes the global `HttpError` handler in `bin/server.js` to fall back to `{ message: err.message }` when `err.errors` is `null` or `undefined`, so all `HttpError` responses always include a non-null `errors` object.

**Before:**
```json
{
  "success": false,
  "message": "incorrect username or password",
  "errors": null
}
```

**After:**
```json
{
  "success": false,
  "message": "incorrect username or password",
  "errors": { "message": "incorrect username or password" }
}
```

### Why is this change needed?
`HttpError` is constructed without a third `errors` argument in several places (e.g. the passport local strategy on wrong password). This caused `errors: null` to be serialised in the response, which client applications cannot meaningfully display to users. Mobile and web UIs that read `errors.message` would crash or show nothing instead of a helpful message.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `bin/server.js` (global HttpError handler)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Tested `POST /api/v2/users/loginUser` with an incorrect password. Confirmed the response now returns `errors: { message: "incorrect username or password" }` instead of `errors: null`. Existing `HttpError` responses that already include an explicit `errors` object are unaffected (the `??` operator only triggers on `null`/`undefined`).

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Clients that were explicitly checking `errors === null` to detect wrong-password responses will now receive an object instead. However, this is a more correct and expected shape — no client should rely on a null errors field.

---

## :memo: Additional Notes
The fix uses the nullish coalescing operator (`??`) so it only activates when `errors` is strictly `null` or `undefined`. Explicit `errors` objects (e.g. validation error maps) are passed through unchanged. The one-line change in the `HttpError` branch of the global error handler covers every route in the service uniformly.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error response handling to ensure API error responses consistently include detailed error information instead of potentially returning empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->