### PR TITLE
fix: strip cookies from nginx auth subrequest to prevent API timeouts

### DIFF
--- a/k8s/nginx/development/global-config.yaml
+++ b/k8s/nginx/development/global-config.yaml
@@ -169,6 +169,7 @@ data:
 
       internal;
       resolver                kube-dns.kube-system.svc.cluster.local valid=5s;
+      proxy_set_header        Cookie '';
       proxy_method            $method;
       proxy_pass              http://airqo-dev-auth-api-svc.development.svc.cluster.local:3000/api/v2/users/$verification_path;
       proxy_pass_request_body on;

--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -183,6 +183,7 @@ data:
 
       internal;
       resolver                kube-dns.kube-system.svc.cluster.local valid=5s;
+      proxy_set_header        Cookie '';
       proxy_method            $method;
       proxy_pass              http://airqo-auth-api-svc.production.svc.cluster.local:3000/api/v2/users/$verification_path;
       proxy_pass_request_body on;

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -182,6 +182,7 @@ data:
 
       internal;
       resolver                kube-dns.kube-system.svc.cluster.local valid=5s;
+      proxy_set_header        Cookie '';
       proxy_method            $method;
       proxy_pass              http://airqo-stage-auth-api-svc.staging.svc.cluster.local:3000/api/v2/users/$verification_path;
       proxy_pass_request_body on;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds `proxy_set_header Cookie '';` to the `location = /auth` subrequest block in the nginx global ConfigMap across all three environments (development, staging, production). This prevents browser session cookies from being forwarded to the auth service during per-request verification.

### Why is this change needed?
The nginx `auth_request /auth` subrequest — which runs for every API request — was forwarding the browser's full `Cookie` header (including `__Secure-next-auth.session-token`, `connect.sid`, and others) to the auth service's `/verify` endpoint. The auth service performed a slow session database lookup when these cookies were present, causing the upstream response to exceed both the axios 30-second client timeout and nginx's own upstream timeout, resulting in **504 Gateway Timeout** errors for all authenticated browser requests to device-registry endpoints.

API clients without browser cookies (e.g. Postman) were unaffected and returned responses in ~500ms. The root cause was confirmed by reproducing the failure with cURL using the exact browser request, then stripping only the `Cookie` header — the response returned immediately. Backend APIs authenticate exclusively via the `Authorization: JWT` header; session cookies have no role in backend verification and should never have been forwarded.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `k8s/nginx/production/global-config.yaml` — nginx ConfigMap (production)
- `k8s/nginx/staging/global-config.yaml` — nginx ConfigMap (staging)
- `k8s/nginx/development/global-config.yaml` — nginx ConfigMap (development)

No application microservice code was changed.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Reproduced the failure using cURL with the full browser request (including `Cookie` header) against `analytics.airqo.net/api/v2/devices/cohorts/cached-devices` — result was a 504 Gateway Timeout. Re-ran the identical request with the `Cookie` header stripped — response returned immediately (~500ms). This confirmed cookies as the sole differentiator between failing browser requests and fast Postman requests.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The auth service continues to receive the `Authorization: JWT` header for token verification. Only browser session cookies — which the backend `/verify` endpoint was never intended to process — are now stripped from the subrequest.

---

## :memo: Additional Notes

- All frontend and backend application changes from the earlier "Frontend Fix — 504 on Cohort Devices/Sites" work are correct and unaffected by this change.
- The `location = /auth` whitelist (grids/summary, grids/countries, users endpoints, etc.) is unchanged.
- This fix applies the same one-line change consistently across all environments to ensure parity.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue in the authentication system where session cookies were being unnecessarily transmitted to internal authentication services. This improvement applies across all environments (development, production, staging) and enhances security by ensuring proper data isolation while maintaining full authentication functionality and reliability across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->