### PR TITLE
fix: add query timeouts, cohorts index, and fix grids $lookup

### DIFF
--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -542,6 +542,7 @@ deviceSchema.plugin(uniqueValidator, {
 
 deviceSchema.index({ site_id: 1 });
 deviceSchema.index({ mobility: 1 });
+deviceSchema.index({ cohorts: 1 });
 deviceSchema.index({ mobility: 1, cohorts: 1 });
 // Index for stale entity checks
 deviceSchema.index({ "onlineStatusAccuracy.lastCheck": 1 });

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1423,7 +1423,9 @@ const createCohort = {
       };
 
       // Get total count for pagination metadata before applying limit and skip
-      const total = await DeviceModel(tenant).countDocuments(filter);
+      const total = await DeviceModel(tenant)
+        .countDocuments(filter)
+        .maxTimeMS(45000);
 
       const pipeline = [
         { $match: filter },
@@ -1483,6 +1485,24 @@ const createCohort = {
             localField: "site.grids",
             foreignField: "_id",
             as: "grids",
+          },
+        },
+        {
+          // Trim grids to the same field subset the previous pipeline-form
+          // $project returned, keeping the response payload unchanged.
+          $addFields: {
+            grids: {
+              $map: {
+                input: "$grids",
+                as: "g",
+                in: {
+                  _id: "$$g._id",
+                  name: "$$g.name",
+                  admin_level: "$$g.admin_level",
+                  long_name: "$$g.long_name",
+                },
+              },
+            },
           },
         },
         {
@@ -1569,8 +1589,11 @@ const createCohort = {
         { $project: exclusionProjection },
       ];
 
+      // Mongoose 5.x ignores a plain-object second argument to .aggregate();
+      // options must be applied via .option() on the returned Aggregate instance.
       const paginatedResults = await DeviceModel(tenant)
-        .aggregate(pipeline, { maxTimeMS: 45000 })
+        .aggregate(pipeline)
+        .option({ maxTimeMS: 45000 })
         .allowDiskUse(true);
 
       // Post-processing for consistency
@@ -1738,6 +1761,7 @@ const createCohort = {
       const devicesInCohorts = await DeviceModel(tenant)
         .find(deviceFilter)
         .select("site_id deployment_type")
+        .maxTimeMS(45000)
         .lean();
 
       // Extract unique site IDs (only for static deployments with sites)
@@ -1778,7 +1802,9 @@ const createCohort = {
       };
 
       // Get total count for pagination
-      const total = await SiteModel(tenant).countDocuments(siteFilter);
+      const total = await SiteModel(tenant)
+        .countDocuments(siteFilter)
+        .maxTimeMS(45000);
 
       // Build aggregation pipeline for sites
       const inclusionProjection = constants.SITES_INCLUSION_PROJECTION;
@@ -1856,8 +1882,11 @@ const createCohort = {
         { $project: exclusionProjection },
       ];
 
+      // Mongoose 5.x ignores a plain-object second argument to .aggregate();
+      // options must be applied via .option() on the returned Aggregate instance.
       const paginatedResults = await SiteModel(tenant)
-        .aggregate(pipeline, { maxTimeMS: 45000 })
+        .aggregate(pipeline)
+        .option({ maxTimeMS: 45000 })
         .allowDiskUse(true);
 
       // Post-processing for consistency

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1475,13 +1475,13 @@ const createCohort = {
           },
         },
         {
+          // Simple-form $lookup allows MongoDB to use the _id index on the grids
+          // collection. The previous pipeline-form with $expr/$in blocked index
+          // usage, causing a full grids collection scan per device.
           $lookup: {
             from: "grids",
-            let: { gridIds: { $ifNull: ["$site.grids", []] } },
-            pipeline: [
-              { $match: { $expr: { $in: ["$_id", "$$gridIds"] } } },
-              { $project: { _id: 1, name: 1, admin_level: 1, long_name: 1 } },
-            ],
+            localField: "site.grids",
+            foreignField: "_id",
             as: "grids",
           },
         },
@@ -1570,7 +1570,7 @@ const createCohort = {
       ];
 
       const paginatedResults = await DeviceModel(tenant)
-        .aggregate(pipeline)
+        .aggregate(pipeline, { maxTimeMS: 45000 })
         .allowDiskUse(true);
 
       // Post-processing for consistency
@@ -1857,7 +1857,7 @@ const createCohort = {
       ];
 
       const paginatedResults = await SiteModel(tenant)
-        .aggregate(pipeline)
+        .aggregate(pipeline, { maxTimeMS: 45000 })
         .allowDiskUse(true);
 
       // Post-processing for consistency


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds `{ maxTimeMS: 45000 }` to the `listDevices` and `listSites` MongoDB aggregations so runaway queries are killed by the database after 45 seconds instead of holding a connection indefinitely
- Adds a standalone `{ cohorts: 1 }` index to the Device model so the `listSites` preliminary `DeviceModel.find()` (which filters by `cohorts` without a guaranteed `mobility` field) can use an index rather than scanning the collection
- Replaces the `$expr: { $in: ["$_id", "$$gridIds"] }` pipeline-form `$lookup` on the grids collection with the simple `localField`/`foreignField` form, allowing MongoDB to use the `_id` index instead of performing a full grids collection scan per device

### Why is this change needed?
The cohort endpoints (`/api/v2/devices/cohorts/devices` and `/api/v2/devices/cohorts/sites`) were returning 504 Gateway Timeouts under load. Root cause analysis identified three contributing factors in device-registry:
1. Aggregations had no server-side timeout — a slow query held a MongoDB connection for up to 10 minutes (socket timeout), starving the connection pool
2. The `listSites` pre-query filtered devices by `cohorts` field without a standalone index, causing a partial collection scan when `mobility` was absent from the filter
3. The grids `$lookup` used `$expr` with a pipeline variable, which blocks B-tree index usage and triggers a full grids collection scan for every device on every page

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :wrench: Enhancement/improvement
- [ ] :sparkles: New feature
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `utils/cohort.util.js`, `models/Device.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Tested against the `cohorts/devices` and `cohorts/sites` endpoints under normal single-organisation usage — responses complete within the expected 3–10 second window. The `maxTimeMS` timeout only fires on genuinely runaway queries and returns a descriptive error rather than a silent 504.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Adding indexes does not affect existing reads or writes. `maxTimeMS` only triggers on queries that exceed 45 seconds — these were already timing out at the NGINX layer with a 504, so callers now receive a cleaner error response sooner. The grids `$lookup` change returns the same document shape; null/missing `site.grids` produces an empty array `[]` in both the old and new form.

---

## :memo: Additional Notes
- The two Activity compound indexes (`{ device_id, activityType, createdAt }` and `{ device, activityType, createdAt }`) shipped in a prior PR are already declared in `models/Activity.js`. DevOps should build these indexes manually in MongoDB Atlas before the next deployment to avoid background index build I/O contention at startup.
- A standalone `{ cohorts: 1 }` index is added alongside the existing `{ mobility: 1, cohorts: 1 }` composite — the composite remains for queries that include both fields.
- The grids collection `_id` index is used by the simple-form `$lookup`; no new index needs to be created on that collection.
- The 45-second `maxTimeMS` is intentionally set below the 60-second NGINX `proxy_read_timeout` so the database error propagates to the caller before NGINX closes the connection.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced database query performance and efficiency.
  * Implemented timeout protections on aggregation operations to improve system stability and prevent extended processing delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->