### PR TITLE
fix: mailer timeouts, OAuth ECONNRESET, and duplicate verify token

### DIFF
--- a/src/auth-service/config/mailer.config.js
+++ b/src/auth-service/config/mailer.config.js
@@ -1,14 +1,17 @@
 const nodemailer = require("nodemailer");
 
-// Transporter for immediate, high-priority emails (fail-fast)
+// Transporter for immediate, high-priority emails.
+// 15s timeouts accommodate TLS handshake + DNS round-trip from a container
+// environment. The previous 5s window was too tight and caused frequent
+// fallbacks to the queue even on healthy connections.
 const directTransporter = nodemailer.createTransport({
   service: "gmail",
   auth: {
     user: `${process.env.MAIL_USER}`,
     pass: `${process.env.MAIL_PASS}`,
   },
-  connectionTimeout: 5000, // 5 seconds for quick sends
-  socketTimeout: 5000, // 5 seconds
+  connectionTimeout: 15000, // 15 seconds
+  socketTimeout: 15000, // 15 seconds
 });
 
 // Transporter for background queue processing (longer timeout for resilience)

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -723,7 +723,7 @@ const userController = {
       if (!request) return;
       const { email } = request.body;
       const { tenant } = request.query;
-      const token = userUtil.generateNumericToken(5);
+      const token = userUtil.generateNumericToken(6);
       const result = await userUtil.initiatePasswordReset({
         email,
         token,

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1282,11 +1282,30 @@ const authGoogle = passport.authenticate("google", {
 
 /**
  * Handles the Google OAuth callback (legacy route support).
+ * Wraps passport.authenticate so that transient network errors during the
+ * token exchange (e.g. ECONNRESET / InternalOAuthError) redirect to the
+ * failure URL instead of surfacing as an unhandled 500.
  */
-const authGoogleCallback = passport.authenticate("google", {
-  failureRedirect: `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}`,
-  session: false,
-});
+const authGoogleCallback = (req, res, next) => {
+  passport.authenticate("google", {
+    failureRedirect: `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}`,
+    session: false,
+  })(req, res, (err) => {
+    if (err) {
+      if (err.name === "InternalOAuthError" || err.oauthError) {
+        logger.error(
+          `Google OAuth token exchange failed: ${err.message}`,
+          { oauthError: err.oauthError?.message, code: err.oauthError?.code },
+        );
+        return res.redirect(
+          `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}?error=oauth_failed`,
+        );
+      }
+      return next(err);
+    }
+    next();
+  });
+};
 
 /**
  * Dynamically initiates OAuth flow for any supported provider.
@@ -1319,13 +1338,29 @@ const authOAuth = (req, res, next) => {
 /**
  * Dynamically handles the OAuth callback for any supported provider.
  * Used by the generic GET /auth/callback/:provider route.
+ * Catches InternalOAuthError (e.g. ECONNRESET during token exchange) and
+ * redirects to the failure URL rather than propagating a 500.
  */
 const authOAuthCallback = (req, res, next) => {
   const provider = req.oauthProvider || (req.params.provider || "").toLowerCase() || "google";
   passport.authenticate(provider, {
     failureRedirect: `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}`,
     session: false,
-  })(req, res, next);
+  })(req, res, (err) => {
+    if (err) {
+      if (err.name === "InternalOAuthError" || err.oauthError) {
+        logger.error(
+          `${provider} OAuth token exchange failed: ${err.message}`,
+          { provider, oauthError: err.oauthError?.message, code: err.oauthError?.code },
+        );
+        return res.redirect(
+          `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}?error=oauth_failed`,
+        );
+      }
+      return next(err);
+    }
+    next();
+  });
 };
 
 const authGuest = (req, res, next) => {

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1174,20 +1174,13 @@ function setOAuthProvider(req, res, next) {
     const tenant = req.query.tenant || "airqo";
     const provider = (req.params.provider || "google").toLowerCase();
 
-    const SUPPORTED_PROVIDERS = [
-      "google",
-      "github",
-      "linkedin",
-      "microsoft",
-      "twitter",
-    ];
-    if (!SUPPORTED_PROVIDERS.includes(provider)) {
+    if (!SUPPORTED_OAUTH_PROVIDERS.has(provider)) {
       return next(
         new HttpError(
           `Unsupported OAuth provider: ${provider}`,
           httpStatus.BAD_REQUEST,
           {
-            message: `Supported providers: ${SUPPORTED_PROVIDERS.join(", ")}`,
+            message: `Supported providers: ${[...SUPPORTED_OAUTH_PROVIDERS].join(", ")}`,
           },
         ),
       );
@@ -1280,9 +1273,10 @@ const authGoogle = passport.authenticate("google", {
   prompt: "select_account",
 });
 
-// Providers that are valid values to include in logs. Anything else is
-// replaced with "unknown" to prevent user-controlled input reaching log sinks.
-const KNOWN_OAUTH_PROVIDERS = new Set([
+// Single authoritative provider allowlist used for validation (setOAuthProvider)
+// and log sanitisation (handleOAuthCallbackError). Defined once here to prevent
+// the two lists from drifting out of sync.
+const SUPPORTED_OAUTH_PROVIDERS = new Set([
   "google",
   "github",
   "linkedin",
@@ -1293,10 +1287,13 @@ const KNOWN_OAUTH_PROVIDERS = new Set([
 /**
  * Safely appends ?error=oauth_failed (or &error=oauth_failed) to a redirect
  * URL regardless of whether it already contains a query string.
+ * Falls back to "/" when base is missing or not a string so the error handler
+ * never throws on an unconfigured GMAIL_VERIFICATION_FAILURE_REDIRECT.
  */
 function buildOAuthFailureRedirect(base) {
-  const separator = base.includes("?") ? "&" : "?";
-  return `${base}${separator}error=oauth_failed`;
+  const safeBase = typeof base === "string" && base.trim() !== "" ? base : "/";
+  const separator = safeBase.includes("?") ? "&" : "?";
+  return `${safeBase}${separator}error=oauth_failed`;
 }
 
 /**
@@ -1306,7 +1303,7 @@ function buildOAuthFailureRedirect(base) {
  */
 function handleOAuthCallbackError(err, provider, res, next) {
   if (err.name === "InternalOAuthError" || err.oauthError) {
-    const safeProvider = KNOWN_OAUTH_PROVIDERS.has(provider) ? provider : "unknown";
+    const safeProvider = SUPPORTED_OAUTH_PROVIDERS.has(provider) ? provider : "unknown";
     // Do not log err.message or oauthError.message — they may contain raw
     // OAuth tokens or secrets returned by the upstream provider.
     logger.error("OAuth token exchange failed", {

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1309,8 +1309,10 @@ function handleOAuthCallbackError(err, provider, res, next) {
     logger.error("OAuth token exchange failed", {
       provider: safeProvider,
       errorType: err.name || "OAuthError",
-      // err.oauthError.code is a short string like "ECONNRESET" — safe to log
-      code: err.oauthError?.code || null,
+      // Avoid logging any oauthError-derived content — it may contain raw
+      // OAuth tokens or secrets from the upstream provider. A boolean flag
+      // preserves observability without exposing sensitive data.
+      oauthErrorPresent: Boolean(err.oauthError),
     });
     return res.redirect(
       buildOAuthFailureRedirect(constants.GMAIL_VERIFICATION_FAILURE_REDIRECT),

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1280,6 +1280,48 @@ const authGoogle = passport.authenticate("google", {
   prompt: "select_account",
 });
 
+// Providers that are valid values to include in logs. Anything else is
+// replaced with "unknown" to prevent user-controlled input reaching log sinks.
+const KNOWN_OAUTH_PROVIDERS = new Set([
+  "google",
+  "github",
+  "linkedin",
+  "microsoft",
+  "twitter",
+]);
+
+/**
+ * Safely appends ?error=oauth_failed (or &error=oauth_failed) to a redirect
+ * URL regardless of whether it already contains a query string.
+ */
+function buildOAuthFailureRedirect(base) {
+  const separator = base.includes("?") ? "&" : "?";
+  return `${base}${separator}error=oauth_failed`;
+}
+
+/**
+ * Shared handler for InternalOAuthError inside passport callback wrappers.
+ * Logs a sanitised message (no raw OAuth payloads) and redirects to the
+ * configured failure URL.
+ */
+function handleOAuthCallbackError(err, provider, res, next) {
+  if (err.name === "InternalOAuthError" || err.oauthError) {
+    const safeProvider = KNOWN_OAUTH_PROVIDERS.has(provider) ? provider : "unknown";
+    // Do not log err.message or oauthError.message — they may contain raw
+    // OAuth tokens or secrets returned by the upstream provider.
+    logger.error("OAuth token exchange failed", {
+      provider: safeProvider,
+      errorType: err.name || "OAuthError",
+      // err.oauthError.code is a short string like "ECONNRESET" — safe to log
+      code: err.oauthError?.code || null,
+    });
+    return res.redirect(
+      buildOAuthFailureRedirect(constants.GMAIL_VERIFICATION_FAILURE_REDIRECT),
+    );
+  }
+  return next(err);
+}
+
 /**
  * Handles the Google OAuth callback (legacy route support).
  * Wraps passport.authenticate so that transient network errors during the
@@ -1291,18 +1333,7 @@ const authGoogleCallback = (req, res, next) => {
     failureRedirect: `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}`,
     session: false,
   })(req, res, (err) => {
-    if (err) {
-      if (err.name === "InternalOAuthError" || err.oauthError) {
-        logger.error(
-          `Google OAuth token exchange failed: ${err.message}`,
-          { oauthError: err.oauthError?.message, code: err.oauthError?.code },
-        );
-        return res.redirect(
-          `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}?error=oauth_failed`,
-        );
-      }
-      return next(err);
-    }
+    if (err) return handleOAuthCallbackError(err, "google", res, next);
     next();
   });
 };
@@ -1347,18 +1378,7 @@ const authOAuthCallback = (req, res, next) => {
     failureRedirect: `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}`,
     session: false,
   })(req, res, (err) => {
-    if (err) {
-      if (err.name === "InternalOAuthError" || err.oauthError) {
-        logger.error(
-          `${provider} OAuth token exchange failed: ${err.message}`,
-          { provider, oauthError: err.oauthError?.message, code: err.oauthError?.code },
-        );
-        return res.redirect(
-          `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}?error=oauth_failed`,
-        );
-      }
-      return next(err);
-    }
+    if (err) return handleOAuthCallbackError(err, provider, res, next);
     next();
   });
 };

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -1630,7 +1630,7 @@ const createUserModule = {
         const firebase_uid = firebaseUser.uid;
 
         // Generate the custom token
-        const token = generateNumericToken(5);
+        const token = generateNumericToken(6);
 
         let generateCacheRequest = Object.assign({}, request);
         const userIdentifier = firebaseUser.email
@@ -2278,7 +2278,7 @@ const createUserModule = {
         };
       }
 
-      const token = generateNumericToken(5); // 5-digit code
+      const token = generateNumericToken(6); // 6-digit code
       const update = {
         deletionToken: token,
         deletionTokenExpires: Date.now() + 3600000, // 1 hour
@@ -2303,7 +2303,7 @@ const createUserModule = {
           return {
             success: true,
             message:
-              "Account deletion process initiated. Please check your email for a 5-digit confirmation code.",
+              "Account deletion process initiated. Please check your email for a 6-digit confirmation code.",
             status: httpStatus.OK,
           };
         } else {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -2683,19 +2683,32 @@ const createUserModule = {
       const userId = newUser._doc._id;
 
       // ── STEP 6: Generate mobile verification token ─────────────────────────────
-      const verificationToken = generateNumericToken(5);
+      // Uses 6-digit tokens (1,000,000 space) and retries once on E11000
+      // collision before rolling back the user. The previous 5-digit token
+      // (100,000 space) was the root cause of duplicate key errors in production.
       const tokenExpiry = 86400; // 24 hrs in seconds
+      let verifyTokenResponse;
 
-      const tokenCreationBody = {
-        token: verificationToken,
-        name: newUser._doc.firstName,
-        expires: new Date(Date.now() + tokenExpiry * 1000),
-      };
-
-      const verifyTokenResponse = await VerifyTokenModel(dbTenant).register(
-        tokenCreationBody,
-        next,
-      );
+      for (let attempt = 1; attempt <= 2; attempt++) {
+        const verificationToken = generateNumericToken(6);
+        verifyTokenResponse = await VerifyTokenModel(dbTenant).register(
+          {
+            token: verificationToken,
+            name: newUser._doc.firstName,
+            expires: new Date(Date.now() + tokenExpiry * 1000),
+          },
+          next,
+        );
+        if (
+          verifyTokenResponse.success ||
+          verifyTokenResponse.status !== httpStatus.CONFLICT
+        ) {
+          break;
+        }
+        logger.warn(
+          `Verification token collision on attempt ${attempt} for mobile user ${normalizedEmail} — retrying`,
+        );
+      }
 
       if (verifyTokenResponse && verifyTokenResponse.success === false) {
         logger.error(
@@ -3116,26 +3129,39 @@ const createUserModule = {
         };
       }
 
-      // ✅ STEP 4: Generate mobile verification token (5-digit numeric)
-      const token = generateNumericToken(5);
-
-      const tokenCreationBody = {
-        token,
-        name: user.firstName,
-        expires: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
-      };
+      // ✅ STEP 4: Generate mobile verification token (6-digit numeric)
+      // 6-digit tokens give 1,000,000 possible values — 10× the previous
+      // 5-digit range — and retries once on collision before failing.
 
       // ✅ STEP 5: Create token with cleanup of old expired tokens
       try {
         await VerifyTokenModel(dbTenant).deleteMany({
           name: user.firstName,
-          token: { $regex: /^\d{5}$/ },
+          token: { $regex: /^\d{6}$/ },
           expires: { $lt: new Date() },
         });
 
-        const responseFromCreateToken = await VerifyTokenModel(
-          dbTenant,
-        ).register(tokenCreationBody, next);
+        let responseFromCreateToken;
+        for (let attempt = 1; attempt <= 2; attempt++) {
+          const token = generateNumericToken(6);
+          responseFromCreateToken = await VerifyTokenModel(dbTenant).register(
+            {
+              token,
+              name: user.firstName,
+              expires: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
+            },
+            next,
+          );
+          if (
+            responseFromCreateToken.success ||
+            responseFromCreateToken.status !== httpStatus.CONFLICT
+          ) {
+            break;
+          }
+          logger.warn(
+            `Verification token collision on attempt ${attempt} for mobile resend ${normalizedEmail} — retrying`,
+          );
+        }
 
         if (
           responseFromCreateToken &&

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -2688,9 +2688,11 @@ const createUserModule = {
       // (100,000 space) was the root cause of duplicate key errors in production.
       const tokenExpiry = 86400; // 24 hrs in seconds
       let verifyTokenResponse;
+      let verificationToken; // hoisted so STEP 7 email send can reference it
 
-      for (let attempt = 1; attempt <= 2; attempt++) {
-        const verificationToken = generateNumericToken(6);
+      const MAX_TOKEN_ATTEMPTS = 2;
+      for (let attempt = 1; attempt <= MAX_TOKEN_ATTEMPTS; attempt++) {
+        verificationToken = generateNumericToken(6);
         verifyTokenResponse = await VerifyTokenModel(dbTenant).register(
           {
             token: verificationToken,
@@ -2705,9 +2707,15 @@ const createUserModule = {
         ) {
           break;
         }
-        logger.warn(
-          `Verification token collision on attempt ${attempt} for mobile user ${normalizedEmail} — retrying`,
-        );
+        if (attempt < MAX_TOKEN_ATTEMPTS) {
+          logger.warn(
+            `Verification token collision on attempt ${attempt} for mobile user ${normalizedEmail} — retrying`,
+          );
+        } else {
+          logger.warn(
+            `Verification token collision on attempt ${attempt} for mobile user ${normalizedEmail} — no more retries`,
+          );
+        }
       }
 
       if (verifyTokenResponse && verifyTokenResponse.success === false) {
@@ -3142,8 +3150,11 @@ const createUserModule = {
         });
 
         let responseFromCreateToken;
-        for (let attempt = 1; attempt <= 2; attempt++) {
-          const token = generateNumericToken(6);
+        let token; // hoisted so STEP 6 email send can reference it
+
+        const MAX_TOKEN_ATTEMPTS = 2;
+        for (let attempt = 1; attempt <= MAX_TOKEN_ATTEMPTS; attempt++) {
+          token = generateNumericToken(6);
           responseFromCreateToken = await VerifyTokenModel(dbTenant).register(
             {
               token,
@@ -3158,9 +3169,15 @@ const createUserModule = {
           ) {
             break;
           }
-          logger.warn(
-            `Verification token collision on attempt ${attempt} for mobile resend ${normalizedEmail} — retrying`,
-          );
+          if (attempt < MAX_TOKEN_ATTEMPTS) {
+            logger.warn(
+              `Verification token collision on attempt ${attempt} for mobile resend ${normalizedEmail} — retrying`,
+            );
+          } else {
+            logger.warn(
+              `Verification token collision on attempt ${attempt} for mobile resend ${normalizedEmail} — no more retries`,
+            );
+          }
         }
 
         if (


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes three production errors observed in auth-service logs:

1. **Mailer timeouts** — increases `directTransporter` connection and socket timeouts from 5s to 15s in `config/mailer.config.js` to accommodate TLS handshake latency from containerised environments.

2. **OAuth ECONNRESET (500)** — converts `authGoogleCallback` and `authOAuthCallback` in `middleware/passport.js` from plain `passport.authenticate()` calls to wrapper functions that catch `InternalOAuthError` (socket hang up during the OAuth token exchange) and redirect to the configured failure URL instead of propagating an unhandled 500.

3. **Duplicate verify token (E11000)** — upgrades mobile email verification token generation from 5-digit to 6-digit numeric tokens (100k → 1M possible values) and adds a retry-on-collision loop in both the mobile registration and mobile verification resend flows in `utils/user.util.js`. Previously, a token collision silently deleted the newly created user account. Also updates the expired-token cleanup regex from `/^\d{5}$/` to `/^\d{6}$/`.

### Why is this change needed?
All three issues were observed in production logs on 2026-04-13 and 2026-04-15:

- **Mailer:** `High-priority email send failed ... Error: Timeout / Connection timeout` — emails were falling back to the queue on every send due to a timeout that was too aggressive for containerised Gmail SMTP.
- **OAuth:** `InternalOAuthError: Failed to obtain access token` with `oauthError: socket hang up (ECONNRESET)` — transient network error during Google token exchange caused users to see a 500 page instead of a retry-friendly redirect.
- **Duplicate token:** `E11000 duplicate key error collection: auth_prod_airqo.verify_tokens index: token_1 dup key: { token: "78318" }` — a 5-digit token space (100,000 values) is too small as the user base grows. A collision caused a newly registered user's account to be rolled back and deleted without them knowing.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`
  - `config/mailer.config.js` — directTransporter timeout increase
  - `middleware/passport.js` — OAuth callback error handling
  - `utils/user.util.js` — verify token generation and retry logic

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- **Mailer:** Confirmed high-priority emails send successfully without falling back to queue under normal network conditions.
- **OAuth:** Verified that a simulated ECONNRESET during the Google token exchange redirects to the failure URL with `?error=oauth_failed` instead of returning a 500.
- **Duplicate token:** Verified that a forced E11000 collision on the first attempt is transparently retried with a new token. Confirmed existing registrations with a clean token succeed on the first attempt with no behaviour change. Confirmed the expired-token cleanup query matches the new 6-digit format.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Mobile clients checking the length of the verification token (5 digits) will now receive a 6-digit token. If any client-side input mask enforces exactly 5 digits, it will need updating. The mobile app does not currently enforce a digit count on the verification input — confirmed safe.

---

## :memo: Additional Notes

- The OAuth fix uses the custom `next` callback form of `passport.authenticate()` — this is the documented pattern for error interception and does not change the success path.
- The token retry loop runs at most twice to avoid unbounded loops. If both attempts collide (astronomically unlikely with 1M token space), the error is returned as before — user is not deleted without reason.
- `authOAuth` (the initiation middleware) is unchanged — only the callback handlers needed the fix.
- The `directTransporter` timeout increase does not affect the `queueTransporter` (already 20s), which remains the fallback for sustained delivery failures.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth error handling with sanitized logs, consistent failure redirects, and more robust callback routing.
  * Added retry behavior for verification token registration to reduce transient conflicts.

* **Improvements**
  * Increased mobile verification codes from 5 to 6 digits and aligned related messaging.
  * Swapped password reset numeric tokens to 6 digits for stronger security.
  * Increased email delivery timeouts to improve reliability on slow connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->