### PR TITLE
fix: improve countries endpoint performance and reliability

### DIFF
--- a/src/device-registry/config/definitions/country-flags.js
+++ b/src/device-registry/config/definitions/country-flags.js
@@ -55,19 +55,15 @@ const countryCodes = {
   Madagascar: "mg",
 };
 
+// Pre-built lowercase Map for O(1) lookup instead of O(n) scan per call.
+const _flagLookup = new Map(
+  Object.entries(countryCodes).map(([k, v]) => [k.toLowerCase(), v])
+);
+
 const getFlagUrl = (countryName) => {
-  if (!countryName) {
-    return null;
-  }
-  const lowerCountryName = countryName.toLowerCase().trim();
-  const countryEntry = Object.entries(countryCodes).find(
-    ([key, value]) => key.toLowerCase() === lowerCountryName
-  );
-  if (countryEntry) {
-    const code = countryEntry[1];
-    return `https://flagcdn.com/w320/${code.toLowerCase()}.png`;
-  }
-  return null;
+  if (!countryName) return null;
+  const code = _flagLookup.get(countryName.toLowerCase().trim());
+  return code ? `https://flagcdn.com/w320/${code}.png` : null;
 };
 
 module.exports = {

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -1787,11 +1787,11 @@ const createGrid = {
 
       // Use cached helper — avoids a full Cohort→Device join on every request.
       // Cache is per-tenant with a 5-minute TTL (see getPrivateSiteIds above).
-      const privateSiteIds = await getPrivateSiteIds(tenant);
+      const privateSiteIds = await getPrivateSiteIds(normalizedTenant);
 
       let cohortSiteIds = [];
       if (cohort_id) {
-        const siteIdsResponse = await getSiteIdsFromCohort(tenant, cohort_id);
+        const siteIdsResponse = await getSiteIdsFromCohort(normalizedTenant, cohort_id);
         if (!siteIdsResponse.success) {
           return siteIdsResponse;
         }
@@ -1856,7 +1856,7 @@ const createGrid = {
         },
       ];
 
-      const results = await GridModel(tenant)
+      const results = await GridModel(normalizedTenant)
         .aggregate(pipeline)
         .option({ maxTimeMS: 15000 })
         .allowDiskUse(true);
@@ -1915,6 +1915,9 @@ createGrid._getPrivateSiteIds = getPrivateSiteIds;
 createGrid._clearPrivateSiteIdsCache = () => {
   _privateSiteIdsCache.clear();
   _inflight.clear();
+};
+createGrid._clearCountriesCache = () => {
+  _countriesCache.clear();
 };
 
 module.exports = createGrid;

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -91,6 +91,15 @@ const _gridSummaryCountCache = new LRUCache({
   maxAge: GRID_SUMMARY_COUNT_TTL_MS,
 });
 
+// Pod-local LRU cache for GET /grids/countries.
+// Countries and their site counts change infrequently; a 3-minute TTL
+// eliminates redundant full-collection aggregations under concurrent load.
+const COUNTRIES_CACHE_TTL_MS = 3 * 60 * 1000;
+const _countriesCache = new LRUCache({
+  max: 50,
+  maxAge: COUNTRIES_CACHE_TTL_MS,
+});
+
 /**
  * Stable string key for the summary data cache.
  * Includes all parameters that affect the paginated result set.
@@ -1759,6 +1768,23 @@ const createGrid = {
   listCountries: async (request, next) => {
     try {
       const { tenant, cohort_id } = request.query;
+
+      // Stable cache key includes tenant and sorted cohort IDs (if any)
+      const cohortKey = cohort_id
+        ? (Array.isArray(cohort_id) ? cohort_id : cohort_id.split(",").map((s) => s.trim()))
+            .sort()
+            .join(",")
+        : "";
+      const normalizedTenant =
+        (tenant && tenant.toString().trim().toLowerCase()) ||
+        constants.DEFAULT_TENANT ||
+        "airqo";
+      const cacheKey = `${normalizedTenant}:${cohortKey}`;
+      const cached = _countriesCache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
       // Use cached helper — avoids a full Cohort→Device join on every request.
       // Cache is per-tenant with a 5-minute TTL (see getPrivateSiteIds above).
       const privateSiteIds = await getPrivateSiteIds(tenant);
@@ -1782,78 +1808,74 @@ const createGrid = {
         }
       }
 
+      // Build site filter conditions for the $lookup sub-pipeline.
+      // $nin/$in on _id push filtering to the DB level rather than loading
+      // full site documents into memory and filtering with $addFields.$filter.
+      const siteMatchStage = {
+        $expr: { $in: ["$$gridId", { $ifNull: ["$grids", []] }] },
+      };
+      const idCondition = {};
+      if (privateSiteIds.length > 0) idCondition.$nin = privateSiteIds;
+      if (cohort_id && cohortSiteIds.length > 0) idCondition.$in = cohortSiteIds;
+      if (Object.keys(idCondition).length > 0) siteMatchStage._id = idCondition;
+
       const pipeline = [
         {
           $match: { admin_level: "country" },
         },
         {
+          // Use a correlated sub-pipeline so only the count is returned per
+          // country, avoiding loading full site documents into memory.
           $lookup: {
             from: "sites",
-            localField: "_id",
-            foreignField: "grids",
-            as: "sites",
+            let: { gridId: "$_id" },
+            pipeline: [
+              { $match: siteMatchStage },
+              { $count: "n" },
+            ],
+            as: "siteCount",
           },
         },
         {
           $addFields: {
-            sites: {
-              $filter: {
-                input: "$sites",
-                as: "site",
-                cond:
-                  cohort_id && cohortSiteIds.length > 0
-                    ? {
-                        $and: [
-                          { $not: { $in: ["$$site._id", privateSiteIds] } },
-                          { $in: ["$$site._id", cohortSiteIds] },
-                        ],
-                      }
-                    : { $not: { $in: ["$$site._id", privateSiteIds] } },
-              },
-            },
-          },
-        },
-        {
-          $project: {
-            _id: 0,
-            country: { $toLower: "$name" },
-            sites: { $size: "$sites" },
+            sites: { $ifNull: [{ $arrayElemAt: ["$siteCount.n", 0] }, 0] },
           },
         },
         {
           $match: { sites: { $gt: 0 } },
         },
         {
-          $sort: {
-            country: 1,
+          $project: {
+            _id: 0,
+            country: { $toLower: "$name" },
+            sites: 1,
           },
+        },
+        {
+          $sort: { country: 1 },
         },
       ];
 
       const results = await GridModel(tenant)
         .aggregate(pipeline)
-        .option({ maxTimeMS: 45000 })
+        .option({ maxTimeMS: 15000 })
         .allowDiskUse(true);
 
       const countriesWithFlags = results.map((countryData) => {
-        // Safely handle null or undefined country names
         const rawCountryName =
           typeof countryData.country === "string" ? countryData.country : "";
 
-        // Normalize name: handle underscores, hyphens, apostrophes, and extra spaces
-        // before converting to a standardized Title Case format.
         const formattedCountryName = rawCountryName
           .replace(/_/g, " ")
-          .split(/(\s+|-|')/) // Split by spaces, hyphens, or apostrophes, keeping delimiters
-          .filter(Boolean) // Remove empty strings from the result
+          .split(/(\s+|-|')/)
+          .filter(Boolean)
           .map((part) => {
-            // Only capitalize word parts, not delimiters
             if (part.match(/^[a-zA-Z0-9]+$/)) {
               return (
                 part.charAt(0).toLocaleUpperCase() + part.slice(1).toLowerCase()
               );
             }
-            return part; // Return delimiters as is
+            return part;
           })
           .join("")
           .trim();
@@ -1864,12 +1886,15 @@ const createGrid = {
         };
       });
 
-      return {
+      const response = {
         success: true,
         message: "Successfully retrieved countries and site counts.",
         data: countriesWithFlags,
         status: httpStatus.OK,
       };
+
+      _countriesCache.set(cacheKey, response);
+      return response;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/utils/test/ut_grid.util.js
+++ b/src/device-registry/utils/test/ut_grid.util.js
@@ -204,6 +204,11 @@ describe("Grid Util", () => {
   });
 
   describe("listCountries", () => {
+    beforeEach(() => {
+      gridUtil._clearPrivateSiteIdsCache();
+      gridUtil._clearCountriesCache();
+    });
+
     it("should list countries with site counts, filtering private sites", async () => {
       const request = { query: { tenant: "airqo" } };
       const privateSiteIds = [new mongoose.Types.ObjectId()];
@@ -213,9 +218,17 @@ describe("Grid Util", () => {
       sandbox
         .stub(CohortModel, "default")
         .returns({ aggregate: cohortAggregateStub });
-      const gridAggregateStub = sandbox
-        .stub()
-        .resolves([{ country: "uganda", sites: 10 }]);
+
+      // Return a chainable aggregate mock so .option().allowDiskUse() don't
+      // throw — Mongoose Aggregate is not a plain Promise.
+      const countryData = [{ country: "uganda", sites: 10 }];
+      const aggregateChain = {
+        option: sandbox.stub().returnsThis(),
+        allowDiskUse: sandbox.stub().returnsThis(),
+        then: (res, rej) => Promise.resolve(countryData).then(res, rej),
+        catch: (fn) => Promise.resolve(countryData).catch(fn),
+      };
+      const gridAggregateStub = sandbox.stub().returns(aggregateChain);
       sandbox
         .stub(GridModel, "default")
         .returns({ aggregate: gridAggregateStub });
@@ -224,15 +237,19 @@ describe("Grid Util", () => {
 
       expect(result.success).to.be.true;
       expect(result.data[0].country).to.equal("uganda");
-      const filterStage = gridAggregateStub
-        .getCall(0)
-        .args[0].find(
-          (stage) => stage.$addFields && stage.$addFields.sites.$filter
-        );
-      expect(filterStage).to.exist;
-      expect(
-        filterStage.$addFields.sites.$filter.cond.$not.$in[1]
-      ).to.deep.equal(privateSiteIds);
+
+      // Assert the new correlated sub-pipeline shape
+      const pipelineArg = gridAggregateStub.getCall(0).args[0];
+      const lookupStage = pipelineArg.find(
+        (s) => s.$lookup && s.$lookup.as === "siteCount"
+      );
+      expect(lookupStage).to.exist;
+      expect(lookupStage.$lookup.let).to.deep.equal({ gridId: "$_id" });
+      const subMatch = lookupStage.$lookup.pipeline.find((s) => s.$match);
+      expect(subMatch.$match.$expr).to.deep.equal({
+        $in: ["$$gridId", { $ifNull: ["$grids", []] }],
+      });
+      expect(subMatch.$match._id.$nin).to.deep.equal(privateSiteIds);
     });
   });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds a 3-minute pod-local LRU cache to `GET /api/v2/devices/grids/countries` — identical to the pattern already used by the grids summary endpoint
- Rewrites the `$lookup` stage to use a correlated sub-pipeline with `$count`, pushing site filtering to the DB level instead of loading full site documents into memory
- Adds a `$ifNull` guard on `$grids` in the sub-pipeline to prevent a `$in requires an array` aggregation error on site documents missing the field
- Reduces `maxTimeMS` from 45 s to 15 s now that the pipeline is significantly lighter
- Replaces the O(n) linear scan in `getFlagUrl` with a pre-built lowercase `Map` for O(1) lookups

### Why is this change needed?
The `/grids/countries` endpoint was intermittently returning `500 Internal Server Error` under concurrent load. Every request independently ran a full multi-stage MongoDB aggregation with no caching — when multiple requests arrived simultaneously, they all raced toward the 45-second timeout, causing `MongoServerError` responses that surfaced as 500s on the Data Export page (Countries tab).

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
`GET /api/v2/devices/grids/countries` tested manually — returns correct country list with site counts and flag URLs. Verified the `$in requires an array` 500 error is resolved.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Response shape is identical. The only behavioural difference is `maxTimeMS` dropping from 45 s to 15 s — queries that were previously succeeding in the 15–45 s window will now time out, but the lighter pipeline makes this window unreachable under normal conditions.

---

## :memo: Additional Notes
- Caching is pod-local (in-process `lru-cache`), consistent with how `listSummary` is already cached. No Redis or L2 (MongoDB) cache is needed — the cost of a cold miss on pod restart is a single lightweight aggregation.
- A frontend feedback document for optional hardening (client-side retry + stale-while-revalidate alignment) has been added at `src/device-registry/docs/frontend-countries-endpoint-feedback.md`.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance of flag URL resolution through optimized lookups.
  * Enhanced countries list endpoint with response caching (3-minute refresh interval) and streamlined data retrieval logic for faster API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->