### PR TITLE
fix(device-registry): restore missing imports, drop REDIS_URL env var, fix config bugs

### DIFF
--- a/src/device-registry/config/definitions/db-projections.js
+++ b/src/device-registry/config/definitions/db-projections.js
@@ -1,3 +1,5 @@
+const { logText, logObject } = require("@utils/shared");
+
 /**
  * ProjectionFactory - A factory pattern implementation for handling database projections
  */

--- a/src/device-registry/config/definitions/db-projections.js
+++ b/src/device-registry/config/definitions/db-projections.js
@@ -1,4 +1,4 @@
-const { logText, logObject } = require("@utils/shared");
+const { logText, logObject } = require("../../utils/shared");
 
 /**
  * ProjectionFactory - A factory pattern implementation for handling database projections
@@ -1838,9 +1838,9 @@ const dbProjections = {
           .replace(/-/g, "_") // kebab-case → snake_case
           .toUpperCase() + "_EXCLUSION_PROJECTION";
 
-      // If the projection exists as a function, call it
+      // If the projection exists as a function, call it with the path argument.
       if (typeof this[keyName] === "function") {
-        return this[keyName]();
+        return this[keyName](path);
       }
 
       // If it exists as an object, return it
@@ -1997,11 +1997,6 @@ const dbProjections = {
   // Include the fields to exclude constants
   GRID_SHAPE_FIELDS_TO_EXCLUDE: ["coordinates"],
   SITE_FIELDS_TO_EXCLUDE: [
-    "altitude",
-    "greenness",
-    "landform_90",
-    "landform_270",
-    "aspect",
     "altitude",
     "greenness",
     "landform_90",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

- Restores `logText` and `logObject` imports in `config/definitions/db-projections.js` that were accidentally removed during the `config-cleanup` refactor, causing a runtime crash on all endpoints that exercise the projection factory.
- Removes `REDIS_URL` as an environment variable entirely — the Redis connection URL is now always computed internally from `REDIS_SERVER` and `REDIS_PORT`. All templates, example files, and `KNOWN_FLAT_ALIASES` are updated to match.
- Fixes `parseBool` in `constants.js` so that an empty string (`""`) is treated as "not set" and falls back to the default value, rather than being coerced to `true`.
- Fixes two silent bugs in `env-loader.js → reportDrift`: keys present in the flat file but absent from the JSON were silently dropped instead of reported; and `!value` in the JSON-side loop incorrectly skipped boolean `false` and numeric `0` values.
- Removes four `logger.debug` calls in `config/redis.js` that logged `${prefixedKey}` (environment-derived data), resolving CodeQL "clear-text logging of sensitive information" findings.
- Updates a stale comment in `env-loader.js` that still described the old prefixed-key migration model.
- Fixes a stale file path in `CODEBASE_STRUCTURE.md` (`config/global/aqi.js` → `config/definitions/aqi.js`).

### Why is this change needed?

The `config-cleanup` refactor (`config-cleanup` branch) removed several imports from `config/definitions/db-projections.js` as "unused boilerplate" without verifying usage throughout the file. This introduced a crash (`logText is not defined`) on any endpoint that triggers the projection factory. The remaining fixes address bugs and stale documentation surfaced during code review and CodeQL scanning of that same branch.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [x] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
`GET /api/v2/devices/sites` confirmed returning `200 OK` on staging after restoring the missing imports. Redis connectivity verified via `REDIS_SERVER` + `REDIS_PORT` alone (no `REDIS_URL` in the environment).

---

## :boom: Breaking Changes

- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

`REDIS_URL` is no longer read from the environment. If any deployment relies on setting `REDIS_URL` directly (e.g. in Docker Compose or a CI override), it must be replaced with `REDIS_SERVER` and `REDIS_PORT`. No AKV or flat-file changes are needed for environments that already had both of those values set.

---

## :memo: Additional Notes

This PR is a direct follow-up to `config-cleanup`. It should be merged immediately after (or rebased on top of) that branch to avoid the `logText is not defined` crash reaching production.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored runtime logging so application events and errors are properly recorded.
  * Fixed selection logic for path-dependent exclusions so rules tied to specific paths are now applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->