### PR TITLE
Route staging support emails to developer addresses to prevent test email noise

### DIFF
--- a/src/auth-service/config/core/envs.js
+++ b/src/auth-service/config/core/envs.js
@@ -36,7 +36,11 @@ const envs = {
   MAILCHIMP_LIST_ID: process.env.MAILCHIMP_LIST_ID,
   JWT_SECRET: process.env.JWT_SECRET,
   EMAIL: process.env.MAIL_USER,
-  SUPPORT_EMAIL: process.env.SUPPORT_EMAIL,
+  DEVELOPERS_EMAILS: process.env.DEVELOPERS_EMAILS,
+  SUPPORT_EMAIL:
+    process.env.NODE_ENV === "staging"
+      ? process.env.DEVELOPERS_EMAILS || process.env.SUPPORT_EMAIL
+      : process.env.SUPPORT_EMAIL,
   YOUTUBE_CHANNEL: process.env.AIRQO_YOUTUBE,
 
   // ✅ NUMERIC VALUES - Properly converted


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
On staging, `SUPPORT_EMAIL` now resolves to `DEVELOPERS_EMAILS` instead of the real support inbox. Production behaviour is unchanged. `DEVELOPERS_EMAILS` is also wired into `envs.js` as a named constant (it existed in all env templates but was never exposed to the app).

### Why is this change needed?
Staging is used for testing. Emails triggered during testing were landing in the real support inbox, risking noise that could obscure genuine support tickets and confuse the support workflow.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `config/core/envs.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Logic is isolated to a single config resolution in `envs.js`. Verified that on `NODE_ENV=staging`, `constants.SUPPORT_EMAIL` resolves to the `DEVELOPERS_EMAILS` value, and falls back to `SUPPORT_EMAIL` if `DEVELOPERS_EMAILS` is unset. Production path is untouched.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- The fallback `process.env.DEVELOPERS_EMAILS || process.env.SUPPORT_EMAIL` on staging ensures no emails are silently dropped if `DEVELOPERS_EMAILS` is not yet populated in a staging environment.
- `DEVELOPERS_EMAILS` was already present in all three env templates (`.env.staging.template.json`, `.env.production.template.json`, `.env.development.template.json`) but was never read by the app — this PR wires it in.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration for support email routing, enabling environment-specific email handling. In staging deployments, support communications can now route to developer emails when configured, with automatic fallback to the standard support email address.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->