### PR TITLE
Fix per-request IP prefix DB scan by caching result in Redis

### DIFF
--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -43,6 +43,13 @@ const kafka = new Kafka({
   brokers: constants.KAFKA_BOOTSTRAP_SERVERS,
 });
 
+// Cache key and TTL for the IP-prefix blacklist.
+// The prefix list changes rarely; 10 minutes is the right trade-off between
+// freshness and eliminating the unbounded BlacklistedIPPrefixModel.find() that
+// was previously running on every single authenticated request.
+const IP_PREFIX_CACHE_KEY = "ip_prefix_blacklist_cache";
+const IP_PREFIX_CACHE_TTL_SECONDS = 10 * 60; // 10 minutes
+
 const getDay = () => {
   const now = new Date();
   const year = now.getFullYear();
@@ -458,7 +465,31 @@ const isIPBlacklistedHelper = async (
       AccessTokenModel("airqo")
         .findOne(accessTokenFilter)
         .select("name token client_id expiredEmailSent"),
-      BlacklistedIPPrefixModel("airqo").find().select("prefix").lean(),
+      // Redis-first cache for the prefix list — avoids a full-collection scan
+      // on every authenticated request. Falls through to MongoDB on cache miss
+      // or Redis unavailability; both failure paths are non-fatal.
+      (async () => {
+        try {
+          const cached = await redisGetAsync(IP_PREFIX_CACHE_KEY);
+          if (cached) return JSON.parse(cached);
+        } catch (_) {
+          // Redis unavailable — fall through to DB
+        }
+        const prefixes = await BlacklistedIPPrefixModel("airqo")
+          .find()
+          .select("prefix")
+          .lean();
+        try {
+          await redisSetAsync(
+            IP_PREFIX_CACHE_KEY,
+            JSON.stringify(prefixes),
+            IP_PREFIX_CACHE_TTL_SECONDS
+          );
+        } catch (_) {
+          // Cache write failure is non-fatal
+        }
+        return prefixes;
+      })(),
     ]);
 
     const {

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -471,13 +471,29 @@ const isIPBlacklistedHelper = async (
       (async () => {
         try {
           const cached = await redisGetAsync(IP_PREFIX_CACHE_KEY);
-          if (cached) return JSON.parse(cached);
+          if (cached) {
+            const parsed = JSON.parse(cached);
+            // Validate shape before trusting the cached value. A corrupted or
+            // unexpected payload (null, object, array of strings) would cause
+            // blacklistedIpPrefixesData.map(item => item.prefix) to throw and
+            // the outer catch to treat the request as blacklisted. Fall through
+            // to the DB if the shape is wrong.
+            if (
+              Array.isArray(parsed) &&
+              (parsed.length === 0 ||
+                (typeof parsed[0] === "object" &&
+                  parsed[0] !== null &&
+                  typeof parsed[0].prefix === "string"))
+            ) {
+              return parsed;
+            }
+          }
         } catch (_) {
-          // Redis unavailable — fall through to DB
+          // Redis unavailable or JSON.parse failure — fall through to DB
         }
         const prefixes = await BlacklistedIPPrefixModel("airqo")
           .find()
-          .select("prefix")
+          .select("prefix -_id")
           .lean();
         try {
           await redisSetAsync(

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1812,6 +1812,17 @@ const token = {
         finalStatus = httpStatus.BAD_REQUEST;
       }
 
+      // Invalidate the cached prefix list so the new entries are visible
+      // on the next request. Non-fatal — a stale cache is acceptable for
+      // up to IP_PREFIX_CACHE_TTL_SECONDS if Redis is momentarily unavailable.
+      if (successful_responses.length > 0) {
+        redisDelAsync(IP_PREFIX_CACHE_KEY).catch((err) =>
+          logger.warn(
+            `Failed to invalidate IP prefix cache after bulk insert: ${err.message}`,
+          ),
+        );
+      }
+
       return {
         success: true,
         data: { successful_responses, unsuccessful_responses },
@@ -1842,6 +1853,13 @@ const token = {
         { filter },
         next,
       );
+      if (response && response.success) {
+        redisDelAsync(IP_PREFIX_CACHE_KEY).catch((err) =>
+          logger.warn(
+            `Failed to invalidate IP prefix cache after removal: ${err.message}`,
+          ),
+        );
+      }
       return response;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
@@ -2299,6 +2317,13 @@ const token = {
         if (!prefixBlacklistResponse.success) {
           logger.error(
             `Failed to blacklist prefix ${ipPrefix}: ${prefixBlacklistResponse.message}`,
+          );
+        } else {
+          // New prefix written — invalidate cache so the next request picks it up immediately
+          redisDelAsync(IP_PREFIX_CACHE_KEY).catch((err) =>
+            logger.warn(
+              `Failed to invalidate IP prefix cache after auto-blacklist of ${ipPrefix}: ${err.message}`,
+            ),
           );
         }
       }

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -480,10 +480,12 @@ const isIPBlacklistedHelper = async (
             // to the DB if the shape is wrong.
             if (
               Array.isArray(parsed) &&
-              (parsed.length === 0 ||
-                (typeof parsed[0] === "object" &&
-                  parsed[0] !== null &&
-                  typeof parsed[0].prefix === "string"))
+              parsed.every(
+                (item) =>
+                  item !== null &&
+                  typeof item === "object" &&
+                  typeof item.prefix === "string",
+              )
             ) {
               return parsed;
             }
@@ -1760,6 +1762,13 @@ const token = {
         },
         next,
       );
+      if (response && response.success) {
+        redisDelAsync(IP_PREFIX_CACHE_KEY).catch((err) =>
+          logger.warn(
+            `Failed to invalidate IP prefix cache after single insert: ${err.message}`,
+          ),
+        );
+      }
       return response;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Caches the `BlacklistedIPPrefixModel.find()` result in Redis with a 10-minute TTL inside `isIPBlacklistedHelper` in `token.util.js`, replacing the previous behaviour where the entire `blacklisted_ip_prefixes` collection was fetched from MongoDB on every single authenticated API request.

### Why is this change needed?
The `isIPBlacklisted` function runs on every authenticated request as part of the token verification chain. It was executing 4 parallel MongoDB queries via `Promise.all`, one of which was an **unbounded `find()` on the `blacklisted_ip_prefixes` collection** — no filter, no limit, full collection scan — on every request.

This was identified during investigation of slow response times (31-second delays) on staging. While the primary cause of those delays was a separate aggregation pipeline issue, the token verification chain was confirmed to be adding unnecessary MongoDB load on every request across all microservices (since all requests pass through the Nginx gateway → auth-service verification before reaching any downstream service).

IP prefix rules are essentially static configuration data that changes rarely. Caching them for 10 minutes eliminates the per-request DB hit entirely on cache hits (~1 ms Redis read vs. full collection scan on MongoDB).

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :wrench: Enhancement/improvement
- [ ] :sparkles: New feature
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/auth-service` — `utils/token.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that authenticated requests correctly hit the Redis cache on subsequent calls after the first request (cache miss → DB fetch → cache write → cache hit on next request). Confirmed that when Redis is unavailable the function falls through to the MongoDB query transparently with no errors surfaced to the caller — matching the existing resilience pattern used by the rate limiter and blocked-domain cache in the same file.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`blacklistedIpPrefixesData` retains the same shape (`Array<{ prefix: string }>`). All downstream logic that reads `blacklistedIpPrefixes` is unchanged. The only difference is that the data may be up to 10 minutes stale relative to the database — acceptable for a security blocklist that is updated manually and infrequently.

---

## :memo: Additional Notes

**Before vs. after per request:**

| Query | Before | After (cache warm) |
|---|---|---|
| `BlacklistedIPModel.findOne({ ip })` | 1 DB query | unchanged |
| `WhitelistedIPModel.findOne({ ip })` | 1 DB query | unchanged |
| `AccessTokenModel.findOne(filter)` | 1 DB query | unchanged |
| `BlacklistedIPPrefixModel.find()` | **full collection scan every request** | **~1 ms Redis GET** |

**TTL choice — 10 minutes:**
The blocked-domain cache in the same file uses 5 minutes. IP prefix rules (CIDR blocks and single-octet prefixes) change even less frequently than blocked domains, making 10 minutes a safe and appropriate TTL.

**Failure resilience:**
Both the Redis read and write are wrapped in `try/catch`. Any Redis failure silently falls through to the MongoDB query, preserving pre-existing behaviour exactly. This matches the pattern already used by the rate limiter (`checkTokenVerifyRateLimit`) and the blocked-domain cache (`getBlockedDomains`) in this file.

**Consistency with existing patterns:**
The implementation mirrors the `blocked_domains_cache` Redis pattern already in `token.util.js` (lines 2609–2625 before this change), ensuring stylistic consistency and reviewability.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster authentication via a new server-side cache for blacklisted IP prefixes, reducing repeated database lookups.
* **Reliability / Bug Fixes**
  * Cache is invalidated automatically after blacklist updates so changes take effect promptly; cache read/write issues gracefully fall back to the database to preserve correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->