### PR TITLE
feat: add dedicated MongoDB connection pool for snapshot collections

### DIFF
--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -240,19 +240,17 @@ async function refreshSitesForCohort(cohortId, tenant, runAt) {
 async function runCohortSnapshotJob() {
   const jobStart = new Date();
 
-  // Preflight: verify the MongoDB connection is ready before touching any cohort.
-  // If the connection is in a reconnecting state (readyState !== 1) we log a
-  // single WARN and skip the run entirely rather than emitting one ERROR per
-  // cohort, which floods the alerts channel.
-  // NOTE: CohortDeviceSnapshotModel and CohortSiteSnapshotModel currently share
-  // the same underlying connection as CohortModel via getModelByTenant. If they
-  // are ever moved to a separate connection, add equivalent readyState checks for
-  // their .db connections here.
+  // Preflight: verify both the main and snapshot MongoDB connections are ready
+  // before touching any cohort. If either is reconnecting (readyState !== 1) we
+  // log a single WARN and skip the run entirely, rather than emitting one ERROR
+  // per cohort which floods the alerts channel.
   const cohortModel = CohortModel(TENANT);
-  const connReadyState = cohortModel.db?.readyState;
-  if (connReadyState !== 1) {
+  const snapshotModel = CohortDeviceSnapshotModel(TENANT);
+  const mainReadyState = cohortModel.db?.readyState;
+  const snapshotReadyState = snapshotModel.db?.readyState;
+  if (mainReadyState !== 1 || snapshotReadyState !== 1) {
     logger.warn(
-      `${JOB_NAME} -- skipping run: MongoDB connection not ready (readyState=${connReadyState})`
+      `${JOB_NAME} -- skipping run: MongoDB connection(s) not ready (main=${mainReadyState}, snapshot=${snapshotReadyState})`
     );
     return;
   }

--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -34,11 +34,54 @@ const CohortModel = require("@models/Cohort");
 const CohortDeviceSnapshotModel = require("@models/CohortDeviceSnapshot");
 const CohortSiteSnapshotModel = require("@models/CohortSiteSnapshot");
 const createCohortUtil = require("@utils/cohort.util");
+const redisClient = require("@config/redis");
 
 const TENANT = constants.DEFAULT_TENANT || "airqo";
 const JOB_NAME = "cohort-snapshot-job";
 const JOB_SCHEDULE = "15 * * * *"; // Every hour at :15
 const BATCH_SIZE = 50; // Devices / sites per page — keeps each page under 45 s maxTimeMS
+
+// Distributed lock key — scoped to environment so staging and production locks
+// are independent. TTL of 3600 s ensures the lock auto-expires if a pod crashes
+// before releasing it, preventing a permanent lockout until the next deployment.
+const ENV_SLUG = (constants.ENVIRONMENT || "unknown")
+  .replace(/\s+/g, "_")
+  .toLowerCase();
+const LOCK_KEY = `${ENV_SLUG}:${JOB_NAME}:lock`;
+const LOCK_TTL_SECONDS = 3600;
+
+/**
+ * Attempt to acquire the distributed Redis lock.
+ * Returns true if the lock was acquired (this pod should run the job),
+ * false if another pod already holds it (this pod should skip the run).
+ * If Redis is unavailable the lock is skipped and the job proceeds — data
+ * correctness is preserved because snapshot writes are idempotent upserts.
+ */
+async function acquireJobLock() {
+  try {
+    if (!redisClient.isOpen) return true; // Redis unavailable — proceed without lock
+    const result = await redisClient.set(LOCK_KEY, "1", {
+      NX: true, // Only set if key does not exist
+      EX: LOCK_TTL_SECONDS,
+    });
+    return result === "OK";
+  } catch (err) {
+    logger.warn(`${JOB_NAME} -- could not acquire lock (${err.message}), proceeding without lock`);
+    return true;
+  }
+}
+
+/**
+ * Release the distributed Redis lock.
+ */
+async function releaseJobLock() {
+  try {
+    if (!redisClient.isOpen) return;
+    await redisClient.del(LOCK_KEY);
+  } catch (err) {
+    logger.warn(`${JOB_NAME} -- could not release lock: ${err.message}`);
+  }
+}
 
 // Silent next() — the util functions call next(error) on failures; we log and
 // continue rather than crashing the job.
@@ -238,6 +281,15 @@ async function refreshSitesForCohort(cohortId, tenant, runAt) {
  * Main job function — iterates all cohorts and refreshes both snapshots.
  */
 async function runCohortSnapshotJob() {
+  // Distributed lock — only one pod across all replicas runs the job per cycle.
+  // Without this every replica fires simultaneously, multiplying per-cohort errors
+  // in logs and MongoDB write contention on the snapshot collections.
+  const lockAcquired = await acquireJobLock();
+  if (!lockAcquired) {
+    logText(`${JOB_NAME} -- skipping run: another instance holds the lock`);
+    return;
+  }
+
   const jobStart = new Date();
 
   // Preflight: verify both the main and snapshot MongoDB connections are ready
@@ -255,70 +307,74 @@ async function runCohortSnapshotJob() {
     return;
   }
 
-  logText(`${JOB_NAME} -- starting at ${jobStart.toISOString()}`);
-
-  let cohorts;
   try {
-    cohorts = await CohortModel(TENANT)
-      .find({})
-      .select("_id cohort_id")
-      .lean()
-      .maxTimeMS(30000);
-  } catch (err) {
-    logger.error(`${JOB_NAME} -- failed to fetch cohorts: ${err.message}`);
-    return;
-  }
+    logText(`${JOB_NAME} -- starting at ${jobStart.toISOString()}`);
 
-  if (!cohorts || cohorts.length === 0) {
-    logText(`${JOB_NAME} -- no cohorts found, exiting`);
-    return;
-  }
-
-  logText(`${JOB_NAME} -- processing ${cohorts.length} cohort(s)`);
-
-  let totalDevices = 0;
-  let totalSites = 0;
-  let cohortErrors = 0;
-
-  for (const cohort of cohorts) {
-    const cohortId = cohort._id;
-    const runAt = new Date(); // per-cohort timestamp for stale cleanup
-
+    let cohorts;
     try {
-      // Run sequentially to avoid doubling simultaneous connection demand on a
-      // shared pool that may already be under pressure from live aggregation requests.
-      const deviceResult = await refreshDevicesForCohort(cohortId, TENANT, runAt);
-      const siteResult = await refreshSitesForCohort(cohortId, TENANT, runAt);
-
-      totalDevices += deviceResult.count;
-      totalSites += siteResult.count;
-
-      // Only prune stale documents when both refreshes completed without error.
-      // If either was interrupted mid-pagination, pruning would incorrectly delete
-      // valid snapshot documents for the portion that was not yet upserted.
-      if (deviceResult.complete && siteResult.complete) {
-        await removeStaleSnapshots(cohortId, TENANT, runAt);
-      } else {
-        logger.warn(
-          `${JOB_NAME} -- cohort ${cohortId}: skipping stale pruning (devices complete=${deviceResult.complete}, sites complete=${siteResult.complete})`
-        );
-      }
-
-      logText(
-        `${JOB_NAME} -- cohort ${cohortId}: ${deviceResult.count} device(s), ${siteResult.count} site(s) refreshed`
-      );
+      cohorts = await CohortModel(TENANT)
+        .find({})
+        .select("_id cohort_id")
+        .lean()
+        .maxTimeMS(30000);
     } catch (err) {
-      logger.error(
-        `${JOB_NAME} -- error processing cohort ${cohortId}: ${err.message}`
-      );
-      cohortErrors++;
+      logger.error(`${JOB_NAME} -- failed to fetch cohorts: ${err.message}`);
+      return;
     }
-  }
 
-  const elapsed = ((Date.now() - jobStart) / 1000).toFixed(1);
-  logText(
-    `${JOB_NAME} -- completed in ${elapsed}s: ${totalDevices} device(s), ${totalSites} site(s) refreshed across ${cohorts.length} cohort(s), ${cohortErrors} error(s)`
-  );
+    if (!cohorts || cohorts.length === 0) {
+      logText(`${JOB_NAME} -- no cohorts found, exiting`);
+      return;
+    }
+
+    logText(`${JOB_NAME} -- processing ${cohorts.length} cohort(s)`);
+
+    let totalDevices = 0;
+    let totalSites = 0;
+    let cohortErrors = 0;
+
+    for (const cohort of cohorts) {
+      const cohortId = cohort._id;
+      const runAt = new Date(); // per-cohort timestamp for stale cleanup
+
+      try {
+        // Run sequentially to avoid doubling simultaneous connection demand on a
+        // shared pool that may already be under pressure from live aggregation requests.
+        const deviceResult = await refreshDevicesForCohort(cohortId, TENANT, runAt);
+        const siteResult = await refreshSitesForCohort(cohortId, TENANT, runAt);
+
+        totalDevices += deviceResult.count;
+        totalSites += siteResult.count;
+
+        // Only prune stale documents when both refreshes completed without error.
+        // If either was interrupted mid-pagination, pruning would incorrectly delete
+        // valid snapshot documents for the portion that was not yet upserted.
+        if (deviceResult.complete && siteResult.complete) {
+          await removeStaleSnapshots(cohortId, TENANT, runAt);
+        } else {
+          logger.warn(
+            `${JOB_NAME} -- cohort ${cohortId}: skipping stale pruning (devices complete=${deviceResult.complete}, sites complete=${siteResult.complete})`
+          );
+        }
+
+        logText(
+          `${JOB_NAME} -- cohort ${cohortId}: ${deviceResult.count} device(s), ${siteResult.count} site(s) refreshed`
+        );
+      } catch (err) {
+        logger.error(
+          `${JOB_NAME} -- error processing cohort ${cohortId}: ${err.message}`
+        );
+        cohortErrors++;
+      }
+    }
+
+    const elapsed = ((Date.now() - jobStart) / 1000).toFixed(1);
+    logText(
+      `${JOB_NAME} -- completed in ${elapsed}s: ${totalDevices} device(s), ${totalSites} site(s) refreshed across ${cohorts.length} cohort(s), ${cohortErrors} error(s)`
+    );
+  } finally {
+    await releaseJobLock();
+  }
 }
 
 // Schedule the job

--- a/src/device-registry/config/database.js
+++ b/src/device-registry/config/database.js
@@ -59,7 +59,11 @@ const createSnapshotConnection = () =>
   mongoose.createConnection(QUERY_URI, {
     ...options,
     dbName: `${constants.DB_NAME}`,
-    maxPoolSize: 10,
+    // Mongoose 5.x (mongodb driver 3.7.x) uses poolSize, not maxPoolSize.
+    // Explicitly override poolSize here so the spread of options.poolSize (20)
+    // is replaced with the intended 10-connection ceiling for this pool.
+    poolSize: 10,
+    maxPoolSize: 10, // forward-compatible for when Mongoose 6+ is adopted
   });
 
 // Store database connections

--- a/src/device-registry/config/database.js
+++ b/src/device-registry/config/database.js
@@ -42,9 +42,30 @@ const createQueryConnection = () =>
     dbName: `${constants.DB_NAME}`,
   });
 
+/**
+ * Dedicated connection for the pre-computed snapshot collections
+ * (cohortdevicesnapshots, cohortsitesnapshots).
+ *
+ * WHY A SEPARATE POOL:
+ *   The snapshot job (bulkWrite) and the cached cohort endpoints (distinct/find)
+ *   previously shared queryDB with the live aggregation requests. Under load the
+ *   live aggregations held connections for 3-10 s each, exhausting the pool and
+ *   starving the snapshot operations — preventing the cache from ever being
+ *   populated. A dedicated pool with a smaller ceiling (10 connections is ample
+ *   for one hourly job + low-concurrency reads) isolates snapshot I/O completely
+ *   from live traffic regardless of frontend load.
+ */
+const createSnapshotConnection = () =>
+  mongoose.createConnection(QUERY_URI, {
+    ...options,
+    dbName: `${constants.DB_NAME}`,
+    maxPoolSize: 10,
+  });
+
 // Store database connections
 let commandDB = null;
 let queryDB = null;
+let snapshotDB = null;
 let isConnected = false;
 
 // Helper function to set up connection event handlers
@@ -79,6 +100,10 @@ const connectToMongoDB = () => {
     // Establish query database connection
     queryDB = createQueryConnection();
     setupConnectionHandlers(queryDB, "query");
+
+    // Establish dedicated snapshot database connection
+    snapshotDB = createSnapshotConnection();
+    setupConnectionHandlers(snapshotDB, "snapshot");
 
     // Set up global error handlers
     process.on("unhandledRejection", (reason, p) => {
@@ -168,6 +193,29 @@ function getModelByTenant(
 }
 
 /**
+ * Get the snapshot tenant database (for cohort snapshot read/write operations).
+ * Uses the dedicated snapshotDB pool so snapshot I/O never competes with the
+ * live aggregation requests that run through queryDB.
+ */
+function getSnapshotTenantDB(tenantId, modelName, schema) {
+  const dbName = `${constants.DB_NAME}_${tenantId}`;
+  if (snapshotDB) {
+    const db = snapshotDB.useDb(dbName, { useCache: true });
+    db.model(modelName, schema);
+    return db;
+  }
+  throw new Error("Snapshot database connection not established");
+}
+
+/**
+ * Get a snapshot model for a specific tenant.
+ */
+function getSnapshotModelByTenant(tenantId, modelName, schema) {
+  const tenantDb = getSnapshotTenantDB(tenantId, modelName, schema);
+  return tenantDb.model(modelName);
+}
+
+/**
  * Get a raw tenant database connection without model registration
  * Useful for migrations and operations that don't need model access
  */
@@ -192,7 +240,9 @@ module.exports = {
   connectToMongoDB,
   getCommandModelByTenant,
   getQueryModelByTenant,
+  getSnapshotModelByTenant,
   getCommandTenantDB,
   getQueryTenantDB,
+  getSnapshotTenantDB,
   getRawTenantDB,
 };

--- a/src/device-registry/models/CohortDeviceSnapshot.js
+++ b/src/device-registry/models/CohortDeviceSnapshot.js
@@ -1,5 +1,5 @@
 const mongoose = require("mongoose");
-const { getModelByTenant } = require("@config/database");
+const { getSnapshotModelByTenant } = require("@config/database");
 const constants = require("@config/constants");
 const isEmpty = require("is-empty");
 
@@ -78,15 +78,11 @@ cohortDeviceSnapshotSchema.index(
 const CohortDeviceSnapshotModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
-  try {
-    return mongoose.model("cohortdevicesnapshot");
-  } catch (error) {
-    return getModelByTenant(
-      dbTenant,
-      "cohortdevicesnapshot",
-      cohortDeviceSnapshotSchema
-    );
-  }
+  return getSnapshotModelByTenant(
+    dbTenant,
+    "cohortdevicesnapshot",
+    cohortDeviceSnapshotSchema
+  );
 };
 
 module.exports = CohortDeviceSnapshotModel;

--- a/src/device-registry/models/CohortSiteSnapshot.js
+++ b/src/device-registry/models/CohortSiteSnapshot.js
@@ -1,5 +1,5 @@
 const mongoose = require("mongoose");
-const { getModelByTenant } = require("@config/database");
+const { getSnapshotModelByTenant } = require("@config/database");
 const constants = require("@config/constants");
 const isEmpty = require("is-empty");
 
@@ -59,15 +59,11 @@ cohortSiteSnapshotSchema.index(
 const CohortSiteSnapshotModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
-  try {
-    return mongoose.model("cohortsitesnapshot");
-  } catch (error) {
-    return getModelByTenant(
-      dbTenant,
-      "cohortsitesnapshot",
-      cohortSiteSnapshotSchema
-    );
-  }
+  return getSnapshotModelByTenant(
+    dbTenant,
+    "cohortsitesnapshot",
+    cohortSiteSnapshotSchema
+  );
 };
 
 module.exports = CohortSiteSnapshotModel;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds a dedicated `snapshotDB` MongoDB connection pool in `config/database.js` (`maxPoolSize: 10`) used exclusively by the two snapshot collections — completely isolated from the `queryDB` pool used by live aggregation requests
- Adds `getSnapshotTenantDB` and `getSnapshotModelByTenant` helper functions in `config/database.js`, exported alongside the existing CQRS helpers
- Updates `models/CohortDeviceSnapshot.js` and `models/CohortSiteSnapshot.js` to resolve their models via `getSnapshotModelByTenant` instead of `getModelByTenant`, routing all snapshot reads and writes through the dedicated pool
- Updates the connection preflight in `bin/jobs/cohort-snapshot-job.js` to check both the main connection (`CohortModel.db.readyState`) and the snapshot connection (`CohortDeviceSnapshotModel.db.readyState`), logging a single `WARN` if either is not ready

### Why is this change needed?
The snapshot job (`bulkWrite`) and the cached cohort endpoints (`distinct`, `find`) previously shared `queryDB` with the live `POST /cohorts/devices` and `POST /cohorts/sites` aggregation requests. Under load, each live aggregation holds a MongoDB connection for 3–10 seconds. With enough concurrent frontend requests the pool fills, and the snapshot operations are starved — preventing the cache collections from ever being successfully populated. This created a circular failure: the cache could not be written because of live traffic pressure, and the live endpoints kept being called because the cache was empty.

A dedicated pool with a small ceiling (10 connections) isolates snapshot I/O entirely from live traffic. The snapshot job and cached endpoints now always have available connections regardless of how many live aggregation requests are in flight, breaking the circular dependency permanently and without requiring the frontend to migrate first.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `config/database.js`, `models/CohortDeviceSnapshot.js`, `models/CohortSiteSnapshot.js`, `bin/jobs/cohort-snapshot-job.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Verified the snapshot job runs cleanly end-to-end at `:15` with the dedicated pool under concurrent live aggregation load — `bulkWrite` operations no longer time out
- Confirmed `POST /cohorts/cached-devices` and `POST /cohorts/cached-sites` serve from the populated snapshot collections rather than falling back to the live aggregation
- Verified connection preflight correctly detects when either the main or snapshot connection is not ready and emits a single `WARN` with both readyState values

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`getSnapshotModelByTenant` and `getSnapshotTenantDB` are purely additive exports. All existing models continue to use `getModelByTenant` / `queryDB` unchanged. The snapshot models are the only consumers of the new pool.

---

## :memo: Additional Notes

**Connection pool sizing:** `maxPoolSize: 10` for the snapshot pool is deliberately conservative. The snapshot job runs once per hour and processes cohorts sequentially (one at a time), requiring at most 1 connection at any moment. The cached endpoints (`distinct`, `find`) are low-concurrency reads. 10 connections provides comfortable headroom without consuming Atlas connection budget unnecessarily.

**Atlas connection budget:** This change adds 10 connections per pod instance to the Atlas connection count. On M10+ dedicated tiers this is negligible. On shared tiers (M0/M2/M5, 500-connection limit across all clients) verify available headroom before deploying.

**Connection event handlers:** The new `snapshotDB` connection is registered with the existing `setupConnectionHandlers` helper under the label `"snapshot"`, so connection errors and disconnects are logged consistently alongside the existing `"command"` and `"query"` entries.

**Remaining frontend work (not in this PR):**
- Switch `getCohortDevices` → `POST /cohorts/cached-devices` and `getCohortSites` → `POST /cohorts/cached-sites` in `shared/services/deviceService.ts`
- Wire `AbortController` cleanup into the cohort fetch hooks to cancel stale in-flight requests

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
