### PR TITLE
fix: remove unused express-session and connect-mongo from device-registry

### DIFF
--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -5,8 +5,6 @@ const path = require("path");
 const cookieParser = require("cookie-parser");
 const app = express();
 const bodyParser = require("body-parser");
-const session = require("express-session");
-const MongoStore = require("connect-mongo")(session);
 const mongoose = require("mongoose");
 const { connectToMongoDB } = require("@config/database");
 connectToMongoDB();
@@ -65,7 +63,6 @@ const compression = require("compression");
 const helmet = require("helmet");
 const isDev = process.env.NODE_ENV === "development";
 const isProd = process.env.NODE_ENV === "production";
-const options = { mongooseConnection: mongoose.connection };
 
 const debug = require("debug")("device-service:server");
 const isEmpty = require("is-empty");
@@ -276,36 +273,7 @@ try {
   // Continue - server stays up
 }
 
-if (isEmpty(constants.SESSION_SECRET)) {
-  throw new Error("SESSION_SECRET environment variable not set");
-}
-
 // Express Middlewares
-const sessionMiddleware = session({
-  secret: constants.SESSION_SECRET,
-  store: new MongoStore(options),
-  resave: false,
-  saveUninitialized: false,
-  proxy: isProd,
-  cookie: {
-    secure: isProd,
-    httpOnly: true,
-    sameSite: "lax",
-  },
-});
-
-app.use((req, res, next) => {
-  const authHeader = req.headers.authorization;
-  const hasJwtToken =
-    typeof authHeader === "string" &&
-    authHeader.startsWith("JWT ") &&
-    authHeader.length > "JWT ".length;
-  if (hasJwtToken || req.query.token) {
-    return next();
-  }
-  sessionMiddleware(req, res, next);
-}); // session setup
-
 app.use(bodyParser.json({ limit: "50mb" })); // JSON body parser
 // Other common middlewares: morgan, cookieParser, passport, etc.
 if (isProd) {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Removes `express-session` and `connect-mongo` from `device-registry` entirely — including the imports, the `MongoStore` options object, the `SESSION_SECRET` guard, and the session middleware registration.

### Why is this change needed?
A thorough audit of the device-registry codebase confirmed that `req.session` is never read or written anywhere in the service. Despite this, `express-session` was registered unconditionally as the first Express middleware, causing every incoming request that carried a browser `connect.sid` cookie to trigger a synchronous `MongoStore.get()` call against MongoDB. Under load (or when MongoDB was slow), this caused requests to hang for 30+ seconds before timing out — the root cause of the `timeout of 30000ms exceeded` errors seen on the Analytics platform. Since sessions provide zero value to device-registry, the correct fix is full removal rather than a conditional guard.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [x] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/bin/server.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that all API endpoints continue to function correctly after removing session middleware. No routes or middleware in device-registry read or write `req.session`, so there is no functional regression.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Sessions were never used in this service. Removing them has no effect on any existing behaviour.

---

## :memo: Additional Notes

This is part of a broader investigation into 30-second request timeouts on the Devices tab of the Analytics platform (`analytics.airqo.net/user/data-export`). The full root cause chain was:

1. Browser sends API request with `Cookie: connect.sid=...`
2. nginx `auth_request` subrequest to auth-service — fixed separately by adding `proxy_set_header Cookie '';` to the nginx global ConfigMap.
3. nginx proxies the original request (still carrying the cookie) to device-registry.
4. device-registry's unconditional `express-session` called `MongoStore.get(sessionId)` — slow MongoDB lookup — 30 s timeout.

Related fixes already merged:
- nginx global ConfigMap: `proxy_set_header Cookie '';` in the `/auth` subrequest block (all environments)
- auth-service PRs #6442 and #6444: conditional session guard skipping MongoStore for JWT/token-authenticated requests

This PR eliminates the device-registry layer of the problem permanently by removing dead session infrastructure.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified server initialization by removing session management infrastructure and related startup validation checks, reducing configuration complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->