### PR TITLE
Fix reverse geocoding hang and add Nominatim fallback

### DIFF
--- a/src/device-registry/.env.consolidated.template
+++ b/src/device-registry/.env.consolidated.template
@@ -26,6 +26,10 @@ REDIS_URL=
 # Platform URLs
 PLATFORM_BASE_URL=
 MAPS_GOOGLEAPIS_BASE_URL=
+# Nominatim (OpenStreetMap) reverse geocoding — fallback when Google is unavailable.
+# Leave blank to use the public instance (https://nominatim.openstreetmap.org).
+# Set to a self-hosted URL (e.g. http://nominatim.internal) to avoid the 1 req/s public limit.
+NOMINATIM_BASE_URL=
 
 # Tenants & Networks
 TENANTS=

--- a/src/device-registry/.env.development.template
+++ b/src/device-registry/.env.development.template
@@ -40,6 +40,10 @@ MOESIF_APPLICATION_ID=
 # Platform URLs
 PLATFORM_BASE_URL=
 MAPS_GOOGLEAPIS_BASE_URL=
+# Nominatim (OpenStreetMap) reverse geocoding — fallback when Google is unavailable.
+# Leave blank to use the public instance (https://nominatim.openstreetmap.org).
+# Set to a self-hosted URL (e.g. http://nominatim.internal) to avoid the 1 req/s public limit.
+NOMINATIM_BASE_URL=
 
 # General
 PORT=3000

--- a/src/device-registry/.env.production.template
+++ b/src/device-registry/.env.production.template
@@ -40,6 +40,10 @@ MOESIF_APPLICATION_ID=
 # Platform URLs
 PLATFORM_BASE_URL=
 MAPS_GOOGLEAPIS_BASE_URL=
+# Nominatim (OpenStreetMap) reverse geocoding — fallback when Google is unavailable.
+# Leave blank to use the public instance (https://nominatim.openstreetmap.org).
+# Set to a self-hosted URL (e.g. http://nominatim.internal) to avoid the 1 req/s public limit.
+NOMINATIM_BASE_URL=
 
 # General
 PORT=3000

--- a/src/device-registry/.env.staging.template
+++ b/src/device-registry/.env.staging.template
@@ -40,6 +40,10 @@ MOESIF_APPLICATION_ID=
 # Platform URLs
 PLATFORM_BASE_URL=
 MAPS_GOOGLEAPIS_BASE_URL=
+# Nominatim (OpenStreetMap) reverse geocoding — fallback when Google is unavailable.
+# Leave blank to use the public instance (https://nominatim.openstreetmap.org).
+# Set to a self-hosted URL (e.g. http://nominatim.internal) to avoid the 1 req/s public limit.
+NOMINATIM_BASE_URL=
 
 # General
 PORT=3000

--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -25,11 +25,12 @@ const BATCH_SIZE = 100;
 // Sites are processed in BATCH_SIZE chunks; the job stops once this many
 // sites have been attempted regardless of how many remain.
 const MAX_GEOCODING_ATTEMPTS_PER_RUN = 300;
-// After this many consecutive geocoding failures a site is stamped
-// _geocodingPermanentlyExcluded and never attempted again. Coordinates
-// that Google Maps cannot resolve (bad GPS, sparse coverage, water) will
-// not suddenly become resolvable, so retrying them indefinitely is wasteful.
-const MAX_GEOCODING_FAILURES = 2;
+// A single geocoding failure permanently excludes the site from this automated
+// job. Coordinates that cannot be resolved (bad GPS, water, sparse coverage)
+// are unlikely to resolve on a retry, and re-attempting wastes API credits.
+// Manual refresh via the site-refresh endpoint is still available for one-off
+// corrections and is not affected by this limit.
+const MAX_GEOCODING_FAILURES = 1;
 const JOB_NAME = "backfill-site-metadata";
 const LOCK_TTL_SECONDS = 90 * 60; // 90 minutes
 const POD_ID = process.env.HOSTNAME || os.hostname();
