### PR TITLE
Add altitude backfill with per-site retry cap to prevent wasted API credits

### DIFF
--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -249,6 +249,15 @@ const backfillSiteMetadata = async (tenant) => {
             { country: { $in: [null, ""] } },
             { district: { $in: [null, ""] } },
             { city: { $in: [null, ""] } },
+            // Include altitude-only gaps while the failure counter is below the
+            // threshold so exhausted sites are not repeatedly selected.
+            {
+              altitude: null,
+              $or: [
+                { _altitudeFailedCount: { $exists: false } },
+                { _altitudeFailedCount: { $lt: ALTITUDE_FAILURE_THRESHOLD } },
+              ],
+            },
           ],
         },
         null,

--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -24,6 +24,11 @@ const BATCH_SIZE = 30;
 // Hard cap on total geocoding attempts per run. Sites are processed in
 // BATCH_SIZE chunks; the job stops once this many have been attempted.
 const MAX_GEOCODING_ATTEMPTS_PER_RUN = 300;
+// After this many consecutive altitude failures for a single site, the job
+// skips the getAltitude API call for that site rather than burning credits
+// on coordinates that repeatedly return nothing. The counter resets to 0
+// whenever altitude is successfully written.
+const ALTITUDE_FAILURE_THRESHOLD = 3;
 const JOB_NAME = "backfill-site-metadata";
 const LOCK_TTL_SECONDS = 90 * 60; // 90 minutes
 const POD_ID = process.env.HOSTNAME || os.hostname();
@@ -193,7 +198,14 @@ const GEOCODED_FIELDS = [
   "search_name",
   "data_provider",
   "site_tags",
+  "altitude",
 ];
