### PR TITLE
fix: prevent token loss on failed generation using atomic upsert

### DIFF
--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -61,6 +61,8 @@ const getDay = () => {
   return `${year}-${month}-${day}`;
 };
 
+const API_TOKEN_TTL_MS = 5110 * 3600 * 1000; // 7 months (matches AccessToken model)
+
 const createUnauthorizedResponse = () => {
   return {
     success: false,
@@ -1295,18 +1297,31 @@ const token = {
       // atomically. This avoids the delete-before-create pattern where a
       // failed register() would leave the user with no token at all.
       const tokenModel = AccessTokenModel(tenant.toLowerCase());
-      let expires = tokenCreationBody.expires;
-      if (isEmpty(expires)) {
-        expires =
-          Date.now() +
-          (5110 * 60 * 60 + 0 * 60 + 0) * 1000; // 7 months
-      }
+      const expires = tokenCreationBody.expires || Date.now() + API_TOKEN_TTL_MS;
 
-      const replacedDoc = await tokenModel.findOneAndReplace(
-        { client_id: ObjectId(client_id) },
-        { ...tokenCreationBody, expires },
-        { upsert: true, new: true, runValidators: true },
-      );
+      let replacedDoc;
+      try {
+        replacedDoc = await tokenModel.findOneAndReplace(
+          { client_id: ObjectId(client_id) },
+          { ...tokenCreationBody, expires },
+          {
+            upsert: true,
+            new: true,
+            runValidators: true,
+            setDefaultsOnInsert: true,
+          },
+        );
+      } catch (replaceErr) {
+        if (replaceErr.code === 11000) {
+          return {
+            success: false,
+            message: "A token already exists for one of the provided unique fields",
+            status: httpStatus.CONFLICT,
+            errors: { token: "the token must be unique" },
+          };
+        }
+        throw replaceErr;
+      }
 
       if (!replacedDoc) {
         return {

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1260,21 +1260,6 @@ const token = {
         )
         .toUpperCase();
 
-      // Remove any existing token for this client before creating a new one.
-      // The access_tokens collection enforces a unique index on client_id
-      // (one token per client). Without this, a second call for the same
-      // client hits E11000 from MongoDB. Deleting first makes the endpoint
-      // behave as a token refresh — the old token is immediately invalidated.
-      // Using deleteOne (Mongoose native) rather than the custom remove() static
-      // because remove() emits a logger.error when no document is found, which
-      // would fire on every first-time token creation (normal path).
-      // Note: delete-then-create is not fully atomic. In the unlikely event of
-      // two truly concurrent requests for the same client_id, one will win and
-      // the other will receive a 409 from the E11000 handler in register().
-      await AccessTokenModel(tenant.toLowerCase()).deleteOne({
-        client_id: ObjectId(client_id),
-      });
-
       // Resolve the user's current subscription tier so the new token is
       // stamped with the correct tier and scopes at creation time. Falls back
       // to Free if the user cannot be found — never throws.
@@ -1305,11 +1290,39 @@ const token = {
       tokenCreationBody.category = "api";
       tokenCreationBody.tier   = tokenTier;
       tokenCreationBody.scopes = tokenScopes;
-      const responseFromCreateToken = await AccessTokenModel(
-        tenant.toLowerCase(),
-      ).register(tokenCreationBody, next);
 
-      return responseFromCreateToken;
+      // Use findOneAndReplace with upsert so the old token is replaced
+      // atomically. This avoids the delete-before-create pattern where a
+      // failed register() would leave the user with no token at all.
+      const tokenModel = AccessTokenModel(tenant.toLowerCase());
+      let expires = tokenCreationBody.expires;
+      if (isEmpty(expires)) {
+        expires =
+          Date.now() +
+          (5110 * 60 * 60 + 0 * 60 + 0) * 1000; // 7 months
+      }
+
+      const replacedDoc = await tokenModel.findOneAndReplace(
+        { client_id: ObjectId(client_id) },
+        { ...tokenCreationBody, expires },
+        { upsert: true, new: true, runValidators: true },
+      );
+
+      if (!replacedDoc) {
+        return {
+          success: false,
+          message: "Token could not be created",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+          errors: { message: "findOneAndReplace returned null" },
+        };
+      }
+
+      return {
+        success: true,
+        message: "Token created",
+        status: httpStatus.OK,
+        data: replacedDoc,
+      };
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces the `deleteOne` + `register()` sequence in `createAccessToken` with a single atomic `findOneAndReplace({ upsert: true, new: true, runValidators: true })` call. Also corrects the `scopes` field type in `AccessTokenSchema` from `[ObjectId]` to `[String]`, and updates the `$lookup` in `AccessToken.list()` to join on `foreignField: "scope"` instead of `foreignField: "_id"`.

### Why is this change needed?
Users with an active API client were hitting "A record with these details already exists" on every "Generate Token" click and ending up with no usable token. The root cause was two compounding bugs:

1. **Schema type mismatch** — `AccessTokenSchema.scopes` was declared as `[ObjectId]` but every write path (`createAccessToken`, subscription webhook) stores plain string scope names from `TIER_SCOPE_MAP` (e.g. `"read:recent_measurements"`). Mongoose's `create()` runs full validation and throws a `CastError` on each attempt, returning a 409 that the frontend renders as "A record with these details already exists."

2. **Destructive ordering** — `deleteOne` ran unconditionally *before* `register()`. So on every failed generation attempt the user's existing token was deleted but no new token was written, leaving them with no token at all. The `findOneAndReplace` approach replaces both steps with one atomic operation: the old token is only evicted once the new document is successfully committed.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Existing unit tests in `ut_access-token.model.js` use string values for scopes and continue to pass without modification. Manual verification confirmed that "Generate Token" no longer returns a 409 and that a second click (when no prior token exists) also succeeds cleanly via the upsert path.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The schema change from `ObjectId` to `String` is backward-compatible. Existing tokens with empty `scopes` arrays are unaffected. Tokens already stored with string scopes via `findByIdAndUpdate` (payment webhook path, which bypasses Mongoose validators) continue to work correctly. The `$lookup` change in `list()` now correctly resolves scope name strings to Scope documents via the `scope` string field instead of `_id`.

The switch from `deleteOne` + `register()` to `findOneAndReplace` is externally transparent — the endpoint still behaves as a token refresh. The only observable difference is that a failure during token creation no longer silently destroys the user's existing token.

---

## :memo: Additional Notes

Users who had already clicked "Generate Token" one or more times before this fix will have had their existing token deleted by the old destructive flow. After this fix is deployed they can click "Generate Token" once more — the `upsert` path will create a fresh token with no manual intervention needed.

The `findByIdAndUpdate` calls in `transaction.util.js` (subscription upgrade/downgrade webhook) already bypass Mongoose validators, so those were never affected by the schema type mismatch and require no changes here.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access token creation to be more reliable and atomic, reducing race conditions during token replacement.
  * Added default token expiry handling when not provided, preventing unexpected token lifetimes.
  * Better handling of token conflicts and unexpected failures, returning clearer error outcomes for token operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->