### PR TITLE
Add fire-and-forget rawOnlineStatus refresh on device API endpoints

### DIFF
--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -17,6 +17,7 @@ const {
 } = require("@utils/shared");
 
 const isEmpty = require("is-empty");
+const rawStatusUpdater = require("@utils/common/update-raw-status.util");
 function handleResponse({
   result,
   key = "data",
@@ -226,8 +227,16 @@ const deviceController = {
         ? defaultTenant
         : req.query.tenant;
 
-      const result = await createDeviceUtil.getDeviceById(req, next); // Call the utility function
+      const result = await createDeviceUtil.getDeviceById(req, next);
       handleResponse({ result, res });
+
+      // Fire-and-forget: keep rawOnlineStatus fresh without blocking the response
+      if (result?.success && result?.data?.[0]?._id) {
+        rawStatusUpdater.fireAndForget(
+          [result.data[0]._id],
+          req.query.tenant
+        );
+      }
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -231,9 +231,9 @@ const deviceController = {
       handleResponse({ result, res });
 
       // Fire-and-forget: keep rawOnlineStatus fresh without blocking the response
-      if (result?.success && result?.data?.[0]?._id) {
+      if (result?.success && result?.data?._id) {
         rawStatusUpdater.fireAndForget(
-          [result.data[0]._id],
+          [result.data._id],
           req.query.tenant
         );
       }

--- a/src/device-registry/utils/common/update-raw-status.util.js
+++ b/src/device-registry/utils/common/update-raw-status.util.js
@@ -1,0 +1,292 @@
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- utils/update-raw-status.util`
+);
+const DeviceModel = require("@models/Device");
+const createFeedUtil = require("@utils/feed.util");
+const createDeviceUtil = require("@utils/device.util");
+const { getNetworkAdapter } = require("@utils/network.util");
+const { getUptimeAccuracyUpdateObject } = require("@utils/common");
+const isEmpty = require("is-empty");
+
+// Skip re-checking a device whose lastRawData is fresher than this threshold.
+// Balances freshness against ThingSpeak / external-API rate pressure.
+const RECENCY_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
+const RAW_INACTIVE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours (matches job)
+const THINGSPEAK_TIMEOUT_MS = 30000;
+const EXTERNAL_API_TIMEOUT_MS = 20000;
+
+const STATUSES_FOR_PRIMARY_UPDATE = (
+  constants.VALID_DEVICE_STATUSES || []
+).filter((s) => s !== "deployed");
+
+const isDeviceRawActive = (lastFeedTime) => {
+  if (!lastFeedTime) return false;
+  return Date.now() - new Date(lastFeedTime).getTime() < RAW_INACTIVE_THRESHOLD_MS;
+};
+
+const isDeviceActuallyMobile = (device) => {
+  const type = (device?.deployment_type || "").toString().toLowerCase();
+  return device?.mobility === true || type === "mobile";
+};
+
+const mockNext = (error) => {
+  logger.error(`Error in fire-and-forget raw status update: ${error.message}`);
+};
+
+/**
+ * Update rawOnlineStatus for a single device document already fetched from DB.
+ * Returns a Promise that resolves when the DB write completes (or on any error).
+ * Never rejects — errors are logged and swallowed.
+ */
+const processDevice = async (device) => {
+  const hasExistingRawData =
+    device.lastRawData && !isNaN(new Date(device.lastRawData).getTime());
+  const existingDataAge = hasExistingRawData
+    ? Date.now() - new Date(device.lastRawData).getTime()
+    : Infinity;
+  const shouldMarkOfflineFromStaleData =
+    existingDataAge >= RAW_INACTIVE_THRESHOLD_MS;
+
+  let isRawOnline = false;
+  let lastFeedTime = null;
+  let updateReason = "no_device_number";
+
+  // ── AirQo device path ──────────────────────────────────────────────────────
+  if (device.device_number) {
+    // Fetch readKey (lean query — only what we need)
+    let apiKey;
+    try {
+      const detail = await DeviceModel("airqo")
+        .findOne({ device_number: device.device_number })
+        .select("readKey")
+        .lean();
+
+      if (!detail?.readKey) {
+        isRawOnline = hasExistingRawData ? !shouldMarkOfflineFromStaleData : false;
+        updateReason = shouldMarkOfflineFromStaleData
+          ? "stale_lastRawData"
+          : "no_readkey";
+        await writeDeviceUpdate(device, isRawOnline, null, updateReason);
+        return;
+      }
+
+      const decryptResponse = await createDeviceUtil.decryptKey(
+        detail.readKey,
+        mockNext
+      );
+      if (!decryptResponse.success) {
+        isRawOnline = hasExistingRawData ? !shouldMarkOfflineFromStaleData : false;
+        updateReason = shouldMarkOfflineFromStaleData
+          ? "stale_lastRawData"
+          : "decryption_failed";
+        await writeDeviceUpdate(device, isRawOnline, null, updateReason);
+        return;
+      }
+      apiKey = decryptResponse.data;
+    } catch (err) {
+      logger.warn(
+        `[update-raw-status] key fetch/decrypt failed for ${device.name}: ${err.message}`
+      );
+      return;
+    }
+
+    try {
+      const thingspeakData = await Promise.race([
+        createFeedUtil.fetchThingspeakData({
+          channel: device.device_number,
+          api_key: apiKey,
+        }),
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error("ThingSpeak fetch timeout")),
+            THINGSPEAK_TIMEOUT_MS
+          )
+        ),
+      ]);
+
+      if (thingspeakData?.feeds?.[0]) {
+        lastFeedTime = thingspeakData.feeds[0].created_at;
+        isRawOnline = isDeviceRawActive(lastFeedTime);
+        updateReason = isRawOnline ? "online_raw" : "offline_raw";
+      } else if (shouldMarkOfflineFromStaleData) {
+        isRawOnline = false;
+        updateReason = "stale_lastRawData";
+      }
+    } catch (err) {
+      logger.warn(
+        `[update-raw-status] ThingSpeak fetch failed for ${device.name}: ${err.message}`
+      );
+      isRawOnline = hasExistingRawData ? !shouldMarkOfflineFromStaleData : false;
+      updateReason = shouldMarkOfflineFromStaleData
+        ? "stale_lastRawData"
+        : "fetch_error";
+    }
+
+    await writeDeviceUpdate(device, isRawOnline, lastFeedTime, updateReason);
+    return;
+  }
+
+  // ── External device path ───────────────────────────────────────────────────
+  const externalAdapter =
+    device.api_code && device.network && device.network !== "airqo"
+      ? await getNetworkAdapter(device.network).catch(() => null)
+      : null;
+
+  if (externalAdapter?.online_check_via_feed) {
+    try {
+      const externalResult = await Promise.race([
+        createFeedUtil.fetchExternalDeviceData({ device, adapter: externalAdapter }),
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error("External API timeout")),
+            EXTERNAL_API_TIMEOUT_MS
+          )
+        ),
+      ]);
+
+      if (externalResult.success && !isEmpty(externalResult.data)) {
+        const data = externalResult.data;
+        const tsValue =
+          data.timestamp || data.time || data.created_at || data.recordedAt || data.ts || null;
+        if (tsValue) {
+          lastFeedTime = tsValue;
+          isRawOnline = isDeviceRawActive(tsValue);
+        } else {
+          isRawOnline = true;
+          lastFeedTime = new Date().toISOString();
+        }
+        updateReason = isRawOnline ? "online_external_api" : "offline_external_api";
+      } else {
+        isRawOnline = false;
+        updateReason = "offline_external_api";
+      }
+    } catch (err) {
+      logger.warn(
+        `[update-raw-status] external API failed for ${device.name}: ${err.message}`
+      );
+      isRawOnline = hasExistingRawData ? !shouldMarkOfflineFromStaleData : false;
+      updateReason = shouldMarkOfflineFromStaleData
+        ? "stale_lastRawData"
+        : "external_api_error";
+    }
+
+    await writeDeviceUpdate(device, isRawOnline, lastFeedTime, updateReason);
+    return;
+  }
+
+  // ── Fallback: stale-data only ──────────────────────────────────────────────
+  isRawOnline = hasExistingRawData ? !shouldMarkOfflineFromStaleData : false;
+  updateReason = shouldMarkOfflineFromStaleData ? "stale_lastRawData" : "no_device_number";
+  await writeDeviceUpdate(device, isRawOnline, null, updateReason);
+};
+
+/**
+ * Write rawOnlineStatus (and related fields) to the Device document.
+ */
+const writeDeviceUpdate = async (device, isRawOnline, lastFeedTime, reason) => {
+  try {
+    const { setUpdate, incUpdate } = getUptimeAccuracyUpdateObject({
+      isCurrentlyOnline: device.rawOnlineStatus,
+      isNowOnline: isRawOnline,
+      currentStats: device.onlineStatusAccuracy,
+      reason,
+    });
+
+    const updateFields = { rawOnlineStatus: isRawOnline, ...setUpdate };
+    if (lastFeedTime) {
+      updateFields.lastRawData = new Date(lastFeedTime);
+    }
+    if (
+      STATUSES_FOR_PRIMARY_UPDATE.includes(device.status) ||
+      isDeviceActuallyMobile(device)
+    ) {
+      updateFields.isOnline = isRawOnline;
+      if (lastFeedTime) {
+        updateFields.lastActive = new Date(lastFeedTime);
+      }
+    }
+
+    const updateDoc = { $set: updateFields };
+    if (incUpdate) {
+      updateDoc.$inc = incUpdate;
+    }
+
+    await DeviceModel(device.tenant || "airqo").findByIdAndUpdate(
+      device._id,
+      updateDoc,
+      { new: false }
+    );
+  } catch (err) {
+    logger.warn(
+      `[update-raw-status] DB write failed for ${device.name}: ${err.message}`
+    );
+  }
+};
+
+/**
+ * Fetch lightweight device documents for the given IDs, apply the recency
+ * guard, and process each one.  Resolves when all updates finish (or fail).
+ */
+const updateDevices = async (deviceIds, tenant = "airqo") => {
+  if (!deviceIds?.length) return;
+
+  let devices;
+  try {
+    devices = await DeviceModel(tenant)
+      .find({ _id: { $in: deviceIds } })
+      .select(
+        "_id name device_number api_code network rawOnlineStatus lastRawData " +
+          "status deployment_type mobility site_id isPrimaryInLocation " +
+          "onlineStatusAccuracy readKey"
+      )
+      .lean();
+  } catch (err) {
+    logger.warn(`[update-raw-status] device fetch failed: ${err.message}`);
+    return;
+  }
+
+  // Apply recency guard: skip devices updated within RECENCY_THRESHOLD_MS
+  const staleDevices = devices.filter((d) => {
+    if (!d.lastRawData) return true;
+    return Date.now() - new Date(d.lastRawData).getTime() >= RECENCY_THRESHOLD_MS;
+  });
+
+  if (!staleDevices.length) return;
+
+  // Attach tenant so writeDeviceUpdate can use the right model
+  for (const d of staleDevices) {
+    d.tenant = tenant;
+  }
+
+  // Sequential with setImmediate yields to keep the event loop responsive
+  for (const device of staleDevices) {
+    await new Promise((resolve) => setImmediate(resolve));
+    await processDevice(device).catch((err) =>
+      logger.warn(
+        `[update-raw-status] unhandled error for ${device.name}: ${err.message}`
+      )
+    );
+  }
+};
+
+/**
+ * Fire-and-forget wrapper for a single device view.
+ *
+ * Usage:
+ *   fireAndForget([deviceId], tenant);   // no await — intentional
+ *
+ * setImmediate ensures the HTTP response is flushed before the update starts.
+ */
+const fireAndForget = (deviceIds, tenant = "airqo") => {
+  if (!deviceIds?.length) return;
+
+  setImmediate(() => {
+    updateDevices(deviceIds, tenant).catch((err) =>
+      logger.warn(`[update-raw-status] fire-and-forget error: ${err.message}`)
+    );
+  });
+};
+
+module.exports = { fireAndForget };

--- a/src/device-registry/utils/common/update-raw-status.util.js
+++ b/src/device-registry/utils/common/update-raw-status.util.js
@@ -10,8 +10,9 @@ const { getNetworkAdapter } = require("@utils/network.util");
 const { getUptimeAccuracyUpdateObject } = require("@utils/common");
 const isEmpty = require("is-empty");
 
-// Skip re-checking a device whose lastRawData is fresher than this threshold.
-// Balances freshness against ThingSpeak / external-API rate pressure.
+// Skip re-checking a device whose lastRawStatusCheckedAt is fresher than this.
+// Using a dedicated throttle field rather than lastRawData ensures devices with
+// no feed data are also throttled correctly.
 const RECENCY_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
 const RAW_INACTIVE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours (matches job)
 const THINGSPEAK_TIMEOUT_MS = 30000;
@@ -23,12 +24,23 @@ const STATUSES_FOR_PRIMARY_UPDATE = (
 
 const isDeviceRawActive = (lastFeedTime) => {
   if (!lastFeedTime) return false;
-  return Date.now() - new Date(lastFeedTime).getTime() < RAW_INACTIVE_THRESHOLD_MS;
+  const t = new Date(lastFeedTime).getTime();
+  if (isNaN(t)) return false;
+  return Date.now() - t < RAW_INACTIVE_THRESHOLD_MS;
 };
 
 const isDeviceActuallyMobile = (device) => {
   const type = (device?.deployment_type || "").toString().toLowerCase();
   return device?.mobility === true || type === "mobile";
+};
+
+// Returns a Promise.race-compatible pair that always clears its timer.
+const withTimeout = (promise, ms, label) => {
+  let timerId;
+  const timeout = new Promise((_, reject) => {
+    timerId = setTimeout(() => reject(new Error(`${label} timeout`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timerId));
 };
 
 const mockNext = (error) => {
@@ -55,7 +67,6 @@ const processDevice = async (device) => {
 
   // ── AirQo device path ──────────────────────────────────────────────────────
   if (device.device_number) {
-    // Fetch readKey (lean query — only what we need)
     let apiKey;
     try {
       const detail = await DeviceModel("airqo")
@@ -76,7 +87,8 @@ const processDevice = async (device) => {
         detail.readKey,
         mockNext
       );
-      if (!decryptResponse.success) {
+      // Guard against undefined return from decryptKey
+      if (!decryptResponse?.success) {
         isRawOnline = hasExistingRawData ? !shouldMarkOfflineFromStaleData : false;
         updateReason = shouldMarkOfflineFromStaleData
           ? "stale_lastRawData"
@@ -89,29 +101,33 @@ const processDevice = async (device) => {
       logger.warn(
         `[update-raw-status] key fetch/decrypt failed for ${device.name}: ${err.message}`
       );
+      // Write a stale-data fallback rather than leaving the device unupdated
+      isRawOnline = hasExistingRawData ? !shouldMarkOfflineFromStaleData : false;
+      updateReason = shouldMarkOfflineFromStaleData
+        ? "stale_lastRawData"
+        : "key_fetch_or_decrypt_error";
+      await writeDeviceUpdate(device, isRawOnline, null, updateReason);
       return;
     }
 
     try {
-      const thingspeakData = await Promise.race([
+      const thingspeakData = await withTimeout(
         createFeedUtil.fetchThingspeakData({
           channel: device.device_number,
           api_key: apiKey,
         }),
-        new Promise((_, reject) =>
-          setTimeout(
-            () => reject(new Error("ThingSpeak fetch timeout")),
-            THINGSPEAK_TIMEOUT_MS
-          )
-        ),
-      ]);
+        THINGSPEAK_TIMEOUT_MS,
+        "ThingSpeak fetch"
+      );
 
       if (thingspeakData?.feeds?.[0]) {
         lastFeedTime = thingspeakData.feeds[0].created_at;
         isRawOnline = isDeviceRawActive(lastFeedTime);
         updateReason = isRawOnline ? "online_raw" : "offline_raw";
-      } else if (shouldMarkOfflineFromStaleData) {
-        isRawOnline = false;
+      } else {
+        // No new feed data — fall back to existing lastRawData to avoid
+        // incorrectly flipping a recently-active device offline
+        isRawOnline = isDeviceRawActive(device.lastRawData);
         updateReason = "stale_lastRawData";
       }
     } catch (err) {
@@ -136,15 +152,11 @@ const processDevice = async (device) => {
 
   if (externalAdapter?.online_check_via_feed) {
     try {
-      const externalResult = await Promise.race([
+      const externalResult = await withTimeout(
         createFeedUtil.fetchExternalDeviceData({ device, adapter: externalAdapter }),
-        new Promise((_, reject) =>
-          setTimeout(
-            () => reject(new Error("External API timeout")),
-            EXTERNAL_API_TIMEOUT_MS
-          )
-        ),
-      ]);
+        EXTERNAL_API_TIMEOUT_MS,
+        "External API"
+      );
 
       if (externalResult.success && !isEmpty(externalResult.data)) {
         const data = externalResult.data;
@@ -159,8 +171,10 @@ const processDevice = async (device) => {
         }
         updateReason = isRawOnline ? "online_external_api" : "offline_external_api";
       } else {
-        isRawOnline = false;
-        updateReason = "offline_external_api";
+        // Empty/unsuccessful response — fall back to lastRawData rather than
+        // immediately marking offline
+        isRawOnline = isDeviceRawActive(device.lastRawData);
+        updateReason = "stale_lastRawData";
       }
     } catch (err) {
       logger.warn(
@@ -184,6 +198,9 @@ const processDevice = async (device) => {
 
 /**
  * Write rawOnlineStatus (and related fields) to the Device document.
+ *
+ * Uses a conditional filter on lastRawData so we never overwrite fresher data
+ * that the batch job may have written between our fetch and this write.
  */
 const writeDeviceUpdate = async (device, isRawOnline, lastFeedTime, reason) => {
   try {
@@ -194,18 +211,32 @@ const writeDeviceUpdate = async (device, isRawOnline, lastFeedTime, reason) => {
       reason,
     });
 
-    const updateFields = { rawOnlineStatus: isRawOnline, ...setUpdate };
+    const updateFields = {
+      rawOnlineStatus: isRawOnline,
+      // Durable throttle timestamp — used by the recency guard so devices with
+      // no feed data are also dampened correctly
+      lastRawStatusCheckedAt: new Date(),
+      ...setUpdate,
+    };
+
     if (lastFeedTime) {
-      updateFields.lastRawData = new Date(lastFeedTime);
+      const parsedTime = new Date(lastFeedTime);
+      if (!isNaN(parsedTime.getTime())) {
+        updateFields.lastRawData = parsedTime;
+        if (
+          STATUSES_FOR_PRIMARY_UPDATE.includes(device.status) ||
+          isDeviceActuallyMobile(device)
+        ) {
+          updateFields.lastActive = parsedTime;
+        }
+      }
     }
+
     if (
       STATUSES_FOR_PRIMARY_UPDATE.includes(device.status) ||
       isDeviceActuallyMobile(device)
     ) {
       updateFields.isOnline = isRawOnline;
-      if (lastFeedTime) {
-        updateFields.lastActive = new Date(lastFeedTime);
-      }
     }
 
     const updateDoc = { $set: updateFields };
@@ -213,11 +244,20 @@ const writeDeviceUpdate = async (device, isRawOnline, lastFeedTime, reason) => {
       updateDoc.$inc = incUpdate;
     }
 
-    await DeviceModel(device.tenant || "airqo").findByIdAndUpdate(
-      device._id,
+    // Conditional write: only apply if lastRawData hasn't advanced since we
+    // fetched the device, preventing overwrites from the concurrent batch job.
+    const filter = { _id: device._id, lastRawData: device.lastRawData || null };
+    const updated = await DeviceModel(device.tenant || "airqo").findOneAndUpdate(
+      filter,
       updateDoc,
       { new: false }
     );
+
+    if (!updated) {
+      logger.debug(
+        `[update-raw-status] skipped write for ${device.name} — lastRawData advanced by another writer`
+      );
+    }
   } catch (err) {
     logger.warn(
       `[update-raw-status] DB write failed for ${device.name}: ${err.message}`
@@ -238,8 +278,8 @@ const updateDevices = async (deviceIds, tenant = "airqo") => {
       .find({ _id: { $in: deviceIds } })
       .select(
         "_id name device_number api_code network rawOnlineStatus lastRawData " +
-          "status deployment_type mobility site_id isPrimaryInLocation " +
-          "onlineStatusAccuracy readKey"
+          "lastRawStatusCheckedAt status deployment_type mobility site_id " +
+          "isPrimaryInLocation onlineStatusAccuracy"
       )
       .lean();
   } catch (err) {
@@ -247,15 +287,18 @@ const updateDevices = async (deviceIds, tenant = "airqo") => {
     return;
   }
 
-  // Apply recency guard: skip devices updated within RECENCY_THRESHOLD_MS
+  // Recency guard: prefer lastRawStatusCheckedAt (always written), fall back to
+  // lastRawData. Treat invalid/missing timestamps as stale (include in batch).
   const staleDevices = devices.filter((d) => {
-    if (!d.lastRawData) return true;
-    return Date.now() - new Date(d.lastRawData).getTime() >= RECENCY_THRESHOLD_MS;
+    const checkField = d.lastRawStatusCheckedAt || d.lastRawData;
+    if (!checkField) return true;
+    const t = new Date(checkField).getTime();
+    if (isNaN(t)) return true;
+    return Date.now() - t >= RECENCY_THRESHOLD_MS;
   });
 
   if (!staleDevices.length) return;
 
-  // Attach tenant so writeDeviceUpdate can use the right model
   for (const d of staleDevices) {
     d.tenant = tenant;
   }


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds an opportunistic, fire-and-forget `rawOnlineStatus` refresh triggered when a client views a single device's details:

- Introduces **`utils/common/update-raw-status.util.js`** — a self-contained utility that replicates the per-device status-check logic from the hourly batch job (ThingSpeak fetch for AirQo devices, external-adapter fetch for third-party networks, stale-data fallback for others). Includes a **15-minute recency guard** (skips devices whose `lastRawData` is already fresh) and sequential processing with `setImmediate` yields to stay event-loop friendly.
- Wires **`fireAndForget([deviceId], tenant)`** into `getDeviceDetailsById` — triggers a single-device refresh strictly after the response is sent, with zero impact on response latency.

### Why is this change needed?
The hourly cron job (`update-raw-online-status-job`, schedule `35 * * * *`) is the only mechanism that updates `rawOnlineStatus`. Between runs, status can be up to ~60 minutes stale. This PR adds a second, complementary approach: whenever a client views a specific device, its status is opportunistically refreshed in the background. Scoped to single-device detail views only (not list endpoints) to keep the approach lightweight and avoid any external API pressure from bulk queries. The job frequency is intentionally unchanged — this is purely additive.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`
  - `utils/common/update-raw-status.util.js` _(new file)_
  - `controllers/device.controller.js` _(fire-and-forget hook added to `getDeviceDetailsById`)_

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually verified that `GET /devices/:id` response time is unchanged. Confirmed via logs that `rawOnlineStatus` updates fire after the response in a background tick. Recency guard confirmed to skip devices with a `lastRawData` timestamp fresher than 15 minutes.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The **recency threshold is 15 minutes** (`RECENCY_THRESHOLD_MS` in the utility). This means at most ~4 ThingSpeak calls per device per hour can be triggered via this path — well within rate limits and a significant improvement over the once-per-hour baseline.
- The existing hourly job is untouched and continues to run as the primary bulk-update mechanism. This utility is a supplementary layer.
- `utils/common/` is the correct home for this file per project conventions (root `utils/` is reserved for use-case-specific util files).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device status auto-refresh: When accessing device details, the system now automatically updates device online/offline status in the background using the latest available feed data, without impacting response time.
  * Adaptive refresh logic: Recently synced devices are skipped to optimize resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->