### PR TITLE
feat(auth-service): rate limit query-token endpoints at 10 req/min

### DIFF
--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -272,6 +272,24 @@ const transactionLimiter = rateLimit({
 });
 app.use("/api/v2/users/transactions", transactionLimiter);
 
+// Rate limit query-token-only endpoints at 10 req/min per IP.
+// Uses the same URI set and matching logic as the JWT-blocking check in
+// passport.js (specificRoutes / matchesRoute) so the two are always in sync.
+const {
+  queryTokenRateLimiter,
+} = require("@middleware/rate-limit.middleware");
+const {
+  specificRouteUris,
+  matchesRoute,
+} = require("@middleware/passport");
+app.use((req, res, next) => {
+  const endpoint = req.headers["x-original-uri"] || req.originalUrl || req.url;
+  if (matchesRoute(endpoint, specificRouteUris)) {
+    return queryTokenRateLimiter(req, res, next);
+  }
+  next();
+});
+
 app.use("/api/v2/users", require("@routes/v2"));
 app.use("/api/v3/users", require("@routes/v3"));
 

--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -283,8 +283,12 @@ const {
   matchesRoute,
 } = require("@middleware/passport");
 app.use((req, res, next) => {
-  const endpoint = req.headers["x-original-uri"] || req.originalUrl || req.url;
-  if (matchesRoute(endpoint, specificRouteUris)) {
+  const forwardedUri = req.headers["x-original-uri"] || null;
+  const localUri = req.originalUrl || req.url;
+  if (
+    (forwardedUri && matchesRoute(forwardedUri, specificRouteUris)) ||
+    matchesRoute(localUri, specificRouteUris)
+  ) {
     return queryTokenRateLimiter(req, res, next);
   }
   next();

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1806,6 +1806,11 @@ try {
   logger.error("Failed to validate route configuration:", error);
 }
 
+// Flat list of every URI that blocks JWT and requires query-token auth.
+// Exported so consumers (e.g. rate limiting) can match on the same set
+// without duplicating the route definitions.
+const specificRouteUris = specificRoutes.flatMap((r) => r.uri);
+
 module.exports = {
   setLocalAuth,
   setJWTAuth,
@@ -1823,4 +1828,6 @@ module.exports = {
   refreshTokenAuth,
   authenticateJWT,
   optionalJWTAuth,
+  specificRouteUris,
+  matchesRoute,
 };

--- a/src/auth-service/middleware/rate-limit.middleware.js
+++ b/src/auth-service/middleware/rate-limit.middleware.js
@@ -411,6 +411,19 @@ const tokenVerifyRateLimiter = createSafeRateLimiter({
 });
 
 /**
+ * Rate limiter for query-token-only endpoints (10 req/min per IP).
+ * These endpoints intentionally block JWT — see specificRoutes in passport.js.
+ */
+const queryTokenRateLimiter = createSafeRateLimiter({
+  windowMs: 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message:
+    "Too many requests. Query-token endpoints are limited to 10 requests per minute per IP.",
+});
+
+/**
  * Custom rate limiter factory
  */
 const createCustomRateLimiter = ({ windowMs, max, message }) => {
@@ -544,6 +557,7 @@ module.exports = {
   readRateLimiter,
   tokenVerifyIpRateLimiter,
   tokenVerifyRateLimiter,
+  queryTokenRateLimiter,
 
   // Subscription tier-aware limiter (apply after JWT auth)
   tierBasedRateLimiter,

--- a/src/auth-service/middleware/rate-limit.middleware.js
+++ b/src/auth-service/middleware/rate-limit.middleware.js
@@ -205,14 +205,15 @@ const keyGenerator = (req) => {
  * Custom handler for rate limit exceeded
  * Never throws errors - always returns a response
  */
-const rateLimitHandler = (req, res) => {
+const rateLimitHandler = (req, res, message) => {
   try {
     const ip = extractIp(req);
     logger.warn(`Rate limit exceeded for IP: ${ip} on ${req.path}`);
 
     return res.status(httpStatus.TOO_MANY_REQUESTS).json({
       success: false,
-      message: "Too many requests from this IP, please try again later.",
+      message:
+        message || "Too many requests from this IP, please try again later.",
       errors: {
         message:
           "Rate limit exceeded. Please wait before making more requests.",
@@ -275,13 +276,14 @@ const createSafeRateLimiter = (config) => {
   // IP-based key. Placing ...config last would let callers override store,
   // skip, and handler too, which is undesirable — so we only allow
   // keyGenerator to be customised.
-  const { keyGenerator: configKeyGenerator, ...restConfig } = config;
+  // Extract message so the custom handler can surface it in the 429 body.
+  const { keyGenerator: configKeyGenerator, message: configMessage, ...restConfig } = config;
   try {
     return rateLimit({
       ...restConfig,
       store: rateStore,
       skip: skipFunction,
-      handler: rateLimitHandler,
+      handler: (req, res) => rateLimitHandler(req, res, configMessage),
       keyGenerator: configKeyGenerator || keyGenerator,
       // Suppress the trust-proxy validation error — we use custom x-client-ip
       // headers via keyGenerator so req.ip trustworthiness is irrelevant here.


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Enforces a **10 requests per minute per IP** rate limit exclusively on endpoints that intentionally disallow JWT and require query-parameter token authentication. All JWT-authenticated endpoints remain fully exempt.

Three files changed:

- **`middleware/passport.js`** — exports `specificRouteUris` (flat URI list derived from the existing `specificRoutes` config) and `matchesRoute` (already-existing path matching function), making them consumable by other layers without duplicating the route definitions.
- **`middleware/rate-limit.middleware.js`** — adds `queryTokenRateLimiter` using the existing `createSafeRateLimiter` factory (60-second window, max 10, IP-keyed via HAProxy headers, Redis-backed with in-memory fallback).
- **`bin/server.js`** — applies a global `app.use` middleware that reads `x-original-uri || originalUrl || url` (the same header chain used by `enhancedJWTAuth`) and delegates to `queryTokenRateLimiter` only when the request path matches a query-token URI.

### Why is this change needed?

Query-token endpoints are more exposed to abuse and DoS attacks because they bypass JWT's stricter controls — any caller with a valid query token can hit them freely. A dedicated rate limit at the gateway layer throttles runaway or malicious callers before they saturate downstream services (events-registry, analytics, device-registry, metadata). Using `matchesRoute` as the shared selector keeps the rate limiter's path coverage automatically in sync with the JWT-blocking logic in passport.js — adding or removing a URI from `specificRoutes` updates both behaviours at once.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

- Confirmed that after 10 requests within one minute from the same IP to a query-token endpoint (e.g. `/api/v2/devices/events`), subsequent requests receive **HTTP 429** with the message `"Query-token endpoints are limited to 10 requests per minute per IP."` and the standard `RateLimit-*` response headers.
- Confirmed that JWT-authenticated endpoints (e.g. `/api/v2/users`) are completely unaffected — no rate limit is applied.
- Confirmed that IPs in `RATE_LIMIT_WHITELIST` bypass the limiter as expected.
- Confirmed graceful fallback to in-memory store when Redis is unavailable (`USE_REDIS_RATE_LIMIT=false`).

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Callers making fewer than 10 requests per minute are entirely unaffected. The 429 response body and headers follow the same shape as every other rate limiter in the service.

---

## :memo: Additional Notes

- The limiter reuses `createSafeRateLimiter` from `rate-limit.middleware.js`, inheriting its Redis-or-memory store selection, IP whitelist support, and fail-open error handling — no new dependencies.
- IP extraction follows the same HAProxy header priority (`x-client-ip` → `x-client-original-ip` → `req.ip`) used throughout the auth-service, so the key is consistent with other limiters.
- The `x-original-uri` header (set by the upstream proxy) is checked first when determining which path to match, mirroring `enhancedJWTAuth` exactly.
- `matchesRoute` and `specificRouteUris` are now part of the public `passport.js` exports; any future consumer can import them without touching the internal `specificRoutes` array.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional rate limiting for specific authentication endpoints (10 requests per minute) to reduce abuse.
  * Rate limit responses can now provide configurable messages for clearer client feedback.
* **Chores**
  * Shared route list exposed for consistent route matching across middleware (no API signature changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->