### PR TITLE
fix: accept require_secret as alias for requireClientSecret on client update

### DIFF
--- a/src/auth-service/utils/client.util.js
+++ b/src/auth-service/utils/client.util.js
@@ -28,7 +28,19 @@ const client = {
       const { tenant } = query;
       const filter = generateFilter.clients(request, next);
       let update = Object.assign({}, body);
-      if (update.require_secret !== undefined) {
+      const hasAlias = Object.prototype.hasOwnProperty.call(update, "require_secret");
+      const hasCanonical = Object.prototype.hasOwnProperty.call(update, "requireClientSecret");
+      if (hasAlias && hasCanonical) {
+        if (update.require_secret !== update.requireClientSecret) {
+          return next(
+            new HttpError("Bad Request", httpStatus.BAD_REQUEST, {
+              message:
+                "Conflicting values for require_secret and requireClientSecret",
+            }),
+          );
+        }
+        delete update.require_secret;
+      } else if (hasAlias) {
         update.requireClientSecret = update.require_secret;
         delete update.require_secret;
       }

--- a/src/auth-service/utils/client.util.js
+++ b/src/auth-service/utils/client.util.js
@@ -28,6 +28,10 @@ const client = {
       const { tenant } = query;
       const filter = generateFilter.clients(request, next);
       let update = Object.assign({}, body);
+      if (update.require_secret !== undefined) {
+        update.requireClientSecret = update.require_secret;
+        delete update.require_secret;
+      }
       if (update.client_secret) {
         delete update.client_secret;
       }

--- a/src/auth-service/validators/clients.validators.js
+++ b/src/auth-service/validators/clients.validators.js
@@ -161,6 +161,28 @@ const update = [
         }
         return true;
       }),
+    body("require_secret")
+      .optional()
+      .isBoolean()
+      .withMessage("require_secret must be a boolean value")
+      .toBoolean()
+      .custom(async (value, { req }) => {
+        if (value !== true) return true;
+        const tenant =
+          (req.query && req.query.tenant) || constants.DEFAULT_TENANT;
+        const client_id = req.params && req.params.client_id;
+        if (!client_id) throw new Error("client_id param is required");
+        const client = await ClientModel(tenant).findOne(
+          { _id: client_id },
+          { client_secret: 1 },
+        );
+        if (!client || !client.client_secret) {
+          throw new Error(
+            "A client_secret must exist before enabling require_secret — call PATCH /:client_id/secret first",
+          );
+        }
+        return true;
+      }),
   ],
 ];
 

--- a/src/auth-service/validators/clients.validators.js
+++ b/src/auth-service/validators/clients.validators.js
@@ -95,6 +95,30 @@ const validateClientIdParam = oneOf([
 
 const updateClientSecret = [validateTenant, validateClientIdParam];
 
+const makeRequireSecretValidator = (fieldName) =>
+  body(fieldName)
+    .optional()
+    .isBoolean()
+    .withMessage(`${fieldName} must be a boolean value`)
+    .toBoolean()
+    .custom(async (value, { req }) => {
+      if (value !== true) return true;
+      const tenant =
+        (req.query && req.query.tenant) || constants.DEFAULT_TENANT;
+      const client_id = req.params && req.params.client_id;
+      if (!client_id) throw new Error("client_id param is required");
+      const client = await ClientModel(tenant).findOne(
+        { _id: client_id },
+        { client_secret: 1 },
+      );
+      if (!client || !client.client_secret) {
+        throw new Error(
+          `A client_secret must exist before enabling ${fieldName} — call PATCH /:client_id/secret first`,
+        );
+      }
+      return true;
+    });
+
 const update = [
   validateTenant,
   validateClientIdParam,
@@ -139,50 +163,8 @@ const update = [
       .isURL()
       .withMessage("the redirect_url is not a valid URL")
       .trim(),
-    body("requireClientSecret")
-      .optional()
-      .isBoolean()
-      .withMessage("requireClientSecret must be a boolean value")
-      .toBoolean()
-      .custom(async (value, { req }) => {
-        if (value !== true) return true;
-        const tenant =
-          (req.query && req.query.tenant) || constants.DEFAULT_TENANT;
-        const client_id = req.params && req.params.client_id;
-        if (!client_id) throw new Error("client_id param is required");
-        const client = await ClientModel(tenant).findOne(
-          { _id: client_id },
-          { client_secret: 1 },
-        );
-        if (!client || !client.client_secret) {
-          throw new Error(
-            "A client_secret must exist before enabling requireClientSecret — call PATCH /:client_id/secret first",
-          );
-        }
-        return true;
-      }),
-    body("require_secret")
-      .optional()
-      .isBoolean()
-      .withMessage("require_secret must be a boolean value")
-      .toBoolean()
-      .custom(async (value, { req }) => {
-        if (value !== true) return true;
-        const tenant =
-          (req.query && req.query.tenant) || constants.DEFAULT_TENANT;
-        const client_id = req.params && req.params.client_id;
-        if (!client_id) throw new Error("client_id param is required");
-        const client = await ClientModel(tenant).findOne(
-          { _id: client_id },
-          { client_secret: 1 },
-        );
-        if (!client || !client.client_secret) {
-          throw new Error(
-            "A client_secret must exist before enabling require_secret — call PATCH /:client_id/secret first",
-          );
-        }
-        return true;
-      }),
+    makeRequireSecretValidator("requireClientSecret"),
+    makeRequireSecretValidator("require_secret"),
   ],
 ];
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds `require_secret` as an accepted alias for `requireClientSecret` on the client update endpoint (`PUT /api/v2/users/clients/:client_id`). Both field names now pass validation and persist correctly to the database.

### Why is this change needed?
The UI integration guide shared with the frontend team used `require_secret` (snake_case) while the backend validator and schema exclusively recognised `requireClientSecret` (camelCase). Sending `require_secret` passed validation silently (the field is optional) but Mongoose's strict mode dropped it before the database write — so the update returned a success response but the field was never saved, leaving `requireClientSecret` permanently `false`.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that sending `require_secret: true` on `PUT /api/v2/users/clients/:client_id` now correctly persists `requireClientSecret: true` in MongoDB and is reflected in the subsequent `GET /api/v2/users/clients?user_id=` response. Existing behaviour using `requireClientSecret` directly is unchanged.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Both field names are accepted. Existing consumers already using `requireClientSecret` are unaffected.

---

## :memo: Additional Notes

Two files changed:

**`utils/client.util.js`** — normalises the alias before the database write:
```diff
+ if (update.require_secret !== undefined) {
+   update.requireClientSecret = update.require_secret;
+   delete update.require_secret;
+ }


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `require_secret` parameter in client update requests.
  * Implemented validation to ensure client secret exists before allowing secret requirement configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->