### PR TITLE
fix(auth-service): reduce verify-token log noise and guard Kafka callback

### DIFF
--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -290,11 +290,11 @@ let blacklistQueue = async.queue(async (task, callback) => {
       .then(() => {
         logObject(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
         // logger.info(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
-        callback();
+        if (typeof callback === "function") callback();
       })
       .catch((error) => {
         logObject("kafka producer send error", error);
-        callback();
+        if (typeof callback === "function") callback();
       });
     await kafkaProducer.disconnect().catch((error) => {
       logObject("kafka producer disconnect error", error);
@@ -305,7 +305,7 @@ let blacklistQueue = async.queue(async (task, callback) => {
     // logger.error(
     //   `🐛🐛 KAFKA Producer Internal Server Error --- IP_ADDRESS: ${ip} --- ${error.message}`
     // );
-    callback();
+    if (typeof callback === "function") callback();
   }
 }, 1); // Limit the number of concurrent tasks to 1
 
@@ -1048,7 +1048,7 @@ const token = {
                 ),
               );
           }
-          winstonLogger.info("verify token", {
+          winstonLogger.debug("verify token", {
             token: token,
             service: "verify-token",
             clientIp: ip,

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -282,29 +282,22 @@ let blacklistQueue = async.queue(async (task, callback) => {
       groupId: constants.UNIQUE_PRODUCER_GROUP,
     });
     await kafkaProducer.connect();
-    await kafkaProducer
-      .send({
+    try {
+      await kafkaProducer.send({
         topic: "ip-address",
         messages: [{ value: stringify({ ip }) }],
-      })
-      .then(() => {
-        logObject(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
-        // logger.info(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
-        if (typeof callback === "function") callback();
-      })
-      .catch((error) => {
-        logObject("kafka producer send error", error);
-        if (typeof callback === "function") callback();
       });
-    await kafkaProducer.disconnect().catch((error) => {
-      logObject("kafka producer disconnect error", error);
-    });
-    // callback();
+      logObject(`🤩🤩 Published IP ${ip} to the "ip-address" topic.`);
+    } catch (sendError) {
+      logObject("kafka producer send error", sendError);
+    } finally {
+      await kafkaProducer.disconnect().catch((error) => {
+        logObject("kafka producer disconnect error", error);
+      });
+    }
   } catch (error) {
     logObject("error", error);
-    // logger.error(
-    //   `🐛🐛 KAFKA Producer Internal Server Error --- IP_ADDRESS: ${ip} --- ${error.message}`
-    // );
+  } finally {
     if (typeof callback === "function") callback();
   }
 }, 1); // Limit the number of concurrent tasks to 1
@@ -1049,7 +1042,7 @@ const token = {
               );
           }
           winstonLogger.debug("verify token", {
-            token: token,
+            clientId: accessToken.client_id,
             service: "verify-token",
             clientIp: ip,
             clientOriginalIp: ip,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Downgrades the `"verify token"` log from `winstonLogger.info` to `winstonLogger.debug` in `token.util.js` to eliminate excessive INFO log noise on every successful token verification.
- Adds a `typeof callback === "function"` guard before all `callback()` invocations inside the Kafka IP-address publishing queue worker to prevent `TypeError: callback is not a function` crashes when the function is called without a callback argument.

### Why is this change needed?
- The `winstonLogger.info("verify token", ...)` call fired on every single API request that passed token verification, flooding production and staging ArgoCD logs with thousands of INFO entries per hour, making it harder to spot real issues.
- The unguarded `callback()` calls at lines 293, 297, and 308 of `token.util.js` caused uncaught `TypeError: callback is not a function` errors visible in staging ArgoCD logs, originating from the async Kafka queue worker for IP-address publishing.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `src/auth-service/utils/token.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that token verification still returns valid responses after the log level change. The `callback` guard is a no-op when a callback is provided (existing behaviour unchanged) and silently skips the call when none is provided, eliminating the TypeError.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `winstonLogger.debug` log is still available for local debugging — set the Winston log level to `debug` to see per-request token verification events when needed.
- The Kafka IP-address publishing path (`publishIPAddress` queue worker) is non-critical; the callback guard does not affect the main token verification response flow.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token authentication service stability by adding safety checks to prevent potential runtime errors during callback processing and ensure cleanup always runs.

* **Chores**
  * Reduced logging verbosity for token verification and removed sensitive token details from verification logs to limit exposed information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6527)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->