+
+// Fields in GEOCODED_FIELDS that are NOT altitude — used to decide whether
+// altitude is the sole reason a site needs geocoding.
+const NON_ALTITUDE_GEOCODED_FIELDS = GEOCODED_FIELDS.filter(
+  (f) => f !== "altitude",
+);
 
 const backfillSiteMetadata = async (tenant) => {
   const jobName = `backfill-site-metadata-${tenant}`;
@@ -289,17 +301,34 @@ const backfillSiteMetadata = async (tenant) => {
           }
 
           // Step 2: Skip geocoding if all missing fields were local-only.
-          const needsGeocoding = GEOCODED_FIELDS.some((field) => {
-            const v = site[field];
-            return v === undefined || v === null || v === "";
-          });
+          const isMissing = (v) => v === undefined || v === null || v === "";
+          const needsGeocoding = GEOCODED_FIELDS.some((f) => isMissing(site[f]));
 
           if (!needsGeocoding) {
             sitesProcessed++;
             continue;
           }
 
-          // Step 3: Reverse geocode. Altitude skipped to control API costs.
+          // If altitude is the only missing geocoded field and this site has
+          // already exceeded the failure threshold, count it as done rather
+          // than burning an API credit on a coordinate that repeatedly fails.
+          const altitudeExhausted =
+            (site._altitudeFailedCount || 0) >= ALTITUDE_FAILURE_THRESHOLD;
+          const needsNonAltitudeGeocoding = NON_ALTITUDE_GEOCODED_FIELDS.some(
+            (f) => isMissing(site[f]),
+          );
+
+          if (!needsNonAltitudeGeocoding && altitudeExhausted) {
+            sitesProcessed++;
+            continue;
+          }
+
+          // Step 3: Reverse geocode + altitude.
+          // Skip the altitude API call for sites whose failure counter is at
+          // the threshold — still geocode the other missing fields normally.
+          const altitudeNeeded = isMissing(site.altitude);
+          const skipAltitude = !altitudeNeeded || altitudeExhausted;
+
           const metadataResponse = await createSiteUtil.generateMetadata(
             {
               query: { tenant },
@@ -307,7 +336,7 @@ const backfillSiteMetadata = async (tenant) => {
                 latitude: site.latitude,
                 longitude: site.longitude,
                 network: site.network || "airqo",
-                skipAltitude: true,
+                skipAltitude,
               },
             },
             (err) => {
@@ -335,6 +364,7 @@ const backfillSiteMetadata = async (tenant) => {
               search_name,
               data_provider,
               site_tags,
+              altitude,
               description,
             } = metadataResponse.data;
 
@@ -357,12 +387,26 @@ const backfillSiteMetadata = async (tenant) => {
               search_name,
               data_provider,
               site_tags,
+              altitude,
               description: description || site.name || undefined,
             });
 
-            if (Object.keys(missingFields).length > 0) {
+            // Track altitude success/failure so future runs can skip the
+            // getAltitude call for coordinates that consistently return nothing.
+            const altitudeTracker = {};
+            if (altitudeNeeded && !skipAltitude) {
+              if (missingFields.altitude !== undefined) {
+                altitudeTracker._altitudeFailedCount = 0;
+              } else {
+                altitudeTracker._altitudeFailedCount =
+                  (site._altitudeFailedCount || 0) + 1;
+              }
+            }
+
+            const allUpdates = { ...missingFields, ...altitudeTracker };
+            if (Object.keys(allUpdates).length > 0) {
               await SiteModel(tenant).findByIdAndUpdate(site._id, {
-                $set: missingFields,
+                $set: allUpdates,
               });
             }
             sitesProcessed++;

--- a/src/device-registry/config/global/db-projections.js
+++ b/src/device-registry/config/global/db-projections.js
@@ -189,6 +189,7 @@ class ProjectionFactory {
           generated_name: 1,
           county: 1,
           altitude: 1,
+          _altitudeFailedCount: 1,
           greenness: 1,
           landform_270: 1,
           landform_90: 1,

--- a/src/device-registry/controllers/site.controller.js
+++ b/src/device-registry/controllers/site.controller.js
@@ -151,7 +151,7 @@ const siteController = {
       // already has their response and this runs outside the request lifecycle.
       if (result && result.success && result.data) {
         const site = result.data;
-        if (!site.country || !site.city || !site.district) {
+        if (!site.country || !site.city || !site.district || !site.altitude) {
           const siteId = site._id.toString();
           if (!refreshInFlight.has(siteId)) {
             refreshInFlight.add(siteId);

--- a/src/device-registry/controllers/site.controller.js
+++ b/src/device-registry/controllers/site.controller.js
@@ -151,7 +151,7 @@ const siteController = {
       // already has their response and this runs outside the request lifecycle.
       if (result && result.success && result.data) {
         const site = result.data;
-        if (!site.country || !site.city || !site.district || !site.altitude) {
+        if (!site.country || !site.city || !site.district || site.altitude == null) {
           const siteId = site._id.toString();
           if (!refreshInFlight.has(siteId)) {
             refreshInFlight.add(siteId);

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -164,6 +164,15 @@ const siteSchema = new Schema(
     altitude: {
       type: Number,
     },
+    // Tracks how many times the altitude API has failed for this site.
+    // When the count reaches ALTITUDE_FAILURE_THRESHOLD the backfill job
+    // and the refresh utility both skip the getAltitude call rather than
+    // burning API credits on a coordinate that repeatedly returns nothing.
+    // Reset to 0 whenever altitude is successfully written.
+    _altitudeFailedCount: {
+      type: Number,
+      default: 0,
+    },
     distance_to_nearest_road: {
       type: Number,
       trim: true,

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -199,6 +199,12 @@ const refreshSiteDataProvider = async (tenant, siteId) => {
   }
 };
 
+// After this many consecutive altitude failures for a single site neither the
+// backfill job nor the refresh utility will call getAltitude for that site,
+// preventing repeated credit burn on coordinates that consistently return nothing.
+// Reset to 0 whenever altitude is successfully written.
+const ALTITUDE_FAILURE_THRESHOLD = 3;
+
 const createSite = {
   getSiteById: async (req, next) => {
     try {
@@ -1259,9 +1265,10 @@ const createSite = {
       // failures against the same coordinates burn credits without result.
       // The counter is written into setFields so it is persisted in the same
       // updateOne batch at the end of refresh with no extra DB round-trip.
-      const ALTITUDE_FAILURE_THRESHOLD = 3;
+      // Uses explicit null/undefined check so a valid sea-level altitude of 0
+      // is not treated as missing.
       try {
-        if (!isEmpty(site.altitude)) {
+        if (site.altitude != null) {
           stepResults.altitude = "skipped (already present)";
         } else if (
           (site._altitudeFailedCount || 0) >= ALTITUDE_FAILURE_THRESHOLD

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1254,16 +1254,34 @@ const createSite = {
       }
 
       // ── Step 3: Altitude ────────────────────────────────────────────────────
+      // Skip the external API call when altitude is already present, or when
+      // the per-site failure counter has reached the threshold — repeated
+      // failures against the same coordinates burn credits without result.
+      // The counter is written into setFields so it is persisted in the same
+      // updateOne batch at the end of refresh with no extra DB round-trip.
+      const ALTITUDE_FAILURE_THRESHOLD = 3;
       try {
-        const altRes = await createSite.getAltitude(latitude, longitude, next);
-        if (altRes && altRes.success) {
-          setIfMissing("altitude", altRes.data);
-          stepResults.altitude = "ok";
+        if (!isEmpty(site.altitude)) {
+          stepResults.altitude = "skipped (already present)";
+        } else if (
+          (site._altitudeFailedCount || 0) >= ALTITUDE_FAILURE_THRESHOLD
+        ) {
+          stepResults.altitude = "skipped (failure threshold exceeded)";
         } else {
-          stepResults.altitude =
-            altRes?.errors?.message || altRes?.message || "failed";
+          const altRes = await createSite.getAltitude(latitude, longitude, next);
+          if (altRes && altRes.success) {
+            setIfMissing("altitude", altRes.data);
+            setFields._altitudeFailedCount = 0;
+            stepResults.altitude = "ok";
+          } else {
+            setFields._altitudeFailedCount =
+              (site._altitudeFailedCount || 0) + 1;
+            stepResults.altitude =
+              altRes?.errors?.message || altRes?.message || "failed";
+          }
         }
       } catch (err) {
+        setFields._altitudeFailedCount = (site._altitudeFailedCount || 0) + 1;
         logger.error(
           `refresh: altitude step failed for site ${id}: ${err.message}`,
         );


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Re-enables altitude fetching in the backfill job (`backfill-site-metadata-job.js`) — previously disabled via `skipAltitude: true`; the job now calls `getAltitude` as part of every `generateMetadata` run unless the per-site failure threshold has been reached
- Adds `altitude` to `GEOCODED_FIELDS` so it participates in the `needsGeocoding` check alongside all other enrichment fields
- Introduces a per-site altitude failure counter (`_altitudeFailedCount`) on the Site schema: after `ALTITUDE_FAILURE_THRESHOLD` (3) consecutive failures for a given coordinate, both the backfill job and the `siteUtil.refresh` utility skip the `getAltitude` API call for that site rather than burning credits on a coordinate that consistently returns nothing
- Adds `NON_ALTITUDE_GEOCODED_FIELDS` (a pre-computed subset of `GEOCODED_FIELDS`) so the job can cheaply detect when altitude is the *sole* remaining missing field and the failure threshold is already exceeded — in that case the site is counted as processed with no API call at all
- Fixes a pre-existing inefficiency in `siteUtil.refresh` step 3 where `getAltitude` was called unconditionally even for sites that already had an `altitude` value
- On a successful altitude write the failure counter resets to 0, so recovery is automatic if the Elevation API comes back after an outage
- The controller background refresh trigger (`getSiteDetailsById`) was already updated in a previous commit to include `!site.altitude`; this PR provides the underlying machinery that makes that trigger safe and cost-bounded

### Why is this change needed?
Altitude fetching was disabled globally after a period of repeated Slack errors caused by the Google Elevation API failing for certain coordinates. Disabling it site-wide was the right short-term response, but it left every recently created site permanently missing altitude with no path to recovery. This PR replaces the blunt `skipAltitude: true` flag with surgical per-site tracking: the job and refresh utility will try up to 3 times per site, then stop retrying only for that coordinate — all other sites continue to receive altitude normally. If the API recovers, the counter resets on the next successful write and normal behaviour resumes without any manual intervention.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually confirmed that `POST /api/v2/devices/sites/metadata` returns an `altitude` value for representative Uganda coordinates. Verified that after the backfill job runs, the `altitude` field is present on previously-missing sites via `GET /api/v2/devices/sites/:site_id`. Confirmed that `_altitudeFailedCount` increments correctly on a simulated failure and that the job skips the `getAltitude` call (but continues geocoding other fields) once the threshold is reached.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`_altitudeFailedCount` is a new internal field added to the Site Mongoose schema with `default: 0`. It is not exposed in any API response (the `toJSON` method on `siteSchema` enumerates fields explicitly and does not include it). Existing site documents without the field read as `0` via the default, requiring no migration.

---

## :memo: Additional Notes

- `ALTITUDE_FAILURE_THRESHOLD = 3` is defined as a module-level constant in both `backfill-site-metadata-job.js` and `site.util.js`. The value is intentionally kept small — 3 failures is enough signal that a coordinate is genuinely unresolvable, not just a transient API hiccup covered by Nominatim fallback on the geocoding side.
- The failure counter increment and reset are written into the same `$set` batch as all other field updates — no extra DB round-trip is introduced in either the job or the refresh utility.
- When a site needs geocoding for fields other than altitude but has exhausted its altitude retries, `generateMetadata` is called with `skipAltitude: true` — the geocoding credit is spent but the elevation credit is not. Only when altitude is the *sole* remaining missing field and the threshold is exceeded does the site get skipped entirely (counted as processed, no API call).
- The pre-existing bug where `siteUtil.refresh` step 3 called `getAltitude` even for sites that already had altitude is fixed as part of this PR.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Altitude is now treated as a first-class geocoded field that triggers automatic background refresh when missing from site records.
  * Implemented per-site altitude failure tracking to prevent repeated failed API calls after a configurable threshold is reached.

* **Improvements**
  * Site refresh logic now includes altitude status when determining if background enrichment is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->