### PR TITLE
Fix deployment type derivation, protect lifecycle fields, add metadata cleanup job

### DIFF
--- a/src/device-registry/bin/jobs/device-bulk-update-job.js
+++ b/src/device-registry/bin/jobs/device-bulk-update-job.js
@@ -73,9 +73,20 @@ const releaseJobLock = async (tenant, lockName) => {
 
 // ── Core batch processor ──────────────────────────────────────────────────────
 
+// Fields that may only be changed through dedicated activity endpoints
+// (deploy / recall / maintain). Stripping them here prevents a bulk-update
+// job document stored in the DB from silently overriding deployment state.
+const { LIFECYCLE_FIELDS } = constants;
+
 const runSingleJob = async (job) => {
   const { tenant, _id: jobId, name, filter, updateData, batchSize, dryRun } =
     job;
+
+  // Strip lifecycle fields from the stored updateData before it reaches the DB.
+  // A DeviceBulkUpdateJob document could have been created with any payload;
+  // we must enforce the same invariant the API controllers do.
+  const safeUpdateData = Object.assign({}, updateData);
+  LIFECYCLE_FIELDS.forEach((f) => delete safeUpdateData[f]);
   const lockName = `device-bulk-update-${jobId}`;
 
   const lockAcquired = await acquireJobLock(tenant, lockName);
@@ -152,7 +163,7 @@ const runSingleJob = async (job) => {
       if (dryRun) {
         logger.info(
           `[${POD_ID}] [DRY RUN] Job "${name}": would apply ${JSON.stringify(
-            updateData
+            safeUpdateData
           )} to ${deviceIds.length} device(s).`
         );
         await DeviceBulkUpdateJobModel(tenant).findByIdAndUpdate(jobId, {
@@ -167,7 +178,7 @@ const runSingleJob = async (job) => {
       try {
         await DeviceModel(tenant).updateMany(
           { _id: { $in: deviceIds } },
-          { $set: updateData },
+          { $set: safeUpdateData },
           { runValidators: true }
         );
 

--- a/src/device-registry/bin/jobs/device-metadata-cleanup-job.js
+++ b/src/device-registry/bin/jobs/device-metadata-cleanup-job.js
@@ -1,0 +1,305 @@
+"use strict";
+/**
+ * device-metadata-cleanup-job.js
+ *
+ * Runs three times a day (02:00, 10:00, 18:00 local time).
+ *
+ * Executes four sequential passes to heal bad device metadata that slipped in
+ * before lifecycle-field protection was in place:
+ *
+ *  Pass 1 – backfill_static
+ *    Deployed devices that have a site_id but no deployment_type.
+ *    Action: set deployment_type="static", mobility=false.
+ *
+ *  Pass 2 – backfill_mobile
+ *    Deployed devices that have a grid_id but no deployment_type.
+ *    Action: set deployment_type="mobile", mobility=true.
+ *
+ *  Pass 3 – fix_static_mobility
+ *    Devices with deployment_type="static" but mobility=true.
+ *    Action: set mobility=false.
+ *
+ *  Pass 4 – fix_mobile_mobility
+ *    Devices with deployment_type="mobile" but mobility=false.
+ *    Action: set mobility=true.
+ *
+ * Design principles
+ * -----------------
+ * • Cursor-based pagination (_id > lastSeenId) keeps memory usage O(1)
+ *   regardless of fleet size.  Each DB round-trip fetches at most BATCH_SIZE
+ *   _ids, then issues a targeted updateMany — no full documents are loaded.
+ * • Mongoose middleware is bypassed (collection.updateMany) so the pre-save
+ *   hook's mobility↔deployment_type sync does not re-run and produce
+ *   redundant writes.
+ * • Distributed locking (JobLock) prevents duplicate runs across pods.
+ * • Dry-run mode (DEVICE_METADATA_CLEANUP_DRY_RUN=true) logs what would
+ *   change without writing anything — safe to enable in production for audits.
+ */
+
+const DeviceModel = require("@models/Device");
+const JobLockModel = require("@models/JobLock");
+const constants = require("@config/constants");
+const cron = require("node-cron");
+const log4js = require("log4js");
+const os = require("os");
+const { getSchedule } = require("@utils/common");
+const moment = require("moment-timezone");
+
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- device-metadata-cleanup-job`
+);
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const JOB_NAME = "device-metadata-cleanup-job";
+// Three times a day: 02:00, 10:00, 18:00
+const JOB_SCHEDULE = getSchedule("0 2,10,18 * * *", constants.ENVIRONMENT);
+const TIMEZONE = constants.TIMEZONE || moment.tz.guess();
+const POD_ID = process.env.HOSTNAME || os.hostname();
+const LOCK_TTL_SECONDS = 60 * 60; // 1 hour — generous for large fleets
+const BATCH_SIZE = 500; // IDs fetched per DB round-trip
+const INTER_BATCH_DELAY_MS = 50; // breathing room between batches
+const DRY_RUN = process.env.DEVICE_METADATA_CLEANUP_DRY_RUN === "true";
+
+// Mirror the constant from Device.js / constants
+const UN_DEPLOYED_STATUSES = constants.VALID_DEVICE_STATUSES
+  ? constants.VALID_DEVICE_STATUSES.filter((s) => s !== "deployed")
+  : [
+      "recalled",
+      "ready",
+      "undeployed",
+      "decommissioned",
+      "assembly",
+      "testing",
+      "not deployed",
+    ];
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ── Distributed lock helpers ───────────────────────────────────────────────────
+
+const acquireLock = async (tenant) => {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + LOCK_TTL_SECONDS * 1000);
+  try {
+    const result = await JobLockModel(tenant).findOneAndUpdate(
+      {
+        jobName: JOB_NAME,
+        $or: [
+          { expiresAt: { $lte: now } },
+          { expiresAt: { $exists: false } },
+          { acquiredBy: POD_ID }, // same pod can reclaim its own lock after restart
+        ],
+      },
+      {
+        $set: { acquiredBy: POD_ID, acquiredAt: now, expiresAt },
+        $setOnInsert: { jobName: JOB_NAME },
+      },
+      { upsert: true, new: true, rawResult: false }
+    );
+    return result && result.acquiredBy === POD_ID;
+  } catch (error) {
+    if (error.code === 11000) return false; // Another pod beat us to it
+    logger.error(`[${POD_ID}] Lock acquisition error: ${error.message}`);
+    return false;
+  }
+};
+
+const releaseLock = async (tenant) => {
+  try {
+    await JobLockModel(tenant).findOneAndDelete({
+      jobName: JOB_NAME,
+      acquiredBy: POD_ID,
+    });
+  } catch (error) {
+    logger.error(`[${POD_ID}] Lock release error: ${error.message}`);
+  }
+};
+
+// ── Cursor-based pass runner ───────────────────────────────────────────────────
+
+/**
+ * Runs a single correction pass.
+ *
+ * @param {string}  tenant    - Tenant key (e.g. "airqo")
+ * @param {string}  passName  - Human-readable label for logs
+ * @param {object}  filter    - MongoDB match filter for dirty documents
+ * @param {object}  updateOp  - Raw MongoDB update operator ($set / $unset)
+ * @returns {Promise<number>} Count of modified documents
+ */
+const runPass = async (tenant, passName, filter, updateOp) => {
+  const collection = DeviceModel(tenant).collection;
+
+  // Quick pre-check — avoid acquiring a batch cursor when there's nothing to do
+  const total = await DeviceModel(tenant).countDocuments(filter);
+  if (total === 0) {
+    logger.info(`[${POD_ID}] ${passName}: nothing to fix — skipping.`);
+    return 0;
+  }
+
+  logger.info(
+    `[${POD_ID}] ${passName}: ${total} document(s) need correction.${DRY_RUN ? " [DRY RUN]" : ""}`
+  );
+
+  let lastSeenId = null;
+  let totalModified = 0;
+
+  while (true) {
+    const cursorFilter = lastSeenId
+      ? { ...filter, _id: { $gt: lastSeenId } }
+      : filter;
+
+    // Fetch only _id values — keeps this loop O(1) memory
+    const batch = await DeviceModel(tenant)
+      .find(cursorFilter)
+      .select("_id")
+      .sort({ _id: 1 })
+      .limit(BATCH_SIZE)
+      .lean();
+
+    if (batch.length === 0) break;
+
+    const ids = batch.map((d) => d._id);
+    lastSeenId = ids[ids.length - 1];
+
+    if (DRY_RUN) {
+      logger.info(
+        `[${POD_ID}] ${passName} [DRY RUN]: would apply ${JSON.stringify(
+          updateOp
+        )} to ${ids.length} device(s).`
+      );
+      totalModified += ids.length;
+    } else {
+      const result = await collection.updateMany(
+        { _id: { $in: ids } },
+        updateOp
+      );
+      totalModified += result.modifiedCount;
+      logger.info(
+        `[${POD_ID}] ${passName}: batch of ${ids.length} — modified ${result.modifiedCount}.`
+      );
+    }
+
+    await sleep(INTER_BATCH_DELAY_MS);
+  }
+
+  logger.info(
+    `[${POD_ID}] ${passName}: done. Total ${DRY_RUN ? "would modify" : "modified"}: ${totalModified}.`
+  );
+  return totalModified;
+};
+
+// ── Main job function ──────────────────────────────────────────────────────────
+
+const runCleanup = async (tenant = "airqo") => {
+  if (global.isShuttingDown) return;
+
+  const lockAcquired = await acquireLock(tenant);
+  if (!lockAcquired) {
+    logger.info(
+      `[${POD_ID}] ${JOB_NAME}: could not acquire lock — another pod is running it.`
+    );
+    return;
+  }
+
+  const startedAt = Date.now();
+  logger.info(`[${POD_ID}] ${JOB_NAME}: starting${DRY_RUN ? " [DRY RUN]" : ""}.`);
+
+  try {
+    // ── Pass 1: Backfill deployment_type="static" from site_id ───────────────
+    // Devices that are deployed at a site but were created before deployment_type
+    // was introduced (or had it incorrectly cleared).  Uses the {status,site_id}
+    // compound index.
+    await runPass(
+      tenant,
+      "pass1/backfill_static",
+      {
+        status: "deployed",
+        deployment_type: { $exists: false },
+        site_id: { $exists: true, $ne: null },
+        grid_id: { $in: [null, undefined] },
+      },
+      { $set: { deployment_type: "static", mobility: false } }
+    );
+
+    if (global.isShuttingDown) return;
+
+    // ── Pass 2: Backfill deployment_type="mobile" from grid_id ───────────────
+    // Grid-assigned deployed devices without an explicit deployment_type.
+    await runPass(
+      tenant,
+      "pass2/backfill_mobile",
+      {
+        status: "deployed",
+        deployment_type: { $exists: false },
+        grid_id: { $exists: true, $ne: null },
+      },
+      { $set: { deployment_type: "mobile", mobility: true } }
+    );
+
+    if (global.isShuttingDown) return;
+
+    // ── Pass 3: Fix mobility flag on static devices ───────────────────────────
+    // Old devices (e.g. 2019 cohort) that have deployment_type="static" but
+    // mobility:true stored from an earlier incorrect era.  Uses the
+    // {deployment_type,mobility} compound index.
+    await runPass(
+      tenant,
+      "pass3/fix_static_mobility",
+      { deployment_type: "static", mobility: { $ne: false } },
+      { $set: { mobility: false } }
+    );
+
+    if (global.isShuttingDown) return;
+
+    // ── Pass 4: Fix mobility flag on mobile devices ───────────────────────────
+    await runPass(
+      tenant,
+      "pass4/fix_mobile_mobility",
+      { deployment_type: "mobile", mobility: { $ne: true } },
+      { $set: { mobility: true } }
+    );
+
+    const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+    logger.info(`[${POD_ID}] ${JOB_NAME}: all passes complete in ${elapsed}s.`);
+  } catch (error) {
+    logger.error(`[${POD_ID}] ${JOB_NAME} error: ${error.message}`);
+  } finally {
+    await releaseLock(tenant);
+  }
+};
+
+// ── Schedule ──────────────────────────────────────────────────────────────────
+
+let currentJobPromise = null;
+
+const jobWrapper = async () => {
+  if (currentJobPromise) {
+    logger.warn(
+      `[${POD_ID}] ${JOB_NAME}: previous run still in progress — skipping this tick.`
+    );
+    return;
+  }
+  currentJobPromise = runCleanup("airqo").finally(() => {
+    currentJobPromise = null;
+  });
+  await currentJobPromise;
+};
+
+const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
+  scheduled: true,
+  timezone: TIMEZONE,
+});
+
+if (!global.cronJobs) global.cronJobs = {};
+global.cronJobs[JOB_NAME] = {
+  job: cronJobInstance,
+  schedule: JOB_SCHEDULE,
+  description: "Heals bad device mobility/deployment_type metadata 3x/day",
+};
+
+logger.info(
+  `[${POD_ID}] ${JOB_NAME}: scheduled (${JOB_SCHEDULE}, tz=${TIMEZONE})${DRY_RUN ? " [DRY RUN MODE]" : ""}.`
+);
+
+module.exports = runCleanup;

--- a/src/device-registry/bin/jobs/device-metadata-cleanup-job.js
+++ b/src/device-registry/bin/jobs/device-metadata-cleanup-job.js
@@ -13,7 +13,8 @@
  *
  *  Pass 2 – backfill_mobile
  *    Deployed devices that have a grid_id but no deployment_type.
- *    Action: set deployment_type="mobile", mobility=true.
+ *    Action: set deployment_type="mobile", mobility=true, unset site_id
+ *    (mirrors the pre-save hook that clears site_id for mobile devices).
  *
  *  Pass 3 – fix_static_mobility
  *    Devices with deployment_type="static" but mobility=true.
@@ -28,10 +29,14 @@
  * • Cursor-based pagination (_id > lastSeenId) keeps memory usage O(1)
  *   regardless of fleet size.  Each DB round-trip fetches at most BATCH_SIZE
  *   _ids, then issues a targeted updateMany — no full documents are loaded.
+ * • The write predicate merges the original pass filter with the _id set so
+ *   documents that changed between read and write are not incorrectly patched.
  * • Mongoose middleware is bypassed (collection.updateMany) so the pre-save
  *   hook's mobility↔deployment_type sync does not re-run and produce
  *   redundant writes.
- * • Distributed locking (JobLock) prevents duplicate runs across pods.
+ * • The distributed lock (JobLock) is periodically refreshed while work is
+ *   ongoing. If a refresh fails the run aborts immediately so another pod
+ *   cannot start an overlapping run.
  * • Dry-run mode (DEVICE_METADATA_CLEANUP_DRY_RUN=true) logs what would
  *   change without writing anything — safe to enable in production for audits.
  */
@@ -56,23 +61,11 @@ const JOB_NAME = "device-metadata-cleanup-job";
 const JOB_SCHEDULE = getSchedule("0 2,10,18 * * *", constants.ENVIRONMENT);
 const TIMEZONE = constants.TIMEZONE || moment.tz.guess();
 const POD_ID = process.env.HOSTNAME || os.hostname();
-const LOCK_TTL_SECONDS = 60 * 60; // 1 hour — generous for large fleets
-const BATCH_SIZE = 500; // IDs fetched per DB round-trip
-const INTER_BATCH_DELAY_MS = 50; // breathing room between batches
+const LOCK_TTL_SECONDS = 30 * 60;        // 30 min initial grant
+const LOCK_REFRESH_INTERVAL_MS = 10 * 60 * 1000; // refresh every 10 min
+const BATCH_SIZE = 500;                  // IDs fetched per DB round-trip
+const INTER_BATCH_DELAY_MS = 50;         // breathing room between batches
 const DRY_RUN = process.env.DEVICE_METADATA_CLEANUP_DRY_RUN === "true";
-
-// Mirror the constant from Device.js / constants
-const UN_DEPLOYED_STATUSES = constants.VALID_DEVICE_STATUSES
-  ? constants.VALID_DEVICE_STATUSES.filter((s) => s !== "deployed")
-  : [
-      "recalled",
-      "ready",
-      "undeployed",
-      "decommissioned",
-      "assembly",
-      "testing",
-      "not deployed",
-    ];
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -105,6 +98,26 @@ const acquireLock = async (tenant) => {
   }
 };
 
+/**
+ * Extends the lock TTL from now. Returns true on success, false if the lock
+ * was lost (another pod took it or it expired). The caller must abort if false.
+ */
+const refreshLock = async (tenant) => {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + LOCK_TTL_SECONDS * 1000);
+  try {
+    const result = await JobLockModel(tenant).findOneAndUpdate(
+      { jobName: JOB_NAME, acquiredBy: POD_ID },
+      { $set: { expiresAt } },
+      { new: true }
+    );
+    return !!result;
+  } catch (error) {
+    logger.error(`[${POD_ID}] Lock refresh error: ${error.message}`);
+    return false;
+  }
+};
+
 const releaseLock = async (tenant) => {
   try {
     await JobLockModel(tenant).findOneAndDelete({
@@ -121,13 +134,14 @@ const releaseLock = async (tenant) => {
 /**
  * Runs a single correction pass.
  *
- * @param {string}  tenant    - Tenant key (e.g. "airqo")
- * @param {string}  passName  - Human-readable label for logs
- * @param {object}  filter    - MongoDB match filter for dirty documents
- * @param {object}  updateOp  - Raw MongoDB update operator ($set / $unset)
+ * @param {string}   tenant       - Tenant key (e.g. "airqo")
+ * @param {string}   passName     - Human-readable label for logs
+ * @param {object}   filter       - MongoDB match filter for dirty documents
+ * @param {object}   updateOp     - Raw MongoDB update operator ($set / $unset)
+ * @param {{ isAborted: boolean }} abortSignal - Set .isAborted=true to halt mid-pass
  * @returns {Promise<number>} Count of modified documents
  */
-const runPass = async (tenant, passName, filter, updateOp) => {
+const runPass = async (tenant, passName, filter, updateOp, abortSignal) => {
   const collection = DeviceModel(tenant).collection;
 
   // Quick pre-check — avoid acquiring a batch cursor when there's nothing to do
@@ -145,6 +159,11 @@ const runPass = async (tenant, passName, filter, updateOp) => {
   let totalModified = 0;
 
   while (true) {
+    if (abortSignal.isAborted) {
+      logger.warn(`[${POD_ID}] ${passName}: aborting — lock was lost.`);
+      break;
+    }
+
     const cursorFilter = lastSeenId
       ? { ...filter, _id: { $gt: lastSeenId } }
       : filter;
@@ -170,10 +189,10 @@ const runPass = async (tenant, passName, filter, updateOp) => {
       );
       totalModified += ids.length;
     } else {
-      const result = await collection.updateMany(
-        { _id: { $in: ids } },
-        updateOp
-      );
+      // Merge the original pass filter with the id set so documents that
+      // changed between the read and this write are not incorrectly patched.
+      const writeFilter = { ...filter, _id: { $in: ids } };
+      const result = await collection.updateMany(writeFilter, updateOp);
       totalModified += result.modifiedCount;
       logger.info(
         `[${POD_ID}] ${passName}: batch of ${ids.length} — modified ${result.modifiedCount}.`
@@ -202,6 +221,21 @@ const runCleanup = async (tenant = "airqo") => {
     return;
   }
 
+  // Shared abort signal — set to true if a lock refresh fails so all passes
+  // bail out immediately instead of writing under a lost lock.
+  const abortSignal = { isAborted: false };
+
+  // Periodically refresh the lock TTL while passes are running.
+  const refreshTimer = setInterval(async () => {
+    const refreshed = await refreshLock(tenant);
+    if (!refreshed) {
+      logger.error(
+        `[${POD_ID}] ${JOB_NAME}: lock refresh failed — aborting to prevent overlapping runs.`
+      );
+      abortSignal.isAborted = true;
+    }
+  }, LOCK_REFRESH_INTERVAL_MS);
+
   const startedAt = Date.now();
   logger.info(`[${POD_ID}] ${JOB_NAME}: starting${DRY_RUN ? " [DRY RUN]" : ""}.`);
 
@@ -219,13 +253,16 @@ const runCleanup = async (tenant = "airqo") => {
         site_id: { $exists: true, $ne: null },
         grid_id: { $in: [null, undefined] },
       },
-      { $set: { deployment_type: "static", mobility: false } }
+      { $set: { deployment_type: "static", mobility: false } },
+      abortSignal
     );
 
-    if (global.isShuttingDown) return;
+    if (abortSignal.isAborted || global.isShuttingDown) return;
 
     // ── Pass 2: Backfill deployment_type="mobile" from grid_id ───────────────
     // Grid-assigned deployed devices without an explicit deployment_type.
+    // Also unsets site_id to mirror the pre-save hook that clears it for
+    // mobile devices, preventing stale site_id values from persisting.
     await runPass(
       tenant,
       "pass2/backfill_mobile",
@@ -234,10 +271,14 @@ const runCleanup = async (tenant = "airqo") => {
         deployment_type: { $exists: false },
         grid_id: { $exists: true, $ne: null },
       },
-      { $set: { deployment_type: "mobile", mobility: true } }
+      {
+        $set: { deployment_type: "mobile", mobility: true },
+        $unset: { site_id: "" },
+      },
+      abortSignal
     );
 
-    if (global.isShuttingDown) return;
+    if (abortSignal.isAborted || global.isShuttingDown) return;
 
     // ── Pass 3: Fix mobility flag on static devices ───────────────────────────
     // Old devices (e.g. 2019 cohort) that have deployment_type="static" but
@@ -247,17 +288,19 @@ const runCleanup = async (tenant = "airqo") => {
       tenant,
       "pass3/fix_static_mobility",
       { deployment_type: "static", mobility: { $ne: false } },
-      { $set: { mobility: false } }
+      { $set: { mobility: false } },
+      abortSignal
     );
 
-    if (global.isShuttingDown) return;
+    if (abortSignal.isAborted || global.isShuttingDown) return;
 
     // ── Pass 4: Fix mobility flag on mobile devices ───────────────────────────
     await runPass(
       tenant,
       "pass4/fix_mobile_mobility",
       { deployment_type: "mobile", mobility: { $ne: true } },
-      { $set: { mobility: true } }
+      { $set: { mobility: true } },
+      abortSignal
     );
 
     const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
@@ -265,6 +308,7 @@ const runCleanup = async (tenant = "airqo") => {
   } catch (error) {
     logger.error(`[${POD_ID}] ${JOB_NAME} error: ${error.message}`);
   } finally {
+    clearInterval(refreshTimer);
     await releaseLock(tenant);
   }
 };

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -185,6 +185,13 @@ try {
     `clear-deployment-type-job failed to start: ${err.message}`,
   );
 }
+try {
+  require("@bin/jobs/device-metadata-cleanup-job");
+} catch (err) {
+  global.dedupLogger.error(
+    `device-metadata-cleanup-job failed to start: ${err.message}`,
+  );
+}
 require("@bin/jobs/health-tip-checker-job");
 require("@bin/jobs/daily-activity-summary-job");
 require("@bin/jobs/site-categorization-job");

--- a/src/device-registry/config/global/static-lists.js
+++ b/src/device-registry/config/global/static-lists.js
@@ -16,5 +16,21 @@ const staticLists = {
     "not deployed",
   ],
   DEVICE_FILTER_TYPES: ["lowcost", "gas", "bam", "static", "mobile"],
+  /**
+   * Fields that may only be changed through dedicated lifecycle activity
+   * endpoints (deploy / recall / maintain). Guards in the controller,
+   * model modify()/bulkModify(), and background jobs all reference this
+   * single source of truth.
+   */
+  LIFECYCLE_FIELDS: [
+    "mobility",
+    "deployment_type",
+    "site_id",
+    "grid_id",
+    "status",
+    "deployment_date",
+    "recall_date",
+    "isActive",
+  ],
 };
 module.exports = staticLists;

--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -607,6 +607,10 @@ const deviceController = {
         ? defaultTenant
         : req.query.tenant;
 
+      // Same lifecycle-field guard applied to PUT /soft and PUT /bulk.
+      const { LIFECYCLE_FIELDS } = constants;
+      LIFECYCLE_FIELDS.forEach((f) => delete request.body[f]);
+
       const result = await createDeviceUtil.update(request, next);
 
       if (isEmpty(result) || res.headersSent) {
@@ -1252,10 +1256,7 @@ const deviceController = {
       // Lifecycle fields may only be changed via dedicated activity endpoints
       // (deploy, recall, maintain). Strip them here so a direct PATCH cannot
       // corrupt deployment state or bypass the activity audit trail.
-      const LIFECYCLE_FIELDS = [
-        "mobility", "deployment_type", "site_id", "grid_id",
-        "status", "deployment_date", "recall_date", "isActive",
-      ];
+      const { LIFECYCLE_FIELDS } = constants;
       const stripLifecycleFields = (obj) => {
         if (obj && typeof obj === "object") {
           LIFECYCLE_FIELDS.forEach((f) => delete obj[f]);
@@ -1318,10 +1319,7 @@ const deviceController = {
       // Same lifecycle-field guard as the single-device update endpoint.
       // Also covers request.body.updateData which is the nested payload
       // consumed by updateManyDevicesOnPlatform in the util.
-      const LIFECYCLE_FIELDS = [
-        "mobility", "deployment_type", "site_id", "grid_id",
-        "status", "deployment_date", "recall_date", "isActive",
-      ];
+      const { LIFECYCLE_FIELDS } = constants;
       const stripLifecycleFields = (obj) => {
         if (obj && typeof obj === "object") {
           LIFECYCLE_FIELDS.forEach((f) => delete obj[f]);

--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -1256,7 +1256,12 @@ const deviceController = {
         "mobility", "deployment_type", "site_id", "grid_id",
         "status", "deployment_date", "recall_date", "isActive",
       ];
-      LIFECYCLE_FIELDS.forEach((f) => delete request.body[f]);
+      const stripLifecycleFields = (obj) => {
+        if (obj && typeof obj === "object") {
+          LIFECYCLE_FIELDS.forEach((f) => delete obj[f]);
+        }
+      };
+      stripLifecycleFields(request.body);
 
       const result = await createDeviceUtil.updateOnPlatform(request, next);
 
@@ -1311,11 +1316,19 @@ const deviceController = {
         : req.query.tenant;
 
       // Same lifecycle-field guard as the single-device update endpoint.
+      // Also covers request.body.updateData which is the nested payload
+      // consumed by updateManyDevicesOnPlatform in the util.
       const LIFECYCLE_FIELDS = [
         "mobility", "deployment_type", "site_id", "grid_id",
         "status", "deployment_date", "recall_date", "isActive",
       ];
-      LIFECYCLE_FIELDS.forEach((f) => delete request.body[f]);
+      const stripLifecycleFields = (obj) => {
+        if (obj && typeof obj === "object") {
+          LIFECYCLE_FIELDS.forEach((f) => delete obj[f]);
+        }
+      };
+      stripLifecycleFields(request.body);
+      stripLifecycleFields(request.body.updateData);
 
       const result = await createDeviceUtil.updateManyDevicesOnPlatform(
         request,

--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -1249,6 +1249,15 @@ const deviceController = {
         ? defaultTenant
         : req.query.tenant;
 
+      // Lifecycle fields may only be changed via dedicated activity endpoints
+      // (deploy, recall, maintain). Strip them here so a direct PATCH cannot
+      // corrupt deployment state or bypass the activity audit trail.
+      const LIFECYCLE_FIELDS = [
+        "mobility", "deployment_type", "site_id", "grid_id",
+        "status", "deployment_date", "recall_date", "isActive",
+      ];
+      LIFECYCLE_FIELDS.forEach((f) => delete request.body[f]);
+
       const result = await createDeviceUtil.updateOnPlatform(request, next);
 
       if (isEmpty(result) || res.headersSent) {
@@ -1300,6 +1309,13 @@ const deviceController = {
       request.query.tenant = isEmpty(req.query.tenant)
         ? defaultTenant
         : req.query.tenant;
+
+      // Same lifecycle-field guard as the single-device update endpoint.
+      const LIFECYCLE_FIELDS = [
+        "mobility", "deployment_type", "site_id", "grid_id",
+        "status", "deployment_date", "recall_date", "isActive",
+      ];
+      LIFECYCLE_FIELDS.forEach((f) => delete request.body[f]);
 
       const result = await createDeviceUtil.updateManyDevicesOnPlatform(
         request,

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -102,7 +102,19 @@ function getDeploymentDescription(deploymentType) {
 function computeDeviceCategories(deviceDoc) {
   const doc = deviceDoc.toObject ? deviceDoc.toObject() : deviceDoc;
 
-  const isMobile = doc.mobility === true || doc.deployment_type === "mobile";
+  const primary_category = doc.category || "lowcost";
+  // Priority: explicit deployment_type → grid_id (mobile) → site_id (static) → null.
+  // Deliberately avoids the `mobility` field as a fallback because many old devices
+  // have mobility:true stored incorrectly from an earlier era.
+  const deployment_category =
+    doc.deployment_type ||
+    (doc.grid_id ? "mobile" : doc.site_id ? "static" : null);
+
+  // Derive is_mobile / is_static from deployment_category so they stay
+  // consistent even for old devices where `mobility` was stored incorrectly.
+  // A device with deployment_category === null gets both flags false.
+  const is_mobile = deployment_category === "mobile";
+  const is_static = deployment_category === "static";
 
   // ownership_category — returns raw network value for frontend display
   // null when network is missing or empty string
@@ -111,10 +123,10 @@ function computeDeviceCategories(deviceDoc) {
     ownership_category = doc.network;
   }
 
-  // mobile_category — only meaningful for mobile devices, null for static
+  // mobile_category — only meaningful for mobile devices, null for static/undeployed
   // priority: movement_pattern (most descriptive) → route_id → coverage_area → "mobile"
   let mobile_category = null;
-  if (isMobile) {
+  if (is_mobile) {
     const mm = doc.mobility_metadata || {};
     if (mm.movement_pattern) {
       mobile_category = mm.movement_pattern;
@@ -126,14 +138,6 @@ function computeDeviceCategories(deviceDoc) {
       mobile_category = "mobile";
     }
   }
-
-  const primary_category = doc.category || "lowcost";
-  // Priority: explicit deployment_type → grid_id (mobile) → site_id (static) → null.
-  // Deliberately avoids the `mobility` field as a fallback because many old devices
-  // have mobility:true stored incorrectly from an earlier era.
-  const deployment_category =
-    doc.deployment_type ||
-    (doc.grid_id ? "mobile" : doc.site_id ? "static" : null);
 
   // Use a Set to guarantee no duplicates in all_categories.
   // deployment_category is only added when it is actually set.
@@ -148,8 +152,8 @@ function computeDeviceCategories(deviceDoc) {
     deployment_category,
     ownership_category,
     mobile_category,
-    is_mobile: isMobile,
-    is_static: !isMobile,
+    is_mobile,
+    is_static,
     // Use primary_category (resolved) not doc.category (raw) so flags are
     // consistent when category is missing and defaults to "lowcost"
     is_lowcost: primary_category === "lowcost",
@@ -171,7 +175,7 @@ function computeDeviceCategories(deviceDoc) {
     category_relationships: {
       note:
         "Mobile devices can belong to any equipment category (lowcost, bam, or gas)",
-      mobile_is_subcategory_of: isMobile ? primary_category : null,
+      mobile_is_subcategory_of: is_mobile ? primary_category : null,
     },
   };
 
@@ -1248,13 +1252,25 @@ deviceSchema.statics = {
 
             // Only meaningful for mobile devices — null for static.
             // Priority: movement_pattern → route_id → coverage_area → "mobile"
+            // Uses the same deployment_category $switch so this flag is consistent
+            // with deployment_category even on old devices where mobility was wrong.
             // biome-ignore lint/suspicious/noThenProperty: MongoDB $cond uses a "then" key by design
             mobile_category: {
               $cond: {
                 if: {
-                  $or: [
-                    { $eq: ["$mobility", true] },
-                    { $eq: ["$deployment_type", "mobile"] },
+                  $eq: [
+                    {
+                      $switch: {
+                        branches: [
+                          { case: { $eq: ["$deployment_type", "mobile"] }, then: "mobile" },
+                          { case: { $eq: ["$deployment_type", "static"] }, then: "static" },
+                          { case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] }, then: "mobile" },
+                          { case: { $ne: [{ $ifNull: ["$site_id", null] }, null] }, then: "static" },
+                        ],
+                        default: null,
+                      },
+                    },
+                    "mobile",
                   ],
                 },
                 then: {
@@ -1352,21 +1368,40 @@ deviceSchema.statics = {
               },
             },
 
+            // Derived from deployment_category so consistent with old devices
+            // where `mobility` was stored incorrectly.
             is_mobile: {
-              $or: [
-                { $eq: ["$mobility", true] },
-                { $eq: ["$deployment_type", "mobile"] },
+              $eq: [
+                {
+                  $switch: {
+                    branches: [
+                      { case: { $eq: ["$deployment_type", "mobile"] }, then: "mobile" },
+                      { case: { $eq: ["$deployment_type", "static"] }, then: "static" },
+                      { case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] }, then: "mobile" },
+                      { case: { $ne: [{ $ifNull: ["$site_id", null] }, null] }, then: "static" },
+                    ],
+                    default: null,
+                  },
+                },
+                "mobile",
               ],
             },
-            // Strict negation of is_mobile — $not requires array form in aggregation expressions
+            // Explicitly checks "static" — a null deployment_category device is
+            // neither is_mobile nor is_static (not the negation of is_mobile).
             is_static: {
-              $not: [
+              $eq: [
                 {
-                  $or: [
-                    { $eq: ["$mobility", true] },
-                    { $eq: ["$deployment_type", "mobile"] },
-                  ],
+                  $switch: {
+                    branches: [
+                      { case: { $eq: ["$deployment_type", "mobile"] }, then: "mobile" },
+                      { case: { $eq: ["$deployment_type", "static"] }, then: "static" },
+                      { case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] }, then: "mobile" },
+                      { case: { $ne: [{ $ifNull: ["$site_id", null] }, null] }, then: "static" },
+                    ],
+                    default: null,
+                  },
                 },
+                "static",
               ],
             },
             // Compare against resolved primary_category (via $ifNull) not raw $category,
@@ -1440,9 +1475,19 @@ deviceSchema.statics = {
                         {
                           $cond: {
                             if: {
-                              $or: [
-                                { $eq: ["$mobility", true] },
-                                { $eq: ["$deployment_type", "mobile"] },
+                              $eq: [
+                                {
+                                  $switch: {
+                                    branches: [
+                                      { case: { $eq: ["$deployment_type", "mobile"] }, then: "mobile" },
+                                      { case: { $eq: ["$deployment_type", "static"] }, then: "static" },
+                                      { case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] }, then: "mobile" },
+                                      { case: { $ne: [{ $ifNull: ["$site_id", null] }, null] }, then: "static" },
+                                    ],
+                                    default: null,
+                                  },
+                                },
+                                "mobile",
                               ],
                             },
                             then: [
@@ -1639,9 +1684,19 @@ deviceSchema.statics = {
               mobile_is_subcategory_of: {
                 $cond: [
                   {
-                    $or: [
-                      { $eq: ["$mobility", true] },
-                      { $eq: ["$deployment_type", "mobile"] },
+                    $eq: [
+                      {
+                        $switch: {
+                          branches: [
+                            { case: { $eq: ["$deployment_type", "mobile"] }, then: "mobile" },
+                            { case: { $eq: ["$deployment_type", "static"] }, then: "static" },
+                            { case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] }, then: "mobile" },
+                            { case: { $ne: [{ $ifNull: ["$site_id", null] }, null] }, then: "static" },
+                          ],
+                          default: null,
+                        },
+                      },
+                      "mobile",
                     ],
                   },
                   { $ifNull: ["$category", "lowcost"] },
@@ -1754,6 +1809,21 @@ deviceSchema.statics = {
       }
       const sanitizedUpdate = sanitizeObject(update, invalidKeys);
 
+      // Also strip lifecycle fields nested inside Mongo update operators so a
+      // payload like { $set: { status: "deployed" } } cannot bypass the guard.
+      if (!opts.allowLifecycleFields) {
+        const UPDATE_OPERATORS = [
+          "$set", "$unset", "$setOnInsert", "$rename",
+          "$inc", "$mul", "$min", "$max",
+          "$push", "$pull", "$addToSet", "$pullAll", "$bit",
+        ];
+        for (const op of UPDATE_OPERATORS) {
+          if (sanitizedUpdate[op] && typeof sanitizedUpdate[op] === "object") {
+            constants.LIFECYCLE_FIELDS.forEach((f) => delete sanitizedUpdate[op][f]);
+          }
+        }
+      }
+
       const options = { new: true, ...opts };
 
       if (sanitizedUpdate.access_code) {
@@ -1808,6 +1878,20 @@ deviceSchema.statics = {
         invalidKeys.push(...constants.LIFECYCLE_FIELDS);
       }
       const sanitizedUpdate = sanitizeObject(update, invalidKeys);
+
+      // Also strip lifecycle fields nested inside Mongo update operators.
+      if (!opts.allowLifecycleFields) {
+        const UPDATE_OPERATORS = [
+          "$set", "$unset", "$setOnInsert", "$rename",
+          "$inc", "$mul", "$min", "$max",
+          "$push", "$pull", "$addToSet", "$pullAll", "$bit",
+        ];
+        for (const op of UPDATE_OPERATORS) {
+          if (sanitizedUpdate[op] && typeof sanitizedUpdate[op] === "object") {
+            constants.LIFECYCLE_FIELDS.forEach((f) => delete sanitizedUpdate[op][f]);
+          }
+        }
+      }
 
       // Handle special cases like access code generation
       if (sanitizedUpdate.access_code) {

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -1746,6 +1746,12 @@ deviceSchema.statics = {
     try {
       logText("we are now inside the modify function for devices....");
       const invalidKeys = ["name", "_id", "writeKey", "readKey"];
+      // Lifecycle fields may only be written by activity functions (deploy /
+      // recall / maintain).  Block them here unless the caller explicitly opts
+      // in via opts.allowLifecycleFields — activity callers set this flag.
+      if (!opts.allowLifecycleFields) {
+        invalidKeys.push(...constants.LIFECYCLE_FIELDS);
+      }
       const sanitizedUpdate = sanitizeObject(update, invalidKeys);
 
       const options = { new: true, ...opts };
@@ -1798,6 +1804,9 @@ deviceSchema.statics = {
     try {
       // Sanitize update object
       const invalidKeys = ["name", "_id", "writeKey", "readKey"];
+      if (!opts.allowLifecycleFields) {
+        invalidKeys.push(...constants.LIFECYCLE_FIELDS);
+      }
       const sanitizedUpdate = sanitizeObject(update, invalidKeys);
 
       // Handle special cases like access code generation

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -89,7 +89,8 @@ function getDeploymentDescription(deploymentType) {
     mobile: "Mobile deployment (vehicle-mounted, grid-based)",
     static: "Static deployment (fixed location, site-based)",
   };
-  return descriptions[deploymentType] || "Unknown deployment type";
+  // Return null for missing/un-deployed rather than a misleading fallback string.
+  return descriptions[deploymentType] ?? null;
 }
 
 /**
@@ -1386,7 +1387,47 @@ deviceSchema.statics = {
                     input: {
                       $concatArrays: [
                         [{ $ifNull: ["$category", "lowcost"] }],
-                        ["$deployment_type"],
+                        // Mirror deployment_category derivation so devices inferred
+                        // as static/mobile via site_id/grid_id appear in all_categories.
+                        [
+                          {
+                            $switch: {
+                              branches: [
+                                {
+                                  case: {
+                                    $eq: ["$deployment_type", "mobile"],
+                                  },
+                                  then: "mobile",
+                                },
+                                {
+                                  case: {
+                                    $eq: ["$deployment_type", "static"],
+                                  },
+                                  then: "static",
+                                },
+                                {
+                                  case: {
+                                    $ne: [
+                                      { $ifNull: ["$grid_id", null] },
+                                      null,
+                                    ],
+                                  },
+                                  then: "mobile",
+                                },
+                                {
+                                  case: {
+                                    $ne: [
+                                      { $ifNull: ["$site_id", null] },
+                                      null,
+                                    ],
+                                  },
+                                  then: "static",
+                                },
+                              ],
+                              default: null,
+                            },
+                          },
+                        ],
                         // Include network value when present
                         {
                           $cond: {

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -127,9 +127,12 @@ function computeDeviceCategories(deviceDoc) {
   }
 
   const primary_category = doc.category || "lowcost";
-  // Un-deployed devices have no deployment_type — keep it null rather than
-  // defaulting to "static", which would be semantically incorrect.
-  const deployment_category = doc.deployment_type || null;
+  // Priority: explicit deployment_type → grid_id (mobile) → site_id (static) → null.
+  // Deliberately avoids the `mobility` field as a fallback because many old devices
+  // have mobility:true stored incorrectly from an earlier era.
+  const deployment_category =
+    doc.deployment_type ||
+    (doc.grid_id ? "mobile" : doc.site_id ? "static" : null);
 
   // Use a Set to guarantee no duplicates in all_categories.
   // deployment_category is only added when it is actually set.
@@ -544,6 +547,12 @@ deviceSchema.index({ site_id: 1 });
 deviceSchema.index({ mobility: 1 });
 deviceSchema.index({ cohorts: 1 });
 deviceSchema.index({ mobility: 1, cohorts: 1 });
+// Compound indexes for the device-metadata-cleanup-job — keep cleanup passes
+// O(log n) regardless of fleet size.
+deviceSchema.index({ deployment_type: 1, status: 1 });
+deviceSchema.index({ deployment_type: 1, mobility: 1 });
+deviceSchema.index({ status: 1, site_id: 1 });
+deviceSchema.index({ status: 1, grid_id: 1 });
 // Index for stale entity checks
 deviceSchema.index({ "onlineStatusAccuracy.lastCheck": 1 });
 // Index for offline entity checks
@@ -1199,7 +1208,31 @@ deviceSchema.statics = {
         .addFields({
           device_categories: {
             primary_category: { $ifNull: ["$category", "lowcost"] },
-            deployment_category: "$deployment_type",
+            // Priority: explicit deployment_type → grid_id (mobile) →
+            // site_id (static) → null (un-deployed or unknown).
+            deployment_category: {
+              $switch: {
+                branches: [
+                  {
+                    case: { $eq: ["$deployment_type", "mobile"] },
+                    then: "mobile",
+                  },
+                  {
+                    case: { $eq: ["$deployment_type", "static"] },
+                    then: "static",
+                  },
+                  {
+                    case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] },
+                    then: "mobile",
+                  },
+                  {
+                    case: { $ne: [{ $ifNull: ["$site_id", null] }, null] },
+                    then: "static",
+                  },
+                ],
+                default: null,
+              },
+            },
 
             // Returns the raw network value so the frontend can display it directly.
             // null when network is missing or empty string.
@@ -1508,7 +1541,31 @@ deviceSchema.statics = {
               },
               {
                 level: "deployment",
-                category: "$deployment_type",
+                // Mirrors deployment_category: explicit deployment_type wins, then
+                // infer from location reference, fall back to null.
+                category: {
+                  $switch: {
+                    branches: [
+                      {
+                        case: { $eq: ["$deployment_type", "mobile"] },
+                        then: "mobile",
+                      },
+                      {
+                        case: { $eq: ["$deployment_type", "static"] },
+                        then: "static",
+                      },
+                      {
+                        case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] },
+                        then: "mobile",
+                      },
+                      {
+                        case: { $ne: [{ $ifNull: ["$site_id", null] }, null] },
+                        then: "static",
+                      },
+                    ],
+                    default: null,
+                  },
+                },
                 description: {
                   $switch: {
                     branches: [
@@ -1518,6 +1575,14 @@ deviceSchema.statics = {
                       },
                       {
                         case: { $eq: ["$deployment_type", "static"] },
+                        then: "Static deployment (fixed location, site-based)",
+                      },
+                      {
+                        case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] },
+                        then: "Mobile deployment (vehicle-mounted, grid-based)",
+                      },
+                      {
+                        case: { $ne: [{ $ifNull: ["$site_id", null] }, null] },
                         then: "Static deployment (fixed location, site-based)",
                       },
                     ],

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -2361,9 +2361,12 @@ const createActivity = {
           site_id: null,
           grid_id: null,
           mobility: false,
-          deployment_type: "static",
         },
         $unset: {
+          // deployment_type must be cleared on recall — a recalled device
+          // is no longer deployed anywhere, so assigning it a type is
+          // semantically incorrect and breaks the frontend deployment card.
+          deployment_type: "",
           mountType: "",
           powerType: "",
           height: "",

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -1053,6 +1053,9 @@ const createActivity = {
         const createdActivity = responseFromRegisterActivity.data;
 
         // **STEP 3**: Update device
+        // Mark as an activity call so updateOnPlatform passes allowLifecycleFields
+        // to the model guard — activity functions own lifecycle fields.
+        deviceBody.allowLifecycleFields = true;
         const responseFromUpdateDevice = await createDeviceUtil.updateOnPlatform(
           deviceBody,
           next,

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -96,9 +96,33 @@ const getDeviceCategoriesAddFieldsStage = () => {
     $addFields: {
       device_categories: {
         primary_category: { $ifNull: ["$category", "lowcost"] },
-        // Un-deployed devices have no deployment_type — use the field directly
-        // so they surface as null rather than a misleading "static" default.
-        deployment_category: "$deployment_type",
+        // Priority: explicit deployment_type (authoritative) → grid_id (mobile) →
+        // site_id (static) → null (un-deployed or unknown).
+        // Deliberately avoids the `mobility` field as a fallback because many old
+        // devices have mobility:true stored incorrectly from an earlier era.
+        deployment_category: {
+          $switch: {
+            branches: [
+              {
+                case: { $eq: ["$deployment_type", "mobile"] },
+                then: "mobile",
+              },
+              {
+                case: { $eq: ["$deployment_type", "static"] },
+                then: "static",
+              },
+              {
+                case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] },
+                then: "mobile",
+              },
+              {
+                case: { $ne: [{ $ifNull: ["$site_id", null] }, null] },
+                then: "static",
+              },
+            ],
+            default: null,
+          },
+        },
 
         // Returns the raw network value so the frontend can display it directly.
         // null when network is missing or empty string.
@@ -399,8 +423,31 @@ const getDeviceCategoriesAddFieldsStage = () => {
           },
           {
             level: "deployment",
-            // null for un-deployed devices — no deployment type assigned yet.
-            category: "$deployment_type",
+            // Mirrors deployment_category: explicit deployment_type wins, then
+            // infer from location reference, fall back to null for un-deployed.
+            category: {
+              $switch: {
+                branches: [
+                  {
+                    case: { $eq: ["$deployment_type", "mobile"] },
+                    then: "mobile",
+                  },
+                  {
+                    case: { $eq: ["$deployment_type", "static"] },
+                    then: "static",
+                  },
+                  {
+                    case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] },
+                    then: "mobile",
+                  },
+                  {
+                    case: { $ne: [{ $ifNull: ["$site_id", null] }, null] },
+                    then: "static",
+                  },
+                ],
+                default: null,
+              },
+            },
             description: {
               $switch: {
                 branches: [
@@ -410,6 +457,14 @@ const getDeviceCategoriesAddFieldsStage = () => {
                   },
                   {
                     case: { $eq: ["$deployment_type", "static"] },
+                    then: "Static deployment (fixed location, site-based)",
+                  },
+                  {
+                    case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] },
+                    then: "Mobile deployment (vehicle-mounted, grid-based)",
+                  },
+                  {
+                    case: { $ne: [{ $ifNull: ["$site_id", null] }, null] },
                     then: "Static deployment (fixed location, site-based)",
                   },
                 ],

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2135,7 +2135,13 @@ const deviceUtil = {
       };
 
       return await ActivityLogger.trackOperation(async () => {
-        let opts = {};
+        // Controllers strip lifecycle fields before calling updateOnPlatform,
+        // so any lifecycle field present in `update` here means the caller is
+        // an activity function (deploy/recall/maintain) that legitimately owns
+        // those fields. Pass the opt-in flag so the model guard lets them through.
+        const { LIFECYCLE_FIELDS } = constants;
+        const hasLifecycleFields = LIFECYCLE_FIELDS.some((f) => f in update);
+        let opts = hasLifecycleFields ? { allowLifecycleFields: true } : {};
         const responseFromModifyDevice = await DeviceModel(tenant).modify(
           {
             filter,

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -92,6 +92,23 @@ const buildRecallUpdateOperation = (recallDate) => ({
 });
 
 const getDeviceCategoriesAddFieldsStage = () => {
+  // Shared expression: mirrors deployment_category derivation.
+  // Using the same $switch for is_mobile / is_static / mobile_category gating
+  // keeps all fields consistent even on old devices where `mobility` is wrong.
+  const deploymentCategoryExpr = {
+    $switch: {
+      branches: [
+        { case: { $eq: ["$deployment_type", "mobile"] }, then: "mobile" },
+        { case: { $eq: ["$deployment_type", "static"] }, then: "static" },
+        { case: { $ne: [{ $ifNull: ["$grid_id", null] }, null] }, then: "mobile" },
+        { case: { $ne: [{ $ifNull: ["$site_id", null] }, null] }, then: "static" },
+      ],
+      default: null,
+    },
+  };
+  const isMobileExpr = { $eq: [deploymentCategoryExpr, "mobile"] };
+  const isStaticExpr = { $eq: [deploymentCategoryExpr, "static"] };
+
   return {
     $addFields: {
       device_categories: {
@@ -143,12 +160,7 @@ const getDeviceCategoriesAddFieldsStage = () => {
         // biome-ignore lint/suspicious/noThenProperty: MongoDB $cond uses a "then" key by design
         mobile_category: {
           $cond: {
-            if: {
-              $or: [
-                { $eq: ["$mobility", true] },
-                { $eq: ["$deployment_type", "mobile"] },
-              ],
-            },
+            if: isMobileExpr,
             then: {
               $switch: {
                 branches: [
@@ -234,23 +246,12 @@ const getDeviceCategoriesAddFieldsStage = () => {
           },
         },
 
-        is_mobile: {
-          $or: [
-            { $eq: ["$mobility", true] },
-            { $eq: ["$deployment_type", "mobile"] },
-          ],
-        },
-        // Strict negation of is_mobile — $not requires array form in aggregation expressions
-        is_static: {
-          $not: [
-            {
-              $or: [
-                { $eq: ["$mobility", true] },
-                { $eq: ["$deployment_type", "mobile"] },
-              ],
-            },
-          ],
-        },
+        // Derived from deployment_category — consistent even on old devices
+        // where `mobility` was stored incorrectly.
+        is_mobile: isMobileExpr,
+        // Explicitly checks "static" — a null deployment_category device is
+        // neither is_mobile nor is_static (not simply the negation of is_mobile).
+        is_static: isStaticExpr,
         // Compare against resolved primary_category (via $ifNull) not raw $category,
         // so a device with no category correctly gets is_lowcost: true
         is_lowcost: { $eq: [{ $ifNull: ["$category", "lowcost"] }, "lowcost"] },
@@ -311,12 +312,7 @@ const getDeviceCategoriesAddFieldsStage = () => {
                     // Include mobile_category when device is mobile
                     {
                       $cond: {
-                        if: {
-                          $or: [
-                            { $eq: ["$mobility", true] },
-                            { $eq: ["$deployment_type", "mobile"] },
-                          ],
-                        },
+                        if: isMobileExpr,
                         then: [
                           {
                             $switch: {
@@ -509,12 +505,7 @@ const getDeviceCategoriesAddFieldsStage = () => {
             "Mobile devices can belong to any equipment category (lowcost, bam, or gas)",
           mobile_is_subcategory_of: {
             $cond: [
-              {
-                $or: [
-                  { $eq: ["$mobility", true] },
-                  { $eq: ["$deployment_type", "mobile"] },
-                ],
-              },
+              isMobileExpr,
               { $ifNull: ["$category", "lowcost"] },
               null,
             ],
@@ -2135,13 +2126,13 @@ const deviceUtil = {
       };
 
       return await ActivityLogger.trackOperation(async () => {
-        // Controllers strip lifecycle fields before calling updateOnPlatform,
-        // so any lifecycle field present in `update` here means the caller is
-        // an activity function (deploy/recall/maintain) that legitimately owns
-        // those fields. Pass the opt-in flag so the model guard lets them through.
-        const { LIFECYCLE_FIELDS } = constants;
-        const hasLifecycleFields = LIFECYCLE_FIELDS.some((f) => f in update);
-        let opts = hasLifecycleFields ? { allowLifecycleFields: true } : {};
+        // Only activity call sites (deploy/recall/maintain) set
+        // request.allowLifecycleFields = true before calling updateOnPlatform.
+        // Never infer this from payload content — that would let a crafted body
+        // self-elevate permission to write lifecycle fields.
+        const opts = request.allowLifecycleFields
+          ? { allowLifecycleFields: true }
+          : {};
         const responseFromModifyDevice = await DeviceModel(tenant).modify(
           {
             filter,

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -267,9 +267,39 @@ const getDeviceCategoriesAddFieldsStage = () => {
                 input: {
                   $concatArrays: [
                     [{ $ifNull: ["$category", "lowcost"] }],
-                    // Only include deployment_type when it is set — the $filter
-                    // below removes nulls, so un-deployed devices contribute nothing here.
-                    ["$deployment_type"],
+                    // Use the same inferred deployment value as deployment_category so
+                    // devices without an explicit deployment_type (but with site_id/grid_id)
+                    // still contribute "static"/"mobile" to all_categories.
+                    // The $filter below removes nulls, so un-deployed devices add nothing.
+                    [
+                      {
+                        $switch: {
+                          branches: [
+                            {
+                              case: { $eq: ["$deployment_type", "mobile"] },
+                              then: "mobile",
+                            },
+                            {
+                              case: { $eq: ["$deployment_type", "static"] },
+                              then: "static",
+                            },
+                            {
+                              case: {
+                                $ne: [{ $ifNull: ["$grid_id", null] }, null],
+                              },
+                              then: "mobile",
+                            },
+                            {
+                              case: {
+                                $ne: [{ $ifNull: ["$site_id", null] }, null],
+                              },
+                              then: "static",
+                            },
+                          ],
+                          default: null,
+                        },
+                      },
+                    ],
                     // Include network value when present
                     {
                       $cond: {

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2130,7 +2130,7 @@ const deviceUtil = {
         // request.allowLifecycleFields = true before calling updateOnPlatform.
         // Never infer this from payload content — that would let a crafted body
         // self-elevate permission to write lifecycle fields.
-        const opts = request.allowLifecycleFields
+        const opts = request.allowLifecycleFields === true
           ? { allowLifecycleFields: true }
           : {};
         const responseFromModifyDevice = await DeviceModel(tenant).modify(
@@ -2539,7 +2539,7 @@ const deviceUtil = {
           updateOperation,
         );
 
-        if (recallResult.modifiedCount === 0) {
+        if ((recallResult.modifiedCount ?? recallResult.nModified ?? 0) === 0) {
           throw new HttpError(
             "Device status may have changed during the operation. Please try again.",
             httpStatus.CONFLICT,
@@ -2795,7 +2795,7 @@ const deviceUtil = {
               updateOperation,
             );
 
-            if (recallResult.modifiedCount === 0) {
+            if ((recallResult.modifiedCount ?? recallResult.nModified ?? 0) === 0) {
               throw new Error("Device status changed during recall operation");
             }
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

- Fixes `deployment_category` derivation in MongoDB aggregation (`device.util.js` and `Device.js`) to use `site_id`/`grid_id` as the fallback signal instead of the unreliable `mobility` flag, resolving the "Device Deployment Category" display bug in the Vertex frontend
- Fixes the recall activity to **unset** `deployment_type` instead of incorrectly resetting it to `"static"`
- Guards lifecycle-only fields (`mobility`, `deployment_type`, `site_id`, `grid_id`, `status`, `deployment_date`, `recall_date`, `isActive`) from being changed via the general-purpose `PUT /devices/soft` and `PUT /devices/bulk` endpoints — these fields can now only be mutated through the dedicated activity endpoints (`/deploy`, `/recall`, `/maintain`)
- Adds four compound indexes on `Device` to support efficient cleanup queries at scale
- Introduces a new `device-metadata-cleanup-job` that runs **three times a day** (02:00, 10:00, 18:00) and heals bad device metadata using cursor-based, distributed-lock-safe batch processing

### Why is this change needed?

The Vertex admin frontend was showing **"Device Deployment Category"** as a fallback label on every device page because `deployment_category` was missing from the API response. Root cause: many legacy devices (pre-2019) were stored with `mobility: true` but no explicit `deployment_type`, and the aggregation was using `mobility` as the sole fallback — which produced incorrect "mobile" results for pole-mounted solar devices. The correct authoritative signal is the device's location reference (`site_id` → static, `grid_id` → mobile).

Additionally, a direct `PATCH` to the device update endpoint could overwrite deployment state (e.g. `status`, `site_id`) without creating an activity record, silently corrupting the audit trail and bypassing all validation that the activity endpoints enforce.

The recall activity also had a bug where it re-assigned `deployment_type: "static"` on recall — a recalled device has no deployment, so the field must be cleared.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Verified against three real device API responses:
- `aq_04` (`mobility: true`, `site_id` set, no `deployment_type`) → now correctly returns `deployment_category: "static"`
- `aq_34` (`mobility: true`, `site_id` set, no `deployment_type`) → now correctly returns `deployment_category: "static"`
- `aq_g5_51` (`mobility: false`, `site_id` set, no `deployment_type`) → now correctly returns `deployment_category: "static"`

Verified that `PUT /devices/soft` with `{ "deployment_type": "mobile" }` in the body no longer modifies the field (stripped silently by the controller guard).

The cleanup job was reviewed for correctness of all four pass filters and update operators.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The lifecycle field guard is a **silent strip** (not a 4xx error) so existing API callers that happen to send these fields in a `PATCH` body will not receive an error — the fields will simply be ignored. This is intentional to avoid breaking existing integrations while still protecting data integrity.

---

## :memo: Additional Notes

**Files changed:**

| File | Change |
|---|---|
| `utils/device.util.js` | Fix `deployment_category` and `category_hierarchy[1]` derivation — use `site_id`/`grid_id` fallback, drop `mobility` fallback |
| `models/Device.js` | Same fix in inline aggregation + `computeDeviceCategories()` JS helper; add 4 compound indexes |
| `utils/activity.util.js` | Fix recall: unset `deployment_type` instead of resetting to `"static"` |
| `controllers/device.controller.js` | Strip lifecycle fields from `updateOnPlatform` and `updateManyDevicesOnPlatform` before forwarding to util |
| `bin/jobs/device-metadata-cleanup-job.js` | **New** — 3x/day cursor-based cleanup job with distributed locking |
| `bin/server.js` | Register new cleanup job |

**Cleanup job design notes:**
- Cursor pagination (`_id > lastSeenId`) keeps memory O(1) regardless of fleet size
- Bypasses Mongoose middleware via `collection.updateMany` to avoid spurious hook re-runs
- Overrun guard skips next cron tick if the current run has not yet finished
- Dry-run mode available via `DEVICE_METADATA_CLEANUP_DRY_RUN=true`

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated device metadata cleanup job runs three times daily with optional dry-run logging.

* **Improvements**
  * Smarter deployment-category inference using prioritized rules (explicit, grid, site).
  * New indexes to speed device queries and maintenance.

* **Security**
  * Lifecycle-related device fields are blocked from normal update paths and cannot be applied via bulk jobs unless explicitly allowed.

* **Bug Fixes**
  * Recall flow now clears deployment classification correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->