### PR TITLE
Refactor site refresh: fault-tolerant steps, grids, and missing fields

### DIFF
--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1147,7 +1147,15 @@ const createSite = {
           }
         }
 
-        if (isEmpty(site.lat_long) && latitude && longitude) {
+        if (
+          isEmpty(site.lat_long) &&
+          latitude !== undefined &&
+          latitude !== null &&
+          latitude !== "" &&
+          longitude !== undefined &&
+          longitude !== null &&
+          longitude !== ""
+        ) {
           setFields.lat_long = createSite.generateLatLong(latitude, longitude);
         }
 
@@ -1156,16 +1164,6 @@ const createSite = {
           if (nameRes && nameRes.success) {
             setFields.generated_name = nameRes.data;
           }
-        }
-
-        // description: mirrors backfill job — use site name as the value
-        if (isEmpty(site.description)) {
-          const nameToUse =
-            setFields.name ||
-            site.name ||
-            setFields.generated_name ||
-            site.generated_name;
-          if (nameToUse) setFields.description = nameToUse;
         }
 
         stepResults.localFields = "ok";
@@ -1219,6 +1217,35 @@ const createSite = {
           stepResults.geocoding =
             geoRes?.errors?.message || geoRes?.message || "failed";
         }
+
+        // ── Description (built after geocoding so location data is available) ─
+        // Only written when the site has no description at all.
+        // Strategy: "{name}, {locality}, {country}" — each part is optional
+        // so a partial geocode still produces a useful description.
+        if (isEmpty(site.description) && isEmpty(setFields.description)) {
+          const namePart =
+            setFields.name ||
+            site.name ||
+            setFields.generated_name ||
+            site.generated_name;
+          const localityPart =
+            setFields.search_name ||
+            site.search_name ||
+            setFields.parish ||
+            site.parish ||
+            setFields.city ||
+            site.city ||
+            setFields.district ||
+            site.district;
+          const countryPart = setFields.country || site.country;
+
+          const descParts = [namePart, localityPart, countryPart].filter(
+            (p) => !isEmpty(p),
+          );
+          if (descParts.length > 0) {
+            setFields.description = descParts.join(", ");
+          }
+        }
       } catch (err) {
         logger.error(
           `refresh: geocoding step failed for site ${id}: ${err.message}`,
@@ -1244,45 +1271,43 @@ const createSite = {
       }
 
       // ── Step 4: Grid membership ─────────────────────────────────────────────
-      // Query grids directly for _id + shape — GridModel.list() excludes shape
-      // in its projection so we go to the model directly.
-      // Grids are always replaced (not merged) because polygon boundaries can
-      // change independently of the site.
+      // Use $geoIntersects against the 2dsphere index on shape — handles both
+      // Polygon and MultiPolygon without client-side iteration or geolib.
+      // Only overwrite setFields.grids when we have at least one match; an
+      // empty result is treated as "no matching grids" rather than clearing
+      // existing memberships, in case the grids collection is empty/misconfigured.
       try {
-        const grids = await GridModel(tenant)
-          .find({})
-          .select("_id shape")
+        const matchedGrids = await GridModel(tenant)
+          .find({
+            shape: {
+              $geoIntersects: {
+                $geometry: {
+                  type: "Point",
+                  coordinates: [longitude, latitude],
+                },
+              },
+            },
+          })
+          .select("_id")
           .lean();
 
-        const matchedGridIds = [];
-        for (const grid of grids) {
-          if (
-            !grid.shape ||
-            !Array.isArray(grid.shape.coordinates) ||
-            !grid.shape.coordinates[0]
-          ) {
-            continue;
-          }
-          try {
-            const polygon = grid.shape.coordinates[0].map(([lng, lat]) => ({
-              longitude: lng,
-              latitude: lat,
-            }));
-            if (geolib.isPointInPolygon({ latitude, longitude }, polygon)) {
-              matchedGridIds.push(grid._id);
-            }
-          } catch (polyErr) {
+        if (matchedGrids.length > 0) {
+          setFields.grids = matchedGrids.map((g) => g._id);
+          stepResults.grids = "ok";
+        } else {
+          const hasAnyGrid = await GridModel(tenant).exists({});
+          if (!hasAnyGrid) {
             logger.warn(
-              `refresh: grid ${grid._id} polygon check error: ${polyErr.message}`,
+              `refresh: grids collection appears empty for tenant ${tenant} — skipping grid assignment`,
             );
+            stepResults.grids = "skipped (grids collection empty)";
+          } else {
+            stepResults.grids = "no matching grids for site coordinates";
           }
         }
-
-        setFields.grids = matchedGridIds;
-        stepResults.grids = "ok";
       } catch (err) {
         logger.error(
-          `refresh: grids step failed for site ${id}: ${err.message}`,
+          `refresh: grids step failed for site ${siteDbId}: ${err.message}`,
         );
         stepResults.grids = err.message;
       }
@@ -1319,14 +1344,14 @@ const createSite = {
 
       // ── Step 6: Data provider (always recomputed) ───────────────────────────
       try {
-        const dataProvider = await computeSiteDataProvider(tenant, id);
+        const dataProvider = await computeSiteDataProvider(tenant, siteDbId);
         if (dataProvider !== undefined) {
           setFields.data_provider = dataProvider;
         }
         stepResults.dataProvider = "ok";
       } catch (err) {
         logger.error(
-          `refresh: dataProvider step failed for site ${id}: ${err.message}`,
+          `refresh: dataProvider step failed for site ${siteDbId}: ${err.message}`,
         );
         stepResults.dataProvider = err.message;
       }
@@ -1336,12 +1361,27 @@ const createSite = {
       //   a) strips generated_name and lat_long from $set (restricted fields)
       //   b) converts top-level grids array to $addToSet (unwanted here — we
       //      want a full replace so stale grid memberships are removed)
+      const normalizeStepResult = (v) => {
+        if (typeof v === "string") return v;
+        if (v instanceof Error) return v.message;
+        return String(v);
+      };
+
+      const failedSteps = Object.entries(stepResults)
+        .filter(([, v]) => {
+          const s = normalizeStepResult(v);
+          return s !== "ok" && !s.startsWith("skipped");
+        })
+        .map(([k, v]) => `${k}: ${normalizeStepResult(v)}`);
+
       const hasChanges = !isEmpty(setFields) || tagsToAdd.length > 0;
 
       if (!hasChanges) {
         return {
           success: true,
-          message: "Site metadata is already complete — nothing to update",
+          message: failedSteps.length
+            ? `Site metadata unchanged — some enrichment steps were unsuccessful: ${failedSteps.join("; ")}`
+            : "Site metadata is already complete — nothing to update",
           data: site,
           status: httpStatus.OK,
         };
@@ -1356,11 +1396,23 @@ const createSite = {
           site_tags: { $each: [...new Set(tagsToAdd)] },
         };
       }
+      updateOp.$currentDate = { updatedAt: true };
 
-      await SiteModel(tenant).collection.updateOne(
-        { _id: siteDbId },
-        updateOp,
-      );
+      try {
+        await SiteModel(tenant).collection.updateOne(
+          { _id: siteDbId },
+          updateOp,
+        );
+      } catch (persistErr) {
+        if (persistErr.code === 11000) {
+          logger.error(
+            `refresh: duplicate-key conflict persisting site ${siteDbId}: ${persistErr.message}`,
+          );
+          stepResults.persist = `duplicate-key conflict: ${persistErr.message}`;
+        } else {
+          throw persistErr;
+        }
+      }
 
       // Re-fetch so the response reflects the persisted state
       const refreshedDetails = await createSite.fetchSiteDetails(
@@ -1371,14 +1423,17 @@ const createSite = {
       const updatedSite =
         refreshedDetails.success ? refreshedDetails.data[0] : site;
 
-      const failedSteps = Object.entries(stepResults)
-        .filter(([, v]) => v !== "ok" && !v.startsWith("skipped"))
-        .map(([k, v]) => `${k}: ${v}`);
+      const allFailedSteps = Object.entries(stepResults)
+        .filter(([, v]) => {
+          const s = normalizeStepResult(v);
+          return s !== "ok" && !s.startsWith("skipped");
+        })
+        .map(([k, v]) => `${k}: ${normalizeStepResult(v)}`);
 
       return {
         success: true,
-        message: failedSteps.length
-          ? `Site partially refreshed — some steps were unsuccessful: ${failedSteps.join("; ")}`
+        message: allFailedSteps.length
+          ? `Site partially refreshed — some steps were unsuccessful: ${allFailedSteps.join("; ")}`
           : "Site details successfully refreshed",
         data: updatedSite,
         status: httpStatus.OK,

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1104,50 +1104,286 @@ const createSite = {
   },
   refresh: async (req, next) => {
     try {
-      logObject("the req coming in...", req);
       const { tenant, id } = req.query;
 
+      // Step 0: Fetch current site — required before any enrichment
       const siteDetails = await createSite.fetchSiteDetails(tenant, req, next);
       if (!siteDetails.success) return siteDetails;
 
-      const requestBody = createSite.prepareSiteRequestBody(
-        siteDetails.data[0],
-        tenant,
-        next,
-      );
+      const site = siteDetails.data[0];
+      const { latitude, longitude, _id: siteDbId } = site;
 
-      const airQloudsAndWeatherStations = await createSite.fetchAdditionalSiteDetails(
-        tenant,
-        id,
-        next,
-      );
-      Object.assign(requestBody, airQloudsAndWeatherStations);
+      // setFields  → written via $set  (collection.updateOne bypasses pre-hook)
+      // tagsToAdd  → written via $addToSet so existing tags are never removed
+      const setFields = {};
+      const tagsToAdd = [];
+      const stepResults = {};
 
-      // Pass the site's id in body so generateMetadata can resolve the
-      // correct data_provider from deployed devices rather than body.network.
-      const metadataResponse = await createSite.generateMetadata(
-        { query: { tenant }, body: { ...requestBody, siteId: id } },
-        next,
-      );
-
-      if (!metadataResponse.success) return metadataResponse;
-
-      const updateRequest = {
-        ...req,
-        body: { ...metadataResponse.data },
+      // Queue a scalar field only when the site is currently missing it
+      const setIfMissing = (field, value) => {
+        if (
+          value !== undefined &&
+          value !== null &&
+          value !== "" &&
+          isEmpty(site[field])
+        ) {
+          setFields[field] = value;
+        }
       };
 
-      const updateResponse = await createSite.update(updateRequest, next);
-
-      return updateResponse.success
-        ? {
-            success: true,
-            message: "Site details successfully refreshed",
-            data: updateResponse.data,
+      // ── Step 1: Local fields (no external API calls) ────────────────────────
+      try {
+        if (isEmpty(site.name)) {
+          const { name, parish, county, district } = site;
+          const avail = createSite.pickAvailableValue(
+            { name, parish, county, district },
+            next,
+          );
+          if (avail) {
+            const valid = createSite.validateSiteName(avail, next);
+            setFields.name = valid
+              ? avail
+              : createSite.sanitiseName(avail, next);
           }
-        : updateResponse;
+        }
+
+        if (isEmpty(site.lat_long) && latitude && longitude) {
+          setFields.lat_long = createSite.generateLatLong(latitude, longitude);
+        }
+
+        if (isEmpty(site.generated_name)) {
+          const nameRes = await createSite.generateName(tenant, next);
+          if (nameRes && nameRes.success) {
+            setFields.generated_name = nameRes.data;
+          }
+        }
+
+        // description: mirrors backfill job — use site name as the value
+        if (isEmpty(site.description)) {
+          const nameToUse =
+            setFields.name ||
+            site.name ||
+            setFields.generated_name ||
+            site.generated_name;
+          if (nameToUse) setFields.description = nameToUse;
+        }
+
+        stepResults.localFields = "ok";
+      } catch (err) {
+        logger.error(
+          `refresh: localFields step failed for site ${id}: ${err.message}`,
+        );
+        stepResults.localFields = err.message;
+      }
+
+      // ── Step 2: Reverse geocoding ───────────────────────────────────────────
+      try {
+        const geoRes = await createSite.reverseGeoCode(
+          latitude,
+          longitude,
+          next,
+        );
+        if (geoRes && geoRes.success) {
+          const geo = geoRes.data;
+          [
+            "country",
+            "district",
+            "city",
+            "region",
+            "town",
+            "village",
+            "parish",
+            "sub_county",
+            "division",
+            "street",
+            "formatted_name",
+            "google_place_id",
+            "location_name",
+            "search_name",
+            "geometry",
+          ].forEach((f) => setIfMissing(f, geo[f]));
+
+          if (Array.isArray(geo.site_tags) && geo.site_tags.length > 0) {
+            tagsToAdd.push(...geo.site_tags);
+          }
+
+          // search_name fallback when geocoder had no sublocality data
+          if (isEmpty(site.search_name) && isEmpty(setFields.search_name)) {
+            const fallback =
+              geo.town || geo.street || geo.city || geo.district;
+            if (fallback) setFields.search_name = fallback;
+          }
+
+          stepResults.geocoding = "ok";
+        } else {
+          stepResults.geocoding =
+            geoRes?.errors?.message || geoRes?.message || "failed";
+        }
+      } catch (err) {
+        logger.error(
+          `refresh: geocoding step failed for site ${id}: ${err.message}`,
+        );
+        stepResults.geocoding = err.message;
+      }
+
+      // ── Step 3: Altitude ────────────────────────────────────────────────────
+      try {
+        const altRes = await createSite.getAltitude(latitude, longitude, next);
+        if (altRes && altRes.success) {
+          setIfMissing("altitude", altRes.data);
+          stepResults.altitude = "ok";
+        } else {
+          stepResults.altitude =
+            altRes?.errors?.message || altRes?.message || "failed";
+        }
+      } catch (err) {
+        logger.error(
+          `refresh: altitude step failed for site ${id}: ${err.message}`,
+        );
+        stepResults.altitude = err.message;
+      }
+
+      // ── Step 4: Grid membership ─────────────────────────────────────────────
+      // Query grids directly for _id + shape — GridModel.list() excludes shape
+      // in its projection so we go to the model directly.
+      // Grids are always replaced (not merged) because polygon boundaries can
+      // change independently of the site.
+      try {
+        const grids = await GridModel(tenant)
+          .find({})
+          .select("_id shape")
+          .lean();
+
+        const matchedGridIds = [];
+        for (const grid of grids) {
+          if (
+            !grid.shape ||
+            !Array.isArray(grid.shape.coordinates) ||
+            !grid.shape.coordinates[0]
+          ) {
+            continue;
+          }
+          try {
+            const polygon = grid.shape.coordinates[0].map(([lng, lat]) => ({
+              longitude: lng,
+              latitude: lat,
+            }));
+            if (geolib.isPointInPolygon({ latitude, longitude }, polygon)) {
+              matchedGridIds.push(grid._id);
+            }
+          } catch (polyErr) {
+            logger.warn(
+              `refresh: grid ${grid._id} polygon check error: ${polyErr.message}`,
+            );
+          }
+        }
+
+        setFields.grids = matchedGridIds;
+        stepResults.grids = "ok";
+      } catch (err) {
+        logger.error(
+          `refresh: grids step failed for site ${id}: ${err.message}`,
+        );
+        stepResults.grids = err.message;
+      }
+
+      // ── Step 5: Nearest TAHMO weather station ───────────────────────────────
+      try {
+        if (isEmpty(site.nearest_tahmo_station)) {
+          const stationsRes = await createSite.listWeatherStations(next);
+          if (stationsRes && stationsRes.success && !isEmpty(stationsRes.data)) {
+            const nearest = geolib.findNearest(
+              { latitude, longitude },
+              stationsRes.data,
+            );
+            if (nearest) {
+              setFields.nearest_tahmo_station =
+                createSite.cleanWeatherStationData(nearest);
+            }
+            stepResults.weatherStation = "ok";
+          } else {
+            stepResults.weatherStation =
+              stationsRes?.errors?.message ||
+              stationsRes?.message ||
+              "failed";
+          }
+        } else {
+          stepResults.weatherStation = "skipped (already set)";
+        }
+      } catch (err) {
+        logger.error(
+          `refresh: weatherStation step failed for site ${id}: ${err.message}`,
+        );
+        stepResults.weatherStation = err.message;
+      }
+
+      // ── Step 6: Data provider (always recomputed) ───────────────────────────
+      try {
+        const dataProvider = await computeSiteDataProvider(tenant, id);
+        if (dataProvider !== undefined) {
+          setFields.data_provider = dataProvider;
+        }
+        stepResults.dataProvider = "ok";
+      } catch (err) {
+        logger.error(
+          `refresh: dataProvider step failed for site ${id}: ${err.message}`,
+        );
+        stepResults.dataProvider = err.message;
+      }
+
+      // ── Step 7: Persist ─────────────────────────────────────────────────────
+      // Use collection.updateOne to bypass the Mongoose pre-hook which:
+      //   a) strips generated_name and lat_long from $set (restricted fields)
+      //   b) converts top-level grids array to $addToSet (unwanted here — we
+      //      want a full replace so stale grid memberships are removed)
+      const hasChanges = !isEmpty(setFields) || tagsToAdd.length > 0;
+
+      if (!hasChanges) {
+        return {
+          success: true,
+          message: "Site metadata is already complete — nothing to update",
+          data: site,
+          status: httpStatus.OK,
+        };
+      }
+
+      const updateOp = {};
+      if (!isEmpty(setFields)) {
+        updateOp.$set = setFields;
+      }
+      if (tagsToAdd.length > 0) {
+        updateOp.$addToSet = {
+          site_tags: { $each: [...new Set(tagsToAdd)] },
+        };
+      }
+
+      await SiteModel(tenant).collection.updateOne(
+        { _id: siteDbId },
+        updateOp,
+      );
+
+      // Re-fetch so the response reflects the persisted state
+      const refreshedDetails = await createSite.fetchSiteDetails(
+        tenant,
+        req,
+        next,
+      );
+      const updatedSite =
+        refreshedDetails.success ? refreshedDetails.data[0] : site;
+
+      const failedSteps = Object.entries(stepResults)
+        .filter(([, v]) => v !== "ok" && !v.startsWith("skipped"))
+        .map(([k, v]) => `${k}: ${v}`);
+
+      return {
+        success: true,
+        message: failedSteps.length
+          ? `Site partially refreshed — some steps were unsuccessful: ${failedSteps.join("; ")}`
+          : "Site details successfully refreshed",
+        data: updatedSite,
+        status: httpStatus.OK,
+      };
     } catch (error) {
-      logObject("util errors", error);
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(
         new HttpError(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Rewrites the `PUT /api/v2/devices/sites/refresh` endpoint logic in `site.util.js` to execute each metadata enrichment step independently. Failures in one step no longer abort subsequent steps. Adds support for filling in missing fields (`name`, `description`, `search_name`, `generated_name`, `lat_long`) and replaces deprecated AirQloud membership with Grid membership via polygon intersection.

### Why is this change needed?
The previous implementation ran all enrichment steps in a single linear pipeline — one failure (e.g. a Google Maps API timeout) would silently skip all remaining steps. Sites were also left with incomplete metadata (missing `name`, `generated_name`, `description`, etc.) with no way to recover them. AirQlouds have been deprecated and replaced by Grids, so the refresh logic needed to be updated accordingly.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [x] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/utils/site.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually triggered `PUT /api/v2/devices/sites/refresh?id=<site_id>` against sites with missing metadata fields and confirmed each enrichment step runs independently, partial failures return a descriptive message listing failed steps, and the response always reflects the persisted state via a re-fetch.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The endpoint contract (`PUT /api/v2/devices/sites/refresh`) is unchanged. Response shape is backward-compatible — `success`, `message`, and `data` fields are preserved.

---

## :memo: Additional Notes

- Each enrichment step is wrapped in an independent `try/catch`. All steps run regardless of prior failures.
- Persistence uses `SiteModel(tenant).collection.updateOne()` (raw MongoDB driver) to bypass the Mongoose pre-hook, which strips `generated_name` and `lat_long` from `$set` and converts array fields to `$addToSet`.
- Grid membership uses `GridModel(tenant).find({}).select("_id shape").lean()` directly, because `GridModel.list()` excludes the `shape` field in its projection.
- `site_tags` from geocoding are merged via `$addToSet` so existing tags are never removed.
- `grids` field is always fully replaced (not merged) so stale polygon memberships are cleared when grid boundaries change.
- AirQloud references (`findAirQlouds`, `fetchAdditionalSiteDetails`) have been removed from the refresh flow.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Site data enrichment now uses multi-step validation with improved error tracking and status reporting
  * Optimized update logic to skip unnecessary database operations
  * Enhanced feedback on enrichment step results and any errors encountered

<!-- end of auto-generated comment: release notes by coderabbit.ai -->