### PR TITLE
fix: include screenshot image in feedback notification emails

### DIFF
--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -1716,15 +1716,21 @@ const mailer = {
         );
       }
 
+      const screenshotHtml = params.screenshot_url
+        ? `<p><strong>Screenshot:</strong><br/><img src="${params.screenshot_url}" alt="Feedback screenshot" style="max-width:100%;border:1px solid #ddd;border-radius:4px;margin-top:8px;" /></p>`
+        : "";
+
       return {
         ...baseMailOptions,
-        to: constants.SUPPORT_EMAIL, // Send to support
-        cc: params.email, // Copy user on their feedback
-        subject: params.subject, // Use provided subject
-        text: params.message, // Use text instead of HTML for feedback
-        html: undefined, // Remove HTML for feedback emails
-        bcc: undefined, // No BCC for feedback
-        attachments: undefined, // No attachments for feedback
+        to: constants.SUPPORT_EMAIL,
+        cc: params.email,
+        subject: params.subject,
+        text: params.screenshot_url
+          ? `${params.message}\n\nScreenshot: ${params.screenshot_url}`
+          : params.message,
+        html: `<p>${params.message.replace(/\n/g, "<br/>")}</p>${screenshotHtml}`,
+        bcc: undefined,
+        attachments: undefined,
       };
     },
   ),

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -29,6 +29,20 @@ const processString = (inputString) => {
   const uppercasedString = stringWithSpaces.toUpperCase();
   return uppercasedString;
 };
+const escapeHtml = (str) =>
+  String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+const isSafeHttpsUrl = (url) => {
+  try {
+    return new URL(url).protocol === "https:";
+  } catch {
+    return false;
+  }
+};
 const projectRoot = path.join(__dirname, "..", "..");
 const imagePath = path.join(projectRoot, "config", "images");
 
@@ -1716,19 +1730,27 @@ const mailer = {
         );
       }
 
-      const screenshotHtml = params.screenshot_url
-        ? `<p><strong>Screenshot:</strong><br/><img src="${params.screenshot_url}" alt="Feedback screenshot" style="max-width:100%;border:1px solid #ddd;border-radius:4px;margin-top:8px;" /></p>`
+      const safeScreenshotUrl =
+        params.screenshot_url && isSafeHttpsUrl(params.screenshot_url)
+          ? params.screenshot_url
+          : null;
+      const screenshotHtml = safeScreenshotUrl
+        ? `<p><strong>Screenshot:</strong><br/><img src="${escapeHtml(safeScreenshotUrl)}" alt="Feedback screenshot" style="max-width:100%;border:1px solid #ddd;border-radius:4px;margin-top:8px;" /></p>`
         : "";
+      const escapedMessage = escapeHtml(params.message).replace(
+        /\n/g,
+        "<br/>",
+      );
 
       return {
         ...baseMailOptions,
         to: constants.SUPPORT_EMAIL,
         cc: params.email,
         subject: params.subject,
-        text: params.screenshot_url
-          ? `${params.message}\n\nScreenshot: ${params.screenshot_url}`
+        text: safeScreenshotUrl
+          ? `${params.message}\n\nScreenshot: ${safeScreenshotUrl}`
           : params.message,
-        html: `<p>${params.message.replace(/\n/g, "<br/>")}</p>${screenshotHtml}`,
+        html: `<p>${escapedMessage}</p>${screenshotHtml}`,
         bcc: undefined,
         attachments: undefined,
       };

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -7669,7 +7669,7 @@ const feedbackUtil = {
       // Also dispatch a support email (best-effort; DB record already saved)
       try {
         await mailer.feedback(
-          { email: normalizedEmail, subject, message },
+          { email: normalizedEmail, subject, message, screenshot_url },
           next,
         );
       } catch (emailError) {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes feedback notification emails to include the submitted screenshot. The `screenshot_url` was being saved to the database but never forwarded to the mailer, and the mailer was configured with `html: undefined`, so no image could ever appear. This PR passes `screenshot_url` through to the mailer and builds an HTML email body with the screenshot rendered inline via an `<img>` tag. The plain-text fallback appends the Cloudinary URL for email clients that don't render HTML.

### Why is this change needed?
Users submitting feedback with a screenshot attachment had no indication the screenshot was received — it was silently dropped from the support email even though it was correctly stored in the database.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Submitted feedback with a screenshot via the `/api/v2/users/feedback/submit` endpoint and confirmed the support email renders the screenshot image inline. Also verified that feedback submitted without a screenshot continues to send a clean plain-text email with no broken image tags.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
Two files changed in `auth-service`:
- `utils/user.util.js` — forwards `screenshot_url` to `mailer.feedback()`
- `utils/common/mailer.util.js` — builds an HTML email body with the screenshot rendered inline; plain-text fallback appends the Cloudinary URL

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feedback emails now include HTML-formatted message content (sanitized and newline-preserved) and will embed a screenshot image when a valid HTTPS screenshot URL is provided.
  * Plain-text feedback emails also include the screenshot URL when present.
  * Feedback submissions now pass screenshot URLs through to the support email flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->