### PR TITLE
Fix double-masking and improve token expiry notification email

### DIFF
--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -701,14 +701,19 @@ module.exports = {
     const name = firstName + " " + lastName;
     const { maskedToken, tokenLabel, expiryLine, securityTip } =
       buildTokenEmailSegment({ token, tokenName, expires, expiredMode: false });
+    const tokenCallout = `
+      <div style="margin:16px 0; padding:12px 16px; background:#FFF8E7; border-left:4px solid #F5A623; border-radius:4px;">
+        <span style="font-size:14px;"><strong>Token:</strong> <code>${maskedToken}</code>${tokenLabel}</span>
+      </div>`;
     const content = `
       <tr>
         <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-          <p>Your AirQo API token <strong>${maskedToken}</strong>${tokenLabel} is expiring soon.</p>
+          <p>One of your AirQo API tokens is expiring soon. Please regenerate it before it expires to avoid any interruption to your API access.</p>
+          ${tokenCallout}
           ${expiryLine}
-          <p>You can refresh your token directly — no need to create a new API client. Simply log in to <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>, go to <strong>Settings &rsaquo; API</strong>, and regenerate your token from your existing client.</p>
-          <p>If you have already refreshed your token, please ignore this message.</p>
+          <p>To regenerate, log in to <a href="${constants.LOGIN_PAGE}">AirQo Analytics</a>, go to <strong>Settings &rsaquo; API</strong>, and regenerate your token from your existing client — no need to create a new one.</p>
           <p>If you are using the AirQo mobile app, you can manage your API token settings directly within the app.</p>
+          <p>If you have already regenerated this token, please ignore this message.</p>
           ${securityTip}
         </td>
       </tr>

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -708,7 +708,7 @@ const getEmailSubject = (functionName, params) => {
     newDeviceLogin: "Security Alert: New Sign-In to Your AirQo Account",
     sendBotAlert: "🚨 Security Alert: Automated Bot Activity Detected",
     expiredToken: "Action Required: Your AirQo API Token Has Expired",
-    expiringToken: "Action Required: Your AirQo API Token is Expiring Soon",
+    expiringToken: "Action Required: Your AirQo API Token Expires Soon — Regenerate Now",
 
     // ===== SENSOR MANUFACTURER (NETWORK) REQUEST FUNCTIONS =====
     notifyAdminOfSensorManufacturerRequest: `New Sensor Manufacturer Request: ${sanitizeEmailString(
@@ -2304,20 +2304,15 @@ const mailer = {
   ),
   expiredToken: createSecurityEmailFunction(
     "expiredToken", //
-    (params) => {
-      const maskedToken =
-        params.token && params.token.length > 12
-          ? `${params.token.slice(0, 8)}...${params.token.slice(-4)}`
-          : params.token || "";
-      return msgs.tokenExpired({
+    (params) =>
+      msgs.tokenExpired({
         firstName: params.firstName,
         lastName: params.lastName,
         email: params.email,
-        token: maskedToken,
+        token: params.token,
         tokenName: params.tokenName,
         expires: params.expires,
-      });
-    },
+      }),
     {
       cooldownDays: constants.COMPROMISED_TOKEN_COOLDOWN_DAYS,
       enableCooldown: true,
@@ -2325,20 +2320,15 @@ const mailer = {
   ),
   expiringToken: createSecurityEmailFunction(
     "expiringToken", //
-    (params) => {
-      const maskedToken =
-        params.token && params.token.length > 12
-          ? `${params.token.slice(0, 8)}...${params.token.slice(-4)}`
-          : params.token || "";
-      return msgs.tokenExpiringSoon({
+    (params) =>
+      msgs.tokenExpiringSoon({
         firstName: params.firstName,
         lastName: params.lastName,
         email: params.email,
-        token: maskedToken,
+        token: params.token,
         tokenName: params.tokenName,
         expires: params.expires,
-      });
-    },
+      }),
     {
       cooldownDays: constants.EXPIRING_TOKEN_REMINDER_DAYS,
       enableCooldown: true,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes a double-masking bug on the API token expiry and expired notification emails, adds a highlighted token callout box that clearly identifies the specific expiring token (masked for security), and updates the email subject line to be more urgent and action-oriented.

### Why is this change needed?
The `expiringToken` and `expiredToken` mailer functions were pre-masking the raw token before passing it to the email template, which then masked it a second time via `buildTokenEmailSegment` — resulting in a doubly-mangled display value. Additionally, the previous email body did not visually call out *which* specific token was expiring, leaving users with no way to identify it without logging in first. The new amber callout box surfaces the masked token (first 8 + last 4 characters) and its name inline, following security best practices for partial token display.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`
  - `utils/common/email.msgs.util.js` — `tokenExpiringSoon` template: added amber token callout box, restructured body copy
  - `utils/common/mailer.util.js` — removed pre-masking in `expiredToken` and `expiringToken` (masking now happens once in `buildTokenEmailSegment`); updated `expiringToken` subject line

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that `buildTokenEmailSegment` correctly masks a raw token (first 8 + last 4 chars) exactly once, and that tokens shorter than 12 characters are shown in full. Confirmed the callout div renders the masked token and optional token name with the expiry date as a separate paragraph below the box.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The masking format used is `abcdefgh...xyz1` — enough to identify the token from a known list without leaking the full secret.
- If `token` is empty or missing, `buildTokenEmailSegment` falls back to `N/A` in the callout.
- The `expiredToken` mailer received the same double-masking fix for consistency.
- New subject: `Action Required: Your AirQo API Token Expires Soon — Regenerate Now`

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
