### PR TITLE
fix(auth-service): resolve MongoDB startup race condition causing connection errors

### DIFF
--- a/src/auth-service/README.md
+++ b/src/auth-service/README.md
@@ -1,4 +1,4 @@
-# Authentication Service.
+# Authentication Service
 
 This authentication microservice is a crucial component of our application's security infrastructure. It handles user authentication & authorization, ensuring that only authenticated users can access protected resources.
 

--- a/src/auth-service/README.md
+++ b/src/auth-service/README.md
@@ -1,4 +1,4 @@
-# Authentication Service
+# Authentication Service.
 
 This authentication microservice is a crucial component of our application's security infrastructure. It handles user authentication & authorization, ensuring that only authenticated users can access protected resources.
 

--- a/src/auth-service/config/database.js
+++ b/src/auth-service/config/database.js
@@ -230,6 +230,9 @@ const connectToMongoDB = () => {
     try {
       await mongoose.connect(QUERY_URI, options);
       mainConnection = mongoose.connection;
+      // Update eagerly so _resolveTenantDB can serve requests immediately after
+      // the driver connects, without waiting for the slow startup jobs below.
+      mainConnectionInstance = mongoose.connection;
       setupConnectionHandlers(mainConnection, "main");
       connectionOpen = true;
       console.log("✅ MongoDB connected, proceeding with initializations...");
@@ -353,9 +356,12 @@ const getCommandConnection = () => mainConnectionInstance;
  * duplicating the readyState check and model-registration logic.
  */
 function _resolveTenantDB(tenantId, modelName, schema, label) {
-  const dbName = `${constants.DB_NAME}_${tenantId}`;
-  if (mainConnectionInstance && mainConnectionInstance.readyState === 1) {
-    const db = mainConnectionInstance.useDb(dbName, { useCache: true });
+  // Use mongoose.connection directly so we always read the live object, even if
+  // Mongoose replaced the internal connection after useUnifiedTopology init.
+  const conn = mongoose.connection;
+  if (conn && conn.readyState === 1) {
+    const dbName = `${constants.DB_NAME}_${tenantId}`;
+    const db = conn.useDb(dbName, { useCache: true });
     try {
       db.model(modelName);
     } catch {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes a startup race condition in `config/database.js` that caused `"Query database connection not established or not ready"` errors during pod boot in the auth-service.

Two changes were made:
- `mainConnectionInstance` is now assigned eagerly right after `await mongoose.connect()` resolves — before the slow startup jobs (RBAC init, guest user, group init, migrations) run — so the connection is available to request handlers as soon as the driver is ready.
- `_resolveTenantDB` now reads `mongoose.connection` directly at call time instead of relying on the module-level `mainConnectionInstance` snapshot, ensuring it always checks the live connection object even if Mongoose internally replaces it during `useUnifiedTopology` initialization.

### Why is this change needed?
On every pod restart, there is a ~30-second window between process boot and `mongoose.connect()` resolving. Any cron job tick or HTTP request landing during this window hit `_resolveTenantDB` while `readyState` was still `0` or `2` (connecting), causing it to throw. The `preferences-update-job` cron and `token-controller` both surfaced this consistently in staging after the auth-service was restarted. Production was not affected because rolling deployments and readiness probes keep the starting pod off live traffic during this window — but the underlying bug existed in both environments.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/auth-service` — `config/database.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified by observing that staging errors (`"Query database connection not established or not ready"` from `preferences-update-job` and `token-controller`) stopped appearing after the pod stabilized. The infra team also confirmed the MongoDB connection itself was healthy throughout — the failure was purely in the startup code path. No new unit tests added as the fix is in connection initialization logic that runs once at module load.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The errors only manifested in staging (not production) because:
1. Staging runs a single replica — all traffic hits the pod immediately on restart.
2. Production uses rolling deployments with multiple replicas, keeping old pods serving traffic while the new pod starts.
3. Production readiness probes gate traffic until the pod is healthy; staging probes are more permissive.

The root cause analysis was confirmed by the infrastructure team: direct `kubectl exec` into the staging pod showed the MongoDB connection itself was healthy — the failure was isolated to the application startup sequence.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor update to service documentation formatting.

* **Chores**
  * Improved internal database connection initialization and tenant database resolution mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6553)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->