### PR TITLE
feat(auth-service): add app origin field to feedback submissions

### DIFF
--- a/src/auth-service/models/Feedback.js
+++ b/src/auth-service/models/Feedback.js
@@ -68,6 +68,9 @@ const FeedbackSchema = new mongoose.Schema(
     app: {
       type: String,
       trim: true,
+      set(value) {
+        return value === "" ? undefined : value;
+      },
       maxlength: [100, "app cannot exceed 100 characters"],
     },
     status: {

--- a/src/auth-service/models/Feedback.js
+++ b/src/auth-service/models/Feedback.js
@@ -65,6 +65,11 @@ const FeedbackSchema = new mongoose.Schema(
       },
       default: "web",
     },
+    app: {
+      type: String,
+      trim: true,
+      maxlength: [100, "app cannot exceed 100 characters"],
+    },
     status: {
       type: String,
       enum: {
@@ -94,6 +99,7 @@ const FeedbackSchema = new mongoose.Schema(
 FeedbackSchema.index({ tenant: 1, createdAt: -1 });
 FeedbackSchema.index({ tenant: 1, status: 1 });
 FeedbackSchema.index({ tenant: 1, category: 1 });
+FeedbackSchema.index({ tenant: 1, app: 1 });
 FeedbackSchema.index({ email: 1, tenant: 1 });
 
 FeedbackSchema.statics = {
@@ -208,6 +214,7 @@ FeedbackSchema.methods = {
       rating: this.rating,
       category: this.category,
       platform: this.platform,
+      app: this.app,
       status: this.status,
       userId: this.userId,
       tenant: this.tenant,

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -7616,8 +7616,16 @@ const feedbackUtil = {
     try {
       const { body, query } = request;
       const tenant = resolveFeedbackTenant(query);
-      const { email, subject, message, rating, category, platform, metadata } =
-        body;
+      const {
+        email,
+        subject,
+        message,
+        rating,
+        category,
+        platform,
+        app,
+        metadata,
+      } = body;
 
       // U2: safely normalise email — validator guarantees it's present and a
       // string at the HTTP layer, but guard here so a missing value yields a
@@ -7640,6 +7648,7 @@ const feedbackUtil = {
         rating,
         category,
         platform,
+        app,
         metadata,
         tenant,
         userId: request.user ? request.user._id : undefined,
@@ -7697,6 +7706,7 @@ const feedbackUtil = {
       if (query.status) filter.status = query.status;
       if (query.category) filter.category = query.category;
       if (query.platform) filter.platform = query.platform;
+      if (query.app) filter.app = query.app;
       if (query.email) filter.email = query.email.toLowerCase().trim();
 
       return await FeedbackModel(tenant).list({ skip, limit, filter });

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -7623,9 +7623,13 @@ const feedbackUtil = {
         rating,
         category,
         platform,
-        app,
+        app: rawApp,
         metadata,
       } = body;
+      const app =
+        typeof rawApp === "string" && rawApp.trim()
+          ? rawApp.trim()
+          : undefined;
 
       // U2: safely normalise email — validator guarantees it's present and a
       // string at the HTTP layer, but guard here so a missing value yields a
@@ -7706,7 +7710,8 @@ const feedbackUtil = {
       if (query.status) filter.status = query.status;
       if (query.category) filter.category = query.category;
       if (query.platform) filter.platform = query.platform;
-      if (query.app) filter.app = query.app;
+      if (typeof query.app === "string" && query.app.trim())
+        filter.app = query.app.trim();
       if (query.email) filter.email = query.email.toLowerCase().trim();
 
       return await FeedbackModel(tenant).list({ skip, limit, filter });

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1428,6 +1428,14 @@ const submitFeedback = [
     .withMessage(
       `platform must be one of: ${FEEDBACK_PLATFORMS.join(", ")}`,
     ),
+  body("app")
+    .optional()
+    .notEmpty()
+    .withMessage("app must not be empty if provided")
+    .bail()
+    .isLength({ max: 100 })
+    .withMessage("app cannot exceed 100 characters")
+    .trim(),
   body("metadata")
     .optional()
     .isObject()
@@ -1471,6 +1479,14 @@ const listFeedbackSubmissions = [
     .withMessage(
       `platform must be one of: ${FEEDBACK_PLATFORMS.join(", ")}`,
     ),
+  query("app")
+    .optional()
+    .notEmpty()
+    .withMessage("app must not be empty if provided")
+    .bail()
+    .isLength({ max: 100 })
+    .withMessage("app cannot exceed 100 characters")
+    .trim(),
   query("email")
     .optional()
     .trim()

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1430,12 +1430,12 @@ const submitFeedback = [
     ),
   body("app")
     .optional()
+    .trim()
     .notEmpty()
     .withMessage("app must not be empty if provided")
     .bail()
     .isLength({ max: 100 })
-    .withMessage("app cannot exceed 100 characters")
-    .trim(),
+    .withMessage("app cannot exceed 100 characters"),
   body("metadata")
     .optional()
     .isObject()
@@ -1481,12 +1481,12 @@ const listFeedbackSubmissions = [
     ),
   query("app")
     .optional()
+    .trim()
     .notEmpty()
     .withMessage("app must not be empty if provided")
     .bail()
     .isLength({ max: 100 })
-    .withMessage("app cannot exceed 100 characters")
-    .trim(),
+    .withMessage("app cannot exceed 100 characters"),
   query("email")
     .optional()
     .trim()


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds an optional `app` field to the feedback schema to capture the specific application that submitted feedback (e.g. `airqo-platform`, `airqo-mobile-android`, `airqo-analytics`). The field is persisted to the database, included in API responses, and filterable via the admin list endpoint alongside the existing `platform` filter.

### Why is this change needed?
The existing `platform` field is limited to three coarse values (`web`, `mobile`, `api`) and cannot distinguish which specific AirQo application the feedback came from. This change enables teams to trace every feedback submission back to its exact source app, improving triage, reporting, and product-specific follow-up.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually verified that `POST /api/v2/users/feedback/submit` accepts and persists the `app` field, that `GET /api/v2/users/feedback/submissions?app=airqo-platform` filters correctly, and that omitting `app` in the request body leaves existing behaviour unchanged.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `app` field is fully optional. Existing clients that do not send it are unaffected; stored documents without `app` simply return the field as `undefined`.

---

## :memo: Additional Notes

- `app` is a free-form string (max 100 characters) so new applications can self-identify without requiring a schema update each time.
- A compound index `{ tenant: 1, app: 1 }` was added to `Feedback.js` to keep admin list queries efficient when filtering by app.
- The `platform` field (`web` | `mobile` | `api`) is retained unchanged for backward compatibility and broad categorisation.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for associating feedback submissions with a specific application. Users can now tag feedback with an app identifier when submitting, enabling better organization and categorization of feedback by application source.
  * Feedback submissions can now be filtered by application, allowing users to easily retrieve and review feedback specific to individual applications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6524)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->