### PR TITLE
 Fix site forecast sources and run-date anchoring

### DIFF
--- a/src/workflows/airqo_etl_utils/bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/bigquery_api.py
@@ -1401,7 +1401,9 @@ class BigQueryApi:
         try:
             return self.execute_data_query(query=query)
         except Exception as e:
-            raise RuntimeError(f"Error fetching hourly site forecast data: {e}")
+            raise RuntimeError(
+                f"Error fetching hourly site forecast data: {e}"
+                ) from e
 
     def fetch_hourly_site_data_for_forecast_jobs(
         self,

--- a/src/workflows/airqo_etl_utils/bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/bigquery_api.py
@@ -1331,21 +1331,20 @@ class BigQueryApi:
         end_date_time: str,
         min_hours: int = 16,
     ) -> pd.DataFrame:
-        """Fetch daily site-level forecast input from the consolidated table.
+        """Fetch daily site-level forecast input from the hourly measurements table.
 
-        Despite the legacy method name, this helper now reads from
-        ``BIGQUERY_ANALYTICS_TABLE`` instead of the raw device measurements
-        table. It aggregates hourly consolidated measurements into one row per
-        ``site_id`` and day for site-level forecasting.
+        Despite the legacy method name, this helper reads from
+        ``BIGQUERY_HOURLY_EVENTS_TABLE``. It aggregates hourly measurements into
+        one row per ``site_id`` and day for site-level forecasting.
 
         Data selection rules:
-        - Reads from ``self.consolidated_data_table``.
+        - Reads from ``self.hourly_measurements_table``.
         - Filters to the inclusive date window ``[start_date_time, end_date_time]``.
         - Keeps only rows with non-null ``site_id``.
         - Keeps only rows with non-null ``pm2_5_calibrated_value``.
         - Requires at least ``min_hours`` distinct hourly timestamps per site/day.
         - Left-joins ``self.sites_table`` so missing site names or coordinates on
-          consolidated rows can be backfilled from site metadata.
+          hourly rows can be backfilled from site metadata.
 
         Args:
             start_date_time (str): Start date in a pandas-parseable format,
@@ -1383,8 +1382,8 @@ class BigQueryApi:
                 f"start_date_time must be <= end_date_time, got {start_date} > {end_date}"
             )
 
-        if not self.consolidated_data_table:
-            raise ValueError("Missing required config: BIGQUERY_ANALYTICS_TABLE.")
+        if not self.hourly_measurements_table:
+            raise ValueError("Missing required config: BIGQUERY_HOURLY_EVENTS_TABLE.")
 
         if not self.sites_table:
             raise ValueError("Missing required config: BIGQUERY_SITES_SITES_TABLE.")
@@ -1392,17 +1391,17 @@ class BigQueryApi:
         query = query_manager.get_query(
             "site_daily_aggregated_for_forecast_jobs"
         ).format(
-            consolidated_table=f"`{self.consolidated_data_table}`",
+            hourly_measurements_table=f"`{self.hourly_measurements_table}`",
             sites_table=f"`{self.sites_table}`",
             start_date=str(start_date),
             end_date=str(end_date),
-            min_hours=2,
+            min_hours=min_hours,
         )
 
         try:
             return self.execute_data_query(query=query)
         except Exception as e:
-            raise RuntimeError(f"Error fetching consolidated site forecast data: {e}")
+            raise RuntimeError(f"Error fetching hourly site forecast data: {e}")
 
     def fetch_hourly_site_data_for_forecast_jobs(
         self,
@@ -1412,8 +1411,8 @@ class BigQueryApi:
     ) -> pd.DataFrame:
         """Fetch site-level hourly PM2.5 history for hourly forecast prediction.
 
-        The source is the consolidated hourly measurements table configured by
-        ``BIGQUERY_ANALYTICS_TABLE``. A site is eligible when it has at least
+        The source is the hourly measurements table configured by
+        ``BIGQUERY_HOURLY_EVENTS_TABLE``. A site is eligible when it has at least
         ``min_hours`` hourly records in the lookback window.
         """
         if min_hours <= 0:
@@ -1432,8 +1431,8 @@ class BigQueryApi:
                 f"start_date_time must be <= end_date_time, got {start_timestamp} > {end_timestamp}"
             )
 
-        if not self.consolidated_data_table:
-            raise ValueError("Missing required config: BIGQUERY_ANALYTICS_TABLE.")
+        if not self.hourly_measurements_table:
+            raise ValueError("Missing required config: BIGQUERY_HOURLY_EVENTS_TABLE.")
 
         if not self.sites_table:
             raise ValueError("Missing required config: BIGQUERY_SITES_SITES_TABLE.")
