### PR TITLE
fix: update lastActiveAt on login to prevent false inactivity deactivation

### DIFF
--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -1,4 +1,8 @@
 require("module-alias/register");
+// Provide dummy values for env vars that throw on missing config at require-time.
+process.env.CLOUD_NAME = process.env.CLOUD_NAME || "test";
+process.env.CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY || "test";
+process.env.CLOUDINARY_API_SECRET = process.env.CLOUDINARY_API_SECRET || "test";
 const chai = require("chai");
 const expect = chai.expect;
 const sinon = require("sinon");
@@ -8,7 +12,7 @@ const { stringify } = require("@utils/shared");
 const redis = require("redis");
 const moment = require("moment-timezone");
 const { ObjectId } = require("mongoose").Types;
-const createUser = require("@utils/create-user");
+const createUser = require("@utils/user.util");
 const mailchimp = require("@config/mailchimp");
 const crypto = require("crypto");
 const admin = require("firebase-admin");
@@ -33,7 +37,7 @@ const { getAuth } = require("firebase-admin/auth");
 const constants = require("@config/constants");
 const httpStatus = require("http-status");
 const rewire = require("rewire");
-const rewireCreateUser = rewire("@utils/create-user");
+const rewireCreateUser = rewire("@utils/user.util");
 const UserModel = require("@models/User");
 const LogModel = require("@models/log");
 const NetworkModel = require("@models/Network");
@@ -2977,6 +2981,45 @@ describe("create-user-util", function () {
       expect(result.success).to.be.true;
       expect(result.syncOperation).to.equal("Updated");
       expect(result.user).to.deep.equal(existingUser);
+    });
+  });
+
+  describe("_constructLoginUpdate", function () {
+    const user = { verified: true, preferredTokenStrategy: null };
+
+    it("sets lastActiveAt to a recent Date so the active-status-job does not immediately deactivate the user", function () {
+      const before = Date.now();
+      const result = createUser._constructLoginUpdate(user);
+      const after = Date.now();
+
+      expect(result.$set.lastActiveAt).to.be.an.instanceOf(Date);
+      expect(result.$set.lastActiveAt.getTime()).to.be.within(before, after);
+    });
+
+    it("sets lastLogin and isActive on every login", function () {
+      const before = Date.now();
+      const result = createUser._constructLoginUpdate(user);
+      const after = Date.now();
+
+      expect(result.$set.lastLogin).to.be.an.instanceOf(Date);
+      expect(result.$set.lastLogin.getTime()).to.be.within(before, after);
+      expect(result.$set.isActive).to.equal(true);
+      expect(result.$inc.loginCount).to.equal(1);
+    });
+
+    it("sets verified when autoVerify is true and user is not yet verified", function () {
+      const unverifiedUser = { verified: false, preferredTokenStrategy: null };
+      const result = createUser._constructLoginUpdate(unverifiedUser, null, {
+        autoVerify: true,
+      });
+      expect(result.$set.verified).to.equal(true);
+    });
+
+    it("does not set verified when autoVerify is false", function () {
+      const result = createUser._constructLoginUpdate(user, null, {
+        autoVerify: false,
+      });
+      expect(result.$set.verified).to.be.undefined;
     });
   });
 });

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -6228,6 +6228,7 @@ const createUserModule = {
     const updatePayload = {
       $set: {
         lastLogin: currentDate,
+        lastActiveAt: currentDate,
         isActive: true,
       },
       $inc: { loginCount: 1 },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Sets `lastActiveAt` to the current timestamp inside `_constructLoginUpdate` whenever a user logs in, alongside the existing `lastLogin` update.

### Why is this change needed?

The `active-status-job` cron (runs daily at midnight) uses `lastActiveAt` as the **primary** activity signal and completely ignores `lastLogin` when `lastActiveAt` exists. Pass 2 (reactivation) also only checks `lastActiveAt` — never `lastLogin`.

Before this fix, a user whose `lastActiveAt` was stale (>30 days) would be deactivated by the cron even if they had logged in that same day, because login only wrote `lastLogin` and not `lastActiveAt`. The login's `isActive: true` write would be overwritten by the cron's `isActive: false` within 24 hours.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `utils/user.util.js` (`_constructLoginUpdate`)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that after login `lastActiveAt` is updated in the DB, and that the `active-status-job` no longer deactivates users who have logged in within the 30-day window.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `lastActiveAt` is also written by `preference.util.js` (on preference reads/writes) and `token.util.js` (on token verification). This change makes login a third writer, which is consistent — login is a form of user activity.
- Users already incorrectly marked `isActive: false` due to this bug will be automatically reactivated on their next login (Pass 2 of the cron will pick them up within 24 hours), or can be manually reactivated immediately.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced user activity tracking to properly record both login and last activity timestamps during authentication, providing more accurate user engagement metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->