### PR TITLE
Add events fallback, observability logs, and restore MongoDB socket timeout

### DIFF
--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -351,7 +351,7 @@ async function fetchAndStoreReadings() {
     if (data.length === 0) {
       logger.warn(
         `⚠️ store-readings-job: 0 events returned — readings collection will NOT be updated. ` +
-          `Check EventModel.fetch() filter and whether the events collection has data in the last 7 days.`,
+          `Check EventModel.fetch() filter and whether the events collection has data in the last 3 days.`,
       );
       return;
     }

--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -298,7 +298,9 @@ async function fetchAndStoreReadings() {
     const filter = generateFilter.fetch(request);
 
     const jobStartMs = Date.now();
-    logText("Starting readings processing job");
+    logger.warn(
+      `⏰ store-readings-job STARTED at ${new Date().toISOString()}`,
+    );
 
     let viewEventsResponse;
     try {
@@ -315,7 +317,7 @@ async function fetchAndStoreReadings() {
         fetchError.name === "MongoServerSelectionError" ||
         /timed out|timeout/i.test(fetchError.message);
       logger.error(
-        `🐛 Error fetching events (${
+        `🐛 store-readings-job FAILED fetching events (${
           isTimeout
             ? "TIMEOUT — socketTimeoutMS may be too low"
             : fetchError.name
@@ -329,7 +331,7 @@ async function fetchAndStoreReadings() {
       !Array.isArray(viewEventsResponse.data?.[0]?.data)
     ) {
       logger.warn(
-        `🙀 Invalid or empty response from EventModel.fetch() — success=${
+        `🙀 store-readings-job: invalid or empty response from EventModel.fetch() — success=${
           viewEventsResponse?.success
         } dataShape=${JSON.stringify(
           Object.keys(viewEventsResponse?.data?.[0] || {}),
@@ -339,12 +341,18 @@ async function fetchAndStoreReadings() {
     }
 
     const data = viewEventsResponse.data[0].data;
-    logger.info(
-      `📦 EventModel.fetch() returned ${data.length} events in ${Date.now() -
-        jobStartMs}ms`,
+    const fetchDuration = Date.now() - jobStartMs;
+    logger.warn(
+      `📦 store-readings-job: EventModel.fetch() returned ${
+        data.length
+      } events in ${fetchDuration}ms`,
     );
+
     if (data.length === 0) {
-      logText("No Events found to process into Readings");
+      logger.warn(
+        `⚠️ store-readings-job: 0 events returned — readings collection will NOT be updated. ` +
+          `Check EventModel.fetch() filter and whether the events collection has data in the last 7 days.`,
+      );
       return;
     }
 
@@ -387,16 +395,26 @@ async function fetchAndStoreReadings() {
     // Generate processing report
     const report = batchProcessor.getProcessingReport();
 
-    // Simple success logging
+    // Always surface the final result to Slack so we can confirm the job is healthy
+    const totalDuration = Date.now() - jobStartMs;
     if (report.summary.successRate >= 95) {
-      logText(
-        `✅ Readings processed successfully: ${report.summary.readingsProcessed}/${report.summary.totalDocuments} documents (${report.summary.successRate}% success rate)`,
+      logger.warn(
+        `✅ store-readings-job DONE — ${report.summary.readingsProcessed}/${
+          report.summary.totalDocuments
+        } readings stored (${
+          report.summary.successRate
+        }% success) | fetch ${fetchDuration}ms | total ${totalDuration}ms`,
       );
     } else {
       logger.warn(
-        `⚠️ Readings processing completed with issues: ${report.summary.readingsProcessed}/${report.summary.totalDocuments} documents (${report.summary.successRate}% success rate)`,
+        `⚠️ store-readings-job DONE WITH ISSUES — ${
+          report.summary.readingsProcessed
+        }/${report.summary.totalDocuments} readings stored (${
+          report.summary.successRate
+        }% success) | fetch ${fetchDuration}ms | total ${totalDuration}ms` +
+          ` | timestampFailures=${report.details.timestampValidationFailures}` +
+          ` | avgCalcFailures=${report.details.averageCalculationFailures}`,
       );
-      logger.info(`📊 Processing details: ${stringify(report.details)}`);
     }
   } catch (error) {
     if (isDuplicateKeyError(error)) {

--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -73,11 +73,12 @@ function envConfig(env) {
     // open socket before aborting the operation.  Must be long enough to cover
     // the heaviest aggregation in the service — EventModel.fetch(recent=yes)
     // runs multi-$lookup + $facet across the full events collection.
-    // Default: 300 000 ms (5 min) — sufficient for production-scale data.
+    // Default: 600 000 ms (10 min) — matches the original pre-refactor value and
+    // gives the heavy EventModel.fetch(recent=yes) aggregation full headroom.
     // Override via MONGODB_SOCKET_TIMEOUT_MS in the environment JSON.
     MONGODB_SOCKET_TIMEOUT_MS: (() => {
       const val = parseInt(process.env.MONGODB_SOCKET_TIMEOUT_MS, 10);
-      return Number.isFinite(val) && val > 0 ? val : 300000;
+      return Number.isFinite(val) && val > 0 ? val : 600000;
     })(),
   };
 

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -2955,11 +2955,16 @@ const createEvent = {
       }
 
       // Proceed with database query
+      logger.warn(
+        `readRecentWithFilter: cache MISS — querying ReadingModel.recent() for tenant=${tenant}`,
+      );
+      const dbQueryStart = Date.now();
       const readingsResponse = await ReadingModel(tenant).recent({
         filter,
         skip,
         limit,
       });
+      const dbQueryDuration = Date.now() - dbQueryStart;
 
       if (!readingsResponse) {
         logger.error(
@@ -3003,16 +3008,80 @@ const createEvent = {
 
       if (readingsResponse.success === true) {
         const data = readingsResponse.data;
+        const resultCount = Array.isArray(data) ? data.length : 0;
 
-        // Attempt to set cache but don't let failure affect the response
-        logText("Attempting to set cache...");
-        try {
-          await createEvent.handleCacheOperation("set", data, request, next);
-        } catch (error) {
-          logger.warn(`Cache set operation failed: ${stringify(error)}`);
+        if (resultCount === 0) {
+          // Log the exact DB+collection being queried to help diagnose
+          // whether the wrong collection is being accessed in production.
+          const expectedDb = `${constants.DB_NAME}_${tenant}`;
+          logger.warn(
+            `⚠️ readRecentWithFilter: ReadingModel.recent() returned 0 readings` +
+              ` for tenant=${tenant} in ${dbQueryDuration}ms` +
+              ` (queried db=${expectedDb} collection=readings)` +
+              ` — falling back to events collection`,
+          );
+
+          // Fallback: query the events collection directly so callers always
+          // get data while the readings pipeline issue is being investigated.
+          try {
+            const fallbackRequest = {
+              query: {
+                ...request.query,
+                recent: "yes",
+                metadata: "site_id",
+                active: "yes",
+                brief: "yes",
+              },
+            };
+            const fallbackFilter = generateFilter.fetch(fallbackRequest);
+            const eventsResponse = await EventModel(tenant).fetch(
+              fallbackFilter,
+            );
+
+            if (
+              eventsResponse?.success &&
+              Array.isArray(eventsResponse.data?.[0]?.data) &&
+              eventsResponse.data[0].data.length > 0
+            ) {
+              const eventsData = eventsResponse.data[0].data;
+              logger.warn(
+                `readRecentWithFilter: events fallback succeeded —` +
+                  ` ${eventsData.length} records returned for tenant=${tenant}`,
+              );
+              return {
+                success: true,
+                message: readingsResponse.message,
+                data: eventsData,
+                status: httpStatus.OK,
+                isCache: false,
+              };
+            }
+
+            logger.warn(
+              `readRecentWithFilter: events fallback also returned 0 records` +
+                ` for tenant=${tenant} — both readings and events collections appear empty`,
+            );
+          } catch (fallbackError) {
+            logger.warn(
+              `readRecentWithFilter: events fallback threw for tenant=${tenant}: ${fallbackError.message}`,
+            );
+          }
+        } else {
+          logger.warn(
+            `readRecentWithFilter: ReadingModel.recent() returned ${resultCount} readings` +
+              ` for tenant=${tenant} in ${dbQueryDuration}ms`,
+          );
         }
 
-        logText("Cache operation completed (success or failure ignored).");
+        // Only cache a non-empty readings result — caching empty data would
+        // cause subsequent requests within the TTL to serve stale zero results.
+        if (resultCount > 0) {
+          try {
+            await createEvent.handleCacheOperation("set", data, request, next);
+          } catch (error) {
+            logger.warn(`Cache set operation failed: ${stringify(error)}`);
+          }
+        }
 
         return {
           success: true,

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -3048,9 +3048,29 @@ const createEvent = {
                 `readRecentWithFilter: events fallback succeeded —` +
                   ` ${eventsData.length} records returned for tenant=${tenant}`,
               );
+
+              // Apply language translation to fallback data, mirroring the normal path.
+              if (language !== undefined) {
+                for (const event of eventsData) {
+                  try {
+                    const translatedHealthTips = await translate.translateTips(
+                      { healthTips: event.health_tips, targetLanguage: language },
+                      next,
+                    );
+                    if (translatedHealthTips.success === true) {
+                      event.health_tips = translatedHealthTips.data;
+                    }
+                  } catch (translationError) {
+                    logger.warn(
+                      `Translation failed in fallback: ${translationError.message}`,
+                    );
+                  }
+                }
+              }
+
               return {
                 success: true,
-                message: readingsResponse.message,
+                message: `successfully retrieved ${eventsData.length} measurements`,
                 data: eventsData,
                 status: httpStatus.OK,
                 isCache: false,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds a fallback to the `readRecentWithFilter` util: when `ReadingModel.recent()` returns zero results, the endpoint automatically queries the events collection directly via `EventModel.fetch()` and returns that data — so all downstream consumers (mobile app, dashboards) keep receiving measurements while the root cause is investigated
- Fixes a stale-cache bug: empty results are no longer cached, preventing the in-process fallback cache from serving stale zero-result responses within the TTL window
- Adds `logger.warn` diagnostic logging throughout `store-readings-job` and `readRecentWithFilter` (routed to Slack via `ops-alerts`): job start timestamp, events fetched count + duration, per-run success/failure summary with timing, exact DB + collection being queried, and which code path (readings vs events fallback) served the response
- Restores `MONGODB_SOCKET_TIMEOUT_MS` default to 600,000 ms (10 min) — the original pre-refactor value — to fully eliminate any socket-timeout risk on the heavy `EventModel.fetch(recent=yes)` aggregation
- Reverts the readings lookback window back to 3 days in `ReadingModel.recent()`

### Why is this change needed?
Production has been returning `"no measurements for this search"` from `GET /api/v2/devices/readings/recent` while the events collection demonstrably has data (network-status alerts confirm ~50% of devices are transmitting). The immediate fix unblocks all consumers by routing through the events collection when readings are empty. The observability logs will surface — via Slack — exactly what `store-readings-job` fetches each hour, how long the aggregation takes, and which DB/collection `ReadingModel` is actually querying, giving us the evidence needed to identify whether the root cause is a timeout, a wrong collection, or something else entirely.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified `GET /api/v2/devices/readings/recent` returns measurements via the events fallback when the readings collection is empty. Confirmed Slack receives `store-readings-job` start/done messages at each `:30` run and `readRecentWithFilter` cache-miss + result-count messages on each API call. Confirmed empty results are no longer written to the fallback cache.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The events fallback is intentionally temporary — once `store-readings-job` is confirmed healthy via the new Slack logs, the fallback can be removed or gated behind a feature flag
- The Slack warn log in `readRecentWithFilter` includes the exact DB name (`${DB_NAME}_${tenant}`) that `ReadingModel` is querying; if production is connecting to the wrong database (e.g. `device_reg_prod_airqo_airqo` due to a double-tenant suffix in `DB_NAME`), this will be immediately visible in Slack
- `MONGODB_SOCKET_TIMEOUT_MS` is now configurable via K8s secret — set it explicitly to avoid relying on the in-code default going forward
- The stale-cache fix (skip caching empty arrays) is a correctness improvement that applies regardless of the readings investigation outcome

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Added a fallback event query when primary reads return empty, improving data retrieval reliability and avoiding stale empty caches

* **Improvements**
  - Increased MongoDB socket timeout from 5 to 10 minutes for longer-running DB operations
  - Improved startup, fetch, and completion logs with clearer success/issue summaries, durations, and counts for better operational visibility

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6531)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->