### PR TITLE
Fix readings aggregation timeout exceeding Next.js proxy ceiling

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -82,10 +82,11 @@ function envConfig(env) {
     })(),
 
     // MongoDB maxTimeMS for ReadingModel.recent() aggregation.
-    // Must be comfortably below the load-balancer/upstream timeout (~60s).
+    // Must be below the Next.js proxy timeout (30s) so MongoDB fails fast
+    // before the proxy aborts the upstream connection.
     READINGS_AGGREGATE_TIMEOUT_MS: (() => {
       const val = parseInt(process.env.READINGS_AGGREGATE_TIMEOUT_MS, 10);
-      return Number.isFinite(val) && val > 0 ? val : 55000;
+      return Number.isFinite(val) && val > 0 ? val : 25000;
     })(),
 
     // Temporary diagnostic window for ReadingModel.recent().


### PR DESCRIPTION

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Confirmed via browser console on the Favorites page (`/user/favorites`) that 500 errors on `GET /api/external/devices/readings/recent` are resolved after reducing the MongoDB aggregation timeout below the Next.js proxy ceiling. Slow aggregations now fail fast with structured errors rather than being silently aborted by the proxy.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The timeout remains configurable via the `READINGS_AGGREGATE_TIMEOUT_MS` environment variable — no code change needed to tune it per environment.
- The previous fix (on branch `fix-recent-500`) introduced `maxTimeMS` correctly but set the default value above the proxy ceiling. This PR corrects only that default.
- The `runtime.lastError` messages visible in browser console alongside these 500s are a Chrome extension artifact and are unrelated to this fix.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted timeout settings to improve system reliability and alignment with infrastructure constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->