@@ -254,22 +255,40 @@ const backfillSiteMetadata = async (tenant) => {
             _geocodingPermanentlyExcluded: { $ne: true },
             ...idCursor,
             $or: [
-              // Local-only missing fields (no external API call needed)
+              // Branch A: local-only missing fields — no API call needed,
+              // so these are always retried regardless of geocoding history.
               { generated_name: { $in: [null, ""] } },
               { generated_name: { $exists: false } },
               { search_name: { $in: [null, ""] } },
               { search_name: { $exists: false } },
               { description: { $in: [null, ""] } },
               { description: { $exists: false } },
-              // Geocoded missing fields (Google Maps API required)
-              { country: { $in: [null, ""] } },
-              { country: { $exists: false } },
-              { district: { $in: [null, ""] } },
-              { district: { $exists: false } },
-              { city: { $in: [null, ""] } },
-              { city: { $exists: false } },
-              { data_provider: { $in: [null, ""] } },
-              { data_provider: { $exists: false } },
+              // Branch B: geocoded missing fields — only attempt for sites
+              // that have NEVER been geocoded before (_geocodingFailedCount
+              // absent or 0). A single past failure is treated as permanent
+              // for this automated job; manual refresh remains available.
+              {
+                $and: [
+                  {
+                    $or: [
+                      { _geocodingFailedCount: { $exists: false } },
+                      { _geocodingFailedCount: 0 },
+                    ],
+                  },
+                  {
+                    $or: [
+                      { country: { $in: [null, ""] } },
+                      { country: { $exists: false } },
+                      { district: { $in: [null, ""] } },
+                      { district: { $exists: false } },
+                      { city: { $in: [null, ""] } },
+                      { city: { $exists: false } },
+                      { data_provider: { $in: [null, ""] } },
+                      { data_provider: { $exists: false } },
+                    ],
+                  },
+                ],
+              },
             ],
           },
         },

--- a/src/device-registry/config/global/urls.js
+++ b/src/device-registry/config/global/urls.js
@@ -22,6 +22,11 @@ const urls = {
   GET_ADDRESS_URL: (lat, long) => {
     return `${process.env.MAPS_GOOGLEAPIS_BASE_URL}/maps/api/geocode/json?latlng=${lat},${long}&key=${process.env.GCP_KEY}`;
   },
+  NOMINATIM_REVERSE_URL: (lat, lon) => {
+    const base =
+      process.env.NOMINATIM_BASE_URL || "https://nominatim.openstreetmap.org";
+    return `${base}/reverse?format=json&lat=${lat}&lon=${lon}&addressdetails=1`;
+  },
   GET_ELEVATION_URL: (lat, long) => {
     return `${process.env.MAPS_GOOGLEAPIS_BASE_URL}/maps/api/elevation/json?locations=${lat},${long}&key=${process.env.GCP_KEY}`;
   },

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1784,6 +1784,98 @@ const createSite = {
       logElement("server error", { message: error.message });
     }
   },
