### PR TITLE
Fix intermittent 500 errors on recent readings endpoint due to missing aggregation timeout

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -81,6 +81,13 @@ function envConfig(env) {
       return Number.isFinite(val) && val > 0 ? val : 600000;
     })(),
 
+    // MongoDB maxTimeMS for ReadingModel.recent() aggregation.
+    // Must be comfortably below the load-balancer/upstream timeout (~60s).
+    READINGS_AGGREGATE_TIMEOUT_MS: (() => {
+      const val = parseInt(process.env.READINGS_AGGREGATE_TIMEOUT_MS, 10);
+      return Number.isFinite(val) && val > 0 ? val : 55000;
+    })(),
+
     // Temporary diagnostic window for ReadingModel.recent().
     // Revert to 3 once the root cause of the empty readings collection is confirmed.
     DIAGNOSTIC_WINDOW_DAYS: (() => {

--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -2258,7 +2258,13 @@ eventSchema.statics.fetch = async function(filter) {
     logger.error(
       `🐛🐛 Internal Server Error --- fetch events -- ${error.message}`,
     );
-    return;
+    return {
+      success: false,
+      message: "Internal Server Error",
+      errors: { message: error.message },
+      data: [],
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+    };
   }
 };
 eventSchema.statics.signal = async function(filter) {

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -996,7 +996,6 @@ ReadingsSchema.statics.recent = async function(
       groupBy = "$device_id";
     }
 
-    const AGGREGATE_TIMEOUT_MS = 90000;
     const pipeline = this.aggregate()
       .match({
         ...filter,
@@ -1012,7 +1011,10 @@ ReadingsSchema.statics.recent = async function(
       .replaceRoot("$doc")
       .skip(skip)
       .limit(limit)
-      .option({ allowDiskUse: true, maxTimeMS: AGGREGATE_TIMEOUT_MS });
+      .option({
+        allowDiskUse: true,
+        maxTimeMS: constants.READINGS_AGGREGATE_TIMEOUT_MS,
+      });
 
     const data = await pipeline;
     if (!isEmpty(data)) {

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -996,6 +996,7 @@ ReadingsSchema.statics.recent = async function(
       groupBy = "$device_id";
     }
 
+    const AGGREGATE_TIMEOUT_MS = 90000;
     const pipeline = this.aggregate()
       .match({
         ...filter,
@@ -1011,7 +1012,7 @@ ReadingsSchema.statics.recent = async function(
       .replaceRoot("$doc")
       .skip(skip)
       .limit(limit)
-      .allowDiskUse(true);
+      .option({ allowDiskUse: true, maxTimeMS: AGGREGATE_TIMEOUT_MS });
 
     const data = await pipeline;
     if (!isEmpty(data)) {

--- a/src/device-registry/routes/v2/readings.routes.js
+++ b/src/device-registry/routes/v2/readings.routes.js
@@ -193,19 +193,9 @@ routes.forEach(({ method, path, middlewares, controller }) => {
       ...middlewares,
       checkController(controller),
       (req, res, next) => {
-        // Wrap controller call in try-catch
-        try {
-          eventController[controller](req, res, next);
-        } catch (error) {
-          console.error(
-            `[CONTROLLER_ERROR] Error in ${controller}:`,
-            error.message,
-          );
-          res.status(500).json({
-            error: "Internal server error",
-            message: "Controller execution failed",
-          });
-        }
+        Promise.resolve(eventController[controller](req, res, next)).catch(
+          next,
+        );
       },
     ];
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds `maxTimeMS: 90000` to `ReadingModel.recent()` MongoDB aggregation pipeline, matching the timeout pattern already used in `Event.js`
- Fixes `EventModel.fetch()` to return a structured error object instead of bare `undefined` on catch, so the fallback path in `readRecentWithFilter` can handle failures correctly
- Fixes the readings route handler to forward async controller rejections to Express error middleware via `Promise.resolve().catch(next)`

### Why is this change needed?
The `GET /api/v2/devices/readings/recent` endpoint was intermittently returning 500 errors on the analytics Favorites page (`/user/favorites`), requiring users to refresh 2–3 times before data loaded.

**Root cause:** `ReadingModel.recent()` ran a MongoDB aggregation with no timeout. Under load, the query would exceed the load balancer's HTTP connection timeout (~60s), killing the connection before MongoDB returned results — surfacing as a 500 to the client. A retry succeeded because MongoDB's query plan was already cached, making subsequent runs faster.

Secondary: when the primary `ReadingModel.recent()` returned empty results and the fallback `EventModel.fetch()` errored, it silently returned `undefined`, causing the fallback to produce empty data with no error surfaced.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that `GET /api/v2/devices/readings/recent` no longer intermittently 500s on the Favorites page. The aggregation now fails fast with a proper 500 + error body (within 90s) instead of hanging until the load balancer kills the connection. The fallback path now correctly surfaces errors from `EventModel.fetch()` rather than silently returning empty data.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `maxTimeMS: 90000` value (90 seconds) matches `AGGREGATE_TIMEOUT_MS` defined in `Event.js` and is consistent with the existing timeout strategy across the service.
- The `DIAGNOSTIC_WINDOW_DAYS` constant used in `ReadingModel.recent()` has a comment noting it should be reverted to 3 days once the empty readings collection root cause is confirmed — that revert should happen separately once the data pipeline is healthy.
- The browser console `runtime.lastError` messages seen alongside the 500s are a Chrome extension artifact and are unrelated to this fix.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error handlers now return properly structured failure responses with HTTP status codes and detailed error messages instead of empty responses.
  * Database aggregation queries now enforce a 90-second execution time limit to prevent indefinite request hangs and timeouts.
  * Enhanced error handling and delegation in API endpoints for improved system stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->