### PR TITLE
feat(device-registry): add bulk device import endpoint with CSV upload support

### DIFF
--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -1481,6 +1481,84 @@ const deviceController = {
       return;
     }
   },
+  bulkCreateOnPlatform: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      const tenant = isEmpty(req.query.tenant) ? defaultTenant : req.query.tenant;
+      const { network_override, cohort_id, user_id } = req.body;
+
+      let devices;
+
+      if (req.file) {
+        try {
+          devices = await createDeviceUtil.parseDeviceCSV(req.file.buffer, network_override);
+        } catch (parseError) {
+          return next(
+            new HttpError(
+              `CSV processing failed: ${parseError.message}`,
+              parseError.status || httpStatus.BAD_REQUEST,
+              parseError.errors || { message: parseError.message },
+            ),
+          );
+        }
+
+        if (!devices || devices.length === 0) {
+          return res.status(httpStatus.BAD_REQUEST).json({
+            success: false,
+            message: "CSV file is empty or contains no valid device rows",
+            errors: { message: "No valid rows found" },
+          });
+        }
+
+        if (devices.length > 500) {
+          return res.status(httpStatus.BAD_REQUEST).json({
+            success: false,
+            message: `CSV contains ${devices.length} rows. Maximum allowed per upload is 500.`,
+            errors: { message: "Too many rows" },
+          });
+        }
+      } else {
+        devices = req.body.devices;
+        // Apply network_override to every row when supplied in JSON mode
+        if (network_override) {
+          devices = devices.map((d) => ({ ...d, network: network_override }));
+        }
+      }
+
+      const results = await createDeviceUtil.createDevicesBatch(devices, {
+        tenant,
+        user_id,
+        cohort_id,
+      });
+
+      const succeeded = results.filter((r) => r.success);
+      const failed = results.filter((r) => !r.success);
+
+      return res.status(207).json({
+        success: true,
+        message: `${succeeded.length} device(s) imported successfully, ${failed.length} failed`,
+        imported: succeeded.length,
+        failed: failed.length,
+        total: results.length,
+        results,
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        }),
+      );
+      return;
+    }
+  },
+
   listOnGCP: (req, res, next) => {
     let device = req.params.name;
     const formattedName = client.devicePath(

--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -1495,9 +1495,14 @@ const deviceController = {
 
       let devices;
 
+      // Pre-batch results for rows that failed before reaching createDevicesBatch
+      // (CSV row-level validation errors, JSON array guard failures).
+      const preResults = [];
+
       if (req.file) {
+        let parsed;
         try {
-          devices = await createDeviceUtil.parseDeviceCSV(req.file.buffer, network_override);
+          parsed = await createDeviceUtil.parseDeviceCSV(req.file.buffer, network_override);
         } catch (parseError) {
           return next(
             new HttpError(
@@ -1508,35 +1513,61 @@ const deviceController = {
           );
         }
 
+        // Fold CSV row-level validation errors into pre-results as failures
+        if (parsed.row_errors && parsed.row_errors.length > 0) {
+          parsed.row_errors.forEach((msg) => {
+            preResults.push({ success: false, error: msg });
+          });
+        }
+
+        devices = parsed.devices;
+
         if (!devices || devices.length === 0) {
           return res.status(httpStatus.BAD_REQUEST).json({
             success: false,
-            message: "CSV file is empty or contains no valid device rows",
-            errors: { message: "No valid rows found" },
+            message: "CSV file contains no valid device rows",
+            errors: { message: "No valid rows found", row_errors: parsed.row_errors },
           });
         }
 
         if (devices.length > 500) {
           return res.status(httpStatus.BAD_REQUEST).json({
             success: false,
-            message: `CSV contains ${devices.length} rows. Maximum allowed per upload is 500.`,
+            message: `CSV contains ${devices.length} valid rows. Maximum allowed per upload is 500.`,
             errors: { message: "Too many rows" },
           });
         }
       } else {
-        devices = req.body.devices;
-        // Apply network_override to every row when supplied in JSON mode
-        if (network_override) {
-          devices = devices.map((d) => ({ ...d, network: network_override }));
+        const raw = req.body.devices;
+
+        if (!Array.isArray(raw)) {
+          return res.status(httpStatus.BAD_REQUEST).json({
+            success: false,
+            message: "devices must be an array",
+            errors: { message: "devices field is not an array" },
+          });
         }
+
+        if (raw.length > 500) {
+          return res.status(httpStatus.BAD_REQUEST).json({
+            success: false,
+            message: `devices array contains ${raw.length} items. Maximum allowed is 500.`,
+            errors: { message: "Too many devices" },
+          });
+        }
+
+        devices = network_override
+          ? raw.map((d) => ({ ...d, network: network_override }))
+          : raw;
       }
 
-      const results = await createDeviceUtil.createDevicesBatch(devices, {
+      const batchResults = await createDeviceUtil.createDevicesBatch(devices, {
         tenant,
         user_id,
         cohort_id,
       });
 
+      const results = [...preResults, ...batchResults];
       const succeeded = results.filter((r) => r.success);
       const failed = results.filter((r) => !r.success);
 

--- a/src/device-registry/package-lock.json
+++ b/src/device-registry/package-lock.json
@@ -28,6 +28,7 @@
         "cookie-parser": "~1.4.3",
         "cron-parser": "^5.4.0",
         "crypto-js": "^4.1.1",
+        "csv-parse": "^5.5.6",
         "debug": "~2.6.9",
         "decimal.js": "^10.5.0",
         "dot-object": "^2.1.4",
@@ -110,6 +111,9 @@
         "sinon": "^9.2.4",
         "sinon-chai": "^3.7.0",
         "supertest": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18.19.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4009,6 +4013,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
       "integrity": "sha512-aIThpcErhG5EyHorGqNlTh0TduNBqLrrXLO3x5rku3ZKBxuVfY+T7noyM2G2X/01iQANqJUb6d3+FLoa+N7Xwg=="
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q=="
     },
     "node_modules/d": {
       "version": "1.0.2",

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -75,6 +75,7 @@
     "compression": "^1.7.4",
     "connect-mongo": "^3.2.0",
     "cookie-parser": "~1.4.3",
+    "csv-parse": "^5.5.6",
     "cron-parser": "^5.4.0",
     "crypto-js": "^4.1.1",
     "debug": "~2.6.9",

--- a/src/device-registry/routes/v2/devices.routes.js
+++ b/src/device-registry/routes/v2/devices.routes.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const path = require("path");
 const multer = require("multer");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
@@ -44,21 +45,23 @@ const _bulkUpload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
   fileFilter: (_req, file, cb) => {
-    const allowed = [
+    // text/plain is intentionally excluded: the error message promises ".csv
+    // only" and a plain-text file is not guaranteed to be CSV-structured.
+    const allowedMimetypes = [
       "text/csv",
-      "text/plain",
       "application/csv",
       "text/comma-separated-values",
       "application/vnd.ms-excel",
     ];
-    if (allowed.includes(file.mimetype)) {
+    const ext = path.extname(file.originalname).toLowerCase();
+    if (allowedMimetypes.includes(file.mimetype) && ext === ".csv") {
       cb(null, true);
     } else {
       cb(
         new HttpError(
           "Only .csv files are accepted for bulk import",
           httpStatus.BAD_REQUEST,
-          { message: `Unsupported file type: ${file.mimetype}` },
+          { message: `Unsupported file: mimetype=${file.mimetype}, extension=${ext}` },
         ),
         false,
       );

--- a/src/device-registry/routes/v2/devices.routes.js
+++ b/src/device-registry/routes/v2/devices.routes.js
@@ -1,5 +1,8 @@
 const express = require("express");
 const router = express.Router();
+const multer = require("multer");
+const { HttpError } = require("@utils/shared");
+const httpStatus = require("http-status");
 const deviceController = require("@controllers/device.controller");
 const { headers, pagination, validate } = require("@validators/common");
 const {
@@ -32,8 +35,53 @@ const {
   validateGetDeviceCountSummary,
   validateTransferDevice,
   validateRemoveDevicesFromBatch,
+  validateBulkSoftCreate,
 } = require("@validators/device.validators");
 const constants = require("@config/constants");
+
+// ── Multer setup for CSV bulk import ────────────────────────────────────────
+const _bulkUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+  fileFilter: (_req, file, cb) => {
+    const allowed = [
+      "text/csv",
+      "text/plain",
+      "application/csv",
+      "text/comma-separated-values",
+      "application/vnd.ms-excel",
+    ];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(
+        new HttpError(
+          "Only .csv files are accepted for bulk import",
+          httpStatus.BAD_REQUEST,
+          { message: `Unsupported file type: ${file.mimetype}` },
+        ),
+        false,
+      );
+    }
+  },
+});
+
+// Wraps multer errors into proper HttpErrors so the global error handler
+// formats them consistently with the rest of the API.
+const uploadBulkCSV = (req, res, next) => {
+  _bulkUpload.single("file")(req, res, (err) => {
+    if (!err) return next();
+    if (err instanceof multer.MulterError) {
+      const status = err.code === "LIMIT_FILE_SIZE" ? 413 : httpStatus.BAD_REQUEST;
+      return next(new HttpError(err.message, status, { message: err.message }));
+    }
+    return next(
+      err instanceof HttpError
+        ? err
+        : new HttpError(err.message, httpStatus.BAD_REQUEST, { message: err.message }),
+    );
+  });
+};
 
 router.use(headers);
 
@@ -215,6 +263,19 @@ router.get(
 );
 
 // SOFT OPERATIONS
+
+// Bulk soft-create — accepts a JSON array of devices OR a multipart CSV file.
+// Returns 207 Multi-Status with a per-device result array so the caller can
+// see which rows succeeded and which failed without retrying the whole batch.
+router.post(
+  "/soft/bulk",
+  validateTenant,
+  uploadBulkCSV,
+  validateBulkSoftCreate,
+  validate,
+  deviceController.bulkCreateOnPlatform
+);
+
 router.post(
   "/soft",
   validateTenant,

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1889,10 +1889,14 @@ const deviceUtil = {
 
       if (responseFromRegisterDevice.success === true) {
         try {
-          const kafkaProducer = kafka.producer({
+          // In bulk mode createDevicesBatch attaches a single pre-connected
+          // producer to avoid N connect/disconnect cycles for N devices.
+          // When present, skip lifecycle management entirely.
+          const sharedProducer = request._sharedKafkaProducer || null;
+          const kafkaProducer = sharedProducer || kafka.producer({
             groupId: constants.UNIQUE_PRODUCER_GROUP,
           });
-          await kafkaProducer.connect();
+          if (!sharedProducer) await kafkaProducer.connect();
           let deviceDataString = responseFromRegisterDevice.data
             ? JSON.stringify(responseFromRegisterDevice.data)
             : "";
@@ -1905,7 +1909,7 @@ const deviceUtil = {
               },
             ],
           });
-          await kafkaProducer.disconnect();
+          if (!sharedProducer) await kafkaProducer.disconnect();
         } catch (error) {
           logObject("error on kafka", error);
         }
@@ -5384,84 +5388,99 @@ const deviceUtil = {
       devices.push(device);
     });
 
-    if (rowErrors.length > 0) {
-      throw new HttpError(
-        `CSV validation failed: ${rowErrors.slice(0, 5).join("; ")}${rowErrors.length > 5 ? ` … and ${rowErrors.length - 5} more` : ""}`,
-        httpStatus.BAD_REQUEST,
-        { message: rowErrors.join("; "), row_errors: rowErrors },
-      );
-    }
-
-    return devices;
+    // Return valid devices alongside any row-level validation errors so the
+    // controller can still process good rows and fold failures into the 207
+    // response, rather than aborting the whole import on a single bad row.
+    return { devices, row_errors: rowErrors };
   },
 
   createDevicesBatch: async (devices, { tenant, user_id, cohort_id }, batchSize = 25) => {
     const results = [];
 
-    for (let i = 0; i < devices.length; i += batchSize) {
-      const chunk = devices.slice(i, i + batchSize);
-
-      const chunkOutcomes = await Promise.allSettled(
-        chunk.map(async (device) => {
-          // Capture errors that createOnPlatform routes through next() rather
-          // than throwing, so they don't disappear silently.
-          let capturedError = null;
-          const capturingNext = (err) => {
-            if (err) capturedError = err;
-          };
-
-          const mockRequest = {
-            query: { tenant },
-            body: {
-              ...device,
-              ...(user_id && { user_id }),
-              ...(cohort_id && { cohort_id }),
-            },
-          };
-
-          const outcome = await deviceUtil.createOnPlatform(mockRequest, capturingNext);
-
-          if (capturedError) {
-            return {
-              success: false,
-              message: capturedError.message || "Device creation failed",
-            };
-          }
-
-          return outcome || { success: false, message: "No result returned" };
-        }),
+    // One shared Kafka producer for the whole batch avoids N connect/disconnect
+    // cycles. Falls back to null so createOnPlatform manages its own lifecycle.
+    let sharedProducer = null;
+    try {
+      sharedProducer = kafka.producer({ groupId: constants.UNIQUE_PRODUCER_GROUP });
+      await sharedProducer.connect();
+    } catch (kafkaErr) {
+      logger.warn(
+        `createDevicesBatch: could not connect shared Kafka producer: ${kafkaErr.message}. Per-device fallback will be used.`,
       );
+      sharedProducer = null;
+    }
 
-      chunkOutcomes.forEach((settled, idx) => {
-        const deviceRow = chunk[idx];
-        const identifier = deviceRow.serial_number || deviceRow.long_name || `row_${i + idx + 1}`;
+    try {
+      for (let i = 0; i < devices.length; i += batchSize) {
+        const chunk = devices.slice(i, i + batchSize);
 
-        if (settled.status === "fulfilled") {
-          const outcome = settled.value;
-          if (outcome && outcome.success) {
-            results.push({
-              serial_number: identifier,
-              long_name: deviceRow.long_name,
-              success: true,
-              created_device: outcome.data || null,
-            });
+        const chunkOutcomes = await Promise.allSettled(
+          chunk.map(async (device) => {
+            // Capture errors that createOnPlatform routes through next() rather
+            // than throwing, so they don't disappear silently.
+            let capturedError = null;
+            const capturingNext = (err) => {
+              if (err) capturedError = err;
+            };
+
+            const mockRequest = {
+              query: { tenant },
+              body: {
+                ...device,
+                ...(user_id && { user_id }),
+                ...(cohort_id && { cohort_id }),
+              },
+              _sharedKafkaProducer: sharedProducer,
+            };
+
+            const outcome = await deviceUtil.createOnPlatform(mockRequest, capturingNext);
+
+            if (capturedError) {
+              return {
+                success: false,
+                message: capturedError.message || "Device creation failed",
+              };
+            }
+
+            return outcome || { success: false, message: "No result returned" };
+          }),
+        );
+
+        chunkOutcomes.forEach((settled, idx) => {
+          const deviceRow = chunk[idx];
+          const identifier = deviceRow.serial_number || deviceRow.long_name || `row_${i + idx + 1}`;
+
+          if (settled.status === "fulfilled") {
+            const outcome = settled.value;
+            if (outcome && outcome.success) {
+              results.push({
+                serial_number: identifier,
+                long_name: deviceRow.long_name,
+                success: true,
+                created_device: outcome.data || null,
+              });
+            } else {
+              results.push({
+                serial_number: identifier,
+                long_name: deviceRow.long_name,
+                success: false,
+                error: outcome?.message || "Device creation failed",
+              });
+            }
           } else {
             results.push({
               serial_number: identifier,
               long_name: deviceRow.long_name,
               success: false,
-              error: outcome?.message || "Device creation failed",
+              error: settled.reason?.message || "Unknown error",
             });
           }
-        } else {
-          results.push({
-            serial_number: identifier,
-            long_name: deviceRow.long_name,
-            success: false,
-            error: settled.reason?.message || "Unknown error",
-          });
-        }
-      });
+        });
+      }
+    } finally {
+      if (sharedProducer) {
+        try { await sharedProducer.disconnect(); } catch (_) {}
+      }
     }
 
     return results;

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -5298,6 +5298,174 @@ const deviceUtil = {
       );
     }
   },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // BULK SOFT-CREATE HELPERS
+  // ─────────────────────────────────────────────────────────────────────────
+
+  parseDeviceCSV: async (buffer, networkOverride) => {
+    // csv-parse/sync is the synchronous API shipped with csv-parse v5.x.
+    // Using it inside an async wrapper keeps callers in promise chains.
+    const { parse } = require("csv-parse/sync");
+
+    let rows;
+    try {
+      rows = parse(buffer, {
+        columns: true,       // first row is the header
+        skip_empty_lines: true,
+        trim: true,
+        bom: true,           // strip UTF-8 BOM that Excel often writes
+        relax_column_count: true, // tolerate rows with fewer columns
+      });
+    } catch (parseErr) {
+      throw new HttpError(
+        `CSV parse error: ${parseErr.message}`,
+        httpStatus.BAD_REQUEST,
+        { message: parseErr.message },
+      );
+    }
+
+    const devices = [];
+    const rowErrors = [];
+
+    rows.forEach((row, idx) => {
+      const rowNum = idx + 2; // account for header row
+
+      // Support both AirQo template column names and AirGradient-style names
+      const longName = (row.long_name || row.locationName || "").trim();
+      const network = (networkOverride || row.network || "").trim();
+      const serialNumber = String(row.serial_number || row.locationId || "").trim();
+
+      if (!longName) {
+        rowErrors.push(`Row ${rowNum}: long_name (or locationName) is required`);
+        return;
+      }
+      if (!network) {
+        rowErrors.push(`Row ${rowNum}: network is required (or pass network_override)`);
+        return;
+      }
+      if (!serialNumber) {
+        rowErrors.push(`Row ${rowNum}: serial_number (or locationId) is required`);
+        return;
+      }
+
+      const device = {
+        long_name: longName,
+        network,
+        serial_number: serialNumber,
+        category: (row.category || "lowcost").trim(),
+      };
+
+      if (row.latitude) {
+        const lat = parseFloat(row.latitude);
+        if (!isNaN(lat) && lat >= -90 && lat <= 90) device.latitude = lat;
+      }
+      if (row.longitude) {
+        const lng = parseFloat(row.longitude);
+        if (!isNaN(lng) && lng >= -180 && lng <= 180) device.longitude = lng;
+      }
+      if (row.api_code && row.api_code.trim()) {
+        device.api_code = row.api_code.trim();
+      }
+      if (row.description && row.description.trim()) {
+        device.description = row.description.trim();
+      }
+      if (row.device_number && row.device_number.trim()) {
+        const num = parseInt(row.device_number, 10);
+        if (!isNaN(num)) device.device_number = num;
+      }
+      if (row.tags && row.tags.trim()) {
+        device.tags = row.tags
+          .split("|")
+          .map((t) => t.trim())
+          .filter(Boolean);
+      }
+
+      devices.push(device);
+    });
+
+    if (rowErrors.length > 0) {
+      throw new HttpError(
+        `CSV validation failed: ${rowErrors.slice(0, 5).join("; ")}${rowErrors.length > 5 ? ` … and ${rowErrors.length - 5} more` : ""}`,
+        httpStatus.BAD_REQUEST,
+        { message: rowErrors.join("; "), row_errors: rowErrors },
+      );
+    }
+
+    return devices;
+  },
+
+  createDevicesBatch: async (devices, { tenant, user_id, cohort_id }, batchSize = 25) => {
+    const results = [];
+
+    for (let i = 0; i < devices.length; i += batchSize) {
+      const chunk = devices.slice(i, i + batchSize);
+
+      const chunkOutcomes = await Promise.allSettled(
+        chunk.map(async (device) => {
+          // Capture errors that createOnPlatform routes through next() rather
+          // than throwing, so they don't disappear silently.
+          let capturedError = null;
+          const capturingNext = (err) => {
+            if (err) capturedError = err;
+          };
+
+          const mockRequest = {
+            query: { tenant },
+            body: {
+              ...device,
+              ...(user_id && { user_id }),
+              ...(cohort_id && { cohort_id }),
+            },
+          };
+
+          const outcome = await deviceUtil.createOnPlatform(mockRequest, capturingNext);
+
+          if (capturedError) {
+            return {
+              success: false,
+              message: capturedError.message || "Device creation failed",
+            };
+          }
+
+          return outcome || { success: false, message: "No result returned" };
+        }),
+      );
+
+      chunkOutcomes.forEach((settled, idx) => {
+        const deviceRow = chunk[idx];
+        const identifier = deviceRow.serial_number || deviceRow.long_name || `row_${i + idx + 1}`;
+
+        if (settled.status === "fulfilled") {
+          const outcome = settled.value;
+          if (outcome && outcome.success) {
+            results.push({
+              serial_number: identifier,
+              long_name: deviceRow.long_name,
+              success: true,
+              created_device: outcome.data || null,
+            });
+          } else {
+            results.push({
+              serial_number: identifier,
+              long_name: deviceRow.long_name,
+              success: false,
+              error: outcome?.message || "Device creation failed",
+            });
+          }
+        } else {
+          results.push({
+            serial_number: identifier,
+            long_name: deviceRow.long_name,
+            success: false,
+            error: settled.reason?.message || "Unknown error",
+          });
+        }
+      });
+    }
+
+    return results;
+  },
 };
 
 module.exports = {

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -1586,6 +1586,78 @@ const validateRemoveDevicesFromBatch = [
     }),
 ];
 
+const validateBulkSoftCreate = [
+  // user_id is always required (sets owner and personal cohort)
+  body("user_id")
+    .exists()
+    .withMessage("user_id is required")
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage("user_id must be a valid MongoDB ObjectId")
+    .bail()
+    .customSanitizer((value) => ObjectId(value)),
+
+  // cohort_id is optional
+  body("cohort_id")
+    .optional()
+    .trim()
+    .isMongoId()
+    .withMessage("cohort_id must be a valid MongoDB ObjectId")
+    .customSanitizer((value) => ObjectId(value)),
+
+  // network_override is optional — forces all rows to a single network value
+  body("network_override")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("network_override cannot be an empty string"),
+
+  // JSON body mode: require a devices array when no file is uploaded
+  body("devices")
+    .if((_, { req }) => !req.file)
+    .exists()
+    .withMessage("devices array is required when not uploading a CSV file")
+    .bail()
+    .isArray({ min: 1, max: 500 })
+    .withMessage("devices must be an array of 1–500 items"),
+
+  body("devices.*.long_name")
+    .if((_, { req }) => !req.file)
+    .trim()
+    .notEmpty()
+    .withMessage("long_name is required for each device"),
+
+  body("devices.*.network")
+    .if((_, { req }) => !req.file && !req.body.network_override)
+    .trim()
+    .notEmpty()
+    .withMessage(
+      "network is required for each device (or supply network_override in the request body)",
+    ),
+
+  body("devices.*.serial_number")
+    .if((_, { req }) => !req.file)
+    .trim()
+    .notEmpty()
+    .withMessage("serial_number is required for each device"),
+
+  body("devices.*.latitude")
+    .optional()
+    .isFloat({ min: -90, max: 90 })
+    .withMessage("latitude must be a number between -90 and 90"),
+
+  body("devices.*.longitude")
+    .optional()
+    .isFloat({ min: -180, max: 180 })
+    .withMessage("longitude must be a number between -180 and 180"),
+
+  body("devices.*.category")
+    .optional()
+    .isIn(["lowcost", "bam", "gas"])
+    .withMessage("category must be one of: lowcost, bam, gas"),
+];
+
 const validateUserIdBody = [
   body("user_id")
     .exists()
@@ -1631,4 +1703,5 @@ module.exports = {
   validateUserIdBody,
   validateCreateShippingBatch,
   validateRemoveDevicesFromBatch,
+  validateBulkSoftCreate,
 };

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -1606,10 +1606,12 @@ const validateBulkSoftCreate = [
     .withMessage("cohort_id must be a valid MongoDB ObjectId")
     .customSanitizer((value) => ObjectId(value)),
 
-  // network_override is optional — forces all rows to a single network value
+  // network_override is optional — forces all rows to a single network value.
+  // Normalised to lowercase so "AirGradient" and "airgradient" are equivalent.
   body("network_override")
     .optional()
     .trim()
+    .toLowerCase()
     .notEmpty()
     .withMessage("network_override cannot be an empty string"),
 
@@ -1628,9 +1630,13 @@ const validateBulkSoftCreate = [
     .notEmpty()
     .withMessage("long_name is required for each device"),
 
+  // Normalised to lowercase for the same reason as network_override.
+  // Static whitelist validation is intentionally omitted: valid networks are
+  // DB-driven (Network collection) and cannot be checked at validator level.
   body("devices.*.network")
     .if((_, { req }) => !req.file && !req.body.network_override)
     .trim()
+    .toLowerCase()
     .notEmpty()
     .withMessage(
       "network is required for each device (or supply network_override in the request body)",
@@ -1642,17 +1648,22 @@ const validateBulkSoftCreate = [
     .notEmpty()
     .withMessage("serial_number is required for each device"),
 
+  // Guard optional per-item fields with !req.file so they don't fire when
+  // the CSV file is the source of truth and devices may appear in form fields.
   body("devices.*.latitude")
+    .if((_, { req }) => !req.file)
     .optional()
     .isFloat({ min: -90, max: 90 })
     .withMessage("latitude must be a number between -90 and 90"),
 
   body("devices.*.longitude")
+    .if((_, { req }) => !req.file)
     .optional()
     .isFloat({ min: -180, max: 180 })
     .withMessage("longitude must be a number between -180 and 180"),
 
   body("devices.*.category")
+    .if((_, { req }) => !req.file)
     .optional()
     .isIn(["lowcost", "bam", "gas"])
     .withMessage("category must be one of: lowcost, bam, gas"),


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a new `POST /api/v2/devices/soft/bulk` endpoint to the `device-registry` microservice that allows multiple external devices to be imported in a single request. The endpoint accepts either a **JSON array** of device objects or a **multipart CSV file upload**, processes devices in parallel batches of 25, and returns a `207 Multi-Status` response with a per-device outcome so callers can identify exactly which rows succeeded and which failed without retrying the whole batch.

Key additions:
- `POST /devices/soft/bulk` route with multer-powered CSV file handling (5 MB cap, CSV-only filter)
- `validateBulkSoftCreate` — express-validator chain that validates JSON body mode and skips array checks when a file is uploaded
- `bulkCreateOnPlatform` controller — branches on file vs JSON intake, applies optional `network_override` to all rows, caps uploads at 500 devices, returns `207` with `imported`/`failed`/`results` fields
- `parseDeviceCSV` util — parses a CSV buffer via `csv-parse/sync`; supports both AirQo template column names (`long_name`, `serial_number`) and AirGradient-style names (`locationName`, `locationId`); validates required fields row-by-row
- `createDevicesBatch` util — drives the existing `createOnPlatform` per-device logic in chunked `Promise.allSettled` loops; captures errors routed through `next()` per device so one failure never blocks the rest

### Why is this change needed?

Importing external devices one at a time is a bottleneck for partner onboarding. Partners such as AirGradient provide spreadsheets of tens to hundreds of sensor locations. The existing `POST /devices/soft` endpoint requires one HTTP call per device, making bulk onboarding slow and error-prone to coordinate from the frontend. This change enables a partner's full sensor fleet to be imported in a single upload while maintaining full backward compatibility with the existing single-device flow.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/device-registry` — new route, validator, controller method, and two util helpers; `csv-parse ^5.5.6` added as a dependency

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Manually tested against the AirGradient sample dataset (60+ devices) using both intake modes:

1. **JSON body mode** — `POST /devices/soft/bulk` with `{ "user_id": "...", "devices": [...] }` — verified per-device success/failure reporting and `network_override` application.
2. **CSV upload mode** — same endpoint with `multipart/form-data`, `file` field containing the AirGradient CSV; verified column aliasing (`locationId` → `serial_number`, `locationName` → `long_name`), lat/lng parsing, and graceful skipping of blank/invalid rows.
3. **Error cases** — oversized file (>5 MB), unsupported MIME type, missing required columns, and `cohort_id` not found all return correct 4xx responses without crashing the batch.

---

## :boom: Breaking Changes

- [x] **No breaking changes**

`POST /devices/soft` (single-device import) is completely untouched. The new `/soft/bulk` route is additive. All existing validators, controller methods, and util functions are unchanged.

---

## :memo: Additional Notes

- `csv-parse ^5.5.6` must be installed before deployment: run `npm install` inside `src/device-registry/`.
- The synchronous CSV parser (`csv-parse/sync`) is used inside an `async` wrapper — this is intentional; the parse step is CPU-bound and fast (<1 ms for 500 rows), so the async overhead of a streaming parser is not justified.
- Batch size is 25 concurrent `createOnPlatform` calls per chunk. This is conservative enough to avoid exhausting the MongoDB connection pool but can be tuned via the `batchSize` argument to `createDevicesBatch` if needed.
- The 500-row cap is a safeguard for synchronous processing. If the need for larger imports arises, the `DeviceBulkUpdateJob` queue infrastructure already in the service is the natural next step.
- The `network_override` body parameter lets an uploader lock all rows to a single manufacturer network key, removing the need for a `network` column in every CSV row — useful for partner-specific upload flows (e.g., all AirGradient devices in one upload).

**CSV template column reference for documentation / Belinda's frontend work:**

```
long_name,network,serial_number,latitude,longitude,api_code,category,description,device_number,tags
```

| Column | Required | Notes |
|---|---|---|
| `long_name` | Yes | Device display name. Alias: `locationName` |
| `network` | Yes* | Manufacturer network key. Can be omitted if `network_override` is passed. |
| `serial_number` | Yes | External device ID. Alias: `locationId` |
| `latitude` | No | Decimal degrees |
| `longitude` | No | Decimal degrees |
| `api_code` | No | Full fetch URL; auto-built by network adapter if omitted |
| `category` | No | `lowcost` / `bam` / `gas` — defaults to `lowcost` |
| `description` | No | Free text |
| `device_number` | No | Integer |
| `tags` | No | Pipe-separated: `urban\|residential` |

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk device creation now supported via CSV file uploads (maximum 500 devices per upload) or JSON payload submissions
  * New batch endpoint provides detailed response reporting per-device success and failure information

* **Chores**
  * Added CSV parsing dependency for bulk operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6544)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->