### PR TITLE
fix: validate admin level updates and correct site refresh geocoding

### DIFF
--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1960,10 +1960,13 @@ const createSite = {
       retrievedAddress.google_place_id = google_place_id;
 
       if (retrievedAddress.country) {
-        retrievedAddress.location_name =
+        const qualifier =
           retrievedAddress.country !== "Uganda"
-            ? `${retrievedAddress.region}, ${retrievedAddress.country}`
-            : `${retrievedAddress.district}, ${retrievedAddress.country}`;
+            ? retrievedAddress.region
+            : retrievedAddress.district;
+        retrievedAddress.location_name = qualifier
+          ? `${qualifier}, ${retrievedAddress.country}`
+          : retrievedAddress.country;
       }
 
       if (!retrievedAddress.search_name) {

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1926,7 +1926,7 @@ const createSite = {
       let types = results.types;
       let retrievedAddress = {};
       address_components.forEach((object) => {
-        if (object.types.includes("locality", "administrative_area_level_3")) {
+        if (object.types.includes("locality") || object.types.includes("administrative_area_level_3")) {
           retrievedAddress.town = object.long_name;
           retrievedAddress.city = object.long_name;
         }
@@ -1943,31 +1943,37 @@ const createSite = {
         if (object.types.includes("country")) {
           retrievedAddress.country = object.long_name;
         }
-        if (object.types.includes("sublocality", "sublocality_level_1")) {
+        if (object.types.includes("sublocality") || object.types.includes("sublocality_level_1")) {
           retrievedAddress.parish = object.long_name;
           retrievedAddress.division = object.long_name;
           retrievedAddress.village = object.long_name;
           retrievedAddress.sub_county = object.long_name;
           retrievedAddress.search_name = object.long_name;
         }
-        retrievedAddress.formatted_name = formatted_name;
-        retrievedAddress.geometry = geometry;
-        retrievedAddress.site_tags = types;
-        retrievedAddress.google_place_id = google_place_id;
+      });
+
+      // Computed once after all components are extracted so country/region/district
+      // are fully populated before location_name is built.
+      retrievedAddress.formatted_name = formatted_name;
+      retrievedAddress.geometry = geometry;
+      retrievedAddress.site_tags = types;
+      retrievedAddress.google_place_id = google_place_id;
+
+      if (retrievedAddress.country) {
         retrievedAddress.location_name =
           retrievedAddress.country !== "Uganda"
             ? `${retrievedAddress.region}, ${retrievedAddress.country}`
             : `${retrievedAddress.district}, ${retrievedAddress.country}`;
-        if (!retrievedAddress.search_name) {
-          retrievedAddress.search_name = retrievedAddress.town
-            ? retrievedAddress.town
-            : retrievedAddress.street
-            ? retrievedAddress.street
-            : retrievedAddress.city
-            ? retrievedAddress.city
-            : retrievedAddress.district;
-        }
-      });
+      }
+
+      if (!retrievedAddress.search_name) {
+        retrievedAddress.search_name =
+          retrievedAddress.town ||
+          retrievedAddress.street ||
+          retrievedAddress.city ||
+          retrievedAddress.district;
+      }
+
       return {
         success: true,
         message: "retrieved the Google address details of this site",

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1926,9 +1926,13 @@ const createSite = {
       let types = results.types;
       let retrievedAddress = {};
       address_components.forEach((object) => {
-        if (object.types.includes("locality") || object.types.includes("administrative_area_level_3")) {
+        if (object.types.includes("locality")) {
           retrievedAddress.town = object.long_name;
           retrievedAddress.city = object.long_name;
+        }
+        if (object.types.includes("administrative_area_level_3")) {
+          if (!retrievedAddress.town) retrievedAddress.town = object.long_name;
+          if (!retrievedAddress.city) retrievedAddress.city = object.long_name;
         }
         if (object.types.includes("administrative_area_level_2")) {
           retrievedAddress.district = object.long_name;

--- a/src/device-registry/validators/grids.validators.js
+++ b/src/device-registry/validators/grids.validators.js
@@ -790,13 +790,16 @@ const gridsValidations = {
       .optional()
       .not()
       .exists()
-      .withMessage("admin level names cannot be updated")
+      .withMessage("admin level names cannot be updated"),
+    body("description")
+      .exists({ checkNull: true, checkFalsy: true })
+      .withMessage(
+        "description is required — it is the only updatable field on an admin level",
+      )
       .bail()
       .trim()
-      .matches(/^[a-zA-Z0-9\s\-_]+$/)
-      .withMessage(
-        "the name can only contain letters, numbers, spaces, hyphens and underscores",
-      ),
+      .notEmpty()
+      .withMessage("description cannot be empty"),
     (req, res, next) => {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {

--- a/src/device-registry/validators/grids.validators.js
+++ b/src/device-registry/validators/grids.validators.js
@@ -801,6 +801,20 @@ const gridsValidations = {
       .notEmpty()
       .withMessage("description cannot be empty"),
     (req, res, next) => {
+      const allowed = ["description"];
+      const extra = Object.keys(req.body || {}).filter(
+        (k) => !allowed.includes(k),
+      );
+      if (extra.length > 0) {
+        return next(
+          new HttpError("Validation error", httpStatus.BAD_REQUEST, {
+            message: `unexpected field(s): ${extra.join(", ")} — only 'description' may be updated`,
+          }),
+        );
+      }
+      next();
+    },
+    (req, res, next) => {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {
         return next(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds `description` field validation to the `updateAdminLevel` endpoint — previously, sending an empty request body was accepted silently and produced a no-op update
- Fixes a long-standing bug in `retrieveInformationFromAddress` where `location_name`, `formatted_name`, `geometry`, `site_tags`, `google_place_id`, and `search_name` were re-assigned on every `forEach` iteration using partially-extracted data, causing `location_name` to be built before `country`/`region`/`district` were fully populated
- Corrects two `Array.includes()` calls that were passing a second argument as if it were an additional search term — per the JS spec, the second argument is `fromIndex`, not a search element; both checks now correctly use `||` to match either type as originally intended (`"locality" || "administrative_area_level_3"` and `"sublocality" || "sublocality_level_1"`)

### Why is this change needed?
- An empty `PUT /grids/levels/:level_id` request was returning `200 OK` with a "successfully modified" response despite changing nothing, misleading callers into thinking an update occurred
- Sites with missing metadata (e.g. `country`, `district`, `region`) were not being correctly populated during a manual refresh because `location_name` was computed mid-loop with incomplete data, and the `administrative_area_level_3` / `sublocality_level_1` Google geocoding component types were never being matched despite being part of the original developer's intent

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- Verified that `PUT /grids/levels/:level_id` with an empty body now returns `400 Validation error` with a clear message indicating `description` is required
- Verified that `PUT /grids/levels/:level_id` with a valid `description` body still returns `200` as expected
- Site refresh endpoint manually tested on staging against sites with missing `country` and related metadata fields

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `Array.includes()` fix (`"locality" || "administrative_area_level_3"` and `"sublocality" || "sublocality_level_1"`) is a behaviour expansion — Google geocoding responses for some locations return `administrative_area_level_3` instead of `locality` for town/city, and `sublocality_level_1` instead of `sublocality` for parish/sub-county. The original code silently never matched these types due to a misuse of the `includes(searchElement, fromIndex)` signature. No data is overwritten; the change only affects sites where those specific component types are returned and the corresponding fields are currently missing.
- The `location_name` loop fix moves all post-loop field assignments outside the `forEach` — only affects sites where Google geocoding is used (Nominatim path was already correct)

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed address information retrieval to correctly populate location fields
  * Improved location name construction to properly process all components before assignment
  * Updated admin level update validation to require a description field

<!-- end of auto-generated comment: release notes by coderabbit.ai -->