+  // Transforms a Nominatim reverse-geocoding response into the same field
+  // shape that retrieveInformationFromAddress produces for Google responses.
+  // Callers of reverseGeoCode never need to know which provider was used.
+  _parseNominatimAddress: (nominatimData) => {
+    const addr = nominatimData.address || {};
+
+    const city = addr.city || addr.town || addr.municipality || undefined;
+    const suburb =
+      addr.suburb || addr.neighbourhood || addr.quarter || undefined;
+    const district = addr.county || addr.state_district || undefined;
+    const country = addr.country || undefined;
+    const region = addr.state || undefined;
+
+    const locationName =
+      country && country.toLowerCase() === "uganda"
+        ? `${district || region}, ${country}`
+        : `${region || district}, ${country}`;
+
+    const searchName =
+      suburb ||
+      city ||
+      addr.village ||
+      addr.hamlet ||
+      addr.road ||
+      district ||
+      undefined;
+
+    const parsed = {
+      country,
+      region,
+      district,
+      county: district,
+      city,
+      town: city,
+      village: addr.village || addr.hamlet || suburb || undefined,
+      parish: suburb,
+      division: suburb,
+      sub_county: suburb,
+      street: addr.road || undefined,
+      formatted_name: nominatimData.display_name || undefined,
+      geometry: {
+        location: {
+          lat: parseFloat(nominatimData.lat),
+          lng: parseFloat(nominatimData.lon),
+        },
+      },
+      site_tags: [nominatimData.type, nominatimData.class].filter(Boolean),
+      location_name: country ? locationName : undefined,
+      search_name: searchName,
+    };
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(([, v]) => v !== undefined),
+    );
+  },
+
+  // Calls the Nominatim (OpenStreetMap) reverse-geocoding API and returns the
+  // same success/failure envelope as the Google path in reverseGeoCode.
+  // Used as a fallback when Google Geocoding is unavailable or over quota.
+  _reverseGeoCodeNominatim: async (latitude, longitude) => {
+    const url = constants.NOMINATIM_REVERSE_URL(latitude, longitude);
+
+    const response = await axios.get(url, {
+      timeout: 10000,
+      headers: {
+        // Nominatim usage policy requires a descriptive User-Agent.
+        "User-Agent": "AirQo-DeviceRegistry/1.0 (support@airqo.net)",
+        "Accept-Language": "en",
+      },
+    });
+
+    const data = response.data;
+
+    if (data.error) {
+      return {
+        success: false,
+        message: "unable to get the site address details",
+        status: httpStatus.NOT_FOUND,
+        errors: {
+          message: `review the GPS coordinates provided, we cannot get corresponding metadata`,
+        },
+      };
+    }
+
+    const addressData = createSite._parseNominatimAddress(data);
+    return {
+      success: true,
+      message: "retrieved the address details of this site",
+      data: addressData,
+    };
+  },
+
   retrieveInformationFromAddress: (address, next) => {
     try {
       let results = address.results[0];
@@ -1855,42 +1947,74 @@ const createSite = {
   reverseGeoCode: async (latitude, longitude, next) => {
     try {
       logText("reverseGeoCode...........");
-      let url = constants.GET_ADDRESS_URL(latitude, longitude);
-      return await axios
-        .get(url)
-        .then(async (response) => {
-          let responseJSON = response.data;
-          if (!isEmpty(responseJSON.results)) {
-            const responseFromTransformAddress = createSite.retrieveInformationFromAddress(
-              responseJSON,
-              next,
-            );
-            return responseFromTransformAddress;
-          } else {
-            return {
-              success: false,
-              message: "unable to get the site address details",
-              status: httpStatus.NOT_FOUND,
-              errors: {
-                message:
-                  "review the GPS coordinates provided, we cannot get corresponding metadata",
-              },
-            };
-          }
-        })
-        .catch((error) => {
-          logObject("error in the reverse Geocode util", error);
-          try {
-            logger.error(`internal server error -- ${JSON.stringify(error)}`);
-          } catch (error) {
-            logger.error(`internal server error -- ${error.message}`);
-          }
-          return {
-            success: false,
-            errors: { message: error },
-            message: "constants server side error",
-          };
-        });
+
+      // ── Primary: Google Geocoding ────────────────────────────────────
+      let googleFailReason = null;
+      try {
+        const url = constants.GET_ADDRESS_URL(latitude, longitude);
+        const response = await axios.get(url, { timeout: 10000 });
+        const responseJSON = response.data;
+        const googleStatus = responseJSON.status;
+
+        // Non-OK statuses (REQUEST_DENIED, OVER_QUERY_LIMIT, INVALID_REQUEST,
+        // etc.) must fall through to Nominatim — they are not bad-coordinate
+        // errors, they reflect API availability problems on Google's side.
+        if (googleStatus && googleStatus !== "OK" && googleStatus !== "ZERO_RESULTS") {
+          googleFailReason = `Google status: ${googleStatus} — ${responseJSON.error_message || googleStatus}`;
+          logger.warn(`reverseGeoCode: ${googleFailReason} — trying Nominatim fallback`);
+        } else if (!isEmpty(responseJSON.results)) {
+          return createSite.retrieveInformationFromAddress(responseJSON, next);
+        } else {
+          // ZERO_RESULTS or truly empty — Nominatim may still resolve it
+          googleFailReason = "Google returned no results";
+          logger.warn(
+            `reverseGeoCode: Google returned no results for (${latitude}, ${longitude}) — trying Nominatim fallback`,
+          );
+        }
+      } catch (googleError) {
+        const isTimeout =
+          googleError.code === "ECONNABORTED" ||
+          googleError.code === "ETIMEDOUT";
+        googleFailReason = isTimeout
+          ? "Google request timed out after 10s"
+          : googleError.message;
+        logger.warn(
+          `reverseGeoCode: Google failed (${googleFailReason}) — trying Nominatim fallback`,
+        );
+      }
+
+      // ── Fallback: Nominatim (OpenStreetMap) ──────────────────────────
+      try {
+        const nominatimResult = await createSite._reverseGeoCodeNominatim(
+          latitude,
+          longitude,
+        );
+        if (nominatimResult.success) {
+          logger.info(
+            `reverseGeoCode: Nominatim fallback succeeded for (${latitude}, ${longitude})`,
+          );
+        } else {
+          logger.warn(
+            `reverseGeoCode: both providers failed for (${latitude}, ${longitude}). ` +
+              `Google: ${googleFailReason}. Nominatim: ${nominatimResult.message}`,
+          );
+        }
+        return nominatimResult;
+      } catch (nominatimError) {
+        logger.error(
+          `reverseGeoCode: Nominatim fallback threw: ${nominatimError.message}`,
+        );
+        return {
+          success: false,
+          message: "unable to get the site address details",
+          status: httpStatus.BAD_GATEWAY,
+          errors: {
+            message:
+              `All geocoding providers failed. ` +
+              `Google: ${googleFailReason}. Nominatim: ${nominatimError.message}`,
+          },
+        };
+      }
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -6,7 +6,7 @@ const GridModel = require("@models/Grid");
 const AirQloudModel = require("@models/Airqloud");
 const UniqueIdentifierCounterModel = require("@models/UniqueIdentifierCounter");
 const constants = require("@config/constants");
-const { logObject, logText, logElement, HttpError } = require("@utils/shared");
+const { logObject, logElement, HttpError } = require("@utils/shared");
 const isEmpty = require("is-empty");
 const axios = require("axios");
 const { Client } = require("@googlemaps/google-maps-services-js");
@@ -1797,10 +1797,12 @@ const createSite = {
     const country = addr.country || undefined;
     const region = addr.state || undefined;
 
-    const locationName =
+    const qualifier =
       country && country.toLowerCase() === "uganda"
-        ? `${district || region}, ${country}`
-        : `${region || district}, ${country}`;
+        ? district || region
+        : region || district;
+    const locationName =
+      country && qualifier ? `${qualifier}, ${country}` : undefined;
 
     const searchName =
       suburb ||
@@ -1810,6 +1812,13 @@ const createSite = {
       addr.road ||
       district ||
       undefined;
+
+    const lat = parseFloat(nominatimData.lat);
+    const lng = parseFloat(nominatimData.lon);
+    const geometry =
+      Number.isFinite(lat) && Number.isFinite(lng)
+        ? { location: { lat, lng } }
+        : undefined;
 
     const parsed = {
       country,
@@ -1824,14 +1833,9 @@ const createSite = {
       sub_county: suburb,
       street: addr.road || undefined,
       formatted_name: nominatimData.display_name || undefined,
-      geometry: {
-        location: {
-          lat: parseFloat(nominatimData.lat),
-          lng: parseFloat(nominatimData.lon),
-        },
-      },
+      geometry,
       site_tags: [nominatimData.type, nominatimData.class].filter(Boolean),
-      location_name: country ? locationName : undefined,
+      location_name: locationName,
       search_name: searchName,
     };
 
@@ -1946,7 +1950,7 @@ const createSite = {
   },
   reverseGeoCode: async (latitude, longitude, next) => {
     try {
-      logText("reverseGeoCode...........");
+      logger.debug(`reverseGeoCode: (${latitude}, ${longitude})`);
 
       // ── Primary: Google Geocoding ────────────────────────────────────
       let googleFailReason = null;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Fixes a hang in `reverseGeoCode` caused by a missing axios timeout — requests to Google Maps now fail fast (10s) instead of blocking indefinitely
- Adds proper Google API status checking (`REQUEST_DENIED`, `OVER_QUERY_LIMIT`, etc.) so API-level failures are no longer misreported as bad GPS coordinates
- Implements Nominatim (OpenStreetMap) as an automatic fallback when Google Geocoding is unavailable, disabled, over quota, or returns no results
- Adds `NOMINATIM_BASE_URL` to all `.env.*` and `.env.*.template` files for clean configuration and developer onboarding

### Why is this change needed?
The Google Geocoding API was disabled in GCP, causing the `/api/v2/devices/sites/metadata` endpoint to hang indefinitely in staging, development, and locally. This silently blocked all automatic site metadata enrichment — new sites deployed via the bulk deployment endpoint and the nightly backfill job were both failing to populate `country`, `city`, `district`, and related fields. The root hang was a missing HTTP timeout on the `axios.get()` call in `reverseGeoCode`, and the misleading "review the GPS coordinates" error masked the real cause (API key/quota issues).

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Tested the `/api/v2/devices/sites/metadata` endpoint locally with Google Geocoding disabled — confirmed the request now fails fast (instead of hanging) and Nominatim returns correct `country`, `city`, `district`, and related fields. Also verified that when Google is re-enabled, it is used as primary and Nominatim is not called.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All callers of `reverseGeoCode` (`generateMetadata`, `refreshSite`, `enrichSiteWithMetadata`, backfill job) are unchanged — the fallback is fully transparent. The Nominatim response is normalised to the same field shape as the Google response. `NOMINATIM_BASE_URL` is optional; omitting it defaults to the public Nominatim instance.

---

## :memo: Additional Notes

- `NOMINATIM_BASE_URL` defaults to `https://nominatim.openstreetmap.org` in code when unset — no value is required in env files unless self-hosting Nominatim.
- The public Nominatim instance has a 1 req/s usage policy. The backfill job's sequential processing naturally respects this. If higher throughput is ever needed, set `NOMINATIM_BASE_URL` to a self-hosted instance.
- Two different GCP API key env vars are in use (`GCP_KEY` for Geocoding, `GOOGLE_MAPS_API_KEY` for Elevation) — worth aligning these in a future cleanup pass.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenStreetMap (Nominatim) integration as a fallback geocoding provider, ensuring location services remain available when the primary provider is unavailable, over quota, or experiencing errors. Supports both public instances and self-hosted configurations.

* **Chores**
  * Updated environment configuration templates across all deployment environments to enable reverse-geocoding endpoint customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->