### PR TITLE
feat: replace Redis usage counters with stable MongoDB ApiUsageCounter model

### DIFF
--- a/src/auth-service/models/ApiUsageCounter.js
+++ b/src/auth-service/models/ApiUsageCounter.js
@@ -1,0 +1,46 @@
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+
+const ApiUsageCounterSchema = new mongoose.Schema(
+  {
+    user_id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+    period: {
+      type: String,
+      enum: ["hourly", "daily", "monthly"],
+      required: true,
+    },
+    // Sortable string key that identifies the window:
+    // hourly  → "YYYYMMDDHH"   e.g. "2026052014"
+    // daily   → "YYYYMMDD"     e.g. "20260520"
+    // monthly → "YYYYMM"       e.g. "202605"
+    window_key: {
+      type: String,
+      required: true,
+    },
+    count: {
+      type: Number,
+      default: 0,
+    },
+    // TTL field — MongoDB removes the document automatically after this date.
+    expires_at: {
+      type: Date,
+      required: true,
+    },
+  },
+  { timestamps: false }
+);
+
+// Unique compound index — one document per user per period per window.
+ApiUsageCounterSchema.index(
+  { user_id: 1, period: 1, window_key: 1 },
+  { unique: true }
+);
+
+// TTL index — MongoDB deletes documents once expires_at is in the past.
+ApiUsageCounterSchema.index({ expires_at: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = (tenant) =>
+  getModelByTenant(tenant, "api_usage_counter", ApiUsageCounterSchema);

--- a/src/auth-service/models/test/ut_api-usage-counter.model.js
+++ b/src/auth-service/models/test/ut_api-usage-counter.model.js
@@ -1,0 +1,105 @@
+require("module-alias/register");
+const chai = require("chai");
+const expect = chai.expect;
+const mongoose = require("mongoose");
+const ApiUsageCounterModel = require("@models/ApiUsageCounter");
+
+describe("ApiUsageCounterSchema", () => {
+  let Model;
+
+  before(() => {
+    Model = ApiUsageCounterModel("airqo");
+  });
+
+  describe("schema field validation", () => {
+    it("should reject a document missing user_id", () => {
+      const doc = new Model({
+        period: "hourly",
+        window_key: "2026052014",
+        expires_at: new Date(),
+      });
+      const err = doc.validateSync();
+      expect(err).to.exist;
+      expect(err.errors).to.have.property("user_id");
+    });
+
+    it("should reject a document with an invalid period value", () => {
+      const doc = new Model({
+        user_id: new mongoose.Types.ObjectId(),
+        period: "weekly",
+        window_key: "2026052014",
+        expires_at: new Date(),
+      });
+      const err = doc.validateSync();
+      expect(err).to.exist;
+      expect(err.errors).to.have.property("period");
+    });
+
+    it("should reject a document missing window_key", () => {
+      const doc = new Model({
+        user_id: new mongoose.Types.ObjectId(),
+        period: "daily",
+        expires_at: new Date(),
+      });
+      const err = doc.validateSync();
+      expect(err).to.exist;
+      expect(err.errors).to.have.property("window_key");
+    });
+
+    it("should reject a document missing expires_at", () => {
+      const doc = new Model({
+        user_id: new mongoose.Types.ObjectId(),
+        period: "monthly",
+        window_key: "202605",
+      });
+      const err = doc.validateSync();
+      expect(err).to.exist;
+      expect(err.errors).to.have.property("expires_at");
+    });
+
+    it("should default count to 0 when not provided", () => {
+      const doc = new Model({
+        user_id: new mongoose.Types.ObjectId(),
+        period: "hourly",
+        window_key: "2026052014",
+        expires_at: new Date(),
+      });
+      expect(doc.count).to.equal(0);
+    });
+
+    it("should pass validation for a fully valid document", () => {
+      const doc = new Model({
+        user_id: new mongoose.Types.ObjectId(),
+        period: "daily",
+        window_key: "20260520",
+        count: 5,
+        expires_at: new Date(Date.now() + 86400000 * 3),
+      });
+      const err = doc.validateSync();
+      expect(err).to.be.undefined;
+    });
+  });
+
+  describe("index definitions", () => {
+    it("should define a unique compound index on {user_id, period, window_key}", () => {
+      const indexes = Model.schema.indexes();
+      const compound = indexes.find(
+        ([fields, opts]) =>
+          fields.user_id === 1 &&
+          fields.period === 1 &&
+          fields.window_key === 1 &&
+          opts.unique === true
+      );
+      expect(compound).to.exist;
+    });
+
+    it("should define a TTL index on expires_at with expireAfterSeconds: 0", () => {
+      const indexes = Model.schema.indexes();
+      const ttl = indexes.find(
+        ([fields, opts]) =>
+          fields.expires_at === 1 && opts.expireAfterSeconds === 0
+      );
+      expect(ttl).to.exist;
+    });
+  });
+});

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -170,14 +170,27 @@ const _incrementUsageCounters = (userId) => {
     ? new mongoose.Types.ObjectId(String(userId))
     : userId;
 
-  const upsert = (period, window_key, expires_at) =>
-    Model.findOneAndUpdate(
-      { user_id: uid, period, window_key },
-      { $inc: { count: 1 }, $setOnInsert: { expires_at } },
-      { upsert: true, new: false }
-    ).catch((err) =>
-      logger.error(`Non-critical: usage counter upsert failed (${period}): ${err.message}`)
-    );
+  const upsert = async (period, window_key, expires_at) => {
+    try {
+      await Model.findOneAndUpdate(
+        { user_id: uid, period, window_key },
+        { $inc: { count: 1 }, $setOnInsert: { expires_at } },
+        { upsert: true, new: false }
+      );
+    } catch (err) {
+      if (err.code === 11000) {
+        // Concurrent insert race — document now exists; retry increment without upsert
+        await Model.findOneAndUpdate(
+          { user_id: uid, period, window_key },
+          { $inc: { count: 1 } }
+        ).catch((retryErr) =>
+          logger.error(`Non-critical: usage counter retry failed (${period}): ${retryErr.message}`)
+        );
+      } else {
+        logger.error(`Non-critical: usage counter upsert failed (${period}): ${err.message}`);
+      }
+    }
+  };
 
   Promise.all([
     upsert("hourly",  hourKey,  hourExpiry),

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1,3 +1,4 @@
+const ApiUsageCounterModel = require("@models/ApiUsageCounter");
 const BlacklistedIPModel = require("@models/BlacklistedIP");
 const BlacklistedIPPrefixModel = require("@models/BlacklistedIPPrefix");
 const IPPrefixModel = require("@models/IPPrefix");
@@ -140,6 +141,48 @@ const _checkRlCounter = async (key, limit, ttlSec, ttlMs) => {
     logger.error(`Non-critical: rate limit counter failed for key=${key}: ${err.message}`);
     return true; // Fail open
   }
+};
+
+/**
+ * Atomically increment the MongoDB-backed API usage counters for a user.
+ * Writes hourly, daily, and monthly documents in parallel via upsert + $inc.
+ * Fire-and-forget — never throws; errors are logged and swallowed.
+ */
+const _incrementUsageCounters = (userId) => {
+  const now = new Date();
+  const year  = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day   = String(now.getUTCDate()).padStart(2, "0");
+  const hour  = String(now.getUTCHours()).padStart(2, "0");
+
+  const hourKey  = `${year}${month}${day}${hour}`;
+  const dayKey   = `${year}${month}${day}`;
+  const monthKey = `${year}${month}`;
+
+  // expires_at values — generous buffer beyond the window end
+  const hourExpiry  = new Date(Date.UTC(year, now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 2));
+  const dayExpiry   = new Date(Date.UTC(year, now.getUTCMonth(), now.getUTCDate() + 2));
+  const monthExpiry = new Date(Date.UTC(year, now.getUTCMonth() + 2, 1));
+
+  const Model = ApiUsageCounterModel("airqo");
+  const uid   = mongoose.Types.ObjectId.isValid(userId)
+    ? new mongoose.Types.ObjectId(String(userId))
+    : userId;
+
+  const upsert = (period, window_key, expires_at) =>
+    Model.findOneAndUpdate(
+      { user_id: uid, period, window_key },
+      { $inc: { count: 1 }, $setOnInsert: { expires_at } },
+      { upsert: true, new: false }
+    ).catch((err) =>
+      logger.error(`Non-critical: usage counter upsert failed (${period}): ${err.message}`)
+    );
+
+  Promise.all([
+    upsert("hourly",  hourKey,  hourExpiry),
+    upsert("daily",   dayKey,   dayExpiry),
+    upsert("monthly", monthKey, monthExpiry),
+  ]).catch(() => {});
 };
 
 /**
@@ -1108,6 +1151,11 @@ const token = {
                 `Non-critical: scope check failed, allowing through: ${scopeErr.message}`
               );
             }
+          }
+
+          // Fire-and-forget: increment MongoDB usage counters (hourly/daily/monthly).
+          if (client.user_id) {
+            _incrementUsageCounters(client.user_id);
           }
 
           // Fire-and-forget: record API token usage as user activity so that
@@ -2860,45 +2908,47 @@ const token = {
   },
 
   /**
-   * Read current Redis rate-limit counters and return usage stats.
-   * Returns null for a period when Redis is unavailable or the key doesn't exist yet.
+   * Read MongoDB usage counters and return usage stats for the billing dashboard.
+   * Returns 0 when no calls have been made in the current window.
+   * Returns null only if the DB query itself fails.
    * The shape matches what the frontend UsageStats component expects.
    */
   getApiUsageStats: async (userId, tier) => {
     const limits  = TIER_RATE_LIMITS[tier] || TIER_RATE_LIMITS.Free;
-    const now     = Date.now();
-    const nowDate = new Date();
+    const now     = new Date();
+    const year    = now.getUTCFullYear();
+    const month   = String(now.getUTCMonth() + 1).padStart(2, "0");
+    const day     = String(now.getUTCDate()).padStart(2, "0");
+    const hour    = String(now.getUTCHours()).padStart(2, "0");
 
-    // ---- hourly ----
-    const hourSlot      = Math.floor(now / 3600000);
-    const hourKeyExpiry = (hourSlot + 1) * 3600000; // next slot start = reset time
-    const hourResetTime = new Date(hourKeyExpiry).toISOString();
+    const hourKey  = `${year}${month}${day}${hour}`;
+    const dayKey   = `${year}${month}${day}`;
+    const monthKey = `${year}${month}`;
 
-    // ---- daily ----
-    const daySlot      = Math.floor(now / 86400000);
-    const dayKeyExpiry = (daySlot + 1) * 86400000;
-    const dayResetTime = new Date(dayKeyExpiry).toISOString();
+    const hourResetTime  = new Date(Date.UTC(year, now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 1)).toISOString();
+    const dayResetTime   = new Date(Date.UTC(year, now.getUTCMonth(), now.getUTCDate() + 1)).toISOString();
+    const monthResetTime = new Date(Date.UTC(year, now.getUTCMonth() + 1, 1)).toISOString();
 
-    // ---- monthly ----
-    const year        = nowDate.getUTCFullYear();
-    const month       = nowDate.getUTCMonth(); // 0-based
-    const monthSlot   = year * 100 + (month + 1);
-    const nextMonth   = new Date(Date.UTC(year, month + 1, 1));
-    const monthResetTime = nextMonth.toISOString();
+    const uid = mongoose.Types.ObjectId.isValid(userId)
+      ? new mongoose.Types.ObjectId(String(userId))
+      : userId;
 
-    const readCounter = async (key) => {
+    const readCounter = async (period, window_key) => {
       try {
-        const raw = await redisGetAsync(key);
-        return raw !== null && raw !== undefined ? parseInt(raw, 10) : null;
+        const doc = await ApiUsageCounterModel("airqo")
+          .findOne({ user_id: uid, period, window_key })
+          .select("count")
+          .lean();
+        return doc ? doc.count : 0;
       } catch (_err) {
         return null;
       }
     };
 
     const [hourUsed, dayUsed, monthUsed] = await Promise.all([
-      readCounter(`rl:tv:${userId}:${hourSlot}`),
-      readCounter(`rl:tv:d:${userId}:${daySlot}`),
-      readCounter(`rl:tv:m:${userId}:${monthSlot}`),
+      readCounter("hourly",  hourKey),
+      readCounter("daily",   dayKey),
+      readCounter("monthly", monthKey),
     ]);
 
     return {

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -159,10 +159,11 @@ const _incrementUsageCounters = (userId) => {
   const dayKey   = `${year}${month}${day}`;
   const monthKey = `${year}${month}`;
 
-  // expires_at values — generous buffer beyond the window end
-  const hourExpiry  = new Date(Date.UTC(year, now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 2));
-  const dayExpiry   = new Date(Date.UTC(year, now.getUTCMonth(), now.getUTCDate() + 2));
-  const monthExpiry = new Date(Date.UTC(year, now.getUTCMonth() + 2, 1));
+  // expires_at = end of current window + 2-unit buffer.
+  // +1 advances to the next window boundary; +2 adds the post-reset buffer.
+  const hourExpiry  = new Date(Date.UTC(year, now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 3));
+  const dayExpiry   = new Date(Date.UTC(year, now.getUTCMonth(), now.getUTCDate() + 3));
+  const monthExpiry = new Date(Date.UTC(year, now.getUTCMonth() + 3, 1));
 
   const Model = ApiUsageCounterModel("airqo");
   const uid   = mongoose.Types.ObjectId.isValid(userId)


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces Redis-based API usage counter reads with a new MongoDB-backed `ApiUsageCounter` collection. Introduces a fire-and-forget `_incrementUsageCounters()` helper that atomically upserts hourly, daily, and monthly counters in MongoDB on every successful API token verification. Updates `getApiUsageStats()` to read from MongoDB, returning `0` when no calls have been made in the current window and `null` only on DB failure.

### Why is this change needed?
The previous implementation read usage stats from Redis rate-limit counters, which returned `null` whenever Redis was unavailable — a frequent occurrence in our staging and production environments due to Redis instability. The billing dashboard (`GET /users/transactions/usage`) was therefore unreliable for end users. MongoDB is significantly more stable and is the appropriate store for data that must be reliably readable on the billing page. A TTL index on `expires_at` ensures old counter documents are purged automatically, preventing disk bloat.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified `GET /users/transactions/usage` returns `0` (not `null`) when the user has not yet made API-token calls in the current window. Verified counter documents are created in MongoDB with the correct `window_key`, `count`, and `expires_at` values after a token verification. All 19 existing unit tests pass. Redis instability no longer affects the response.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The response shape of `GET /users/transactions/usage` is unchanged. `used` now returns `0` instead of `null` when no calls have been made — this is a behavioural improvement, not a breaking change.

---

## :memo: Additional Notes

**Changes in detail:**

1. **`models/ApiUsageCounter.js`** (new) — Mongoose schema with:
   - Unique compound index on `{user_id, period, window_key}` — one document per user per window, prevents duplicates
   - TTL index on `expires_at` (`expireAfterSeconds: 0`) — MongoDB deletes documents automatically once the field date passes. Expiry is set to `+3` units from the window start: `+1` reaches the next window boundary, `+2` adds a post-reset buffer. E.g. an hourly counter at 14:xx expires at 17:00 UTC.
   - Window key format: `YYYYMMDDHH` (hourly), `YYYYMMDD` (daily), `YYYYMM` (monthly)

2. **`utils/token.util.js`** — Two changes:
   - `_incrementUsageCounters(userId)` — fires on every successful token verification alongside the existing `lastActiveAt` update. Uses `findOneAndUpdate` with `$inc: { count: 1 }` and `$setOnInsert: { expires_at }` to atomically create or increment. Fully fire-and-forget — errors are caught and logged, never blocking the token response.
   - `getApiUsageStats(userId, tier)` — now queries `ApiUsageCounter` for the current hourly, daily, and monthly `window_key`. Returns `0` when the document doesn't exist (no calls this window), `null` if the DB query itself throws.

**Redis is still used** for rate-limit enforcement (the `ENABLE_*_RATE_LIMITING` flags and `rl:tv:*` keys) — only the usage stats read path has moved to MongoDB.

**On the first deploy:** existing users will see `0` for all periods until their next API token call creates counter documents. This is correct and expected.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review
