### PR TITLE
fix: eliminate per-cohort alert flood on snapshot job connection errors

### DIFF
--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -244,9 +244,12 @@ async function runCohortSnapshotJob() {
   // If the connection is in a reconnecting state (readyState !== 1) we log a
   // single WARN and skip the run entirely rather than emitting one ERROR per
   // cohort, which floods the alerts channel.
-  const connReadyState = CohortModel(TENANT).db
-    ? CohortModel(TENANT).db.readyState
-    : -1;
+  // NOTE: CohortDeviceSnapshotModel and CohortSiteSnapshotModel currently share
+  // the same underlying connection as CohortModel via getModelByTenant. If they
+  // are ever moved to a separate connection, add equivalent readyState checks for
+  // their .db connections here.
+  const cohortModel = CohortModel(TENANT);
+  const connReadyState = cohortModel.db?.readyState;
   if (connReadyState !== 1) {
     logger.warn(
       `${JOB_NAME} -- skipping run: MongoDB connection not ready (readyState=${connReadyState})`

--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -239,6 +239,21 @@ async function refreshSitesForCohort(cohortId, tenant, runAt) {
  */
 async function runCohortSnapshotJob() {
   const jobStart = new Date();
+
+  // Preflight: verify the MongoDB connection is ready before touching any cohort.
+  // If the connection is in a reconnecting state (readyState !== 1) we log a
+  // single WARN and skip the run entirely rather than emitting one ERROR per
+  // cohort, which floods the alerts channel.
+  const connReadyState = CohortModel(TENANT).db
+    ? CohortModel(TENANT).db.readyState
+    : -1;
+  if (connReadyState !== 1) {
+    logger.warn(
+      `${JOB_NAME} -- skipping run: MongoDB connection not ready (readyState=${connReadyState})`
+    );
+    return;
+  }
+
   logText(`${JOB_NAME} -- starting at ${jobStart.toISOString()}`);
 
   let cohorts;

--- a/src/device-registry/models/CohortDeviceSnapshot.js
+++ b/src/device-registry/models/CohortDeviceSnapshot.js
@@ -49,14 +49,7 @@ const cohortDeviceSnapshotSchema = new mongoose.Schema(
       default: Date.now,
     },
   },
-  {
-    timestamps: false,
-    // Fail immediately when no connection is available instead of buffering for
-    // bufferTimeoutMS (10 s). The snapshot job and cached endpoints both have
-    // explicit error handling / fallback logic, so a fast failure is preferable
-    // to a silent 10 s hang under connection pool pressure.
-    bufferCommands: false,
-  }
+  { timestamps: false }
 );
 
 // Unique compound key used for upserts in the snapshot job

--- a/src/device-registry/models/CohortSiteSnapshot.js
+++ b/src/device-registry/models/CohortSiteSnapshot.js
@@ -39,13 +39,7 @@ const cohortSiteSnapshotSchema = new mongoose.Schema(
       default: Date.now,
     },
   },
-  {
-    timestamps: false,
-    // Fail immediately when no connection is available — same rationale as
-    // CohortDeviceSnapshot. Both the snapshot job and cached endpoints handle
-    // errors explicitly, so fast failure beats a silent 10 s buffer timeout.
-    bufferCommands: false,
-  }
+  { timestamps: false }
 );
 
 cohortSiteSnapshotSchema.index(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Removes `bufferCommands: false` from both `CohortDeviceSnapshot` and `CohortSiteSnapshot` Mongoose schemas — restoring default buffering behaviour so operations queue and succeed during Atlas connection drop/reconnect cycles instead of failing immediately
- Adds a connection preflight check at the start of `runCohortSnapshotJob` that reads `CohortModel(TENANT).db.readyState` — if the connection is not ready the job logs a single `WARN` and returns early, rather than emitting one `ERROR` log per cohort

### Why is this change needed?
After `bufferCommands: false` was added to the snapshot schemas in the previous PR, any transient Atlas connection drop/reconnect caused every cohort in the hourly snapshot job to fail immediately with `"Cannot call cohortdevicesnapshots.bulkWrite() before initial connection is complete if bufferCommands = false"`. Because the job processes cohorts sequentially and logs an `ERROR` for each failure, a single reconnect event at `:15` produced 10–15 simultaneous `ERROR` alerts in the Slack alerts channel. Removing `bufferCommands: false` restores Mongoose's reconnect buffering (operations queue and resume automatically). The connection preflight guards against the remaining case where the connection is not yet established at job start time, collapsing what would have been many per-cohort errors into a single `WARN`.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `models/CohortDeviceSnapshot.js`, `models/CohortSiteSnapshot.js`, `bin/jobs/cohort-snapshot-job.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Confirmed that after removing `bufferCommands: false`, the snapshot job no longer floods the alerts channel when the Atlas connection momentarily drops — operations buffer and resume automatically on reconnect
- Verified the connection preflight check fires correctly when `readyState !== 1`, producing a single `WARN` log and an early return with no per-cohort errors
- Confirmed normal job runs (connection ready) continue to process all cohorts and upsert snapshots as expected

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Removing `bufferCommands: false` restores the previous default Mongoose behaviour. The `_isSnapshotUnavailableError` helper in `cohort.util.js` retains the `"before initial connection"` message check so the API-layer fallback continues to handle any fast-fail errors that may surface from other schema types.

---

## :memo: Additional Notes

**Why `bufferCommands: false` was wrong for the job layer:** The API layer (`listCachedDevices`, `listCachedSites`) has explicit fallback logic — a fast failure is desirable there because it immediately triggers the live aggregation fallback. The snapshot job has no fallback; it simply logs each cohort error. Under `bufferCommands: false`, a single Atlas reconnect event at `:15` produced one `ERROR` alert per cohort (10–15 simultaneous alerts), tripping the Slack alerts threshold and causing alert fatigue.

**Why default buffering is correct for the job:** Mongoose's default buffering queues operations during a reconnect and replays them once the connection is restored. For a background job that runs once per hour, a short queue-and-retry delay is far preferable to an outright failure per cohort.

**Connection preflight rationale:** The `readyState` check adds a cheap guard for the narrow window at service startup where the cron fires before the connection is fully established. It collapses what would be N per-cohort errors into a single descriptive `WARN` that does not trip alert thresholds.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added database connection readiness check to cohort snapshot job to prevent execution when the database is unavailable.

* **Refactor**
  * Simplified Mongoose schema configuration for snapshot models by removing explicit command buffering settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->