### PR TITLE
fix: exempt POST network-creation-requests from gateway auth

### DIFF
--- a/k8s/nginx/development/global-config.yaml
+++ b/k8s/nginx/development/global-config.yaml
@@ -151,6 +151,7 @@ data:
       if ($request_uri ~ '/api/(v1|v2)/users') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/grids/summary') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/events/running') { return 200; }
+      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?])') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }    
       if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # None API requests

--- a/k8s/nginx/development/global-config.yaml
+++ b/k8s/nginx/development/global-config.yaml
@@ -151,7 +151,7 @@ data:
       if ($request_uri ~ '/api/(v1|v2)/users') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/grids/summary') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/events/running') { return 200; }
-      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?])') { return 200; }
+      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }    
       if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # None API requests

--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -165,7 +165,7 @@ data:
       if ($request_uri ~ '^/api/(v1|v2)/devices/network-coverage($|[?])') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/network-coverage(/export|/monitors|/countries)($|/|[?])') { return 200; }
       if ($request ~ '^(POST|DELETE) /api/(v1|v2)/devices/network-coverage/registry($|/|[?])') { return 200; }
-      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?])') { return 200; }
+      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }
       if ($request_uri ~ '/argocd') { return 200; }
       if ($request_uri !~ '/api/v') { return 200; } # None API requests

--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -165,6 +165,7 @@ data:
       if ($request_uri ~ '^/api/(v1|v2)/devices/network-coverage($|[?])') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/network-coverage(/export|/monitors|/countries)($|/|[?])') { return 200; }
       if ($request ~ '^(POST|DELETE) /api/(v1|v2)/devices/network-coverage/registry($|/|[?])') { return 200; }
+      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?])') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }
       if ($request_uri ~ '/argocd') { return 200; }
       if ($request_uri !~ '/api/v') { return 200; } # None API requests

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -164,7 +164,7 @@ data:
       if ($request_uri ~ '^/api/(v1|v2)/devices/network-coverage($|[?])') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/network-coverage(/export|/monitors|/countries)($|/|[?])') { return 200; }
       if ($request ~ '^(POST|DELETE) /api/(v1|v2)/devices/network-coverage/registry($|/|[?])') { return 200; }
-      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?])') { return 200; }
+      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }
       if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # None API requests 

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -164,6 +164,7 @@ data:
       if ($request_uri ~ '^/api/(v1|v2)/devices/network-coverage($|[?])') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/network-coverage(/export|/monitors|/countries)($|/|[?])') { return 200; }
       if ($request ~ '^(POST|DELETE) /api/(v1|v2)/devices/network-coverage/registry($|/|[?])') { return 200; }
+      if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?])') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }
       if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # None API requests 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a gateway-level auth exemption for `POST /api/(v1|v2)/devices/network-creation-requests` across all three environments (development, staging, production). The exemption is method-scoped — only `POST` bypasses the auth check; all admin `GET` and `PUT` sub-routes remain protected.

### Why is this change needed?
The sensor manufacturer creation request endpoint is intentionally public — unauthenticated users must be able to submit requests without a token. Without this exemption, NGINX's global `auth_request /auth` directive was intercepting every request to the path and returning `401 Unauthorized` before it reached the service.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `k8s/nginx/development/global-config.yaml`
- `k8s/nginx/staging/global-config.yaml`
- `k8s/nginx/production/global-config.yaml`

No application code changed.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that `POST /api/v2/devices/network-creation-requests` returns `201` without an `Authorization` header. Confirmed that `GET /api/v2/devices/network-creation-requests` and `PUT /api/v2/devices/network-creation-requests/:id/approve` still return `401` without a token.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The exemption uses `$request` (full request line including method) rather than `$request_uri` to ensure the bypass is strictly scoped to the `POST` method on the collection endpoint. The trailing `($|[?])` anchor prevents the rule from accidentally matching sub-paths such as `/:id/approve` or `/:id/deny`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated NGINX authorization configuration across development, production, and staging environments to optimize request handling for device network creation API endpoints through the authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->