### PR TITLE
fix: sanitize OAuth logs and align all token validators to 6-digit

### DIFF
--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1309,10 +1309,6 @@ function handleOAuthCallbackError(err, provider, res, next) {
     logger.error("OAuth token exchange failed", {
       provider: safeProvider,
       errorType: err.name || "OAuthError",
-      // Avoid logging any oauthError-derived content — it may contain raw
-      // OAuth tokens or secrets from the upstream provider. A boolean flag
-      // preserves observability without exposing sensitive data.
-      oauthErrorPresent: Boolean(err.oauthError),
     });
     return res.redirect(
       buildOAuthFailureRedirect(constants.GMAIL_VERIFICATION_FAILURE_REDIRECT),

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -2653,7 +2653,7 @@ const createUserModule = {
             user: null,
             data: {
               verificationEmailSent: true,
-              nextStep: "Check your email for a 5-digit verification code",
+              nextStep: "Check your email for a 6-digit verification code",
             },
           };
         }
@@ -2766,7 +2766,7 @@ const createUserModule = {
                 analyticsVersion: userDoc.analyticsVersion,
               },
               verificationEmailSent: true,
-              nextStep: "Check your email for a 5-digit verification code",
+              nextStep: "Check your email for a 6-digit verification code",
             },
           };
         } else {
@@ -3293,8 +3293,8 @@ const createUserModule = {
 
       const normalizedEmail = email.toLowerCase().trim();
 
-      // ✅ STEP 2: Token format validation for mobile (5-digit numeric)
-      if (!/^\d{5}$/.test(token)) {
+      // ✅ STEP 2: Token format validation for mobile (6-digit numeric)
+      if (!/^\d{6}$/.test(token)) {
         logger.warn(
           `Invalid mobile verification token format for ${normalizedEmail}`,
           {
@@ -3309,7 +3309,7 @@ const createUserModule = {
           success: false,
           message: "Invalid verification code format",
           errors: {
-            token: "Verification code must be a 5-digit number",
+            token: "Verification code must be a 6-digit number",
           },
         };
       }

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -3212,7 +3212,7 @@ const createUserModule = {
                 email: user.email,
                 verified: user.verified,
                 reminderSent: true,
-                codeLength: 5,
+                codeLength: 6,
                 expiresIn: "24 hours",
               },
             };

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -485,8 +485,8 @@ const verifyMobileEmail = [
       .isNumeric()
       .withMessage("Token must be numeric")
       .bail()
-      .isLength({ min: 5, max: 5 })
-      .withMessage("Token must be 5 digits")
+      .isLength({ min: 6, max: 6 })
+      .withMessage("Token must be 6 digits")
       .trim(),
     body("email")
       .exists()
@@ -1049,8 +1049,8 @@ const resetPassword = [
     .bail()
     .isNumeric()
     .withMessage("Token must be numeric")
-    .isLength({ min: 5, max: 5 })
-    .withMessage("Token must be 5 digits")
+    .isLength({ min: 6, max: 6 })
+    .withMessage("Token must be 6 digits")
     .trim(),
   body("password")
     .exists()
@@ -1329,8 +1329,8 @@ const confirmMobileAccountDeletion = [
       .trim()
       .isNumeric()
       .withMessage("token must be a numeric string")
-      .isLength({ min: 5, max: 5 })
-      .withMessage("token must be 5 characters long"),
+      .isLength({ min: 6, max: 6 })
+      .withMessage("token must be 6 characters long"),
   ],
 ];
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Two categories of changes:

**1. OAuth error log sanitisation (`middleware/passport.js`)**
- Removes all data derived from `err.oauthError` from the `logger.error` call inside `handleOAuthCallbackError`. The previous version logged `oauthErrorPresent: Boolean(err.oauthError)` which CodeQL (High) flagged as a clear-text data-flow from a sensitive OAuth error object. The log now contains only `provider` (allowlist-validated) and `errorType` (the error constructor name).

**2. Token length alignment — 5-digit → 6-digit (`validators/`, `utils/`)**
- Updates all request validators, runtime format checks, and user-facing message strings that still referenced 5-digit tokens after the token generation was upgraded to `generateNumericToken(6)` in a prior commit.

  | Location | Change |
  |---|---|
  | `validators/users.validators.js` — `verifyMobileEmail` | `isLength({ min: 5, max: 5 })` → `min: 6, max: 6`; message updated |
  | `validators/users.validators.js` — `resetPassword` | Same |
  | `validators/users.validators.js` — `confirmMobileAccountDeletion` | Same |
  | `utils/user.util.js` — runtime format guard | `/^\d{5}$/` → `/^\d{6}$/`; error message updated |
  | `utils/user.util.js` — two `nextStep` response strings | `"5-digit verification code"` → `"6-digit verification code"` |

### Why is this change needed?
- **OAuth log sanitisation:** CodeQL flagged `Boolean(err.oauthError)` as clear-text logging of sensitive data. Even a boolean derived from a sensitive object is enough to trigger the rule because the data flow touches `oauthError`. Removing the field entirely closes the finding while retaining all operationally useful fields (`provider`, `errorType`).
- **Token length alignment:** The token generators were upgraded to 6-digit in the preceding PR (`fix-auth-errors`) but the validators, runtime checks, and user-facing strings were not updated in the same pass. This left a gap where a valid 6-digit token submitted by the mobile app would be rejected by the 5-digit `isLength` validator before it ever reached the database lookup.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`
  - `middleware/passport.js` — OAuth error log field removed
  - `validators/users.validators.js` — three validators updated
  - `utils/user.util.js` — runtime regex, error message, and two response strings updated

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Submitted a 6-digit verification token through `POST /api/v2/users/verifyMobileEmail` — confirmed the validator now accepts it (previously rejected with "Token must be 5 digits").
- Submitted a 5-digit token — confirmed it is now rejected at the validator layer with "Token must be 6 digits".
- Triggered an OAuth ECONNRESET scenario — confirmed the error log contains only `provider` and `errorType` with no `oauthError`-derived fields; CodeQL finding no longer present.
- Password reset and account deletion flows manually tested end-to-end with 6-digit tokens — both accepted correctly.

---

## :boom: Breaking Changes
- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

Any mobile or web client that submits a **5-digit** token to `verifyMobileEmail`, `resetPassword`, or `confirmMobileAccountDeletion` will now receive a 400 validation error. This is intentional — the backend now only generates and accepts 6-digit tokens. Clients must be updated to handle 6-digit input fields before or alongside this deployment. The web token refresh guide and mobile implementation guide (`AUTHENTICATION_FIX_GUIDE.md`) already reflect the 6-digit format.

---

## :memo: Additional Notes
- The two code comments in `user.util.js` that mention "5-digit" (e.g. `// The previous 5-digit token...`) are historical context notes and were intentionally left unchanged — they accurately describe what the prior value was.
- This PR should be deployed **after** any mobile/web client changes that widen the token input from 5 to 6 digits, or deployed simultaneously if the client can handle both lengths during a transition window.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
