### PR TITLE
fix(device-registry): prevent model overwrite error in tenant DB helpers

### DIFF
--- a/src/device-registry/config/database.js
+++ b/src/device-registry/config/database.js
@@ -157,7 +157,11 @@ function getCommandTenantDB(tenantId, modelName, schema) {
   const dbName = `${constants.DB_NAME}_command_${tenantId}`;
   if (commandDB) {
     const db = commandDB.useDb(dbName, { useCache: true });
-    db.model(modelName, schema);
+    try {
+      db.model(modelName);
+    } catch {
+      db.model(modelName, schema);
+    }
     return db;
   }
   throw new Error("Command database connection not established");
@@ -171,7 +175,11 @@ function getQueryTenantDB(tenantId, modelName, schema) {
   const dbName = `${constants.DB_NAME}_${tenantId}`;
   if (queryDB) {
     const db = queryDB.useDb(dbName, { useCache: true });
-    db.model(modelName, schema);
+    try {
+      db.model(modelName);
+    } catch {
+      db.model(modelName, schema);
+    }
     return db;
   }
   throw new Error("Query database connection not established");
@@ -229,7 +237,11 @@ function getSnapshotTenantDB(tenantId, modelName, schema) {
   const dbName = `${constants.DB_NAME}_${tenantId}`;
   if (snapshotDB) {
     const db = snapshotDB.useDb(dbName, { useCache: true });
-    db.model(modelName, schema);
+    try {
+      db.model(modelName);
+    } catch {
+      db.model(modelName, schema);
+    }
     return db;
   }
   throw new Error("Snapshot database connection not established");

--- a/src/device-registry/config/database.js
+++ b/src/device-registry/config/database.js
@@ -150,6 +150,14 @@ const connectToMongoDB = () => {
   }
 };
 
+function ensureModel(db, modelName, schema) {
+  try {
+    db.model(modelName);
+  } catch {
+    db.model(modelName, schema);
+  }
+}
+
 /**
  * Get a tenant-specific command database (for write operations)
  */
@@ -157,11 +165,7 @@ function getCommandTenantDB(tenantId, modelName, schema) {
   const dbName = `${constants.DB_NAME}_command_${tenantId}`;
   if (commandDB) {
     const db = commandDB.useDb(dbName, { useCache: true });
-    try {
-      db.model(modelName);
-    } catch {
-      db.model(modelName, schema);
-    }
+    ensureModel(db, modelName, schema);
     return db;
   }
   throw new Error("Command database connection not established");
@@ -175,11 +179,7 @@ function getQueryTenantDB(tenantId, modelName, schema) {
   const dbName = `${constants.DB_NAME}_${tenantId}`;
   if (queryDB) {
     const db = queryDB.useDb(dbName, { useCache: true });
-    try {
-      db.model(modelName);
-    } catch {
-      db.model(modelName, schema);
-    }
+    ensureModel(db, modelName, schema);
     return db;
   }
   throw new Error("Query database connection not established");
@@ -237,11 +237,7 @@ function getSnapshotTenantDB(tenantId, modelName, schema) {
   const dbName = `${constants.DB_NAME}_${tenantId}`;
   if (snapshotDB) {
     const db = snapshotDB.useDb(dbName, { useCache: true });
-    try {
-      db.model(modelName);
-    } catch {
-      db.model(modelName, schema);
-    }
+    ensureModel(db, modelName, schema);
     return db;
   }
   throw new Error("Snapshot database connection not established");

--- a/src/device-registry/config/test/ut_database.js
+++ b/src/device-registry/config/test/ut_database.js
@@ -113,4 +113,65 @@ describe("Database Connection Module", () => {
   });
 
   // Add more describe blocks for other functions in the module if necessary
+
+  describe("idempotent model registration", () => {
+    function makeModule(connectionDb) {
+      const freshMongoose = {
+        createConnection: sinon.stub().returns(connectionDb),
+        set: sinon.stub(),
+      };
+      const mod = proxyquire("@config/database", {
+        mongoose: freshMongoose,
+        "@config/constants": constantsStub,
+        log4js: log4jsStub,
+      });
+      mod.connectToMongoDB();
+      return mod;
+    }
+
+    function makeTenantDb() {
+      const tenantDb = { model: sinon.stub() };
+      // First call to model(name) throws — model not yet registered
+      tenantDb.model.withArgs("TestModel").onFirstCall().throws(
+        new Error("Schema hasn't been registered for model 'TestModel'")
+      );
+      return tenantDb;
+    }
+
+    it("registers model on first call and retrieves it (not re-registers) on second query call", () => {
+      const tenantDb = makeTenantDb();
+      const connectionDb = { on: sinon.stub(), useDb: sinon.stub().returns(tenantDb) };
+      const mod = makeModule(connectionDb);
+
+      mod.getQueryTenantDB("airqo", "TestModel", {});
+      mod.getQueryTenantDB("airqo", "TestModel", {});
+
+      const registrations = tenantDb.model.args.filter((a) => a.length === 2);
+      expect(registrations).to.have.length(1);
+    });
+
+    it("registers model on first call and retrieves it (not re-registers) on second command call", () => {
+      const tenantDb = makeTenantDb();
+      const connectionDb = { on: sinon.stub(), useDb: sinon.stub().returns(tenantDb) };
+      const mod = makeModule(connectionDb);
+
+      mod.getCommandTenantDB("airqo", "TestModel", {});
+      mod.getCommandTenantDB("airqo", "TestModel", {});
+
+      const registrations = tenantDb.model.args.filter((a) => a.length === 2);
+      expect(registrations).to.have.length(1);
+    });
+
+    it("registers model on first call and retrieves it (not re-registers) on second snapshot call", () => {
+      const tenantDb = makeTenantDb();
+      const connectionDb = { on: sinon.stub(), useDb: sinon.stub().returns(tenantDb) };
+      const mod = makeModule(connectionDb);
+
+      mod.getSnapshotTenantDB("airqo", "TestModel", {});
+      mod.getSnapshotTenantDB("airqo", "TestModel", {});
+
+      const registrations = tenantDb.model.args.filter((a) => a.length === 2);
+      expect(registrations).to.have.length(1);
+    });
+  });
 });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a try/catch guard around `db.model()` registration in all three tenant database helpers in `config/database.js` — `getCommandTenantDB`, `getQueryTenantDB`, and `getSnapshotTenantDB`.

Before this fix, each helper unconditionally called `db.model(modelName, schema)` on every invocation. After this fix, each helper first attempts to retrieve an already-registered model (`db.model(modelName)`), and only registers the schema if the model does not yet exist — matching the pattern used in `src/auth-service/config/database.js`.

### Why is this change needed?
With `useCache: true`, `mongoose.createConnection().useDb(dbName, { useCache: true })` returns the **same cached `db` object** for a given tenant on every call. Calling `db.model(modelName, schema)` on a model that is already compiled on that cached connection causes Mongoose v5 to throw `"Cannot overwrite <modelName> model once compiled"`. This error surfaces silently on the second (and every subsequent) request for any given tenant+model pair, causing intermittent failures across all DB-backed endpoints in device-registry.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/device-registry` — `config/database.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
The fix mirrors the identical pattern already validated in `src/auth-service/config/database.js`. The try/catch is the standard Mongoose v5 idiom for idempotent model registration on a shared cached connection. No functional behaviour changes — models are registered exactly once per tenant db, subsequent calls retrieve the cached model silently.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

This issue is distinct from the MongoDB startup race condition fixed in `src/auth-service` (PR: `fix-db-startup`). device-registry uses `mongoose.createConnection()` which sets connections synchronously and relies on Mongoose buffering for the brief driver-open window — it does not share the same startup race. The only issue found was the model re-registration pattern addressed here.

The same `try/catch` guard applies to all three connection pools (`commandDB`, `queryDB`, `snapshotDB`) since they all share the same `useCache: true` pattern.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database model registration in multi-tenant environments by implementing a fallback mechanism that prevents errors when models are already registered, ensuring more reliable initialization
  * Enhanced overall stability of database connection pools and model management throughout the application lifecycle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6554)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->