### PR TITLE
fix: env-loader warns on missing JSON config file instead of crashing

### DIFF
--- a/src/auth-service/config/env-loader.js
+++ b/src/auth-service/config/env-loader.js
@@ -10,8 +10,8 @@
  *   - Staging     : placed by the CI/CD pipeline from Azure Key Vault
  *   - Production  : placed by the CI/CD pipeline from Azure Key Vault
  *
- * If the JSON file is absent the loader warns and returns for development, but
- * throws for staging and production to prevent a misconfigured deployment.
+ * If the JSON file is absent the loader warns and returns — the app continues
+ * with whatever is already in process.env (e.g. K8s secret mounts).
  *
  * Performance: one synchronous file read at startup, under 5 ms.
  */
@@ -46,11 +46,6 @@ function loadEnvironment() {
   const jsonPath = path.join(ROOT, `.env.${env}.json`);
 
   if (!fs.existsSync(jsonPath)) {
-    if (env === "staging" || env === "production") {
-      throw new Error(
-        `[env-loader] ${jsonPath} not found — cannot start in ${env} without a config file.`,
-      );
-    }
     console.warn(
       `[env-loader] ${path.basename(jsonPath)} not found — relying on process.env only.`,
     );

--- a/src/auth-service/config/env-loader.js
+++ b/src/auth-service/config/env-loader.js
@@ -46,7 +46,8 @@ function loadEnvironment() {
 
   if (!fs.existsSync(jsonPath)) {
     console.warn(
-      `[env-loader] ${path.basename(jsonPath)} not found — relying on process.env only.`,
+      `[env-loader] .env.${env}.json not found (NODE_ENV=${env}) — relying on process.env only. ` +
+        `Running outside K8s? Create .env.${env}.json from .env.development.template.json.`,
     );
     return;
   }

--- a/src/auth-service/config/env-loader.js
+++ b/src/auth-service/config/env-loader.js
@@ -1,17 +1,16 @@
 /**
- * Centralized environment loader — JSON only.
+ * Centralized environment loader.
  *
- * Reads .env.{NODE_ENV}.json and applies all non-empty values to process.env.
- * Variables already present in process.env (set by Docker / K8s / shell) are
- * never overwritten — consistent with standard dotenv behaviour.
+ * Reads .env.{NODE_ENV}.json (if present) and applies non-empty values to
+ * process.env without overwriting variables that are already set.
  *
- * The JSON file is the single source of truth for all environments:
+ * The JSON file is a local-development convenience only:
  *   - Development : copy .env.development.template.json → .env.development.json, fill in values
- *   - Staging     : placed by the CI/CD pipeline from Azure Key Vault
- *   - Production  : placed by the CI/CD pipeline from Azure Key Vault
+ *   - Staging     : not present in the image — K8s injects vars via envFrom.secretRef (AKV)
+ *   - Production  : not present in the image — K8s injects vars via envFrom.secretRef (AKV)
  *
- * If the JSON file is absent the loader warns and returns — the app continues
- * with whatever is already in process.env (e.g. K8s secret mounts).
+ * When the file is absent the loader logs a warning and returns; the app
+ * continues with whatever is already in process.env.
  *
  * Performance: one synchronous file read at startup, under 5 ms.
  */

--- a/src/device-registry/config/env-loader.js
+++ b/src/device-registry/config/env-loader.js
@@ -45,7 +45,8 @@ function loadEnvironment() {
 
   if (!fs.existsSync(jsonPath)) {
     console.warn(
-      `[env-loader] ${path.basename(jsonPath)} not found — relying on process.env only.`,
+      `[env-loader] .env.${env}.json not found (NODE_ENV=${env}) — relying on process.env only. ` +
+        `Running outside K8s? Create .env.${env}.json from .env.development.template.json.`,
     );
     return;
   }

--- a/src/device-registry/config/env-loader.js
+++ b/src/device-registry/config/env-loader.js
@@ -1,17 +1,16 @@
 /**
- * Centralized environment loader — JSON only.
+ * Centralized environment loader.
  *
- * Reads .env.{NODE_ENV}.json and applies all non-empty values to process.env.
- * Variables already present in process.env (set by Docker / K8s / shell) are
- * never overwritten — consistent with standard dotenv behaviour.
+ * Reads .env.{NODE_ENV}.json (if present) and applies non-empty values to
+ * process.env without overwriting variables that are already set.
  *
- * The JSON file is the single source of truth for all environments:
+ * The JSON file is a local-development convenience only:
  *   - Development : copy .env.development.template.json → .env.development.json, fill in values
- *   - Staging     : placed by the CI/CD pipeline from Azure Key Vault
- *   - Production  : placed by the CI/CD pipeline from Azure Key Vault
+ *   - Staging     : not present in the image — K8s injects vars via envFrom.secretRef (AKV)
+ *   - Production  : not present in the image — K8s injects vars via envFrom.secretRef (AKV)
  *
- * If the JSON file is absent the loader logs a warning and returns — the app
- * continues with whatever is already in process.env (e.g. K8s secret mounts).
+ * When the file is absent the loader logs a warning and returns; the app
+ * continues with whatever is already in process.env.
  *
  * Performance: one synchronous file read at startup, under 5 ms.
  */

--- a/src/device-registry/config/env-loader.js
+++ b/src/device-registry/config/env-loader.js
@@ -45,11 +45,6 @@ function loadEnvironment() {
   const jsonPath = path.join(ROOT, `.env.${env}.json`);
 
   if (!fs.existsSync(jsonPath)) {
-    if (env === "staging" || env === "production") {
-      throw new Error(
-        `[env-loader] ${jsonPath} not found — cannot start in ${env} without a config file.`,
-      );
-    }
     console.warn(
       `[env-loader] ${path.basename(jsonPath)} not found — relying on process.env only.`,
     );


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Removes the hard `throw` in `env-loader.js` for both `auth-service` and `device-registry` when the `.env.{NODE_ENV}.json` file is not found at startup. The loader now logs a warning and continues in all environments, relying on whatever is already in `process.env`.

### Why is this change needed?
The `.env.staging.json` / `.env.production.json` files are never written into the Docker image — they are local-dev convenience files, not runtime artefacts. In K8s, all environment variables are injected by the cluster before the Node process starts, via `envFrom.secretRef` pointing at the Azure Key Vault-backed secret. The hard throw caused both `auth-service` and `device-registry` staging pods to crash-loop immediately on startup with `Error: [env-loader] .env.staging.json not found`, producing 502 Bad Gateway errors on all affected endpoints.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/auth-service/config/env-loader.js`
- `src/device-registry/config/env-loader.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified via ArgoCD pod logs that the crash-loop root cause is the missing JSON file. After this fix the loader falls through to the warn-and-return path, and all env vars come from the K8s secret mount (same source as before the env-loader refactor). Staging pods are expected to start cleanly after redeployment.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The behaviour change only affects pods where the JSON file is absent (all K8s environments). Those pods currently crash; after this fix they start normally using K8s-injected env vars. Local development is unaffected — missing JSON already fell through to the warn path.

---

## :memo: Additional Notes

The `env-loader.js` comment block has also been updated in `auth-service` to reflect the correct behaviour: the JSON file is a local-dev convenience, not a hard runtime requirement. K8s pods rely solely on `envFrom.secretRef` for their environment.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing environment configuration files; the system now logs warnings and continues with existing environment values instead of throwing exceptions, increasing application resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->