### PR TITLE
chore: upgrade Redis to v5 and fix reconnect strategy placement

### DIFF
--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -59,7 +59,7 @@ const LOCK_TTL_SECONDS = 3600;
  */
 async function acquireJobLock() {
   try {
-    if (!redisClient.isOpen) return true; // Redis unavailable — proceed without lock
+    if (!redisClient.isOpen || !redisClient.isReady) return true; // Redis unavailable — proceed without lock
     const result = await redisClient.set(LOCK_KEY, "1", {
       NX: true, // Only set if key does not exist
       EX: LOCK_TTL_SECONDS,
@@ -76,7 +76,7 @@ async function acquireJobLock() {
  */
 async function releaseJobLock() {
   try {
-    if (!redisClient.isOpen) return;
+    if (!redisClient.isOpen || !redisClient.isReady) return;
     await redisClient.del(LOCK_KEY);
   } catch (err) {
     logger.warn(`${JOB_NAME} -- could not release lock: ${err.message}`);

--- a/src/device-registry/bin/jobs/cohort-snapshot-job.js
+++ b/src/device-registry/bin/jobs/cohort-snapshot-job.js
@@ -59,7 +59,7 @@ const LOCK_TTL_SECONDS = 3600;
  */
 async function acquireJobLock() {
   try {
-    if (!redisClient.isOpen || !redisClient.isReady) return true; // Redis unavailable — proceed without lock
+    if (!redisClient.redisUtils.isAvailable()) return true; // Redis unavailable — proceed without lock
     const result = await redisClient.set(LOCK_KEY, "1", {
       NX: true, // Only set if key does not exist
       EX: LOCK_TTL_SECONDS,
@@ -76,7 +76,7 @@ async function acquireJobLock() {
  */
 async function releaseJobLock() {
   try {
-    if (!redisClient.isOpen || !redisClient.isReady) return;
+    if (!redisClient.redisUtils.isAvailable()) return;
     await redisClient.del(LOCK_KEY);
   } catch (err) {
     logger.warn(`${JOB_NAME} -- could not release lock: ${err.message}`);

--- a/src/device-registry/config/redis.js
+++ b/src/device-registry/config/redis.js
@@ -78,31 +78,47 @@ const logThrottledConnectionError = (error) => {
 // Redis v4 configuration with improved retry strategy
 const redisConfig = {
   url: REDIS_URL,
+  // ── RESP protocol version ───────────────────────────────────────────────────
+  // redis@5 defaults to RESP3 which changes return types of certain commands
+  // (e.g. HGETALL returns a Map instead of a plain object). Setting RESP: 2
+  // keeps the same return types as redis@4, ensuring backward compatibility
+  // across all existing callers in the codebase.
+  RESP: 2,
   socket: {
     connectTimeout: 10000, // 10 seconds
     keepAlive: 5000, // Send keep-alive packets every 5 seconds
     tls: REDIS_URL?.startsWith("rediss://") ? true : undefined,
-  },
-  reconnectStrategy: (retries) => {
-    connectionAttempts = retries + 1;
+    // ── Reconnect strategy ──────────────────────────────────────────────────
+    // reconnectStrategy MUST be inside socket (not at the top level of the
+    // config object) — top-level placement is silently ignored by node-redis.
+    // Previously this was at the top level and the default strategy was used.
+    reconnectStrategy: (retries) => {
+      connectionAttempts = retries + 1;
 
-    if (retries > 15) {
-      logger.error(
-        "Redis maximum retry attempts (15) reached. Stopping retries.",
+      if (retries > 15) {
+        logger.error(
+          "Redis maximum retry attempts (15) reached. Stopping retries.",
+        );
+        return new Error("Redis retry limit reached");
+      }
+
+      // Exponential backoff with jitter: 500ms, 1s, 2s … 30s
+      const baseDelay = Math.min(Math.pow(2, retries) * 500, 30000);
+      const jitter = Math.random() * 1000;
+      const delay = baseDelay + jitter;
+
+      logger.warn(
+        `Redis retry attempt ${retries + 1}/15 in ${Math.round(delay)}ms`,
       );
-      return new Error("Redis retry limit reached");
-    }
-
-    // Exponential backoff with jitter
-    const baseDelay = Math.min(Math.pow(2, retries) * 500, 30000); // Start at 500ms, max 30s
-    const jitter = Math.random() * 1000;
-    const delay = baseDelay + jitter;
-
-    logger.warn(
-      `Redis retry attempt ${retries + 1}/15 in ${Math.round(delay)}ms`,
-    );
-    return delay;
+      return delay;
+    },
   },
+  // ── Offline queue ───────────────────────────────────────────────────────────
+  // Intentionally disabled. Unlike auth-service (which enables the queue so
+  // commands replay on reconnect), device-registry uses an in-process fallback
+  // cache (see setFallbackCache / getFallbackCache above) to serve reads when
+  // Redis is unavailable. Commands should fail fast so callers hit the fallback
+  // immediately rather than queuing silently for an unknown duration.
   disableOfflineQueue: true,
 };
 

--- a/src/device-registry/config/redis.js
+++ b/src/device-registry/config/redis.js
@@ -75,7 +75,7 @@ const logThrottledConnectionError = (error) => {
 };
 // --- END: Connection Error Log Throttling ---
 
-// Redis v4 configuration with improved retry strategy
+// redis@5 client configuration (RESP2 enabled for redis@4-compatible return types)
 const redisConfig = {
   url: REDIS_URL,
   // ── RESP protocol version ───────────────────────────────────────────────────
@@ -95,7 +95,7 @@ const redisConfig = {
     reconnectStrategy: (retries) => {
       connectionAttempts = retries + 1;
 
-      if (retries > 15) {
+      if (retries >= 15) {
         logger.error(
           "Redis maximum retry attempts (15) reached. Stopping retries.",
         );
@@ -106,9 +106,10 @@ const redisConfig = {
       const baseDelay = Math.min(Math.pow(2, retries) * 500, 30000);
       const jitter = Math.random() * 1000;
       const delay = baseDelay + jitter;
+      const attemptNumber = Math.min(retries + 1, 15);
 
       logger.warn(
-        `Redis retry attempt ${retries + 1}/15 in ${Math.round(delay)}ms`,
+        `Redis retry attempt ${attemptNumber}/15 in ${Math.round(delay)}ms`,
       );
       return delay;
     },

--- a/src/device-registry/package-lock.json
+++ b/src/device-registry/package-lock.json
@@ -77,7 +77,7 @@
         "point-in-polygon": "^1.1.0",
         "qrcode": "^1.4.4",
         "qs": "^6.9.4",
-        "redis": "^4.7.1",
+        "redis": "^5.11.0",
         "request": "^2.88.2",
         "retry-request": "^4.1.1",
         "serve-favicon": "~2.4.5",
@@ -1597,56 +1597,70 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@redis/bloom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
-      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
-      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
+        "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@redis/graph": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
-      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redis/json": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
-      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/search": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
-      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
-      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -5946,14 +5960,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/generate-password/-/generate-password-1.7.1.tgz",
       "integrity": "sha512-9bVYY+16m7W7GczRBDqXE+VVuCX+bWNrfYKC/2p2JkZukFb2sKxT6E3zZ3mJGz7GMe5iRK0A/WawSL3jQfJuNQ=="
-    },
-    "node_modules/generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -14921,16 +14927,18 @@
       }
     },
     "node_modules/redis": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
-      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "dependencies": {
-        "@redis/bloom": "1.2.0",
-        "@redis/client": "1.6.1",
-        "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.7",
-        "@redis/search": "1.2.0",
-        "@redis/time-series": "1.1.0"
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/referrer-policy": {

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "main": "./bin",
+  "engines": {
+    "node": ">=18.19.0"
+  },
   "scripts": {
     "start": "NODE_ENV=production node --max-old-space-size=4096 ./bin",
     "stage": "NODE_ENV=staging node --max-old-space-size=4096 ./bin",

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -123,7 +123,7 @@
     "point-in-polygon": "^1.1.0",
     "qrcode": "^1.4.4",
     "qs": "^6.9.4",
-    "redis": "^4.7.1",
+    "redis": "^5.11.0",
     "request": "^2.88.2",
     "retry-request": "^4.1.1",
     "serve-favicon": "~2.4.5",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Upgrades the `redis` dependency in `package.json` from `^4.7.1` to `^5.11.0`, aligning device-registry with auth-service which is already on redis@5
- Adds `RESP: 2` to the Redis client config in `config/redis.js` to preserve backward-compatible return types under redis@5's new RESP3 default
- Moves `reconnectStrategy` from the top level of the config object into the `socket` block where node-redis actually reads it — it was silently ignored at the top level, meaning the custom exponential backoff was never applied
- Adds `isReady` checks alongside `isOpen` in the distributed lock functions (`acquireJobLock`, `releaseJobLock`) in `bin/jobs/cohort-snapshot-job.js` to guard against the window where a client is connected but the handshake is not yet complete

### Why is this change needed?
device-registry was on redis@4 while auth-service had already been upgraded to redis@5 as part of a previous migration that replaced deprecated node-redis methods and aligned the reconnect strategy. The gap created version drift between services. Additionally, two silent bugs were present: (1) `reconnectStrategy` placed at the top level of the config was ignored by node-redis — the client was using default reconnect behaviour instead of the intended exponential backoff; (2) `isOpen`-only checks in the distributed job lock could pass during the post-connect handshake window where `isOpen` is true but `isReady` is false, causing the `SET NX` command to fail and the lock to be skipped.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `package.json`, `config/redis.js`, `bin/jobs/cohort-snapshot-job.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Verified Redis client connects successfully after upgrade with `RESP: 2` — all existing `get`/`set`/`del`/`setEx` return types unchanged
- Confirmed reconnect strategy now fires with exponential backoff on connection loss (previously the default strategy was used silently)
- Confirmed `acquireJobLock` correctly returns `true` (proceed without lock) when `isReady` is false, preventing premature lock attempts during handshake

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`RESP: 2` explicitly pins the protocol to RESP2 semantics, preserving identical return types for all Redis commands. Without it, redis@5 defaults to RESP3 which changes the return type of commands like `HGETALL` from a plain object to a `Map`, which would silently break callers reading the result as a plain object. All existing `redisGetAsync`, `redisSetAsync`, `redisDelAsync`, and `redisPingAsync` wrappers continue to work without modification.

Note: `npm install` must be run inside `src/device-registry` after merging to pull in the updated package.

---

## :memo: Additional Notes

**Why `disableOfflineQueue: true` is kept (unlike auth-service):**
auth-service enables the offline queue so commands replay automatically on reconnect, and has no fallback cache. device-registry intentionally disables the offline queue because it has an in-process fallback `Map` cache (`setFallbackCache` / `getFallbackCache`) that serves reads immediately when Redis is unavailable. Queuing commands silently would delay callers from hitting the fallback, undermining the point of having it.

**`reconnectStrategy` placement fix:**
In `node-redis` (all versions), `reconnectStrategy` is a property of the `socket` options object, not the top-level client config. Placing it at the top level is silently ignored. The custom backoff (500ms → 30s with jitter, max 15 retries) was therefore never active — the client used node-redis's default strategy. This is now corrected.

**auth-service ioredis note (out of scope):**
During this review it was noted that auth-service carries both `ioredis` and `redis` as dependencies. `ioredis.js` is a legacy config file that nothing in auth-service imports. The `ioredis` package and `config/ioredis.js` can be removed from auth-service in a separate cleanup PR.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Redis connection handling with stricter readiness checks to prevent errors when Redis is temporarily unavailable.
  * Improved retry logic with exponential backoff and jitter for more resilient reconnection attempts.
  * Disabled offline command queuing to ensure fallback cache logic is used appropriately during Redis unavailability.

* **Chores**
  * Upgraded Redis client library to latest stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->