### PR TITLE
feat: add live API usage stats endpoint and improve rate-limit accuracy

### DIFF
--- a/src/auth-service/controllers/transaction.controller.js
+++ b/src/auth-service/controllers/transaction.controller.js
@@ -850,6 +850,14 @@ const transactions = {
   },
   getApiUsageStats: async (req, res, next) => {
     try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
       const userId = req.user && req.user._id;
       if (!userId) {
         return next(

--- a/src/auth-service/controllers/transaction.controller.js
+++ b/src/auth-service/controllers/transaction.controller.js
@@ -13,6 +13,7 @@ const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- transaction-controller`
 );
 const transactionsUtil = require("@utils/transaction.util");
+const tokenUtil = require("@utils/token.util");
 const { paddleClient, isPaddleConfigured } = require("@config/paddle");
 const UserModel = require("@models/User");
 
@@ -839,6 +840,32 @@ const transactions = {
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  getApiUsageStats: async (req, res, next) => {
+    try {
+      const userId = req.user && req.user._id;
+      if (!userId) {
+        return next(
+          new HttpError("Authentication required", httpStatus.UNAUTHORIZED, {
+            auth: "User must be authenticated to access usage statistics",
+          }),
+        );
+      }
+
+      const tier = (req.user && req.user.subscriptionTier) || "Free";
+      const data = await tokenUtil.getApiUsageStats(String(userId), tier);
+
+      return res.status(httpStatus.OK).json({ success: true, data });
+    } catch (error) {
+      logger.error(`🐛 getApiUsageStats error: ${error.message}`);
+      return next(
         new HttpError(
           "Internal Server Error",
           httpStatus.INTERNAL_SERVER_ERROR,

--- a/src/auth-service/routes/v2/transactions.routes.js
+++ b/src/auth-service/routes/v2/transactions.routes.js
@@ -105,6 +105,14 @@ router.get(
   TransactionController.getSubscriptionStatus
 );
 
+// API Usage Statistics (user-scoped)
+router.get(
+  "/usage",
+  transactionValidations.tenantOperation,
+  enhancedJWTAuth,
+  TransactionController.getApiUsageStats
+);
+
 // Manual Subscription Renewal (user-scoped, no transaction ID needed)
 router.post(
   "/renew-subscription",

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -2830,6 +2830,55 @@ const token = {
       );
     }
   },
+
+  /**
+   * Read current Redis rate-limit counters and return usage stats.
+   * Returns null for a period when Redis is unavailable or the key doesn't exist yet.
+   * The shape matches what the frontend UsageStats component expects.
+   */
+  getApiUsageStats: async (userId, tier) => {
+    const limits  = TIER_RATE_LIMITS[tier] || TIER_RATE_LIMITS.Free;
+    const now     = Date.now();
+    const nowDate = new Date();
+
+    // ---- hourly ----
+    const hourSlot      = Math.floor(now / 3600000);
+    const hourKeyExpiry = (hourSlot + 1) * 3600000; // next slot start = reset time
+    const hourResetTime = new Date(hourKeyExpiry).toISOString();
+
+    // ---- daily ----
+    const daySlot      = Math.floor(now / 86400000);
+    const dayKeyExpiry = (daySlot + 1) * 86400000;
+    const dayResetTime = new Date(dayKeyExpiry).toISOString();
+
+    // ---- monthly ----
+    const year        = nowDate.getUTCFullYear();
+    const month       = nowDate.getUTCMonth(); // 0-based
+    const monthSlot   = year * 100 + (month + 1);
+    const nextMonth   = new Date(Date.UTC(year, month + 1, 1));
+    const monthResetTime = nextMonth.toISOString();
+
+    const readCounter = async (key) => {
+      try {
+        const raw = await redisGetAsync(key);
+        return raw !== null && raw !== undefined ? parseInt(raw, 10) : null;
+      } catch (_err) {
+        return null;
+      }
+    };
+
+    const [hourUsed, dayUsed, monthUsed] = await Promise.all([
+      readCounter(`rl:tv:${userId}:${hourSlot}`),
+      readCounter(`rl:tv:d:${userId}:${daySlot}`),
+      readCounter(`rl:tv:m:${userId}:${monthSlot}`),
+    ]);
+
+    return {
+      hourly:  { used: hourUsed,  limit: limits.hourlyLimit,  resetTime: hourResetTime  },
+      daily:   { used: dayUsed,   limit: limits.dailyLimit,   resetTime: dayResetTime   },
+      monthly: { used: monthUsed, limit: limits.monthlyLimit, resetTime: monthResetTime },
+    };
+  },
 };
 
 module.exports = token;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a new `GET /transactions/usage` endpoint that returns live hourly, daily, and monthly API usage counters for the authenticated user. Also improves rate-limit counter accuracy with atomic Redis INCR+EXPIRE operations, fixes the weekly slot to align on Mondays, extracts tier limits into a shared constants module, and removes legacy environment-prefixed ENV keys from staging and production config files.

### Why is this change needed?
The frontend usage dashboard was fully built but had no backend endpoint to supply real usage counts — all values showed `null`. The new endpoint lives under `/transactions/` alongside subscription status and other billing endpoints, keeping all subscription-related concerns in one route group. Additionally, the existing GET→check→SET counter pattern had a race condition under concurrent requests that could allow users to exceed their limits. The weekly window was also misaligned (Thursday-origin instead of Monday), and tier limit constants were duplicated across three files.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [x] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
All 19 existing unit tests in `ut_transaction.util.js` pass. The new `GET /transactions/usage` endpoint was verified to return correct Redis counter values for hourly, daily, and monthly windows. Atomic INCR+EXPIRE behaviour verified — keys are created and expired correctly. Backward compatible: existing Redis keys retain their TTLs; no counter resets on deploy.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Changes in detail:**

1. **`config/tier-limits.js`** (new) — single source of truth for `TIER_SCOPE_MAP` and `TIER_RATE_LIMITS`; removes duplicate definitions previously spread across `token.util.js`, `transaction.util.js`, and `rate-limit.middleware.js`.

2. **`config/redis.js`** — added `redisIncrAsync` atomic increment helper exposed via `redisWrapper`.

3. **`utils/token.util.js`** — replaced GET→check→SET with atomic INCR+EXPIRE; fixed weekly slot to Monday-aligned epoch; added `getApiUsageStats()` which reads current Redis counters and returns `{hourly, daily, monthly}` usage objects.

4. **`middleware/rate-limit.middleware.js`** — same atomic INCR+EXPIRE and Monday-aligned weekly slot applied to the extended usage limiter.

5. **`utils/transaction.util.js`** — now imports from `@config/tier-limits` instead of maintaining local constants.

6. **`routes/v2/transactions.routes.js`** and **`controllers/transaction.controller.js`** — wire up the new `GET /transactions/usage` route behind `enhancedJWTAuth`, keeping it alongside the other subscription/billing endpoints.

7. **`.env.staging.json` / `.env.production.json`** — removed all legacy `STAGE_*`, `*_STAGE`, `PROD_*`, `*_PROD` prefixed keys that were kept for backward compatibility but are no longer referenced by any code.

8. **`subscription-billing-api.md`** (new) — subscription and billing API reference for the frontend team.

**Production rollout note:** Daily, weekly, and monthly rate-limiting feature flags remain `false` in production. Only hourly limiting (`ENABLE_TOKEN_RATE_LIMITING`) is active. New flags can be enabled incrementally after monitoring.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API usage statistics endpoint for authenticated users. Users can now view comprehensive API usage metrics across three billing periods—hourly, daily, and monthly—including current consumption amounts, subscription tier limits, and exact reset times for each period. This new endpoint enables better tracking and proactive management of API quota utilization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->