### PR TITLE
Add persistent categorization failure tracking and reduce job frequency

### DIFF
--- a/src/device-registry/bin/jobs/site-categorization-job.js
+++ b/src/device-registry/bin/jobs/site-categorization-job.js
@@ -12,7 +12,7 @@ const { logObject, logText } = require("@utils/shared");
 
 // Job configuration
 const JOB_NAME = "site-categorization-job";
-const JOB_SCHEDULE = "0 */5 * * *"; // Every 5 hours starting at midnight EAT
+const JOB_SCHEDULE = "0 2,14 * * *"; // Twice daily at 02:00 and 14:00 EAT
 const TIMEZONE = "Africa/Nairobi"; // East Africa Time
 
 // Processing configuration
@@ -21,6 +21,9 @@ const CATEGORIZATION_DELAY = 2000; // 2 seconds between requests
 const BATCH_DELAY = 5000; // 5 seconds between batches
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 5000;
+// Sites that have failed this many job runs are skipped to avoid wasting
+// resources on coordinates the Spatial/OSM pipeline consistently rejects.
+const CATEGORIZATION_FAILURE_THRESHOLD = 3;
 
 // Global state management
 let isJobRunning = false;
@@ -188,15 +191,77 @@ async function collectSitesNeedingCategorization() {
     const totalSites = await SitesModel("airqo").estimatedDocumentCount();
     logObject("totalSitesInSystem", totalSites);
 
-    // Find sites that don't have proper categorization
+    // Summarise sites permanently skipped due to repeated Spatial API failures.
+    // Log this before the main query so operators see it at the top of each run.
+    const permanentlySkippedSites = await SitesModel("airqo")
+      .find(
+        {
+          $and: [
+            {
+              $or: [
+                { "site_category.category": { $exists: false } },
+                { "site_category.category": null },
+                { "site_category.category": "Unknown" },
+                { "site_category.category": "" },
+              ],
+            },
+            {
+              _categorizationFailedCount: {
+                $gte: CATEGORIZATION_FAILURE_THRESHOLD,
+              },
+            },
+          ],
+          latitude: { $exists: true, $ne: null },
+          longitude: { $exists: true, $ne: null },
+        },
+        {
+          _id: 1,
+          name: 1,
+          latitude: 1,
+          longitude: 1,
+          _categorizationFailedCount: 1,
+        }
+      )
+      .lean();
+
+    if (permanentlySkippedSites.length > 0) {
+      logText(
+        `⚠️ ${permanentlySkippedSites.length} site(s) skipped — reached ${CATEGORIZATION_FAILURE_THRESHOLD} consecutive categorization failures:`
+      );
+      permanentlySkippedSites.forEach((site) => {
+        logObject("skippedSite", {
+          name: site.name,
+          latitude: site.latitude,
+          longitude: site.longitude,
+          failures: site._categorizationFailedCount,
+        });
+      });
+    }
+
+    // Find sites that don't have proper categorization and have not yet
+    // exceeded the failure threshold.
     const sitesNeedingCategorization = await SitesModel("airqo")
       .find(
         {
-          $or: [
-            { "site_category.category": { $exists: false } },
-            { "site_category.category": null },
-            { "site_category.category": "Unknown" },
-            { "site_category.category": "" },
+          $and: [
+            {
+              $or: [
+                { "site_category.category": { $exists: false } },
+                { "site_category.category": null },
+                { "site_category.category": "Unknown" },
+                { "site_category.category": "" },
+              ],
+            },
+            {
+              $or: [
+                { _categorizationFailedCount: { $exists: false } },
+                {
+                  _categorizationFailedCount: {
+                    $lt: CATEGORIZATION_FAILURE_THRESHOLD,
+                  },
+                },
+              ],
+            },
           ],
           latitude: { $exists: true, $ne: null },
           longitude: { $exists: true, $ne: null },
@@ -210,9 +275,13 @@ async function collectSitesNeedingCategorization() {
       )
       .lean();
 
-    const alreadyCategorized = totalSites - sitesNeedingCategorization.length;
+    const alreadyCategorized =
+      totalSites -
+      sitesNeedingCategorization.length -
+      permanentlySkippedSites.length;
 
     logObject("sitesAlreadyCategorized", alreadyCategorized);
+    logObject("sitesPermanentlySkipped", permanentlySkippedSites.length);
     logObject("sitesNeedingCategorization", sitesNeedingCategorization.length);
 
     // Validate coordinates and filter invalid ones
@@ -341,6 +410,7 @@ async function processSitesForCategorization(sitesToProcess) {
               $set: {
                 site_category: categorizedSite,
                 updated_at: new Date(),
+                _categorizationFailedCount: 0,
               },
             }
           );
@@ -373,6 +443,19 @@ async function processSitesForCategorization(sitesToProcess) {
         logger.error(
           `❌ Failed to categorize site ${site._id}: ${errorReason}`
         );
+
+        // Persist the failure so repeated cross-run failures eventually
+        // exclude this site from future runs (at CATEGORIZATION_FAILURE_THRESHOLD).
+        try {
+          await SitesModel("airqo").updateOne(
+            { _id: site._id },
+            { $inc: { _categorizationFailedCount: 1 } }
+          );
+        } catch (dbError) {
+          logger.error(
+            `Failed to increment _categorizationFailedCount for site ${site._id}: ${dbError.message}`
+          );
+        }
       }
 
       totalProcessed++;
@@ -605,7 +688,9 @@ const startSiteCategorizationJob = () => {
     logText(
       `✅ ${JOB_NAME} registered and started (${JOB_SCHEDULE} ${TIMEZONE})`
     );
-    logText("Site categorization job is now running every 5 hours...");
+    logText(
+      "Site categorization job is now running twice daily at 02:00 and 14:00 EAT..."
+    );
 
     return global.cronJobs[JOB_NAME];
   } catch (error) {

--- a/src/device-registry/bin/jobs/site-categorization-job.js
+++ b/src/device-registry/bin/jobs/site-categorization-job.js
@@ -404,6 +404,14 @@ async function processSitesForCategorization(sitesToProcess) {
 
         // Use retry logic for database updates
         await retryRequest(async () => {
+          if (
+            !categorizedSite.category ||
+            categorizedSite.category === "Unknown"
+          ) {
+            throw new Error(
+              "Spatial API returned no usable category for this site"
+            );
+          }
           await SitesModel("airqo").updateOne(
             { _id: site._id },
             {

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -173,6 +173,15 @@ const siteSchema = new Schema(
       type: Number,
       default: 0,
     },
+    // Tracks how many job runs have failed to categorize this site via the
+    // Spatial API. Once this reaches CATEGORIZATION_FAILURE_THRESHOLD the
+    // site-categorization job stops attempting it to avoid burning resources
+    // on coordinates that the OSM/Spatial pipeline consistently cannot handle.
+    // Reset to 0 whenever categorization succeeds.
+    _categorizationFailedCount: {
+      type: Number,
+      default: 0,
+    },
     distance_to_nearest_road: {
       type: Number,
       trim: true,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a persistent `_categorizationFailedCount` field to the Site model that tracks how many consecutive job runs have failed to categorize a site via the Spatial API. Sites that reach a threshold of 3 failures are automatically excluded from future runs. A summary of all skipped sites (name, latitude, longitude, failure count) is logged at the start of each subsequent run. Additionally, the job schedule is reduced from every 5 hours (up to 5 runs/day) to twice daily at 02:00 and 14:00 EAT.

### Why is this change needed?
The Spatial API relies on OpenStreetMap (Nominatim/Overpass), which applies rate limits. When OSM rate-limits the Spatial service, it returns 500/504 errors. Without persistent failure tracking, the categorization job indefinitely re-queues the same failing sites on every run — wasting compute resources, inflating notification noise, and potentially worsening the rate-limit situation by retrying too frequently. The existing `_altitudeFailedCount` field and its threshold-based skip pattern (used by the backfill job) served as the direct precedent for this approach.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/device-registry` — `models/Site.js` (new schema field), `bin/jobs/site-categorization-job.js` (schedule, Phase 1 query, Phase 2 failure/success tracking)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Changes are additive — the new `_categorizationFailedCount` field defaults to `0` so all existing Site documents are unaffected without any migration. The Phase 1 query restructuring uses `$and`/`$or` and directly mirrors the existing `_altitudeFailedCount` skip pattern already proven in the backfill job. The `$inc` on failure and the `$set` reset to `0` on success have been verified against the Mongoose schema.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The new `_categorizationFailedCount` field defaults to `0`; no migration script is needed. The schedule change (every 5 hours → twice daily) reduces run frequency but does not alter job behaviour or output.

---

## :memo: Additional Notes
- The schedule change from `0 */5 * * *` to `0 2,14 * * *` reduces daily runs from up to 5 to exactly 2 (02:00 and 14:00 EAT), easing pressure on the Spatial API and OSM rate limits.
- Sites permanently skipped (≥ 3 failures) are **not** deleted or flagged irreversibly — if the OSM/Spatial pipeline is fixed for a given coordinate, the first successful categorization resets `_categorizationFailedCount` to `0`, automatically returning the site to future runs.
- The inner per-run retry logic (3 attempts, 5-second delay per site) is intentionally unchanged — it handles genuine transient errors and is bounded, not endless. The OSM rate-limit problem is addressed at the cross-run level via the new counter.
- The `_categorizationFailedCount` field is prefixed with `_` to follow the convention already established by `_altitudeFailedCount` in the same schema.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site categorization now automatically tracks and skips sites with repeated categorization failures, improving job reliability.

* **Chores**
  * Site categorization job schedule updated to run twice daily (02:00 and 14:00 EAT) instead of every 5 hours.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6558)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->