### PR TITLE
fix: handle snapshot connection pool exhaustion with graceful fallback

### DIFF
--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -269,10 +269,10 @@ async function runCohortSnapshotJob() {
     const runAt = new Date(); // per-cohort timestamp for stale cleanup
 
     try {
-      const [deviceResult, siteResult] = await Promise.all([
-        refreshDevicesForCohort(cohortId, TENANT, runAt),
-        refreshSitesForCohort(cohortId, TENANT, runAt),
-      ]);
+      // Run sequentially to avoid doubling simultaneous connection demand on a
+      // shared pool that may already be under pressure from live aggregation requests.
+      const deviceResult = await refreshDevicesForCohort(cohortId, TENANT, runAt);
+      const siteResult = await refreshSitesForCohort(cohortId, TENANT, runAt);
 
       totalDevices += deviceResult.count;
       totalSites += siteResult.count;

--- a/src/device-registry/models/CohortDeviceSnapshot.js
+++ b/src/device-registry/models/CohortDeviceSnapshot.js
@@ -49,7 +49,14 @@ const cohortDeviceSnapshotSchema = new mongoose.Schema(
       default: Date.now,
     },
   },
-  { timestamps: false }
+  {
+    timestamps: false,
+    // Fail immediately when no connection is available instead of buffering for
+    // bufferTimeoutMS (10 s). The snapshot job and cached endpoints both have
+    // explicit error handling / fallback logic, so a fast failure is preferable
+    // to a silent 10 s hang under connection pool pressure.
+    bufferCommands: false,
+  }
 );
 
 // Unique compound key used for upserts in the snapshot job

--- a/src/device-registry/models/CohortSiteSnapshot.js
+++ b/src/device-registry/models/CohortSiteSnapshot.js
@@ -39,7 +39,13 @@ const cohortSiteSnapshotSchema = new mongoose.Schema(
       default: Date.now,
     },
   },
