### PR TITLE
feat: add pre-computed cohort snapshot endpoints and cross-service query timeouts

### DIFF
--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -1,0 +1,293 @@
+/**
+ * cohort-snapshot-job.js
+ *
+ * Runs every hour at :15 and pre-populates the CohortDeviceSnapshot and
+ * CohortSiteSnapshot collections for every active cohort.
+ *
+ * WHY:
+ *   POST /cohorts/devices and POST /cohorts/sites run a multi-$lookup MongoDB
+ *   aggregation that takes 3–10 seconds per page under normal load and times out
+ *   (504) under concurrent load. Pre-computing the results hourly means the new
+ *   POST /cohorts/cached-devices and POST /cohorts/cached-sites endpoints can
+ *   answer with a simple find() in <100 ms regardless of load.
+ *
+ * HOW:
+ *   1. Fetch all cohorts for the configured tenant.
+ *   2. For each cohort, call the existing listDevices / listSites util functions
+ *      in pages (BATCH_SIZE devices / sites per page) so each page stays within
+ *      the maxTimeMS budget already set on those functions.
+ *   3. Upsert each device / site into the snapshot collection keyed by
+ *      (cohort_id, device_id|site_id, tenant).
+ *   4. After a successful full refresh, remove any stale snapshot documents for
+ *      the cohort whose _snapshot_generated_at is older than the current run
+ *      (handles devices / sites that left the cohort since the last run).
+ */
+
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/cohort-snapshot-job`
+);
+const { logText } = require("@utils/shared");
+const cron = require("node-cron");
+const mongoose = require("mongoose");
+
+const CohortModel = require("@models/Cohort");
+const CohortDeviceSnapshotModel = require("@models/CohortDeviceSnapshot");
+const CohortSiteSnapshotModel = require("@models/CohortSiteSnapshot");
+const createCohortUtil = require("@utils/cohort.util");
+
+const TENANT = constants.DEFAULT_TENANT || "airqo";
+const JOB_NAME = "cohort-snapshot-job";
+const JOB_SCHEDULE = "15 * * * *"; // Every hour at :15
+const BATCH_SIZE = 50; // Devices / sites per page — keeps each page under 45 s maxTimeMS
+
+// Silent next() — the util functions call next(error) on failures; we log and
+// continue rather than crashing the job.
+const noop = (err) => {
+  if (err) logger.error(`${JOB_NAME} -- util error: ${err.message}`);
+};
+
+/**
+ * Build a synthetic request object that the util functions accept.
+ */
+function buildRequest({ cohortIds, tenant, skip, limit, extra = {} }) {
+  return {
+    body: { cohort_ids: cohortIds.map((id) => id.toString()) },
+    query: { tenant, skip, limit, ...extra },
+    params: {},
+  };
+}
+
+/**
+ * Upsert a batch of snapshot documents for devices.
+ */
+async function upsertDeviceSnapshots(cohortId, tenant, devices, runAt) {
+  if (!devices.length) return;
+  const ops = devices.map((device) => ({
+    updateOne: {
+      filter: {
+        cohort_id: cohortId,
+        device_id: device._id,
+        tenant,
+      },
+      update: {
+        $set: {
+          cohort_id: cohortId,
+          device_id: device._id,
+          tenant,
+          name: device.name || null,
+          isOnline: device.isOnline !== undefined ? device.isOnline : null,
+          status: device.status || null,
+          category: device.category || null,
+          network: device.network || null,
+          data: device,
+          _snapshot_generated_at: runAt,
+        },
+      },
+      upsert: true,
+    },
+  }));
+  await CohortDeviceSnapshotModel(tenant).bulkWrite(ops, { ordered: false });
+}
+
+/**
+ * Upsert a batch of snapshot documents for sites.
+ */
+async function upsertSiteSnapshots(cohortId, tenant, sites, runAt) {
+  if (!sites.length) return;
+  const ops = sites.map((site) => ({
+    updateOne: {
+      filter: {
+        cohort_id: cohortId,
+        site_id: site._id,
+        tenant,
+      },
+      update: {
+        $set: {
+          cohort_id: cohortId,
+          site_id: site._id,
+          tenant,
+          name: site.name || null,
+          search_name: site.search_name || null,
+          country: site.country || null,
+          data: site,
+          _snapshot_generated_at: runAt,
+        },
+      },
+      upsert: true,
+    },
+  }));
+  await CohortSiteSnapshotModel(tenant).bulkWrite(ops, { ordered: false });
+}
+
+/**
+ * Remove snapshot documents for a cohort that were NOT touched in this run.
+ * This cleans up devices / sites that have left the cohort since the last run.
+ */
+async function removeStaleSnapshots(cohortId, tenant, runAt) {
+  await Promise.all([
+    CohortDeviceSnapshotModel(tenant).deleteMany({
+      cohort_id: cohortId,
+      tenant,
+      _snapshot_generated_at: { $lt: runAt },
+    }),
+    CohortSiteSnapshotModel(tenant).deleteMany({
+      cohort_id: cohortId,
+      tenant,
+      _snapshot_generated_at: { $lt: runAt },
+    }),
+  ]);
+}
+
+/**
+ * Refresh the device snapshot for a single cohort.
+ */
+async function refreshDevicesForCohort(cohortId, tenant, runAt) {
+  let skip = 0;
+  let totalUpserted = 0;
+
+  while (true) {
+    const request = buildRequest({
+      cohortIds: [cohortId],
+      tenant,
+      skip,
+      limit: BATCH_SIZE,
+    });
+
+    let result;
+    try {
+      result = await createCohortUtil.listDevices(request, noop);
+    } catch (err) {
+      logger.error(
+        `${JOB_NAME} -- listDevices failed for cohort ${cohortId} skip=${skip}: ${err.message}`
+      );
+      break;
+    }
+
+    if (!result || !result.success || !result.data || !result.data.length) {
+      break;
+    }
+
+    await upsertDeviceSnapshots(cohortId, tenant, result.data, runAt);
+    totalUpserted += result.data.length;
+
+    if (result.data.length < BATCH_SIZE) break;
+    skip += BATCH_SIZE;
+  }
+
+  return totalUpserted;
+}
+
+/**
+ * Refresh the site snapshot for a single cohort.
+ */
+async function refreshSitesForCohort(cohortId, tenant, runAt) {
+  let skip = 0;
+  let totalUpserted = 0;
+
+  while (true) {
+    const request = buildRequest({
+      cohortIds: [cohortId],
+      tenant,
+      skip,
+      limit: BATCH_SIZE,
+    });
+
+    let result;
+    try {
+      result = await createCohortUtil.listSites(request, noop);
+    } catch (err) {
+      logger.error(
+        `${JOB_NAME} -- listSites failed for cohort ${cohortId} skip=${skip}: ${err.message}`
+      );
+      break;
+    }
+
+    if (!result || !result.success || !result.data || !result.data.length) {
+      break;
+    }
+
+    await upsertSiteSnapshots(cohortId, tenant, result.data, runAt);
+    totalUpserted += result.data.length;
+
+    if (result.data.length < BATCH_SIZE) break;
+    skip += BATCH_SIZE;
+  }
+
+  return totalUpserted;
+}
+
+/**
+ * Main job function — iterates all cohorts and refreshes both snapshots.
+ */
+async function runCohortSnapshotJob() {
+  const jobStart = new Date();
+  logText(`${JOB_NAME} -- starting at ${jobStart.toISOString()}`);
+
+  let cohorts;
+  try {
+    cohorts = await CohortModel(TENANT)
+      .find({})
+      .select("_id cohort_id")
+      .lean()
+      .maxTimeMS(30000);
+  } catch (err) {
+    logger.error(`${JOB_NAME} -- failed to fetch cohorts: ${err.message}`);
+    return;
+  }
+
+  if (!cohorts || cohorts.length === 0) {
+    logText(`${JOB_NAME} -- no cohorts found, exiting`);
+    return;
+  }
+
+  logText(`${JOB_NAME} -- processing ${cohorts.length} cohort(s)`);
+
+  let totalDevices = 0;
+  let totalSites = 0;
+  let cohortErrors = 0;
+
+  for (const cohort of cohorts) {
+    const cohortId = cohort._id;
+    const runAt = new Date(); // per-cohort timestamp for stale cleanup
+
+    try {
+      const [deviceCount, siteCount] = await Promise.all([
+        refreshDevicesForCohort(cohortId, TENANT, runAt),
+        refreshSitesForCohort(cohortId, TENANT, runAt),
+      ]);
+
+      // Remove devices / sites that left this cohort since the last run
+      await removeStaleSnapshots(cohortId, TENANT, runAt);
+
+      totalDevices += deviceCount;
+      totalSites += siteCount;
+
+      logText(
+        `${JOB_NAME} -- cohort ${cohortId}: ${deviceCount} device(s), ${siteCount} site(s) refreshed`
+      );
+    } catch (err) {
+      logger.error(
+        `${JOB_NAME} -- error processing cohort ${cohortId}: ${err.message}`
+      );
+      cohortErrors++;
+    }
+  }
+
+  const elapsed = ((Date.now() - jobStart) / 1000).toFixed(1);
+  logText(
+    `${JOB_NAME} -- completed in ${elapsed}s: ${totalDevices} devices, ${totalSites} sites refreshed across ${cohorts.length} cohort(s), ${cohortErrors} error(s)`
+  );
+}
+
+// Schedule the job
+cron.schedule(JOB_SCHEDULE, () => {
+  runCohortSnapshotJob().catch((err) => {
+    logger.error(`${JOB_NAME} -- unhandled error: ${err.message}`);
+  });
+});
+
+logText(`${JOB_NAME} -- scheduled (${JOB_SCHEDULE})`);
+
+module.exports = { runCohortSnapshotJob };

--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -30,8 +30,6 @@ const logger = log4js.getLogger(
 );
 const { logText } = require("@utils/shared");
 const cron = require("node-cron");
-const mongoose = require("mongoose");
-
 const CohortModel = require("@models/Cohort");
 const CohortDeviceSnapshotModel = require("@models/CohortDeviceSnapshot");
 const CohortSiteSnapshotModel = require("@models/CohortSiteSnapshot");
@@ -162,21 +160,30 @@ async function refreshDevicesForCohort(cohortId, tenant, runAt) {
       logger.error(
         `${JOB_NAME} -- listDevices failed for cohort ${cohortId} skip=${skip}: ${err.message}`
       );
-      break;
+      // Propagate incomplete flag so the caller skips stale pruning
+      return { count: totalUpserted, complete: false };
     }
 
-    if (!result || !result.success || !result.data || !result.data.length) {
-      break;
+    if (!result || !result.success) {
+      logger.error(
+        `${JOB_NAME} -- listDevices returned failure for cohort ${cohortId} skip=${skip}`
+      );
+      return { count: totalUpserted, complete: false };
+    }
+
+    // Natural end of data — pagination exhausted
+    if (!result.data || !result.data.length) {
+      return { count: totalUpserted, complete: true };
     }
 
     await upsertDeviceSnapshots(cohortId, tenant, result.data, runAt);
     totalUpserted += result.data.length;
 
-    if (result.data.length < BATCH_SIZE) break;
+    if (result.data.length < BATCH_SIZE) {
+      return { count: totalUpserted, complete: true };
+    }
     skip += BATCH_SIZE;
   }
-
-  return totalUpserted;
 }
 
 /**
@@ -201,21 +208,30 @@ async function refreshSitesForCohort(cohortId, tenant, runAt) {
       logger.error(
         `${JOB_NAME} -- listSites failed for cohort ${cohortId} skip=${skip}: ${err.message}`
       );
-      break;
+      // Propagate incomplete flag so the caller skips stale pruning
+      return { count: totalUpserted, complete: false };
     }
 
-    if (!result || !result.success || !result.data || !result.data.length) {
-      break;
+    if (!result || !result.success) {
+      logger.error(
+        `${JOB_NAME} -- listSites returned failure for cohort ${cohortId} skip=${skip}`
+      );
+      return { count: totalUpserted, complete: false };
+    }
+
+    // Natural end of data — pagination exhausted
+    if (!result.data || !result.data.length) {
+      return { count: totalUpserted, complete: true };
     }
 
     await upsertSiteSnapshots(cohortId, tenant, result.data, runAt);
     totalUpserted += result.data.length;
 
-    if (result.data.length < BATCH_SIZE) break;
+    if (result.data.length < BATCH_SIZE) {
+      return { count: totalUpserted, complete: true };
+    }
     skip += BATCH_SIZE;
   }
-
-  return totalUpserted;
 }
 
 /**
@@ -253,19 +269,27 @@ async function runCohortSnapshotJob() {
     const runAt = new Date(); // per-cohort timestamp for stale cleanup
 
     try {
-      const [deviceCount, siteCount] = await Promise.all([
+      const [deviceResult, siteResult] = await Promise.all([
         refreshDevicesForCohort(cohortId, TENANT, runAt),
         refreshSitesForCohort(cohortId, TENANT, runAt),
       ]);
 
-      // Remove devices / sites that left this cohort since the last run
-      await removeStaleSnapshots(cohortId, TENANT, runAt);
+      totalDevices += deviceResult.count;
+      totalSites += siteResult.count;
 
-      totalDevices += deviceCount;
-      totalSites += siteCount;
+      // Only prune stale documents when both refreshes completed without error.
+      // If either was interrupted mid-pagination, pruning would incorrectly delete
+      // valid snapshot documents for the portion that was not yet upserted.
+      if (deviceResult.complete && siteResult.complete) {
+        await removeStaleSnapshots(cohortId, TENANT, runAt);
+      } else {
+        logger.warn(
+          `${JOB_NAME} -- cohort ${cohortId}: skipping stale pruning (devices complete=${deviceResult.complete}, sites complete=${siteResult.complete})`
+        );
+      }
 
       logText(
-        `${JOB_NAME} -- cohort ${cohortId}: ${deviceCount} device(s), ${siteCount} site(s) refreshed`
+        `${JOB_NAME} -- cohort ${cohortId}: ${deviceResult.count} device(s), ${siteResult.count} site(s) refreshed`
       );
     } catch (err) {
       logger.error(
@@ -277,7 +301,7 @@ async function runCohortSnapshotJob() {
 
   const elapsed = ((Date.now() - jobStart) / 1000).toFixed(1);
   logText(
-    `${JOB_NAME} -- completed in ${elapsed}s: ${totalDevices} devices, ${totalSites} sites refreshed across ${cohorts.length} cohort(s), ${cohortErrors} error(s)`
+    `${JOB_NAME} -- completed in ${elapsed}s: ${totalDevices} device(s), ${totalSites} site(s) refreshed across ${cohorts.length} cohort(s), ${cohortErrors} error(s)`
   );
 }
 

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -263,7 +263,9 @@ try {
 try {
   require("@bin/jobs/cohort-snapshot-job");
 } catch (jobError) {
-  console.error(`❌ cohort-snapshot-job failed to start: ${jobError.message}`);
+  global.dedupLogger.error(
+    `❌ cohort-snapshot-job failed to start: ${jobError.message}`
+  );
   // Continue - server stays up
 }
 

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -259,6 +259,14 @@ try {
   }
 }
 
+// Cohort snapshot pre-computation job (every hour at :15)
+try {
+  require("@bin/jobs/cohort-snapshot-job");
+} catch (jobError) {
+  console.error(`❌ cohort-snapshot-job failed to start: ${jobError.message}`);
+  // Continue - server stays up
+}
+
 if (isEmpty(constants.SESSION_SECRET)) {
   throw new Error("SESSION_SECRET environment variable not set");
 }

--- a/src/device-registry/controllers/cohort.controller.js
+++ b/src/device-registry/controllers/cohort.controller.js
@@ -377,6 +377,28 @@ const createCohort = {
       handleError(error, next);
     }
   },
+  listCachedDevicesByCohort: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await createCohortUtil.listCachedDevices(request, next);
+      handleResponse({ res, result, key: "devices" });
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
+  listCachedSitesByCohort: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await createCohortUtil.listCachedSites(request, next);
+      handleResponse({ res, result, key: "sites" });
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
   promoteCohorts: async (req, res, next) => {
     try {
       const request = handleRequest(req, next);

--- a/src/device-registry/models/CohortDeviceSnapshot.js
+++ b/src/device-registry/models/CohortDeviceSnapshot.js
@@ -1,0 +1,87 @@
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+
+/**
+ * CohortDeviceSnapshot — flat pre-computed collection for fast cohort device reads.
+ *
+ * Each document represents one enriched device record for a specific cohort. The
+ * data is exactly what POST /cohorts/devices returns, written here by the hourly
+ * cohort-snapshot-job. The live endpoint POST /cohorts/cached-devices then serves
+ * these documents with a simple find(), skip(), limit() — no aggregation required.
+ *
+ * Indexed filter fields (name, isOnline, status, category, network) are lifted to
+ * the top level so queries can use indexes. The full enriched device document is
+ * stored in the `data` field and returned as-is to the caller.
+ *
+ * TTL: documents auto-expire after 25 hours if the job fails to refresh them.
+ */
+const cohortDeviceSnapshotSchema = new mongoose.Schema(
+  {
+    cohort_id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+    device_id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+    tenant: {
+      type: String,
+      required: true,
+    },
+    // Top-level filter fields — copies from device data to support indexed queries
+    name: { type: String },
+    isOnline: { type: Boolean },
+    status: { type: String },
+    category: { type: String },
+    network: { type: String },
+    // Full enriched device document as returned by listDevices
+    data: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true,
+    },
+    // When this snapshot document was last computed
+    _snapshot_generated_at: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+  },
+  { timestamps: false }
+);
+
+// Unique compound key used for upserts in the snapshot job
+cohortDeviceSnapshotSchema.index(
+  { cohort_id: 1, device_id: 1, tenant: 1 },
+  { unique: true }
+);
+
+// Support search on name within a cohort
+cohortDeviceSnapshotSchema.index({ cohort_id: 1, tenant: 1, name: 1 });
+
+// Support isOnline / status filter within a cohort
+cohortDeviceSnapshotSchema.index({ cohort_id: 1, tenant: 1, isOnline: 1 });
+
+// Auto-expire stale documents after 25 hours (safety net if the job stops running)
+cohortDeviceSnapshotSchema.index(
+  { _snapshot_generated_at: 1 },
+  { expireAfterSeconds: 90000 }
+);
+
+const CohortDeviceSnapshotModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("cohortdevicesnapshots");
+  } catch (error) {
+    return getModelByTenant(
+      dbTenant,
+      "cohortdevicesnapshot",
+      cohortDeviceSnapshotSchema
+    );
+  }
+};
+
+module.exports = CohortDeviceSnapshotModel;

--- a/src/device-registry/models/CohortDeviceSnapshot.js
+++ b/src/device-registry/models/CohortDeviceSnapshot.js
@@ -61,8 +61,13 @@ cohortDeviceSnapshotSchema.index(
 // Support search on name within a cohort
 cohortDeviceSnapshotSchema.index({ cohort_id: 1, tenant: 1, name: 1 });
 
-// Support isOnline / status filter within a cohort
+// Support isOnline filter within a cohort
 cohortDeviceSnapshotSchema.index({ cohort_id: 1, tenant: 1, isOnline: 1 });
+
+// Support status / category / network filters within a cohort
+cohortDeviceSnapshotSchema.index({ cohort_id: 1, tenant: 1, status: 1 });
+cohortDeviceSnapshotSchema.index({ cohort_id: 1, tenant: 1, category: 1 });
+cohortDeviceSnapshotSchema.index({ cohort_id: 1, tenant: 1, network: 1 });
 
 // Auto-expire stale documents after 25 hours (safety net if the job stops running)
 cohortDeviceSnapshotSchema.index(
@@ -74,7 +79,7 @@ const CohortDeviceSnapshotModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
   try {
-    return mongoose.model("cohortdevicesnapshots");
+    return mongoose.model("cohortdevicesnapshot");
   } catch (error) {
     return getModelByTenant(
       dbTenant,

--- a/src/device-registry/models/CohortSiteSnapshot.js
+++ b/src/device-registry/models/CohortSiteSnapshot.js
@@ -48,6 +48,7 @@ cohortSiteSnapshotSchema.index(
 );
 
 cohortSiteSnapshotSchema.index({ cohort_id: 1, tenant: 1, name: 1 });
+cohortSiteSnapshotSchema.index({ cohort_id: 1, tenant: 1, search_name: 1 });
 cohortSiteSnapshotSchema.index({ cohort_id: 1, tenant: 1, country: 1 });
 
 cohortSiteSnapshotSchema.index(
@@ -59,7 +60,7 @@ const CohortSiteSnapshotModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
   try {
-    return mongoose.model("cohortsitesnapshots");
+    return mongoose.model("cohortsitesnapshot");
   } catch (error) {
     return getModelByTenant(
       dbTenant,

--- a/src/device-registry/models/CohortSiteSnapshot.js
+++ b/src/device-registry/models/CohortSiteSnapshot.js
@@ -1,0 +1,72 @@
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+
+/**
+ * CohortSiteSnapshot — flat pre-computed collection for fast cohort site reads.
+ *
+ * Mirror of CohortDeviceSnapshot for sites. Each document represents one enriched
+ * site record for a specific cohort, written hourly by cohort-snapshot-job and
+ * served by POST /cohorts/cached-sites using a simple find() with no aggregation.
+ */
+const cohortSiteSnapshotSchema = new mongoose.Schema(
+  {
+    cohort_id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+    site_id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+    tenant: {
+      type: String,
+      required: true,
+    },
+    // Top-level filter fields
+    name: { type: String },
+    search_name: { type: String },
+    country: { type: String },
+    // Full enriched site document as returned by listSites
+    data: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true,
+    },
+    _snapshot_generated_at: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+  },
+  { timestamps: false }
+);
+
+cohortSiteSnapshotSchema.index(
+  { cohort_id: 1, site_id: 1, tenant: 1 },
+  { unique: true }
+);
+
+cohortSiteSnapshotSchema.index({ cohort_id: 1, tenant: 1, name: 1 });
+cohortSiteSnapshotSchema.index({ cohort_id: 1, tenant: 1, country: 1 });
+
+cohortSiteSnapshotSchema.index(
+  { _snapshot_generated_at: 1 },
+  { expireAfterSeconds: 90000 }
+);
+
+const CohortSiteSnapshotModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("cohortsitesnapshots");
+  } catch (error) {
+    return getModelByTenant(
+      dbTenant,
+      "cohortsitesnapshot",
+      cohortSiteSnapshotSchema
+    );
+  }
+};
+
+module.exports = CohortSiteSnapshotModel;

--- a/src/device-registry/routes/v2/cohorts.routes.js
+++ b/src/device-registry/routes/v2/cohorts.routes.js
@@ -177,6 +177,24 @@ router.post(
   createCohortController.listDevicesByCohort,
 );
 
+// Pre-computed snapshot endpoints — same request body / response shape as the
+// live endpoints above, served from a flat pre-populated collection (no
+// aggregation pipeline at request time). Falls back to the live query when the
+// snapshot is not yet populated for a given cohort.
+router.post(
+  "/cached-sites",
+  cohortValidations.listSites,
+  pagination(),
+  createCohortController.listCachedSitesByCohort,
+);
+
+router.post(
+  "/cached-devices",
+  cohortValidations.listDevices,
+  pagination(),
+  createCohortController.listCachedDevicesByCohort,
+);
+
 router.get(
   "/:cohort_id",
   cohortValidations.getCohort,

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -2048,8 +2048,8 @@ const createCohort = {
         } = {},
       } = request;
 
-      const _skip = parseInt(rawSkip, 10) || 0;
-      const _limit = Math.min(parseInt(rawLimit, 10) || 10, 100);
+      const _skip = Math.max(0, parseInt(rawSkip, 10) || 0);
+      const _limit = Math.min(Math.max(1, parseInt(rawLimit, 10) || 10), 100);
 
       if (!cohort_ids.length) {
         return {
@@ -2073,22 +2073,22 @@ const createCohort = {
         };
       }
 
-      // Check whether the snapshot collection has data for these cohorts
-      const snapshotExists = await CohortDeviceSnapshotModel(tenant)
-        .findOne({ cohort_id: { $in: cohortObjectIds }, tenant })
-        .select("_id")
-        .lean()
+      // Check whether the snapshot collection has data for ALL requested cohorts.
+      // distinct() returns one entry per cohort that has at least one snapshot,
+      // so comparing the count against cohortObjectIds.length detects partial coverage.
+      const coveredCohortIds = await CohortDeviceSnapshotModel(tenant)
+        .distinct("cohort_id", { cohort_id: { $in: cohortObjectIds }, tenant })
         .maxTimeMS(5000);
 
-      // Fall back to the live aggregation if the snapshot is not yet populated
-      if (!snapshotExists) {
+      // Fall back to the live aggregation if any cohort lacks snapshot data
+      if (coveredCohortIds.length < cohortObjectIds.length) {
         logger.warn(
-          `listCachedDevices -- no snapshot found for cohort_ids [${cohort_ids}], falling back to live query`
+          `listCachedDevices -- snapshot incomplete for cohort_ids [${cohort_ids}] (${coveredCohortIds.length}/${cohortObjectIds.length} covered), falling back to live query`
         );
         return createCohort.listDevices(request, next);
       }
 
-      // Build the filter
+      // Build the filter — use top-level indexed fields, not data.*
       const filter = {
         cohort_id: { $in: cohortObjectIds },
         tenant,
@@ -2097,13 +2097,13 @@ const createCohort = {
         filter.name = { $regex: search, $options: "i" };
       }
       if (status) {
-        filter["data.status"] = status;
+        filter.status = status;
       }
       if (category) {
-        filter["data.category"] = category;
+        filter.category = category;
       }
       if (network) {
-        filter["data.network"] = network;
+        filter.network = network;
       }
 
       const [total, snapshots] = await Promise.all([
@@ -2114,22 +2114,38 @@ const createCohort = {
           .find(filter)
           .skip(_skip)
           .limit(_limit)
-          .select("data _snapshot_generated_at")
+          .select("device_id data _snapshot_generated_at")
           .lean()
           .maxTimeMS(10000),
       ]);
 
-      const devices = snapshots.map((s) => s.data);
+      // Deduplicate by device_id when a device appears in multiple cohorts
+      const seen = new Map();
+      for (const s of snapshots) {
+        const key = s.device_id.toString();
+        if (!seen.has(key)) seen.set(key, s.data);
+      }
+      const devices = [...seen.values()];
+
+      // Report the oldest snapshot age so the caller knows the cache staleness
       const cacheGeneratedAt =
-        snapshots.length > 0 ? snapshots[0]._snapshot_generated_at : null;
+        snapshots.length > 0
+          ? new Date(Math.min(...snapshots.map((s) => +s._snapshot_generated_at)))
+          : null;
+
+      const totalPages = Math.ceil(total / _limit);
 
       return {
         success: true,
         message: "Successfully retrieved cached devices",
         data: devices,
-        total,
-        skip: _skip,
-        limit: _limit,
+        meta: {
+          total,
+          skip: _skip,
+          limit: _limit,
+          page: Math.floor(_skip / _limit) + 1,
+          totalPages,
+        },
         cache_generated_at: cacheGeneratedAt,
       };
     } catch (error) {
@@ -2162,8 +2178,8 @@ const createCohort = {
         } = {},
       } = request;
 
-      const _skip = parseInt(rawSkip, 10) || 0;
-      const _limit = Math.min(parseInt(rawLimit, 10) || 10, 100);
+      const _skip = Math.max(0, parseInt(rawSkip, 10) || 0);
+      const _limit = Math.min(Math.max(1, parseInt(rawLimit, 10) || 10), 100);
 
       if (!cohort_ids.length) {
         return {
@@ -2187,15 +2203,14 @@ const createCohort = {
         };
       }
 
-      const snapshotExists = await CohortSiteSnapshotModel(tenant)
-        .findOne({ cohort_id: { $in: cohortObjectIds }, tenant })
-        .select("_id")
-        .lean()
+      // Check whether the snapshot collection has data for ALL requested cohorts
+      const coveredCohortIds = await CohortSiteSnapshotModel(tenant)
+        .distinct("cohort_id", { cohort_id: { $in: cohortObjectIds }, tenant })
         .maxTimeMS(5000);
 
-      if (!snapshotExists) {
+      if (coveredCohortIds.length < cohortObjectIds.length) {
         logger.warn(
-          `listCachedSites -- no snapshot found for cohort_ids [${cohort_ids}], falling back to live query`
+          `listCachedSites -- snapshot incomplete for cohort_ids [${cohort_ids}] (${coveredCohortIds.length}/${cohortObjectIds.length} covered), falling back to live query`
         );
         return createCohort.listSites(request, next);
       }
@@ -2222,22 +2237,38 @@ const createCohort = {
           .find(filter)
           .skip(_skip)
           .limit(_limit)
-          .select("data _snapshot_generated_at")
+          .select("site_id data _snapshot_generated_at")
           .lean()
           .maxTimeMS(10000),
       ]);
 
-      const sites = snapshots.map((s) => s.data);
+      // Deduplicate by site_id when a site appears in multiple cohorts
+      const seen = new Map();
+      for (const s of snapshots) {
+        const key = s.site_id.toString();
+        if (!seen.has(key)) seen.set(key, s.data);
+      }
+      const sites = [...seen.values()];
+
+      // Report the oldest snapshot age so the caller knows the cache staleness
       const cacheGeneratedAt =
-        snapshots.length > 0 ? snapshots[0]._snapshot_generated_at : null;
+        snapshots.length > 0
+          ? new Date(Math.min(...snapshots.map((s) => +s._snapshot_generated_at)))
+          : null;
+
+      const totalPages = Math.ceil(total / _limit);
 
       return {
         success: true,
         message: "Successfully retrieved cached sites",
         data: sites,
-        total,
-        skip: _skip,
-        limit: _limit,
+        meta: {
+          total,
+          skip: _skip,
+          limit: _limit,
+          page: Math.floor(_skip / _limit) + 1,
+          totalPages,
+        },
         cache_generated_at: cacheGeneratedAt,
       };
     } catch (error) {

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -1,6 +1,8 @@
 const CohortModel = require("@models/Cohort");
 const DeviceModel = require("@models/Device");
 const SiteModel = require("@models/Site");
+const CohortDeviceSnapshotModel = require("@models/CohortDeviceSnapshot");
+const CohortSiteSnapshotModel = require("@models/CohortSiteSnapshot");
 const qs = require("qs");
 const networkUtil = require("@utils/network.util");
 const isEmpty = require("is-empty");
@@ -1933,19 +1935,29 @@ const createCohort = {
                 : latestRecallment
               : latestRecall || latestRecallment || null;
 
-          const deviceActivitySummary = site.devices.map((device) => {
-            const deviceActivities = site.activities.filter(
-              (activity) =>
-                activity.device === device.name ||
-                (activity.device_id &&
-                  activity.device_id.toString() === device._id.toString()),
-            );
-            return {
-              device_id: device._id,
-              device_name: device.name,
-              activity_count: deviceActivities.length,
-            };
-          });
+          // Build separate count maps (O(n)) to avoid an O(n²) nested filter
+          // across site.devices × site.activities for every site.
+          // Activities with device_id are keyed by id; legacy name-only
+          // activities are keyed by name — matching the original OR logic
+          // without the risk of double-counting an activity that carries both.
+          const activityCountById = {};
+          const activityCountByName = {};
+          for (const activity of site.activities) {
+            if (activity.device_id) {
+              const key = activity.device_id.toString();
+              activityCountById[key] = (activityCountById[key] || 0) + 1;
+            } else if (activity.device) {
+              activityCountByName[activity.device] =
+                (activityCountByName[activity.device] || 0) + 1;
+            }
+          }
+          const deviceActivitySummary = site.devices.map((device) => ({
+            device_id: device._id,
+            device_name: device.name,
+            activity_count:
+              (activityCountById[device._id.toString()] || 0) +
+              (activityCountByName[device.name] || 0),
+          }));
           site.device_activity_summary = deviceActivitySummary;
         } else {
           site.activities_by_type = {};
@@ -2008,6 +2020,234 @@ const createCohort = {
           httpStatus.INTERNAL_SERVER_ERROR,
           { message: error.message },
         ),
+      );
+    }
+  },
+
+
+  /**
+   * listCachedDevices — serve devices from the pre-computed CohortDeviceSnapshot
+   * collection. Falls back transparently to the live listDevices aggregation when
+   * the snapshot is empty (e.g. new cohort, first run before the job fires).
+   *
+   * Accepts the same request body / query shape as listDevices so callers need
+   * only swap the endpoint URL.
+   */
+  listCachedDevices: async (request, next) => {
+    try {
+      const {
+        body: { cohort_ids = [] } = {},
+        query: {
+          tenant,
+          skip: rawSkip = 0,
+          limit: rawLimit = 10,
+          search,
+          status,
+          category,
+          network,
+        } = {},
+      } = request;
+
+      const _skip = parseInt(rawSkip, 10) || 0;
+      const _limit = Math.min(parseInt(rawLimit, 10) || 10, 100);
+
+      if (!cohort_ids.length) {
+        return {
+          success: false,
+          status: httpStatus.BAD_REQUEST,
+          message: "cohort_ids is required",
+          errors: { message: "cohort_ids array must not be empty" },
+        };
+      }
+
+      const cohortObjectIds = cohort_ids
+        .filter((id) => ObjectId.isValid(id))
+        .map((id) => ObjectId(id));
+
+      if (!cohortObjectIds.length) {
+        return {
+          success: false,
+          status: httpStatus.BAD_REQUEST,
+          message: "No valid cohort_ids provided",
+          errors: { message: "cohort_ids must be valid MongoDB ObjectIds" },
+        };
+      }
+
+      // Check whether the snapshot collection has data for these cohorts
+      const snapshotExists = await CohortDeviceSnapshotModel(tenant)
+        .findOne({ cohort_id: { $in: cohortObjectIds }, tenant })
+        .select("_id")
+        .lean()
+        .maxTimeMS(5000);
+
+      // Fall back to the live aggregation if the snapshot is not yet populated
+      if (!snapshotExists) {
+        logger.warn(
+          `listCachedDevices -- no snapshot found for cohort_ids [${cohort_ids}], falling back to live query`
+        );
+        return createCohort.listDevices(request, next);
+      }
+
+      // Build the filter
+      const filter = {
+        cohort_id: { $in: cohortObjectIds },
+        tenant,
+      };
+      if (search) {
+        filter.name = { $regex: search, $options: "i" };
+      }
+      if (status) {
+        filter["data.status"] = status;
+      }
+      if (category) {
+        filter["data.category"] = category;
+      }
+      if (network) {
+        filter["data.network"] = network;
+      }
+
+      const [total, snapshots] = await Promise.all([
+        CohortDeviceSnapshotModel(tenant)
+          .countDocuments(filter)
+          .maxTimeMS(10000),
+        CohortDeviceSnapshotModel(tenant)
+          .find(filter)
+          .skip(_skip)
+          .limit(_limit)
+          .select("data _snapshot_generated_at")
+          .lean()
+          .maxTimeMS(10000),
+      ]);
+
+      const devices = snapshots.map((s) => s.data);
+      const cacheGeneratedAt =
+        snapshots.length > 0 ? snapshots[0]._snapshot_generated_at : null;
+
+      return {
+        success: true,
+        message: "Successfully retrieved cached devices",
+        data: devices,
+        total,
+        skip: _skip,
+        limit: _limit,
+        cache_generated_at: cacheGeneratedAt,
+      };
+    } catch (error) {
+      logger.error(`listCachedDevices -- ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  /**
+   * listCachedSites — serve sites from the pre-computed CohortSiteSnapshot
+   * collection. Falls back to the live listSites aggregation when the snapshot
+   * is not yet populated.
+   */
+  listCachedSites: async (request, next) => {
+    try {
+      const {
+        body: { cohort_ids = [] } = {},
+        query: {
+          tenant,
+          skip: rawSkip = 0,
+          limit: rawLimit = 10,
+          search,
+          country,
+        } = {},
+      } = request;
+
+      const _skip = parseInt(rawSkip, 10) || 0;
+      const _limit = Math.min(parseInt(rawLimit, 10) || 10, 100);
+
+      if (!cohort_ids.length) {
+        return {
+          success: false,
+          status: httpStatus.BAD_REQUEST,
+          message: "cohort_ids is required",
+          errors: { message: "cohort_ids array must not be empty" },
+        };
+      }
+
+      const cohortObjectIds = cohort_ids
+        .filter((id) => ObjectId.isValid(id))
+        .map((id) => ObjectId(id));
+
+      if (!cohortObjectIds.length) {
+        return {
+          success: false,
+          status: httpStatus.BAD_REQUEST,
+          message: "No valid cohort_ids provided",
+          errors: { message: "cohort_ids must be valid MongoDB ObjectIds" },
+        };
+      }
+
+      const snapshotExists = await CohortSiteSnapshotModel(tenant)
+        .findOne({ cohort_id: { $in: cohortObjectIds }, tenant })
+        .select("_id")
+        .lean()
+        .maxTimeMS(5000);
+
+      if (!snapshotExists) {
+        logger.warn(
+          `listCachedSites -- no snapshot found for cohort_ids [${cohort_ids}], falling back to live query`
+        );
+        return createCohort.listSites(request, next);
+      }
+
+      const filter = {
+        cohort_id: { $in: cohortObjectIds },
+        tenant,
+      };
+      if (search) {
+        filter.$or = [
+          { name: { $regex: search, $options: "i" } },
+          { search_name: { $regex: search, $options: "i" } },
+        ];
+      }
+      if (country) {
+        filter.country = country;
+      }
+
+      const [total, snapshots] = await Promise.all([
+        CohortSiteSnapshotModel(tenant)
+          .countDocuments(filter)
+          .maxTimeMS(10000),
+        CohortSiteSnapshotModel(tenant)
+          .find(filter)
+          .skip(_skip)
+          .limit(_limit)
+          .select("data _snapshot_generated_at")
+          .lean()
+          .maxTimeMS(10000),
+      ]);
+
+      const sites = snapshots.map((s) => s.data);
+      const cacheGeneratedAt =
+        snapshots.length > 0 ? snapshots[0]._snapshot_generated_at : null;
+
+      return {
+        success: true,
+        message: "Successfully retrieved cached sites",
+        data: sites,
+        total,
+        skip: _skip,
+        limit: _limit,
+        cache_generated_at: cacheGeneratedAt,
+      };
+    } catch (error) {
+      logger.error(`listCachedSites -- ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
       );
     }
   },

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -490,7 +490,10 @@ const deviceUtil = {
         },
       ];
 
-      const results = await DeviceModel(tenant).aggregate(pipeline);
+      const results = await DeviceModel(tenant)
+        .aggregate(pipeline)
+        .option({ maxTimeMS: 45000 })
+        .allowDiskUse(true);
 
       const summary = results[0] || {
         total_monitors: 0,
@@ -606,7 +609,9 @@ const deviceUtil = {
       const { query } = request;
       const { tenant } = query;
       const filter = generateFilter.devices(request, next);
-      const count = await DeviceModel(tenant).countDocuments(filter);
+      const count = await DeviceModel(tenant)
+        .countDocuments(filter)
+        .maxTimeMS(45000);
       return {
         success: true,
         message: "retrieved the number of devices",
@@ -1474,6 +1479,7 @@ const deviceUtil = {
 
       const results = await DeviceModel(tenant)
         .aggregate(facetPipeline)
+        .option({ maxTimeMS: 45000 })
         .allowDiskUse(true);
 
       const paginatedResults = results[0].paginatedResults;

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -852,6 +852,7 @@ const createGrid = {
 
       const results = await GridModel(tenant)
         .aggregate(facetPipeline)
+        .option({ maxTimeMS: 45000 })
         .allowDiskUse(true);
 
       const agg =
@@ -1304,6 +1305,7 @@ const createGrid = {
             },
           },
         ])
+        .option({ maxTimeMS: 45000 })
         .exec();
 
       logObject("responseFromListAssignedSites", responseFromListAssignedSites);
@@ -1580,7 +1582,10 @@ const createGrid = {
         },
       ];
 
-      const results = await GridModel(tenant).aggregate(pipeline).allowDiskUse(true);
+      const results = await GridModel(tenant)
+        .aggregate(pipeline)
+        .option({ maxTimeMS: 45000 })
+        .allowDiskUse(true);
 
       const countriesWithFlags = results.map((countryData) => {
         // Safely handle null or undefined country names

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -84,7 +84,10 @@ const getSiteCountSummary = async (request, next) => {
       },
     ];
 
-    const results = await SiteModel(tenant).aggregate(pipeline);
+    const results = await SiteModel(tenant)
+      .aggregate(pipeline)
+      .option({ maxTimeMS: 45000 })
+      .allowDiskUse(true);
     const defaultSummary = {
       total_sites: 0,
       operational: 0,
@@ -1357,6 +1360,7 @@ const createSite = {
 
       const results = await SiteModel(tenant)
         .aggregate(facetPipeline)
+        .option({ maxTimeMS: 45000 })
         .allowDiskUse(true);
 
       const paginatedResults = results[0].paginatedResults;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds two new pre-computed snapshot endpoints (`POST /cohorts/cached-devices` and `POST /cohorts/cached-sites`) backed by flat MongoDB collections (`cohortdevicesnapshots`, `cohortsitesnapshots`) that are pre-populated hourly by a new background job
- Adds `bin/jobs/cohort-snapshot-job.js` — runs at `:15` every hour, iterates all cohorts, calls the existing `listDevices` / `listSites` util functions in pages of 50, bulk-upserts results into the snapshot collections, and removes stale documents for cohorts that have shrunk
- Adds `models/CohortDeviceSnapshot.js` and `models/CohortSiteSnapshot.js` with compound unique indexes for upsert efficiency, indexed filter fields (`name`, `isOnline`, `status`, `category`, `country`) for fast querying, and a 25-hour TTL index as a safety net
- Extends `maxTimeMS: 45000` to aggregations and count queries in `site.util.js`, `device.util.js`, and `grid.util.js` so all device-registry endpoints used by the analytics platform have a server-side query time limit
- Fixes an O(n²) device activity summary loop in `listSites` — replaced the inner `.filter()` loop with two O(n) pre-built Maps keyed by `device_id` and `device.name`

### Why is this change needed?
`POST /cohorts/devices` and `POST /cohorts/sites` run a multi-stage MongoDB aggregation (7 and 4 `$lookup` stages respectively) that takes 3–10 seconds per page under normal load and produces 504 Gateway Timeout errors under concurrent load, specifically when users switch organisations rapidly without in-flight requests being cancelled. Pre-computing the results hourly means the new cached endpoints serve pre-computed data with a simple `find()` in under 100 ms regardless of server load. The `maxTimeMS` extension ensures runaway queries across all analytics-page endpoints release MongoDB connections instead of holding them indefinitely.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `models/CohortDeviceSnapshot.js`, `models/CohortSiteSnapshot.js`, `bin/jobs/cohort-snapshot-job.js`, `bin/server.js`, `utils/cohort.util.js`, `utils/site.util.js`, `utils/device.util.js`, `utils/grid.util.js`, `controllers/cohort.controller.js`, `routes/v2/cohorts.routes.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Verified `POST /cohorts/cached-devices` and `POST /cohorts/cached-sites` return the same response shape as the live endpoints (`devices` / `sites` array, `total`, `skip`, `limit`) with an additional `cache_generated_at` field
- Confirmed the fallback path fires and returns live data when the snapshot collection is empty (e.g. before the first job run or for a new cohort)
- Confirmed stale snapshot documents for a cohort are removed after a job run in which the cohort's membership shrank
- Verified `maxTimeMS` additions in `site.util.js`, `device.util.js`, and `grid.util.js` do not affect normal-latency queries

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The new endpoints are additive. All existing endpoints (`/cohorts/devices`, `/cohorts/sites`) are unchanged. The new snapshot collections are created automatically on first job run. The `maxTimeMS` additions only trigger on queries that were already timing out at the NGINX layer (504), so callers receive a faster, descriptive error instead of a silent gateway timeout.

---

## :memo: Additional Notes

**Endpoint comparison:**

| Endpoint | Mechanism | Typical latency |
|---|---|---|
| `POST /cohorts/devices` | Live aggregation (7 `$lookup` stages) | 3–10 s |
| `POST /cohorts/cached-devices` | `find()` on pre-computed collection | < 100 ms |
| `POST /cohorts/sites` | Live aggregation (4 `$lookup` stages + pre-query) | 3–10 s |
| `POST /cohorts/cached-sites` | `find()` on pre-computed collection | < 100 ms |

**Cache freshness:** snapshots are at most ~1 hour stale. The response includes `cache_generated_at` so the frontend can display data age if needed.

**Fallback:** if no snapshot exists for the requested `cohort_ids` (new cohort added between job runs, or pre-first-run), both endpoints fall back transparently to the live aggregation and log a warning. No change in behaviour from the caller's perspective.

**Frontend migration:** the frontend team can switch `POST /cohorts/devices` → `POST /cohorts/cached-devices` and `POST /cohorts/sites` → `POST /cohorts/cached-sites` independently per page. Request body, query params, and response shape are identical.

**MongoDB Atlas — DevOps action:** the two new collections (`cohortdevicesnapshots`, `cohortsitesnapshots`) will be auto-created on first job run. No manual Atlas action is required. The 25-hour TTL index is also auto-created via `autoIndex: true`.

**Root cause note:** the underlying cause of 504 errors under rapid org-switching remains a missing `AbortController` / SWR `signal` wiring in the frontend (`shared/services/deviceService.ts`, `shared/hooks/useDevice.ts`). The cached endpoints eliminate the 504 for normal usage; the frontend fix is still needed to prevent connection pool exhaustion under rapid org switching. See `src/device-registry/docs/504-TROUBLESHOOTING.md` for full details.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new cached API endpoints for querying cohort devices and sites with faster response times
  * Introduced hourly automated refresh of cohort data to maintain cache freshness

* **Performance**
  * Applied execution time limits to database queries for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->