### PR TITLE
feat: add declared_places support to user preferences for exposure

### DIFF
--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -330,7 +330,7 @@ const PreferenceSchema = new mongoose.Schema(
       },
     ],
     selected_sites: [siteSchema],
-    declared_places: [declaredPlaceSchema],
+    declared_places: { type: [declaredPlaceSchema], default: [] },
     selected_grids: [gridSchema],
     selected_devices: [deviceSchema],
     selected_cohorts: [cohortSchema],
@@ -490,7 +490,7 @@ PreferenceSchema.methods = {
       period: this.period,
       createdAt: this.createdAt,
       selected_sites: this.selected_sites,
-      declared_places: this.declared_places,
+      declared_places: this.declared_places || [],
       selected_grids: this.selected_grids,
       selected_devices: this.selected_devices,
       selected_cohorts: this.selected_cohorts,
@@ -615,6 +615,7 @@ PreferenceSchema.statics = {
               (a, b) => b.createdAt - a.createdAt
             );
           }
+          preference.declared_places = preference.declared_places || [];
         });
 
         // Update lastAccessed timestamp for all found preferences

--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -171,6 +171,35 @@ const airqloudSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const timeWindowSchema = new mongoose.Schema(
+  {
+    arrive_h: { type: Number, min: 0, max: 23, required: true },
+    arrive_m: { type: Number, min: 0, max: 59, required: true },
+    leave_h: { type: Number, min: 0, max: 23, required: true },
+    leave_m: { type: Number, min: 0, max: 59, required: true },
+  },
+  { _id: false }
+);
+
+const declaredPlaceSchema = new mongoose.Schema(
+  {
+    site_id: { type: String, required: true },
+    display_name: { type: String, required: true },
+    location_name: { type: String, required: true },
+    city: { type: String, required: true },
+    type: {
+      type: String,
+      enum: ["home", "work", "school", "gym", "family", "other"],
+      required: true,
+    },
+    absent_on_weekdays: { type: Boolean, required: true },
+    absent_on_weekends: { type: Boolean, required: true },
+    weekday_window: { type: timeWindowSchema, default: null },
+    weekend_window: { type: timeWindowSchema, default: null },
+  },
+  { _id: false }
+);
+
 const locationPreferenceSchema = new mongoose.Schema(
   {
     trackingEnabled: { type: Boolean, default: true },
@@ -301,6 +330,7 @@ const PreferenceSchema = new mongoose.Schema(
       },
     ],
     selected_sites: [siteSchema],
+    declared_places: [declaredPlaceSchema],
     selected_grids: [gridSchema],
     selected_devices: [deviceSchema],
     selected_cohorts: [cohortSchema],
@@ -460,6 +490,7 @@ PreferenceSchema.methods = {
       period: this.period,
       createdAt: this.createdAt,
       selected_sites: this.selected_sites,
+      declared_places: this.declared_places,
       selected_grids: this.selected_grids,
       selected_devices: this.selected_devices,
       selected_cohorts: this.selected_cohorts,

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -508,6 +508,13 @@ const preferences = {
 
       const update = prepareUpdate(body, fieldsToUpdate, fieldsToAddToSet);
 
+      // declared_places: full replace semantics, no _id deduplication
+      if (body.declared_places !== undefined) {
+        update["$set"] = update["$set"] || {};
+        update["$set"].declared_places = body.declared_places;
+        delete update.declared_places;
+      }
+
       const options = { upsert: true, new: true };
 
       const modifyResponse = await PreferenceModel(tenant).findOneAndUpdate(

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -509,7 +509,7 @@ const preferences = {
       const update = prepareUpdate(body, fieldsToUpdate, fieldsToAddToSet);
 
       // declared_places: full replace semantics, no _id deduplication
-      if (body.declared_places !== undefined) {
+      if (Array.isArray(body.declared_places)) {
         update["$set"] = update["$set"] || {};
         update["$set"].declared_places = body.declared_places;
         delete update.declared_places;

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -689,6 +689,134 @@ const commonValidations = {
       next();
     };
   },
+  declaredPlaces: () => {
+    return (req, res, next) => {
+      const declaredPlaces = req.body.declared_places;
+
+      if (declaredPlaces === undefined || declaredPlaces === null) {
+        return next();
+      }
+
+      if (!Array.isArray(declaredPlaces)) {
+        return res.status(400).json({
+          success: false,
+          message: "Validation Error: declared_places must be an array",
+          errors: { declared_places: "Expected an array of place objects" },
+        });
+      }
+
+      const VALID_TYPES = ["home", "work", "school", "gym", "family", "other"];
+      const errors = {};
+
+      const validateTimeWindow = (window, path) => {
+        const windowErrors = [];
+        if (typeof window !== "object" || Array.isArray(window)) {
+          windowErrors.push("must be an object");
+          return windowErrors;
+        }
+        ["arrive_h", "arrive_m", "leave_h", "leave_m"].forEach((key) => {
+          if (window[key] === undefined) {
+            windowErrors.push(`${key} is required`);
+          } else if (!Number.isInteger(window[key])) {
+            windowErrors.push(`${key} must be an integer`);
+          }
+        });
+        if (
+          window.arrive_h !== undefined &&
+          (window.arrive_h < 0 || window.arrive_h > 23)
+        ) {
+          windowErrors.push("arrive_h must be 0–23");
+        }
+        if (
+          window.arrive_m !== undefined &&
+          (window.arrive_m < 0 || window.arrive_m > 59)
+        ) {
+          windowErrors.push("arrive_m must be 0–59");
+        }
+        if (
+          window.leave_h !== undefined &&
+          (window.leave_h < 0 || window.leave_h > 23)
+        ) {
+          windowErrors.push("leave_h must be 0–23");
+        }
+        if (
+          window.leave_m !== undefined &&
+          (window.leave_m < 0 || window.leave_m > 59)
+        ) {
+          windowErrors.push("leave_m must be 0–59");
+        }
+        return windowErrors;
+      };
+
+      declaredPlaces.forEach((place, idx) => {
+        const placeErrors = [];
+        const prefix = `declared_places[${idx}]`;
+
+        if (!place || typeof place !== "object" || Array.isArray(place)) {
+          errors[prefix] = ["each declared place must be an object"];
+          return;
+        }
+
+        if (!place.site_id) {
+          placeErrors.push("site_id is required");
+        } else if (!isMongoId(String(place.site_id))) {
+          placeErrors.push("site_id must be a valid MongoDB ObjectId");
+        }
+
+        ["display_name", "location_name", "city"].forEach((field) => {
+          if (!place[field] || typeof place[field] !== "string") {
+            placeErrors.push(`${field} is required and must be a non-empty string`);
+          }
+        });
+
+        if (!place.type) {
+          placeErrors.push("type is required");
+        } else if (!VALID_TYPES.includes(place.type)) {
+          placeErrors.push(
+            `type must be one of: ${VALID_TYPES.join(", ")}`
+          );
+        }
+
+        ["absent_on_weekdays", "absent_on_weekends"].forEach((field) => {
+          if (place[field] === undefined) {
+            placeErrors.push(`${field} is required`);
+          } else if (typeof place[field] !== "boolean") {
+            placeErrors.push(`${field} must be a boolean`);
+          }
+        });
+
+        if (place.weekday_window !== undefined && place.weekday_window !== null) {
+          const winErrors = validateTimeWindow(
+            place.weekday_window,
+            `${prefix}.weekday_window`
+          );
+          winErrors.forEach((e) => placeErrors.push(`weekday_window: ${e}`));
+        }
+
+        if (place.weekend_window !== undefined && place.weekend_window !== null) {
+          const winErrors = validateTimeWindow(
+            place.weekend_window,
+            `${prefix}.weekend_window`
+          );
+          winErrors.forEach((e) => placeErrors.push(`weekend_window: ${e}`));
+        }
+
+        if (placeErrors.length > 0) {
+          errors[prefix] = placeErrors;
+        }
+      });
+
+      if (Object.keys(errors).length > 0) {
+        return res.status(400).json({
+          success: false,
+          message: "Validation errors found in declared_places",
+          errors,
+        });
+      }
+
+      next();
+    };
+  },
   preferenceBody: [
     //validations for the request body itself
     oneOf([
@@ -1128,6 +1256,7 @@ const preferenceValidations = {
     ...commonValidations.userId,
     ...commonValidations.preferenceBody,
     commonValidations.selectedSites(["_id", "search_name", "name"], true),
+    commonValidations.declaredPlaces(),
   ],
   update: [
     ...commonValidations.tenant,

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -691,11 +691,16 @@ const commonValidations = {
   },
   declaredPlaces: () => {
     return (req, res, next) => {
-      const declaredPlaces = req.body.declared_places;
-
-      if (declaredPlaces === undefined || declaredPlaces === null) {
+      if (req.body.declared_places === undefined) {
         return next();
       }
+
+      if (req.body.declared_places === null) {
+        req.body.declared_places = [];
+        return next();
+      }
+
+      const declaredPlaces = req.body.declared_places;
 
       if (!Array.isArray(declaredPlaces)) {
         return res.status(400).json({
@@ -708,7 +713,7 @@ const commonValidations = {
       const VALID_TYPES = ["home", "work", "school", "gym", "family", "other"];
       const errors = {};
 
-      const validateTimeWindow = (window, path) => {
+      const validateTimeWindow = (window) => {
         const windowErrors = [];
         if (typeof window !== "object" || Array.isArray(window)) {
           windowErrors.push("must be an object");
@@ -764,8 +769,11 @@ const commonValidations = {
         }
 
         ["display_name", "location_name", "city"].forEach((field) => {
-          if (!place[field] || typeof place[field] !== "string") {
+          const val = typeof place[field] === "string" ? place[field].trim() : "";
+          if (!val) {
             placeErrors.push(`${field} is required and must be a non-empty string`);
+          } else {
+            place[field] = val;
           }
         });
 
@@ -786,18 +794,12 @@ const commonValidations = {
         });
 
         if (place.weekday_window !== undefined && place.weekday_window !== null) {
-          const winErrors = validateTimeWindow(
-            place.weekday_window,
-            `${prefix}.weekday_window`
-          );
+          const winErrors = validateTimeWindow(place.weekday_window);
           winErrors.forEach((e) => placeErrors.push(`weekday_window: ${e}`));
         }
 
         if (place.weekend_window !== undefined && place.weekend_window !== null) {
-          const winErrors = validateTimeWindow(
-            place.weekend_window,
-            `${prefix}.weekend_window`
-          );
+          const winErrors = validateTimeWindow(place.weekend_window);
           winErrors.forEach((e) => placeErrors.push(`weekend_window: ${e}`));
         }
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Extends the existing user preferences document with a `declared_places` array to support the new **Exposure** feature in the AirQo mobile app. No new endpoints are introduced — the two existing preferences endpoints are extended:

- **`GET /api/v2/users/preferences/:userId`** — now returns `declared_places` alongside `selected_sites` (empty array if the user has none yet).
- **`PATCH /api/v2/users/preferences/replace`** — now accepts and persists `declared_places` from the request body using full replace semantics (the app sends the complete list every time).

Each declared place captures where a user spends time (home, work, school, etc.), whether they are absent on weekdays/weekends, and optional arrival/departure time windows.

### Why is this change needed?

The mobile Exposure feature needs to know which physical locations a user frequents and their typical schedules so it can compute personalised air-quality exposure scores. This data lives naturally in the user preferences document alongside the already-existing `selected_sites`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Manually verified via Postman:
- `PATCH /api/v2/users/preferences/replace` with a `declared_places` payload persists the full array correctly and returns it in the response.
- `GET /api/v2/users/preferences/:userId` returns `declared_places` (populated or empty array) alongside `selected_sites`.
- Omitting `declared_places` from the PATCH body leaves the existing stored value untouched.
- Invalid payloads (bad `type` enum, missing required fields, out-of-range time window values) are rejected with descriptive 400 errors.

---

## :boom: Breaking Changes

- [x] **No breaking changes**

Both endpoints are additive-only. Existing clients that do not send or read `declared_places` are unaffected. Users with no declared places receive an empty array in the GET response.

---

## :memo: Additional Notes

**Schema — `DeclaredPlace`**

| Field | Type | Required |
|---|---|---|
| `site_id` | MongoDB ObjectId string | Yes |
| `display_name` | string | Yes |
| `location_name` | string | Yes |
| `city` | string | Yes |
| `type` | `home` \| `work` \| `school` \| `gym` \| `family` \| `other` | Yes |
| `absent_on_weekdays` | boolean | Yes |
| `absent_on_weekends` | boolean | Yes |
| `weekday_window` | `TimeWindow` \| null | No |
| `weekend_window` | `TimeWindow` \| null | No |

**Schema — `TimeWindow`**

| Field | Type | Range |
|---|---|---|
| `arrive_h` | integer | 0–23 |
| `arrive_m` | integer | 0–59 |
| `leave_h` | integer | 0–23 |
| `leave_m` | integer | 0–59 |

Time windows support overnight spans (e.g. arrive 22:00, leave 06:00).

**Implementation note:** `declared_places` is written directly into `$set` in the `replace` utility, bypassing the `_id`-based deduplication used for `selected_sites` (declared places have no `_id` field).

The device-registry changes (hourly readings endpoint) will follow in a separate PR.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to declare preferred work locations with customizable absence schedules for weekdays and weekends.
  * Users can configure specific arrival and departure time windows for each declared location.
  * Enhanced validation ensures proper data integrity for location-based preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->