### PR TITLE
fix: remove dead passport.session() call from auth-service middleware chain

### DIFF
--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -186,16 +186,10 @@ app.use((req, res, next) => {
     return next();
   }
 
-  // For non-API requests (browser/OAuth), run the full session middleware chain.
-  // 1. sessionMiddleware: Loads session data from the store.
-  // 2. passport.initialize(): Initializes Passport.
-  // 3. passport.session(): Restores the user from the session (`req.user`).
-  // Errors from sessionMiddleware (e.g., store connection issues) are now
-  // correctly propagated to the main error handler.
-  sessionMiddleware(req, res, (err) => {
-    if (err) return next(err);
-    passport.session()(req, res, next);
-  });
+  // For non-API requests (browser/OAuth), load session data so that
+  // req.session.oauthTenant is available across the OAuth redirect round-trip.
+  // All passport strategies use session:false, so passport.session() is not needed.
+  sessionMiddleware(req, res, next);
 });
 
 app.use(bodyParser.json({ limit: "50mb" })); // JSON body parser


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Removes the `passport.session()` call from the conditional session middleware chain in `auth-service`, replacing the chained callback with a direct `sessionMiddleware(req, res, next)` call.

### Why is this change needed?
`passport.session()` deserializes a user from the session store on every browser request (any request without an `Authorization` header or `?token` param). However, every passport strategy in auth-service is configured with `session: false` — meaning no user is ever serialized into the session in the first place. The `passport.session()` call was therefore performing a wasted deserialization attempt on every non-JWT browser request, adding unnecessary overhead. The only reason sessions are still needed at all is to persist `req.session.oauthTenant` across the OAuth provider redirect round-trip — `passport.session()` plays no role in that.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [x] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `src/auth-service/bin/server.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
OAuth login flows (Google, etc.) continue to work correctly since `req.session.oauthTenant` is still populated by `sessionMiddleware`. JWT-authenticated API requests are unaffected — they bypass session entirely via the existing guard. No user-facing behaviour changes.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`passport.session()` was never doing useful work. All strategies already opt out of session-based auth via `session: false`. Removing it has no effect on any existing authentication flow.

---

## :memo: Additional Notes

This is a follow-up cleanup to auth-service PRs #6442 and #6444 (session guard for JWT requests) and the device-registry session removal PR. The full picture of changes across this investigation:

| Layer | Fix |
|---|---|
| nginx global ConfigMap | `proxy_set_header Cookie '';` strips cookies from the `/auth` subrequest |
| auth-service (#6442, #6444) | Conditional guard skips `express-session` for JWT/token requests |
| auth-service (this PR) | Removes dead `passport.session()` call for non-JWT requests |
| device-registry | `express-session` and `connect-mongo` removed entirely (sessions were never used) |

`passport.initialize()` remains in place — it is still required for strategy-based authentication even when `session: false` is used.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined authentication middleware to improve session persistence during OAuth workflows while reducing unnecessary middleware operations and maintaining secure session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->