### PR TITLE
fix: always return requireClientSecret in clients list response

### DIFF
--- a/src/auth-service/config/global/db-projections.js
+++ b/src/auth-service/config/global/db-projections.js
@@ -940,7 +940,7 @@ const dbProjections = {
     description: 1,
     networks: "$networks",
     access_token: { $arrayElemAt: ["$access_token", 0] },
-    requireClientSecret: 1,
+    requireClientSecret: { $ifNull: ["$requireClientSecret", false] },
   },
   CLIENTS_EXCLUSION_PROJECTION: function (category) {
     const initialProjection = {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Updates `CLIENTS_INCLUSION_PROJECTION` in the auth-service to use `$ifNull` for the `requireClientSecret` field, ensuring it is always present in the `/api/v2/users/clients` response.

### Why is this change needed?
The `requireClientSecret` field was added to the `Client` schema with a default of `false`, but documents created before that migration have no stored value in MongoDB. In an aggregation `$project` stage, projecting a non-existent field with `1` silently omits it — so older clients returned no `requireClientSecret` key at all. The UI team cannot distinguish between "user has never set this" and "user has explicitly set this to false" without a guaranteed field in the response.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that calling `/api/v2/users/clients?user_id=` returns `requireClientSecret: false` for client documents that predate the field, and `requireClientSecret: true` for clients where the setting has been enabled. No regression in other client response fields.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The response shape is additive — `requireClientSecret` was previously absent for older documents and is now always present as a boolean.

---

## :memo: Additional Notes
Single-line change in `src/auth-service/config/global/db-projections.js`:

```diff
- requireClientSecret: 1,
+ requireClientSecret: { $ifNull: ["$requireClientSecret", false] },


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client authentication queries to ensure the client secret requirement is always reported as a proper boolean value instead of potentially undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->