@@ -1441,7 +1440,7 @@ class BigQueryApi:
         query = query_manager.get_query(
             "site_hourly_measurements_for_forecast_jobs"
         ).format(
-            consolidated_table=f"`{self.consolidated_data_table}`",
+            hourly_measurements_table=f"`{self.hourly_measurements_table}`",
             sites_table=f"`{self.sites_table}`",
             start_timestamp=start_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
             end_timestamp=end_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
@@ -1451,7 +1450,7 @@ class BigQueryApi:
         try:
             return self.execute_data_query(query=query)
         except Exception as e:
-            raise RuntimeError(f"Error fetching consolidated site hourly data: {e}") from e
+            raise RuntimeError(f"Error fetching hourly site data: {e}") from e
 
     def fetch_device_data_for_satellite_job(
         self,

--- a/src/workflows/airqo_etl_utils/ml_utils.py
+++ b/src/workflows/airqo_etl_utils/ml_utils.py
@@ -1897,6 +1897,54 @@ class ForecastModelTrainer(BaseMlUtils):
         )
 
     @staticmethod
+    def _extend_site_daily_history_to_forecast_start(
+        history: pd.DataFrame,
+        forecast_start_day: pd.Timestamp,
+    ) -> pd.DataFrame:
+        """Carry each site's latest observed value to the day before forecasting."""
+        if history.empty:
+            return history
+
+        forecast_start_day = pd.Timestamp(forecast_start_day).normalize()
+        anchor_day = forecast_start_day - pd.Timedelta(days=1)
+        history = history[history["day"] < forecast_start_day].copy()
+        if history.empty:
+            return history
+
+        padded_rows = []
+        for _, site_history in history.sort_values(["site_id", "day"]).groupby(
+            "site_id",
+            sort=False,
+        ):
+            latest = site_history.iloc[-1]
+            latest_day = pd.Timestamp(latest["day"]).normalize()
+            if latest_day >= anchor_day:
+                continue
+
+            for missing_day in pd.date_range(
+                latest_day + pd.Timedelta(days=1),
+                anchor_day,
+                freq="D",
+            ):
+                padded_rows.append(
+                    {
+                        "site_id": latest["site_id"],
+                        "site_name": latest["site_name"],
+                        "day": missing_day,
+                        "pm25_mean": latest["pm25_mean"],
+                    }
+                )
+
+        if not padded_rows:
+            return history
+
+        return (
+            pd.concat([history, pd.DataFrame(padded_rows)], ignore_index=True)
+            .sort_values(["site_id", "day"])
+            .reset_index(drop=True)
+        )
+
+    @staticmethod
     def generate_site_daily_forecasts(
         raw_data: pd.DataFrame,
         *,
@@ -1954,6 +2002,17 @@ class ForecastModelTrainer(BaseMlUtils):
             run_timestamp = run_timestamp.tz_convert("UTC")
 
         recursive_history = history[["site_id", "site_name", "day", "pm25_mean"]].copy()
+        forecast_start_day = run_timestamp.normalize().tz_localize(None)
+        recursive_history = (
+            ForecastModelTrainer._extend_site_daily_history_to_forecast_start(
+                recursive_history,
+                forecast_start_day,
+            )
+        )
+        if recursive_history.empty:
+            raise ValueError(
+                "No usable historical site data available before the forecast start date."
+            )
         site_meta = ForecastModelTrainer._resolve_site_forecast_metadata(history)
         predictions: List[pd.DataFrame] = []
 
@@ -2280,6 +2339,59 @@ class ForecastModelTrainer(BaseMlUtils):
         return state
 
     @staticmethod
+    def _extend_site_hourly_history_to_forecast_start(
+        history: pd.DataFrame,
+        forecast_start_hour: pd.Timestamp,
+    ) -> pd.DataFrame:
+        """Carry each site's latest observed value to the hour before forecasting."""
+        if history.empty:
+            return history
+
+        forecast_start_hour = pd.Timestamp(forecast_start_hour)
+        if forecast_start_hour.tzinfo is None:
+            forecast_start_hour = forecast_start_hour.tz_localize("UTC")
+        else:
+            forecast_start_hour = forecast_start_hour.tz_convert("UTC")
+        forecast_start_hour = forecast_start_hour.floor("h")
+        anchor_hour = forecast_start_hour - pd.Timedelta(hours=1)
+        history = history[history["timestamp"] < forecast_start_hour].copy()
+        if history.empty:
+            return history
+
+        padded_rows = []
+        for _, site_history in history.sort_values(["site_id", "timestamp"]).groupby(
+            "site_id",
+            sort=False,
+        ):
+            latest = site_history.iloc[-1]
+            latest_hour = pd.Timestamp(latest["timestamp"]).floor("h")
+            if latest_hour >= anchor_hour:
+                continue
+
+            for missing_hour in pd.date_range(
+                latest_hour + pd.Timedelta(hours=1),
+                anchor_hour,
+                freq="h",
+            ):
+                padded_rows.append(
+                    {
+                        "site_id": latest["site_id"],
+                        "site_name": latest["site_name"],
+                        "timestamp": missing_hour,
+                        "pm25_mean": latest["pm25_mean"],
+                    }
+                )
+
+        if not padded_rows:
+            return history
+
+        return (
+            pd.concat([history, pd.DataFrame(padded_rows)], ignore_index=True)
+            .sort_values(["site_id", "timestamp"])
+            .reset_index(drop=True)
+        )
+
+    @staticmethod
     def _build_next_site_hourly_forecast_candidates(
         site_meta: pd.DataFrame,
         recursive_state: Dict[str, Dict[str, Any]],
@@ -2404,6 +2516,17 @@ class ForecastModelTrainer(BaseMlUtils):
         recursive_history = history[
             ["site_id", "site_name", "timestamp", "pm25_mean"]
         ].copy()
+        forecast_start_hour = run_timestamp.floor("h")
+        recursive_history = (
+            ForecastModelTrainer._extend_site_hourly_history_to_forecast_start(
+                recursive_history,
+                forecast_start_hour,
+            )
+        )
+        if recursive_history.empty:
+            raise ValueError(
+                "No usable historical site hourly data available before the forecast start hour."
+            )
         site_meta = ForecastModelTrainer._resolve_site_hourly_forecast_metadata(history)
         recursive_state = ForecastModelTrainer._initialize_site_hourly_forecast_state(
             recursive_history
@@ -3084,7 +3207,11 @@ class ForecastModelTrainer(BaseMlUtils):
         }
 
     @staticmethod
-    def _save_site_hourly_forecasts_to_mongo(data: pd.DataFrame) -> Dict[str, Any]:
+    def _save_site_hourly_forecasts_to_mongo(
+        data: pd.DataFrame,
+        *,
+        prune_stale_rows: bool = True,
+    ) -> Dict[str, Any]:
         """Upsert stored hourly forecasts in MongoDB."""
         if not configuration.MONGO_URI:
             raise ValueError("Missing required config: MONGO_URI.")
@@ -3098,7 +3225,6 @@ class ForecastModelTrainer(BaseMlUtils):
             raise ValueError("No site hourly forecasts available to persist.")
 
         collection_name = configuration.MONGO_SITE_HOURLY_FORECAST_COLLECTION
-        site_ids = prepared["site_id"].dropna().astype(str).unique().tolist()
         records = []
         for row in prepared.to_dict(orient="records"):
             document = {
@@ -3151,6 +3277,22 @@ class ForecastModelTrainer(BaseMlUtils):
                     upsert=True,
                 )
             )
+        prune_operations = []
+        if prune_stale_rows:
+            for site_id, site_frame in prepared.groupby("site_id", dropna=True):
+                timestamps = [
+                    pd.Timestamp(timestamp).to_pydatetime()
+                    for timestamp in site_frame["timestamp"].dropna().unique()
+                ]
+                if timestamps:
+                    prune_operations.append(
+                        pm.DeleteMany(
+                            {
+                                "site_id": str(site_id),
+                                "timestamp": {"$nin": timestamps},
+                            }
+                        )
+                    )
         retention_hours = int(configuration.SITE_HOURLY_FORECAST_HORIZON_HOURS or 240)
         retention_cutoff = (
             pd.Timestamp.utcnow() - pd.Timedelta(hours=retention_hours)
@@ -3167,45 +3309,32 @@ class ForecastModelTrainer(BaseMlUtils):
             mongo_db = client[configuration.MONGO_DATABASE_NAME]
             collection = mongo_db[collection_name]
             if bulk_operations:
-                for i in range(0, len(bulk_operations), batch_size):
-                    collection.bulk_write(
-                        bulk_operations[i : i + batch_size], ordered=False
+                collection.create_index(
+                    [("site_id", pm.ASCENDING), ("timestamp", pm.ASCENDING)],
+                    name="site_hourly_forecasts_site_timestamp_idx",
+                    background=True,
+                )
+                collection.create_index(
+                    [("timestamp", pm.ASCENDING)],
+                    name="site_hourly_forecasts_timestamp_idx",
+                    background=True,
+                )
+                write_operations = bulk_operations + prune_operations
+                for i in range(0, len(write_operations), batch_size):
+                    bulk_result = collection.bulk_write(
+                        write_operations[i : i + batch_size], ordered=False
                     )
+                    try:
+                        deleted_rows += int(
+                            getattr(bulk_result, "deleted_count", 0) or 0
+                        )
+                    except (TypeError, ValueError):
+                        pass
                     bulk_batches += 1
-                if site_ids:
-                    existing_docs = list(
-                        collection.find(
-                            {"site_id": {"$in": site_ids}},
-                            {"_id": 1, "site_id": 1, "timestamp": 1},
-                        )
-                    )
-                    if existing_docs:
-                        existing = pd.DataFrame(existing_docs)
-                        existing["timestamp"] = pd.to_datetime(
-                            existing["timestamp"], utc=True, errors="coerce"
-                        )
-                        retained_ids = set(
-                            existing.dropna(subset=["timestamp"])
-                            .sort_values(
-                                ["site_id", "timestamp"],
-                                ascending=[True, False],
-                            )
-                            .groupby("site_id", group_keys=False)
-                            .head(retention_hours)["_id"]
-                            .tolist()
-                        )
-                        stale_ids = [
-                            doc["_id"]
-                            for doc in existing_docs
-                            if doc["_id"] not in retained_ids
-                        ]
-                        if stale_ids:
-                            deleted_rows += collection.delete_many(
-                                {"_id": {"$in": stale_ids}}
-                            ).deleted_count
-                deleted_rows += collection.delete_many(
-                    {"timestamp": {"$lt": retention_cutoff}}
-                ).deleted_count
+                if prune_stale_rows:
+                    deleted_rows += collection.delete_many(
+                        {"timestamp": {"$lt": retention_cutoff}}
+                    ).deleted_count
 
         return {
             "rows": len(records),
@@ -3223,11 +3352,18 @@ class ForecastModelTrainer(BaseMlUtils):
         return ForecastModelTrainer._save_site_daily_forecasts_to_mongo(data)
 
     @staticmethod
-    def save_site_hourly_forecasts_to_mongo(data: pd.DataFrame) -> Dict[str, Any]:
+    def save_site_hourly_forecasts_to_mongo(
+        data: pd.DataFrame,
+        *,
+        prune_stale_rows: bool = True,
+    ) -> Dict[str, Any]:
         """Public wrapper for persisting site hourly forecasts to MongoDB only."""
         if data.empty:
             raise ValueError("No site hourly forecasts available to persist.")
-        return ForecastModelTrainer._save_site_hourly_forecasts_to_mongo(data)
+        return ForecastModelTrainer._save_site_hourly_forecasts_to_mongo(
+            data,
+            prune_stale_rows=prune_stale_rows,
+        )
 
     @staticmethod
     def save_site_daily_forecasts_best_effort(data: pd.DataFrame) -> Dict[str, Any]:

--- a/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
+++ b/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
@@ -38,13 +38,9 @@ ORDER BY day, site_id;
 SELECT
     DATE(t1.timestamp) AS day,
     t1.site_id,
-    ANY_VALUE(COALESCE(t1.site_name, t2.display_name, t2.name, t1.site_id)) AS site_name,
-    ANY_VALUE(
-        COALESCE(t1.site_latitude, t2.approximate_latitude, t2.latitude)
-    ) AS site_latitude,
-    ANY_VALUE(
-        COALESCE(t1.site_longitude, t2.approximate_longitude, t2.longitude)
-    ) AS site_longitude,
+    ANY_VALUE(COALESCE(t2.display_name, t2.name, t1.site_id)) AS site_name,
+    ANY_VALUE(COALESCE(t2.approximate_latitude, t2.latitude)) AS site_latitude,
+    ANY_VALUE(COALESCE(t2.approximate_longitude, t2.longitude)) AS site_longitude,
     AVG(t1.pm2_5_calibrated_value) AS pm25_mean,
     MIN(t1.pm2_5_calibrated_value) AS pm25_min,
     MAX(t1.pm2_5_calibrated_value) AS pm25_max,
@@ -71,13 +67,9 @@ WITH site_hourly AS (
     SELECT
         TIMESTAMP_TRUNC(t1.timestamp, HOUR) AS timestamp,
         t1.site_id,
-        ANY_VALUE(COALESCE(t1.site_name, t2.display_name, t2.name, t1.site_id)) AS site_name,
-        ANY_VALUE(
-            COALESCE(t1.site_latitude, t2.approximate_latitude, t2.latitude)
-        ) AS site_latitude,
-        ANY_VALUE(
-            COALESCE(t1.site_longitude, t2.approximate_longitude, t2.longitude)
-        ) AS site_longitude,
+        ANY_VALUE(COALESCE(t2.display_name, t2.name, t1.site_id)) AS site_name,
+        ANY_VALUE(COALESCE(t2.approximate_latitude, t2.latitude)) AS site_latitude,
+        ANY_VALUE(COALESCE(t2.approximate_longitude, t2.longitude)) AS site_longitude,
         AVG(t1.pm2_5_calibrated_value) AS pm25_mean
     FROM {hourly_measurements_table} AS t1
     LEFT JOIN {sites_table} AS t2

--- a/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
+++ b/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
@@ -30,7 +30,7 @@ ORDER BY day, site_id;
 -- name: site_daily_aggregated_for_forecast_jobs
 -- Daily aggregated site PM2.5 for site-forecast prediction jobs with site metadata backfill.
 -- Placeholders:
--- {consolidated_table} -> consolidated data table (e.g. project.dataset.table)
+-- {hourly_measurements_table} -> hourly measurements table (e.g. project.dataset.table)
 -- {sites_table} -> sites metadata table (e.g. project.dataset.table)
 -- {start_date} / {end_date} -> date strings (YYYY-MM-DD)
 -- {min_hours} -> minimum hourly points per day (INT)
@@ -49,7 +49,7 @@ SELECT
     MIN(t1.pm2_5_calibrated_value) AS pm25_min,
     MAX(t1.pm2_5_calibrated_value) AS pm25_max,
     COUNT(DISTINCT TIMESTAMP_TRUNC(t1.timestamp, HOUR)) AS n_hours
-FROM {consolidated_table} AS t1
+FROM {hourly_measurements_table} AS t1
 LEFT JOIN {sites_table} AS t2
     ON t1.site_id = t2.id
 WHERE DATE(t1.timestamp) BETWEEN DATE('{start_date}') AND DATE('{end_date}')
@@ -62,7 +62,7 @@ ORDER BY day, t1.site_id;
 -- name: site_hourly_measurements_for_forecast_jobs
 -- Hourly site PM2.5 history for recursive site-hourly forecast prediction jobs.
 -- Placeholders:
--- {consolidated_table} -> consolidated hourly measurements table (e.g. project.dataset.table)
+-- {hourly_measurements_table} -> hourly measurements table (e.g. project.dataset.table)
 -- {sites_table} -> sites metadata table (e.g. project.dataset.table)
 -- {start_timestamp} / {end_timestamp} -> timestamp strings
 -- {min_hours} -> minimum hourly points per site over the full lookback window
@@ -79,7 +79,7 @@ WITH site_hourly AS (
             COALESCE(t1.site_longitude, t2.approximate_longitude, t2.longitude)
         ) AS site_longitude,
         AVG(t1.pm2_5_calibrated_value) AS pm25_mean
-    FROM {consolidated_table} AS t1
+    FROM {hourly_measurements_table} AS t1
     LEFT JOIN {sites_table} AS t2
         ON t1.site_id = t2.id
     WHERE t1.timestamp >= TIMESTAMP('{start_timestamp}')

--- a/src/workflows/airqo_etl_utils/tests/test_bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/tests/test_bigquery_api.py
@@ -132,6 +132,64 @@ def test_fetch_data_bigquery_error(mock_bigquery_client, start_date_time):
     assert df.empty
 
 
+def test_fetch_raw_site_data_for_forecast_jobs_uses_hourly_table(monkeypatch):
+    captured = {}
+
+    def fake_execute_data_query(self, query, *args, **kwargs):
+        captured["query"] = query
+        return pd.DataFrame()
+
+    monkeypatch.setattr(
+        "airqo_etl_utils.bigquery_api.bigquery.Client", lambda: mock.Mock()
+    )
+    monkeypatch.setattr(BigQueryApi, "execute_data_query", fake_execute_data_query)
+
+    api = BigQueryApi()
+    api.hourly_measurements_table = "project.dataset.hourly_device_measurements"
+    api.consolidated_data_table = "project.dataset.consolidated_data"
+    api.sites_table = "project.dataset.sites"
+
+    result = api.fetch_raw_site_data_for_forecast_jobs(
+        start_date_time="2026-03-01",
+        end_date_time="2026-03-31",
+        min_hours=1,
+    )
+
+    assert result.empty
+    assert "`project.dataset.hourly_device_measurements` AS t1" in captured["query"]
+    assert "project.dataset.consolidated_data" not in captured["query"]
+    assert ">= 1" in captured["query"]
+
+
+def test_fetch_hourly_site_data_for_forecast_jobs_uses_hourly_table(monkeypatch):
+    captured = {}
+
+    def fake_execute_data_query(self, query, *args, **kwargs):
+        captured["query"] = query
+        return pd.DataFrame()
+
+    monkeypatch.setattr(
+        "airqo_etl_utils.bigquery_api.bigquery.Client", lambda: mock.Mock()
+    )
+    monkeypatch.setattr(BigQueryApi, "execute_data_query", fake_execute_data_query)
+
+    api = BigQueryApi()
+    api.hourly_measurements_table = "project.dataset.hourly_device_measurements"
+    api.consolidated_data_table = "project.dataset.consolidated_data"
+    api.sites_table = "project.dataset.sites"
+
+    result = api.fetch_hourly_site_data_for_forecast_jobs(
+        start_date_time="2026-03-01 00:00:00",
+        end_date_time="2026-03-02 00:00:00",
+        min_hours=2,
+    )
+
+    assert result.empty
+    assert "`project.dataset.hourly_device_measurements` AS t1" in captured["query"]
+    assert "project.dataset.consolidated_data" not in captured["query"]
+    assert ">= 2" in captured["query"]
+
+
 def test_fetch_raw_readings_empty(mock_bigquery_client):
     api = BigQueryApi()
     api.client = mock_bigquery_client

--- a/src/workflows/airqo_etl_utils/tests/test_bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/tests/test_bigquery_api.py
@@ -158,6 +158,10 @@ def test_fetch_raw_site_data_for_forecast_jobs_uses_hourly_table(monkeypatch):
     assert result.empty
     assert "`project.dataset.hourly_device_measurements` AS t1" in captured["query"]
     assert "project.dataset.consolidated_data" not in captured["query"]
+    assert "t1.site_name" not in captured["query"]
+    assert "t1.site_latitude" not in captured["query"]
+    assert "t1.site_longitude" not in captured["query"]
+    assert "COALESCE(t2.display_name, t2.name, t1.site_id)" in captured["query"]
     assert ">= 1" in captured["query"]
 
 
@@ -187,6 +191,10 @@ def test_fetch_hourly_site_data_for_forecast_jobs_uses_hourly_table(monkeypatch)
     assert result.empty
     assert "`project.dataset.hourly_device_measurements` AS t1" in captured["query"]
     assert "project.dataset.consolidated_data" not in captured["query"]
+    assert "t1.site_name" not in captured["query"]
+    assert "t1.site_latitude" not in captured["query"]
+    assert "t1.site_longitude" not in captured["query"]
+    assert "COALESCE(t2.display_name, t2.name, t1.site_id)" in captured["query"]
     assert ">= 2" in captured["query"]
 
 

--- a/src/workflows/airqo_etl_utils/tests/test_ml_utils.py
+++ b/src/workflows/airqo_etl_utils/tests/test_ml_utils.py
@@ -474,6 +474,150 @@ def test_generate_site_daily_forecasts_can_skip_met_enrichment(monkeypatch):
     assert "wind_speed" not in forecasts.columns
 
 
+def test_generate_site_daily_forecasts_anchors_sparse_history_to_run_date(monkeypatch):
+    history = pd.DataFrame(
+        [
+            {
+                "day": pd.Timestamp("2026-03-20"),
+                "site_id": "site-1",
+                "site_name": "Makerere",
+                "site_latitude": 0.333333,
+                "site_longitude": 32.555555,
+                "pm25_mean": 12.3,
+                "pm25_min": 10.1,
+                "pm25_max": 15.6,
+                "n_hours": 1,
+            }
+        ]
+    )
+    feature_columns = [
+        "day_of_week",
+        "day_of_year",
+        "month",
+        "pm25_mean_lag_1",
+        "pm25_mean_lag_2",
+        "pm25_mean_lag_3",
+        "pm25_mean_lag_7",
+        "pm25_mean_lag_14",
+        "roll7_mean",
+        "roll7_std",
+        "roll14_mean",
+        "roll14_std",
+        "site_id_code",
+    ]
+
+    monkeypatch.setattr(
+        ForecastModelTrainer,
+        "_load_site_forecast_artifacts",
+        staticmethod(
+            lambda: {
+                "mean": {
+                    "model": DummyForecastModel(0.5),
+                    "features": feature_columns,
+                    "site_id_mapping": {"site-1": 0},
+                },
+                "min": {
+                    "model": DummyForecastModel(-1.0),
+                    "features": feature_columns,
+                    "site_id_mapping": {"site-1": 0},
+                },
+                "max": {
+                    "model": DummyForecastModel(2.0),
+                    "features": feature_columns,
+                    "site_id_mapping": {"site-1": 0},
+                },
+                "low": {
+                    "model": DummyForecastModel(-0.5),
+                    "features": feature_columns,
+                    "site_id_mapping": {"site-1": 0},
+                },
+                "high": {
+                    "model": DummyForecastModel(1.5),
+                    "features": feature_columns,
+                    "site_id_mapping": {"site-1": 0},
+                },
+            }
+        ),
+    )
+
+    forecasts = ForecastModelTrainer.generate_site_daily_forecasts(
+        history,
+        horizon=2,
+        run_timestamp=pd.Timestamp("2026-03-31T03:00:00Z"),
+        include_met_no_weather=False,
+    )
+
+    assert forecasts["site_id"].tolist() == ["site-1", "site-1"]
+    assert forecasts["date"].tolist() == [
+        pd.Timestamp("2026-03-31").date(),
+        pd.Timestamp("2026-04-01").date(),
+    ]
+
+
+def test_generate_site_daily_forecasts_starts_today_for_stale_lookback_data(
+    monkeypatch,
+):
+    history = pd.DataFrame(
+        [
+            {
+                "day": pd.Timestamp("2026-05-09"),
+                "site_id": "site-1",
+                "site_name": "Makerere",
+                "site_latitude": 0.333333,
+                "site_longitude": 32.555555,
+                "pm25_mean": 12.3,
+            }
+        ]
+    )
+    feature_columns = [
+        "day_of_week",
+        "day_of_year",
+        "month",
+        "pm25_mean_lag_1",
+        "pm25_mean_lag_2",
+        "pm25_mean_lag_3",
+        "pm25_mean_lag_7",
+        "pm25_mean_lag_14",
+        "roll7_mean",
+        "roll7_std",
+        "roll14_mean",
+        "roll14_std",
+        "site_id_code",
+    ]
+
+    monkeypatch.setattr(
+        ForecastModelTrainer,
+        "_load_site_forecast_artifacts",
+        staticmethod(
+            lambda: {
+                label: {
+                    "model": DummyForecastModel(offset),
+                    "features": feature_columns,
+                    "site_id_mapping": {"site-1": 0},
+                }
+                for label, offset in {
+                    "mean": 0.5,
+                    "min": -1.0,
+                    "max": 2.0,
+                    "low": -0.5,
+                    "high": 1.5,
+                }.items()
+            }
+        ),
+    )
+
+    forecasts = ForecastModelTrainer.generate_site_daily_forecasts(
+        history,
+        horizon=10,
+        run_timestamp=pd.Timestamp("2026-05-18T03:00:00Z"),
+        include_met_no_weather=False,
+    )
+
+    assert forecasts["date"].min() == pd.Timestamp("2026-05-18").date()
+    assert forecasts["date"].max() == pd.Timestamp("2026-05-27").date()
+    assert forecasts["date"].nunique() == 10
+
+
 def test_enrich_site_daily_forecasts_with_met_falls_back_on_failure(monkeypatch):
     forecasts = pd.DataFrame(
         [

--- a/src/workflows/airqo_etl_utils/tests/test_site_hourly_forecast.py
+++ b/src/workflows/airqo_etl_utils/tests/test_site_hourly_forecast.py
@@ -119,6 +119,49 @@ def test_generate_site_hourly_forecasts_includes_sparse_sites(monkeypatch):
     assert forecasts["forecast_confidence"].between(0, 100).all()
 
 
+def test_generate_site_hourly_forecasts_starts_at_run_hour_for_stale_lookback_data(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        ForecastModelTrainer,
+        "_load_site_hourly_forecast_artifacts",
+        staticmethod(_hourly_artifacts),
+    )
+    history = pd.DataFrame(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-05-09T08:00:00Z"),
+                "site_id": "site-1",
+                "site_name": "Makerere",
+                "site_latitude": 0.3123456,
+                "site_longitude": 32.5123456,
+                "pm25_mean": 12.0,
+            },
+            {
+                "timestamp": pd.Timestamp("2026-05-09T09:00:00Z"),
+                "site_id": "site-1",
+                "site_name": "Makerere",
+                "site_latitude": 0.3123456,
+                "site_longitude": 32.5123456,
+                "pm25_mean": 13.0,
+            },
+        ]
+    )
+
+    forecasts = ForecastModelTrainer.generate_site_hourly_forecasts(
+        history,
+        horizon_hours=3,
+        run_timestamp=pd.Timestamp("2026-05-18T03:00:00Z"),
+        include_met_no_weather=False,
+    )
+
+    assert forecasts["timestamp"].tolist() == [
+        pd.Timestamp("2026-05-18T03:00:00Z"),
+        pd.Timestamp("2026-05-18T04:00:00Z"),
+        pd.Timestamp("2026-05-18T05:00:00Z"),
+    ]
+
+
 def test_generate_site_hourly_forecasts_rejects_none_input():
     with pytest.raises(
         ValueError, match="fetch_site_prediction_data task returned None"
@@ -207,6 +250,7 @@ def test_save_site_hourly_forecasts_to_mongo_replaces_existing_site_rows(monkeyp
 
     mock_collection = MagicMock()
     mock_collection.find.return_value = []
+    mock_collection.bulk_write.return_value.deleted_count = 0
     mock_collection.delete_many.return_value.deleted_count = 0
 
     mock_db = MagicMock()
@@ -227,6 +271,9 @@ def test_save_site_hourly_forecasts_to_mongo_replaces_existing_site_rows(monkeyp
         "site_hourly_forecasts",
     )
     monkeypatch.setattr(
+        ml_utils_module.configuration, "MONGO_BULK_WRITE_BATCH_SIZE", 500
+    )
+    monkeypatch.setattr(
         ml_utils_module.pm,
         "MongoClient",
         lambda *args, **kwargs: mock_client_manager,
@@ -237,25 +284,40 @@ def test_save_site_hourly_forecasts_to_mongo_replaces_existing_site_rows(monkeyp
     mock_collection.bulk_write.assert_called_once()
     assert mock_collection.bulk_write.call_args.kwargs["ordered"] is False
     bulk_operations = mock_collection.bulk_write.call_args.args[0]
-    assert len(bulk_operations) == 2
-    assert all(operation._upsert for operation in bulk_operations)
-    assert bulk_operations[0]._filter == {
+    upsert_operations = [
+        operation
+        for operation in bulk_operations
+        if getattr(operation, "_upsert", False)
+    ]
+    prune_operations = [
+        operation
+        for operation in bulk_operations
+        if not getattr(operation, "_upsert", False)
+    ]
+    assert len(upsert_operations) == 2
+    assert len(prune_operations) == 1
+    assert upsert_operations[0]._filter == {
         "site_id": "site-1",
         "timestamp": pd.Timestamp("2026-03-04T08:00:00Z").to_pydatetime(),
     }
-    assert bulk_operations[0]._doc["$set"]["pm2_5_mean"] == 12.1
-    assert bulk_operations[0]._doc["$setOnInsert"] == {
+    assert upsert_operations[0]._doc["$set"]["pm2_5_mean"] == 12.1
+    assert upsert_operations[0]._doc["$setOnInsert"] == {
         "site_name": "Makerere",
         "site_id": "site-1",
         "timestamp": pd.Timestamp("2026-03-04T08:00:00Z").to_pydatetime(),
         "created_at": pd.Timestamp("2026-03-04T08:00:00Z").to_pydatetime(),
     }
+    assert prune_operations[0]._filter["site_id"] == "site-1"
+    assert set(prune_operations[0]._filter["timestamp"].keys()) == {"$nin"}
     mock_collection.delete_many.assert_called_once()
     delete_filter = mock_collection.delete_many.call_args.args[0]
     assert set(delete_filter.keys()) == {"timestamp"}
     assert set(delete_filter["timestamp"].keys()) == {"$lt"}
     mock_collection.insert_many.assert_not_called()
-    mock_collection.create_index.assert_not_called()
+    assert mock_collection.create_index.call_count == 2
+    assert mock_collection.create_index.call_args_list[0].kwargs["name"] == (
+        "site_hourly_forecasts_site_timestamp_idx"
+    )
     assert result == {
         "rows": 2,
         "collection": "site_hourly_forecasts",
@@ -289,6 +351,7 @@ def test_save_site_hourly_forecasts_to_mongo_preserves_existing_met_fields(
 
     mock_collection = MagicMock()
     mock_collection.find.return_value = []
+    mock_collection.bulk_write.return_value.deleted_count = 0
     mock_collection.delete_many.return_value.deleted_count = 0
 
     mock_db = MagicMock()
@@ -317,13 +380,78 @@ def test_save_site_hourly_forecasts_to_mongo_preserves_existing_met_fields(
     ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(forecasts)
 
     bulk_operations = mock_collection.bulk_write.call_args.args[0]
-    update_doc = bulk_operations[0]._doc
+    update_doc = next(
+        operation
+        for operation in bulk_operations
+        if getattr(operation, "_upsert", False)
+    )._doc
     assert "air_temperature" not in update_doc["$set"]
     assert "relative_humidity" not in update_doc["$set"]
     assert "site_name" not in update_doc["$set"]
     assert "created_at" not in update_doc["$set"]
     assert update_doc["$set"]["pm2_5_mean"] == 12.1
     assert update_doc["$setOnInsert"]["site_name"] == "Makerere"
+
+
+def test_save_site_hourly_forecasts_to_mongo_can_skip_pruning(monkeypatch):
+    forecasts = pd.DataFrame(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-03-04T08:00:00Z"),
+                "site_id": "site-1",
+                "site_name": "Makerere",
+                "site_latitude": 0.3123456,
+                "site_longitude": 32.5123456,
+                "pm2_5_mean": 12.1,
+                "pm2_5_q10": 10.2,
+                "pm2_5_q90": 14.8,
+                "forecast_confidence": 80.0,
+                "air_temperature": 27.7,
+                "created_at": pd.Timestamp("2026-03-04T08:00:00Z"),
+            }
+        ]
+    )
+
+    mock_collection = MagicMock()
+    mock_collection.bulk_write.return_value.deleted_count = 0
+
+    mock_db = MagicMock()
+    mock_db.__getitem__.return_value = mock_collection
+
+    mock_client = MagicMock()
+    mock_client.__getitem__.return_value = mock_db
+
+    mock_client_manager = MagicMock()
+    mock_client_manager.__enter__.return_value = mock_client
+    mock_client_manager.__exit__.return_value = None
+
+    monkeypatch.setattr(ml_utils_module.configuration, "MONGO_URI", "mongodb://test")
+    monkeypatch.setattr(ml_utils_module.configuration, "MONGO_DATABASE_NAME", "airqo")
+    monkeypatch.setattr(
+        ml_utils_module.configuration,
+        "MONGO_SITE_HOURLY_FORECAST_COLLECTION",
+        "site_hourly_forecasts",
+    )
+    monkeypatch.setattr(
+        ml_utils_module.configuration, "MONGO_BULK_WRITE_BATCH_SIZE", 500
+    )
+    monkeypatch.setattr(
+        ml_utils_module.pm,
+        "MongoClient",
+        lambda *args, **kwargs: mock_client_manager,
+    )
+
+    result = ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(
+        forecasts,
+        prune_stale_rows=False,
+    )
+
+    bulk_operations = mock_collection.bulk_write.call_args.args[0]
+    assert len(bulk_operations) == 1
+    assert bulk_operations[0]._upsert is True
+    mock_collection.find.assert_not_called()
+    mock_collection.delete_many.assert_not_called()
+    assert result["deleted_rows"] == 0
 
 
 def test_save_site_hourly_forecasts_to_mongo_prunes_old_rows(monkeypatch):
@@ -363,14 +491,10 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_old_rows(monkeypatch):
 
     mock_collection = MagicMock()
     mock_collection.find.return_value = existing_docs
-    stale_delete_result = MagicMock()
-    stale_delete_result.deleted_count = 1
+    mock_collection.bulk_write.return_value.deleted_count = 1
     expired_delete_result = MagicMock()
     expired_delete_result.deleted_count = 0
-    mock_collection.delete_many.side_effect = [
-        stale_delete_result,
-        expired_delete_result,
-    ]
+    mock_collection.delete_many.return_value = expired_delete_result
 
     mock_db = MagicMock()
     mock_db.__getitem__.return_value = mock_collection
@@ -390,6 +514,9 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_old_rows(monkeypatch):
         "site_hourly_forecasts",
     )
     monkeypatch.setattr(
+        ml_utils_module.configuration, "MONGO_BULK_WRITE_BATCH_SIZE", 500
+    )
+    monkeypatch.setattr(
         ml_utils_module.configuration, "SITE_HOURLY_FORECAST_HORIZON_HOURS", "2"
     )
     monkeypatch.setattr(
@@ -401,10 +528,16 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_old_rows(monkeypatch):
     result = ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(forecasts)
 
     mock_collection.bulk_write.assert_called_once()
-    assert mock_collection.delete_many.call_args_list[0].args[0] == {
-        "_id": {"$in": [1]}
-    }
-    timestamp_delete_filter = mock_collection.delete_many.call_args_list[1].args[0]
+    bulk_operations = mock_collection.bulk_write.call_args.args[0]
+    prune_filter = next(
+        operation._filter
+        for operation in bulk_operations
+        if not getattr(operation, "_upsert", False)
+    )
+    assert prune_filter["site_id"] == "site-1"
+    assert set(prune_filter["timestamp"].keys()) == {"$nin"}
+    mock_collection.find.assert_not_called()
+    timestamp_delete_filter = mock_collection.delete_many.call_args.args[0]
     assert set(timestamp_delete_filter.keys()) == {"timestamp"}
     assert set(timestamp_delete_filter["timestamp"].keys()) == {"$lt"}
     assert result == {
@@ -438,6 +571,7 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_expired_rows_for_absent_site
 
     mock_collection = MagicMock()
     mock_collection.find.return_value = []
+    mock_collection.bulk_write.return_value.deleted_count = 0
     mock_collection.delete_many.return_value.deleted_count = 4
 
     mock_db = MagicMock()
@@ -456,6 +590,9 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_expired_rows_for_absent_site
         ml_utils_module.configuration,
         "MONGO_SITE_HOURLY_FORECAST_COLLECTION",
         "site_hourly_forecasts",
+    )
+    monkeypatch.setattr(
+        ml_utils_module.configuration, "MONGO_BULK_WRITE_BATCH_SIZE", 500
     )
     monkeypatch.setattr(
         ml_utils_module.configuration, "SITE_HOURLY_FORECAST_HORIZON_HOURS", "2"
@@ -518,12 +655,13 @@ def test_site_hourly_forecast_query_is_registered():
     query = query_manager.get_query("site_hourly_measurements_for_forecast_jobs")
 
     assert {
-        "consolidated_table",
+        "hourly_measurements_table",
         "sites_table",
         "start_timestamp",
         "end_timestamp",
         "min_hours",
     }.issubset(query.placeholders)
+    assert "FROM {hourly_measurements_table} AS t1" in query.sql
     assert "HAVING COUNT(DISTINCT timestamp) >= {min_hours}" in query.sql
 
 

--- a/src/workflows/dags/dag_docs.py
+++ b/src/workflows/dags/dag_docs.py
@@ -432,7 +432,7 @@ site_hourly_forecasting_doc = """
 Generate 10-day hourly site-level PM2.5 forecasts and enrich them with MET.no hourly weather data.
 
 #### Workflow
-1. Fetch up to 14 days of consolidated hourly site PM2.5 history from BigQuery.
+1. Fetch up to 14 days of hourly site PM2.5 history from BigQuery.
 2. Generate recursive hourly mean, q10, and q90 forecasts with the deployed GCS models.
 3. Save forecast-only rows to MongoDB after deleting old rows for the affected sites.
 4. Fetch hourly MET.no weather data by rounded site coordinates.
@@ -440,7 +440,7 @@ Generate 10-day hourly site-level PM2.5 forecasts and enrich them with MET.no ho
 
 #### Notes
 Data sources:
-- BigQuery: consolidated hourly device measurements
+- BigQuery: hourly device measurements
 - GCS: hourly 10-day PM2.5 model artifacts
 - MET.no: hourly weather forecasts
 

--- a/src/workflows/dags/forecast_prediction_jobs.py
+++ b/src/workflows/dags/forecast_prediction_jobs.py
@@ -210,12 +210,14 @@ def make_site_daily_forecasts():
         )
 
     @task()
-    def generate_site_forecasts(data):
+    def generate_site_forecasts(data, **kwargs):
         """Generate forward site-level daily forecasts without MET enrichment."""
         horizon = int(Config.DAILY_FORECAST_HORIZON or 7)
+        execution_date = kwargs["dag_run"].execution_date
         return ForecastModelTrainer.generate_site_daily_forecasts(
             data,
             horizon=horizon,
+            run_timestamp=execution_date,
             include_met_no_weather=False,
         )
 
@@ -293,12 +295,14 @@ def make_site_hourly_forecasts():
         )
 
     @task(doc_md=generate_site_hourly_forecasts_doc)
-    def generate_site_forecasts(data: Any) -> Any:
+    def generate_site_forecasts(data: Any, **kwargs: Any) -> Any:
         """Generate recursive hourly PM2.5 forecasts without MET enrichment."""
         horizon_hours = int(Config.SITE_HOURLY_FORECAST_HORIZON_HOURS or 240)
+        execution_date = kwargs["dag_run"].execution_date
         return ForecastModelTrainer.generate_site_hourly_forecasts(
             data,
             horizon_hours=horizon_hours,
+            run_timestamp=execution_date,
             include_met_no_weather=False,
         )
 
@@ -339,7 +343,10 @@ def make_site_hourly_forecasts():
         if data is None:
             return {"updated": False, "reason": "met_unavailable"}
 
-        details = ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(data)
+        details = ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(
+            data,
+            prune_stale_rows=False,
+        )
         return {"updated": True, "details": details}
 
     site_data = fetch_site_prediction_data()

--- a/src/workflows/dags/task_docs.py
+++ b/src/workflows/dags/task_docs.py
@@ -125,7 +125,7 @@ fetch_site_hourly_prediction_data_doc = """
 #### Purpose
 Fetch site-level hourly PM2.5 history for the hourly forecast lookback window.
 #### Notes
-- Reads from the consolidated hourly BigQuery table configured in `.env`.
+- Reads from the hourly measurements BigQuery table configured in `.env`.
 - Caps the lookback at 14 days.
 - Keeps sites with at least 2 hourly measurements so sparse sites still receive forecasts.
 """


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
This PR updates the site-level daily and hourly forecast pipelines to:

- Read prediction input data from the hourly measurements table instead of the consolidated table.

- Keep quarterly site forecast training on the consolidated table.

- Allow stale-but-valid lookback data to forecast from the DAG run date/time.

- Optimize hourly forecast MongoDB persistence by avoiding expensive readback cleanup and skipping duplicate cleanup during MET updates.

- Add regression tests for forecast source selection, stale lookback anchoring, and MongoDB persistence behavior.

### Why is this change needed?
Some sites may have data inside the lookback window but no fresh data on the DAG run date. Previously, forecasts could start from the site’s last observed date/time instead of the current DAG run date/time. This meant stale sites could produce forecasts for old dates instead of the expected current forecast horizon.

The MongoDB hourly forecast save tasks were also taking too long because cleanup loaded existing forecast rows into Python before deleting stale data. Moving cleanup into MongoDB bulk operations and skipping duplicate cleanup in the MET update step should make the DAG faster while still removing old forecast rows.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable pruning for hourly forecast storage (option to skip stale-row pruning)

* **Improvements**
  * Forecasts now sourced from raw hourly measurements
  * Forecast history padded to cover full prediction horizons
  * Forecast start aligned to scheduled run timestamps

* **Bug Fixes**
  * Improved error reporting for query failures (preserves original exceptions)

* **Tests**
  * Added unit tests for forecasting inputs, hourly persistence, and pruning behavior

* **Documentation**
  * Updated docs to reference hourly measurements as the data source

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->