### PR TITLE
Fix data_provider missing and erased across backfill, refresh, and recall paths

### DIFF
--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -249,6 +249,7 @@ const backfillSiteMetadata = async (tenant) => {
             { country: { $in: [null, ""] } },
             { district: { $in: [null, ""] } },
             { city: { $in: [null, ""] } },
+            { data_provider: { $in: [null, ""] } },
             // Include altitude-only gaps while the failure counter is below the
             // threshold so exhausted sites are not repeatedly selected.
             {
@@ -346,6 +347,7 @@ const backfillSiteMetadata = async (tenant) => {
                 longitude: site.longitude,
                 network: site.network || "airqo",
                 skipAltitude,
+                siteId: site._id.toString(),
               },
             },
             (err) => {

--- a/src/device-registry/controllers/site.controller.js
+++ b/src/device-registry/controllers/site.controller.js
@@ -151,7 +151,13 @@ const siteController = {
       // already has their response and this runs outside the request lifecycle.
       if (result && result.success && result.data) {
         const site = result.data;
-        if (!site.country || !site.city || !site.district || site.altitude == null) {
+        if (
+          !site.country ||
+          !site.city ||
+          !site.district ||
+          site.altitude == null ||
+          !site.data_provider
+        ) {
           const siteId = site._id.toString();
           if (!refreshInFlight.has(siteId)) {
             refreshInFlight.add(siteId);

--- a/src/device-registry/controllers/site.controller.js
+++ b/src/device-registry/controllers/site.controller.js
@@ -178,6 +178,18 @@ const siteController = {
                   logger.warn(
                     `background refresh failed for site ${siteId}: ${refreshResult.message || "unknown error"}`,
                   );
+                } else if (
+                  refreshResult &&
+                  refreshResult.success &&
+                  !refreshResult.data?.data_provider
+                ) {
+                  // Refresh completed but data_provider is still null — the site
+                  // has no active device and no network field. It will re-trigger
+                  // every REFRESH_TTL_MS with the same result. Log once per TTL
+                  // window so the data team can identify and fix stuck sites.
+                  logger.warn(
+                    `background refresh: data_provider still null for site ${siteId} [reason: no-active-device-no-network]`,
+                  );
                 }
               } catch (err) {
                 logger.warn(

--- a/src/device-registry/controllers/site.controller.js
+++ b/src/device-registry/controllers/site.controller.js
@@ -151,44 +151,56 @@ const siteController = {
       // already has their response and this runs outside the request lifecycle.
       if (result && result.success && result.data) {
         const site = result.data;
-        if (
+        const needsGeocoding =
           !site.country ||
           !site.city ||
           !site.district ||
-          site.altitude == null ||
-          !site.data_provider
-        ) {
+          site.altitude == null;
+        const needsDataProvider = !site.data_provider;
+
+        if (needsGeocoding || needsDataProvider) {
           const siteId = site._id.toString();
           if (!refreshInFlight.has(siteId)) {
             refreshInFlight.add(siteId);
             setTimeout(() => refreshInFlight.delete(siteId), REFRESH_TTL_MS);
             setImmediate(async () => {
               try {
-                const refreshResult = await siteUtil.refresh(
-                  { query: { id: siteId, tenant: req.query.tenant } },
-                  (err) => {
-                    if (err) {
-                      logger.warn(
-                        `background refresh failed for site ${siteId}: ${err.message}`,
-                      );
-                    }
-                  },
-                );
-                if (refreshResult && refreshResult.success === false) {
-                  logger.warn(
-                    `background refresh failed for site ${siteId}: ${refreshResult.message || "unknown error"}`,
+                if (needsGeocoding) {
+                  // Full refresh — reverse-geocoding, altitude, and data_provider.
+                  const refreshResult = await siteUtil.refresh(
+                    { query: { id: siteId, tenant: req.query.tenant } },
+                    (err) => {
+                      if (err) {
+                        logger.warn(
+                          `background refresh failed for site ${siteId}: ${err.message}`,
+                        );
+                      }
+                    },
                   );
-                } else if (
-                  refreshResult &&
-                  refreshResult.success &&
-                  !refreshResult.data?.data_provider
-                ) {
-                  // Refresh completed but data_provider is still null — the site
-                  // has no active device and no network field. It will re-trigger
-                  // every REFRESH_TTL_MS with the same result. Log once per TTL
-                  // window so the data team can identify and fix stuck sites.
-                  logger.warn(
-                    `background refresh: data_provider still null for site ${siteId} [reason: no-active-device-no-network]`,
+                  if (refreshResult && refreshResult.success === false) {
+                    logger.warn(
+                      `background refresh failed for site ${siteId}: ${refreshResult.message || "unknown error"}`,
+                    );
+                  } else if (
+                    refreshResult &&
+                    refreshResult.success &&
+                    !refreshResult.data?.data_provider
+                  ) {
+                    // Refresh completed but data_provider is still null — the site
+                    // has no active device and no network field. It will re-trigger
+                    // every REFRESH_TTL_MS with the same result. Log once per TTL
+                    // window so the data team can identify and fix stuck sites.
+                    logger.warn(
+                      `background refresh: data_provider still null for site ${siteId} [reason: no-active-device-no-network]`,
+                    );
+                  }
+                } else {
+                  // Only data_provider is missing — skip reverse-geocoding entirely.
+                  // refreshSiteDataProvider calls computeSiteDataProvider which falls
+                  // back to site.network, so no external API calls are made.
+                  await siteUtil.refreshSiteDataProvider(
+                    req.query.tenant,
+                    siteId,
                   );
                 }
               } catch (err) {

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -134,7 +134,18 @@ const computeSiteDataProvider = async (tenant, siteId) => {
       .select("network")
       .lean();
 
-    if (!devices || devices.length === 0) return null;
+    if (!devices || devices.length === 0) {
+      // No active (deployed) device at this site — fall back to the site's own
+      // network field. This covers recalled-device sites: the device is gone
+      // but the site still belongs to the same organisation.
+      const site = await SiteModel(tenant)
+        .findById(siteId)
+        .select("network")
+        .lean();
+      if (!site || !site.network) return null;
+      const label = constants.DATA_PROVIDER_MAPPINGS(site.network.trim());
+      return label || null;
+    }
 
     // Step 1: map raw network ids → display labels via the mapping fn.
     // Step 2: filter out any unmappable values.
@@ -179,9 +190,8 @@ const refreshSiteDataProvider = async (tenant, siteId) => {
     const SiteModel = require("@models/Site");
     const dataProvider = await computeSiteDataProvider(tenant, siteId);
 
-    // Write the result unconditionally:
-    // - non-null  → sets the correct derived value
-    // - null      → clears a stale value when the last device is recalled
+    // Write the result unconditionally. null is only possible if the site
+    // document has no network field, which should not happen in practice.
     await SiteModel(tenant).findByIdAndUpdate(
       siteId,
       { $set: { data_provider: dataProvider } },

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -114,13 +114,14 @@ const getSiteCountSummary = async (request, next) => {
 };
 
 /**
- * Derives a display-ready data_provider string from the networks of all
- * devices currently deployed at a given site.
+ * Derives a display-ready data_provider string for a site.
  *
  * Rules:
- *   - No devices at the site → returns null (callers such as refreshSiteDataProvider() should clear any stale stored value)
- *   - Single network       → e.g. "AIRQO"
- *   - Multiple networks    → e.g. "AIRQO / METONE" (sorted for determinism)
+ *   - Active devices found  → map each device's network through DATA_PROVIDER_MAPPINGS,
+ *                             deduplicate, sort, and join (e.g. "AIRQO / METONE")
+ *   - No active devices     → fall back to the site's own network field via
+ *                             DATA_PROVIDER_MAPPINGS (covers recalled-device sites)
+ *   - No active devices AND no site.network → returns null
  *
  * @param {string}   tenant  - The tenant identifier
  * @param {ObjectId} siteId  - The site whose devices will be queried
@@ -143,7 +144,7 @@ const computeSiteDataProvider = async (tenant, siteId) => {
         .select("network")
         .lean();
       if (!site || !site.network) return null;
-      const label = constants.DATA_PROVIDER_MAPPINGS(site.network.trim());
+      const label = constants.DATA_PROVIDER_MAPPINGS(site.network);
       return label || null;
     }
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Closes all known gaps in the `data_provider` pipeline across the backfill job, the site refresh utility, and the per-request background trigger. Five targeted changes across three files ensure the field is reliably written on first geocoding, preserved through device recall, and self-healed on any individual site fetch where it is still missing.

**`utils/site.util.js` — `computeSiteDataProvider`**
When no `isActive: true` device exists for a site (e.g. the only device has been recalled), the function now falls back to the site's own `network` field and runs it through the same `DATA_PROVIDER_MAPPINGS` function, rather than returning `null`. Previously this caused `refreshSiteDataProvider` — which writes its result unconditionally — to silently erase a previously correct `data_provider` value on every recall.

**`bin/jobs/backfill-site-metadata-job.js` — query selector**
Added `{ data_provider: { $in: [null, ""] } }` to the `$or` selector so the nightly job actually selects sites missing this field. Without this, sites with every other field complete were invisible to the job.

**`bin/jobs/backfill-site-metadata-job.js` — `generateMetadata` body**
Added `siteId: site._id.toString()` to the request body passed to `generateMetadata`. Without `resolvedSiteId` being non-null inside that function, `computeSiteDataProvider` was never invoked and `data_provider` was never computed for any site going through the backfill path.

**`controllers/site.controller.js` — background refresh trigger**
Added `!site.data_provider` to the incomplete-fields condition that fires a background `siteUtil.refresh` call. Any site still missing the field after the backfill runs will now self-heal on the next `GET /devices/sites/:site_id` request.

### Why is this change needed?

Sites deployed by external partners (e.g. Maputo, Mozambique) showed a blank **OWNER** column in the AirQo Platform data export table. Investigation confirmed the field existed in `SITES_INCLUSION_PROJECTION` and was not excluded by the `sites.summary` path strategy — the field was simply never written, or was being erased.

Root cause breakdown:

| Scenario | Root cause |
|---|---|
| Site created, backfill job runs | Job query did not select sites missing `data_provider`; even if selected, `siteId` was missing from `generateMetadata` body so `computeSiteDataProvider` was never called |
| Device recalled | `computeSiteDataProvider` returned `null` (no active device) → `refreshSiteDataProvider` wrote `null` unconditionally, erasing a previously correct value |
| Individual site fetch with missing field | Controller background trigger did not check for `!site.data_provider`, so no self-healing occurred |

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`
  - `utils/site.util.js` — `computeSiteDataProvider` fallback to `site.network`; stale comment removed from `refreshSiteDataProvider`
  - `bin/jobs/backfill-site-metadata-job.js` — `$or` query selector; `siteId` in `generateMetadata` body
  - `controllers/site.controller.js` — `!site.data_provider` added to background refresh trigger

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

- Called `PUT /api/v2/devices/sites/refresh?id=<maputo-site-id>` for a site whose only device had been recalled. Before this fix, response showed `data_provider: null`. After the fix, the same call returns `data_provider: "AIRQO"` derived from the site's `network: "airqo"` field.
- Verified sites with an active device are unaffected — `data_provider` still resolves from the device's `network` field via the primary path.
- Confirmed `activity.util.js` requires no changes — all four call sites (single deploy, batch deploy, recall, maintenance) pass through `refreshSiteDataProvider` unchanged and now receive the correct value.
- Verified `data_provider: 1` is present in `SITES_INCLUSION_PROJECTION` and absent from `pathStrategies.sites.summary.additionalExclusions`, confirming the field is not suppressed anywhere in the projection pipeline.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `computeSiteDataProvider` returns `null` only if the site document has no `network` field — which cannot happen since `network` is required in the Site schema.
- Sites with multiple active devices from different networks continue to produce a deterministic joined label (e.g. `"AIRQO / US EMBASSY"`). The `site.network` fallback only runs when `devices.length === 0`.
- `isActive: true` on the device query is intentional and correct — it is the deployment flag (set on deploy, cleared on recall), not an operational/online status flag. Removing it would risk computing `data_provider` from a historically deployed but currently inactive device at a different site.
- The four `refreshSiteDataProvider` call sites in `activity.util.js` (single deploy `_deployStatic`, batch deploy, recall, maintenance) are all structurally correct and required no changes. The fix is fully contained to `computeSiteDataProvider`.
- Sites that had `data_provider` erased by past recalls will be repaired progressively: by the nightly backfill job (02:00, 10:00, 18:00 Nairobi time) or by the background trigger on the next individual site fetch.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved site selection criteria for metadata updates to include more records for processing.
  * Enhanced data provider information retrieval with fallback mechanisms for sites with incomplete data.
  * Expanded automatic refresh triggers to ensure site information completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->