### PR TITLE
fix: correct AccessToken scopes schema type from ObjectId to String

### DIFF
--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -35,7 +35,7 @@ const AccessTokenSchema = new mongoose.Schema(
       required: [true, "client_id is required!"],
     },
     permissions: [{ type: ObjectId, ref: "permission" }],
-    scopes: [{ type: ObjectId, ref: "scope" }],
+    scopes: [{ type: String }],
     name: { type: String, required: [true, "name is required!"] },
     token: {
       type: String,
@@ -222,7 +222,7 @@ AccessTokenSchema.statics = {
         .lookup({
           from: "scopes",
           localField: "scopes",
-          foreignField: "_id",
+          foreignField: "scope",
           as: "scopes",
         })
         .lookup({


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Changes the `scopes` field in `AccessTokenSchema` from `[{ type: ObjectId, ref: "scope" }]` to `[{ type: String }]`, and updates the `$lookup` stage in `AccessToken.list()` to join on `foreignField: "scope"` instead of `foreignField: "_id"`.

### Why is this change needed?
Every code path that writes scopes — `createAccessToken` in `token.util.js` and `findByIdAndUpdate` calls in `transaction.util.js` — stores plain string scope names sourced from `TIER_SCOPE_MAP` (e.g. `"read:recent_measurements"`). The schema declared `ObjectId` references, so Mongoose's `create()` in `register()` threw a cast validation error on every new token creation. The `findByIdAndUpdate` calls in the payment/subscription webhook never surfaced the bug because they bypass Mongoose validators by default.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Existing unit tests in `ut_access-token.model.js` use string values for scopes and continue to pass without modification. Manual verification confirmed `AccessToken.register()` no longer throws a cast error when `scopes` contains scope name strings from `TIER_SCOPE_MAP`.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The schema change is backward-compatible. Existing tokens with empty `scopes` arrays are unaffected. Any tokens whose `scopes` were already stored as strings (via `findByIdAndUpdate` on the payment webhook path) continue to work correctly. The `$lookup` change in `list()` correctly resolves scope name strings to Scope documents via the `scope` string field.

---

## :memo: Additional Notes

The `checkUriScope` function in `token.util.js` already treats scopes as strings (`effectiveScopes.includes(rule.scope)`), confirming that the entire scope enforcement stack is built around string scope names — not ObjectId references. The schema was the only outlier.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