-  { timestamps: false }
+  {
+    timestamps: false,
+    // Fail immediately when no connection is available — same rationale as
+    // CohortDeviceSnapshot. Both the snapshot job and cached endpoints handle
+    // errors explicitly, so fast failure beats a silent 10 s buffer timeout.
+    bufferCommands: false,
+  }
 );
 
 cohortSiteSnapshotSchema.index(

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -2026,6 +2026,30 @@ const createCohort = {
 
 
   /**
+   * Returns true when an error indicates the snapshot collection is temporarily
+   * unreachable — either because the connection pool is exhausted (buffering
+   * timeout) or because bufferCommands:false caused an immediate fast-fail
+   * before a connection was available. In both cases the right response is to
+   * fall back to the live aggregation rather than returning a 500.
+   */
+  _isSnapshotUnavailableError(error) {
+    if (!error) return false;
+    const unavailableNames = new Set([
+      "MongooseError",
+      "MongoServerSelectionError",
+      "MongoNetworkTimeoutError",
+      "MongoPoolClearedError",
+    ]);
+    if (unavailableNames.has(error.name)) return true;
+    const msg = error.message || "";
+    return (
+      msg.includes("buffering timed out") ||
+      msg.includes("before initial connection") ||
+      msg.includes("checking out a connection")
+    );
+  },
+
+  /**
    * listCachedDevices — serve devices from the pre-computed CohortDeviceSnapshot
    * collection. Falls back transparently to the live listDevices aggregation when
    * the snapshot is empty (e.g. new cohort, first run before the job fires).
@@ -2149,11 +2173,11 @@ const createCohort = {
         cache_generated_at: cacheGeneratedAt,
       };
     } catch (error) {
-      // Snapshot collection unavailable (connection pool exhausted or collection not yet
-      // created by the job) — fall back to the live aggregation transparently.
-      if (error.message && error.message.includes("buffering timed out")) {
+      // Snapshot collection unavailable — covers both the legacy "buffering timed
+      // out" message and the fast-fail messages emitted by bufferCommands:false.
+      if (createCohort._isSnapshotUnavailableError(error)) {
         logger.warn(
-          `listCachedDevices -- snapshot unavailable (${error.message}), falling back to live query`
+          `listCachedDevices -- snapshot unavailable (${error.name}: ${error.message}), falling back to live query`
         );
         return createCohort.listDevices(request, next);
       }
@@ -2280,10 +2304,10 @@ const createCohort = {
         cache_generated_at: cacheGeneratedAt,
       };
     } catch (error) {
-      // Snapshot collection unavailable — fall back to the live aggregation transparently.
-      if (error.message && error.message.includes("buffering timed out")) {
+      // Snapshot collection unavailable — same broadened check as listCachedDevices.
+      if (createCohort._isSnapshotUnavailableError(error)) {
         logger.warn(
-          `listCachedSites -- snapshot unavailable (${error.message}), falling back to live query`
+          `listCachedSites -- snapshot unavailable (${error.name}: ${error.message}), falling back to live query`
         );
         return createCohort.listSites(request, next);
       }

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -2149,6 +2149,14 @@ const createCohort = {
         cache_generated_at: cacheGeneratedAt,
       };
     } catch (error) {
+      // Snapshot collection unavailable (connection pool exhausted or collection not yet
+      // created by the job) — fall back to the live aggregation transparently.
+      if (error.message && error.message.includes("buffering timed out")) {
+        logger.warn(
+          `listCachedDevices -- snapshot unavailable (${error.message}), falling back to live query`
+        );
+        return createCohort.listDevices(request, next);
+      }
       logger.error(`listCachedDevices -- ${error.message}`);
       next(
         new HttpError(
@@ -2272,6 +2280,13 @@ const createCohort = {
         cache_generated_at: cacheGeneratedAt,
       };
     } catch (error) {
+      // Snapshot collection unavailable — fall back to the live aggregation transparently.
+      if (error.message && error.message.includes("buffering timed out")) {
+        logger.warn(
+          `listCachedSites -- snapshot unavailable (${error.message}), falling back to live query`
+        );
+        return createCohort.listSites(request, next);
+      }
       logger.error(`listCachedSites -- ${error.message}`);
       next(
         new HttpError(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds a graceful fallback in `listCachedDevices` and `listCachedSites` — when a Mongoose buffering timeout is caught (snapshot collection unreachable due to connection pool pressure), both functions transparently fall back to the live aggregation instead of returning a 500 Internal Server Error
- Changes the snapshot job (`cohort-snapshot-job.js`) to run device and site refreshes **sequentially per cohort** instead of in parallel via `Promise.all`, halving the job's simultaneous connection demand on the shared pool
- Adds `bufferCommands: false` to both `CohortDeviceSnapshot` and `CohortSiteSnapshot` Mongoose schemas so that operations on these models fail immediately when no connection is available, rather than silently buffering for the default 10 s before timing out

### Why is this change needed?
The snapshot job and `POST /cohorts/cached-devices` endpoint were surfacing `"Operation cohortdevicesnapshots.distinct() buffering timed out after 10000ms"` / `"Operation cohortsitesnapshots.bulkWrite() buffering timed out after 10000ms"` errors in both staging and production. The root cause is connection pool exhaustion: the live `/cohorts/devices` aggregation pipeline holds each MongoDB connection for 3–10 seconds; under concurrent load the pool fills and new operations from the snapshot job and cached endpoints queue in Mongoose's buffer until the 10 s default timeout fires.

The `bufferCommands: false` schema option converts the silent 10 s hang into an immediate error, which the updated catch blocks detect and handle by falling back to the live query. The sequential job execution reduces the job's connection footprint without affecting correctness.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `models/CohortDeviceSnapshot.js`, `models/CohortSiteSnapshot.js`, `utils/cohort.util.js`, `bin/jobs/cohort-snapshot-job.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Reproduced the buffering timeout error by calling `POST /cohorts/cached-devices` before the snapshot job had successfully run; confirmed the endpoint now returns live aggregation data instead of a 500
- Verified `POST /cohorts/cached-devices` and `POST /cohorts/cached-sites` continue to return snapshot data correctly when the snapshot collection is populated
- Confirmed the snapshot job no longer surfaces `bulkWrite buffering timed out` errors after the sequential-execution change under moderate load

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All changes are internal error-handling improvements. The public API contract of `POST /cohorts/cached-devices` and `POST /cohorts/cached-sites` is unchanged — callers continue to receive either snapshot data or live aggregation data with an identical response shape. The `bufferCommands: false` schema change only affects how quickly connection errors are surfaced internally.

---

## :memo: Additional Notes

**Root cause context:** The connection pool is already configured at `maxPoolSize: 100` in `config/database.js`. Pool exhaustion is therefore driven entirely by the duration of live aggregation connections (3–10 s each), not by pool size. The permanent resolution is the frontend migrating from `POST /cohorts/devices` → `POST /cohorts/cached-devices` and `POST /cohorts/sites` → `POST /cohorts/cached-sites`, which eliminates the slow aggregation from the hot request path entirely. The changes in this PR are defensive hardening that ensure the system degrades gracefully until that migration is complete.

**`bufferCommands: false` rationale:** Both snapshot models have explicit error handling and fallback logic at every call site. A fast, explicit failure is strongly preferable to a silent 10 s buffer hang — it surfaces the connection problem immediately in logs and triggers the fallback path without making the caller wait.

**Remaining work (not in this PR):**
- Frontend: switch `getCohortDevices` → `POST /cohorts/cached-devices` and `getCohortSites` → `POST /cohorts/cached-sites` in `shared/services/deviceService.ts`
- Frontend: wire `AbortController`/SWR `signal` through cohort fetch hooks to cancel stale in-flight requests and release connections faster
- DevOps: build Activity compound indexes in MongoDB Atlas (`{ device_id, activityType, createdAt }`, `{ device, activityType, createdAt }`)

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when database connection is unavailable—system now responds faster instead of buffering indefinitely
  * Added automatic fallback mechanism to live data aggregation during connection issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->