### PR TITLE
Fix site forecast sources and run-date anchoring

### DIFF
--- a/src/workflows/airqo_etl_utils/bigquery_api.py
+++ b/src/workflows/airqo_etl_utils/bigquery_api.py
@@ -1396,7 +1396,7 @@ class BigQueryApi:
             sites_table=f"`{self.sites_table}`",
             start_date=str(start_date),
             end_date=str(end_date),
-            min_hours=2,
+            min_hours=min_hours,
         )
 
         try:

--- a/src/workflows/airqo_etl_utils/ml_utils.py
+++ b/src/workflows/airqo_etl_utils/ml_utils.py
@@ -1901,6 +1901,7 @@ class ForecastModelTrainer(BaseMlUtils):
         raw_data: pd.DataFrame,
         *,
         horizon: Optional[int] = None,
+        forecast_start_date: Optional[Any] = None,
         run_timestamp: Optional[pd.Timestamp] = None,
         include_met_no_weather: bool = True,
     ) -> pd.DataFrame:
@@ -1953,17 +1954,39 @@ class ForecastModelTrainer(BaseMlUtils):
         else:
             run_timestamp = run_timestamp.tz_convert("UTC")
 
-        recursive_history = history[["site_id", "site_name", "day", "pm25_mean"]].copy()
+        first_forecast_day = None
+        if forecast_start_date is not None:
+            first_forecast_day = pd.Timestamp(forecast_start_date).normalize()
+            if first_forecast_day.tzinfo is not None:
+                first_forecast_day = first_forecast_day.tz_convert("UTC").tz_localize(
+                    None
+                )
+
         site_meta = ForecastModelTrainer._resolve_site_forecast_metadata(history)
+        recursive_history = history[["site_id", "site_name", "day", "pm25_mean"]].copy()
+        if first_forecast_day is not None:
+            recursive_history = recursive_history.loc[
+                recursive_history["day"] < first_forecast_day
+            ].copy()
         predictions: List[pd.DataFrame] = []
 
-        for _ in range(horizon):
-            next_rows = (
-                recursive_history.groupby("site_id", as_index=False)["day"]
-                .max()
-                .assign(day=lambda df: df["day"] + pd.Timedelta(days=1))
-                .merge(site_meta, on="site_id", how="left")
-            )
+        for step in range(horizon):
+            if first_forecast_day is None:
+                next_rows = (
+                    recursive_history.groupby("site_id", as_index=False)["day"]
+                    .max()
+                    .assign(day=lambda df: df["day"] + pd.Timedelta(days=1))
+                    .merge(site_meta, on="site_id", how="left")
+                )
+            else:
+                forecast_day = first_forecast_day + pd.Timedelta(days=step)
+                next_rows = (
+                    site_meta[
+                        ["site_id", "site_name", "site_latitude", "site_longitude"]
+                    ]
+                    .copy()
+                    .assign(day=forecast_day)
+                )
             next_rows["pm25_mean"] = np.nan
 
             feature_source = pd.concat(
@@ -3124,85 +3147,38 @@ class ForecastModelTrainer(BaseMlUtils):
                 {key: value for key, value in document.items() if not pd.isna(value)}
             )
 
-        insert_only_fields = {"site_id", "timestamp", "site_name", "created_at"}
-        bulk_operations = []
-        for record in records:
-            update_doc = {
-                "$set": {
-                    key: value
-                    for key, value in record.items()
-                    if key not in insert_only_fields
-                },
-                "$setOnInsert": {
-                    key: value
-                    for key, value in record.items()
-                    if key in insert_only_fields
-                },
-            }
-            if not update_doc["$set"]:
-                del update_doc["$set"]
-            bulk_operations.append(
-                pm.UpdateOne(
-                    {
-                        "site_id": record["site_id"],
-                        "timestamp": record["timestamp"],
-                    },
-                    update_doc,
-                    upsert=True,
-                )
-            )
         retention_hours = int(configuration.SITE_HOURLY_FORECAST_HORIZON_HOURS or 240)
         retention_cutoff = (
             pd.Timestamp.utcnow() - pd.Timedelta(hours=retention_hours)
         ).to_pydatetime()
-        batch_size = int(
-            getattr(configuration, "MONGO_BULK_WRITE_BATCH_SIZE", 500) or 500
+        configured_batch_size = int(
+            getattr(configuration, "MONGO_BULK_WRITE_BATCH_SIZE", 5000) or 5000
         )
+        batch_size = max(configured_batch_size, 5000)
         deleted_rows = 0
-        bulk_batches = 0
+        inserted_rows = 0
+        insert_batches = 0
 
         with pm.MongoClient(
             configuration.MONGO_URI, serverSelectionTimeoutMS=5000
         ) as client:
             mongo_db = client[configuration.MONGO_DATABASE_NAME]
             collection = mongo_db[collection_name]
-            if bulk_operations:
-                for i in range(0, len(bulk_operations), batch_size):
-                    collection.bulk_write(
-                        bulk_operations[i : i + batch_size], ordered=False
+            collection.create_index(
+                [("site_id", 1), ("timestamp", 1)],
+                background=True,
+            )
+            if site_ids:
+                deleted_rows += collection.delete_many(
+                    {"site_id": {"$in": site_ids}}
+                ).deleted_count
+            if records:
+                for i in range(0, len(records), batch_size):
+                    result = collection.insert_many(
+                        records[i : i + batch_size], ordered=False
                     )
-                    bulk_batches += 1
-                if site_ids:
-                    existing_docs = list(
-                        collection.find(
-                            {"site_id": {"$in": site_ids}},
-                            {"_id": 1, "site_id": 1, "timestamp": 1},
-                        )
-                    )
-                    if existing_docs:
-                        existing = pd.DataFrame(existing_docs)
-                        existing["timestamp"] = pd.to_datetime(
-                            existing["timestamp"], utc=True, errors="coerce"
-                        )
-                        retained_ids = set(
-                            existing.dropna(subset=["timestamp"])
-                            .sort_values(
-                                ["site_id", "timestamp"],
-                                ascending=[True, False],
-                            )
-                            .groupby("site_id", group_keys=False)
-                            .head(retention_hours)["_id"]
-                            .tolist()
-                        )
-                        stale_ids = [
-                            doc["_id"]
-                            for doc in existing_docs
-                            if doc["_id"] not in retained_ids
-                        ]
-                        if stale_ids:
-                            deleted_rows += collection.delete_many(
-                                {"_id": {"$in": stale_ids}}
-                            ).deleted_count
+                    inserted_rows += len(result.inserted_ids)
+                    insert_batches += 1
                 deleted_rows += collection.delete_many(
                     {"timestamp": {"$lt": retention_cutoff}}
                 ).deleted_count
@@ -3211,7 +3187,8 @@ class ForecastModelTrainer(BaseMlUtils):
             "rows": len(records),
             "collection": collection_name,
             "deleted_rows": deleted_rows,
-            "bulk_batches": bulk_batches,
+            "inserted_rows": inserted_rows,
+            "insert_batches": insert_batches,
             "bulk_batch_size": batch_size,
         }
 

--- a/src/workflows/airqo_etl_utils/tests/conftest.py
+++ b/src/workflows/airqo_etl_utils/tests/conftest.py
@@ -452,7 +452,7 @@ class ForecastFixtures:
     def feat_eng_sample_df_hourly():
         data = {
             "timestamp": pd.date_range(
-                end=pd.Timestamp.now(), periods=24 * 14, freq="H"
+                end=pd.Timestamp.now(), periods=24 * 14, freq="h"
             ).tolist(),
             "device_id": ["device1"] * 24 * 14,
             "pm2_5": range(1, 24 * 14 + 1),
@@ -509,7 +509,7 @@ class ForecastFixtures:
                 "site_id": ["site1", "site1", "site2"],
                 "device_number": [1, 1, 2],
                 "pm2_5": [10.0, 15.0, 20.0],
-                "timestamp": pd.date_range("2023-01-01", periods=3, freq="H").tolist(),
+                "timestamp": pd.date_range("2023-01-01", periods=3, freq="h").tolist(),
             }
         )
 

--- a/src/workflows/airqo_etl_utils/tests/conftest.py
+++ b/src/workflows/airqo_etl_utils/tests/conftest.py
@@ -441,7 +441,9 @@ class ForecastFixtures:
     @pytest.fixture
     def feat_eng_sample_df_daily():
         data = {
-            "timestamp": pd.date_range(end=pd.Timestamp.now(), periods=365).tolist(),
+            "timestamp": pd.date_range(
+                end=pd.Timestamp("2025-12-31"), periods=365
+            ).tolist(),
             "device_id": ["device1"] * 365,
             "pm2_5": range(1, 366),
         }
@@ -452,7 +454,7 @@ class ForecastFixtures:
     def feat_eng_sample_df_hourly():
         data = {
             "timestamp": pd.date_range(
-                end=pd.Timestamp.now(), periods=24 * 14, freq="h"
+                end=pd.Timestamp("2025-01-14 23:00:00"), periods=24 * 14, freq="h"
             ).tolist(),
             "device_id": ["device1"] * 24 * 14,
             "pm2_5": range(1, 24 * 14 + 1),
@@ -463,7 +465,9 @@ class ForecastFixtures:
     @pytest.fixture
     def sample_dataframe_for_location_features():
         data = {
-            "timestamp": pd.date_range(end=pd.Timestamp.now(), periods=100).tolist(),
+            "timestamp": pd.date_range(
+                end=pd.Timestamp("2025-04-10"), periods=100
+            ).tolist(),
             "device_id": ["device1"] * 100,
             "latitude": np.random.uniform(-90, 90, 100),
             "longitude": np.random.uniform(-180, 180, 100),

--- a/src/workflows/airqo_etl_utils/tests/test_ml_utils.py
+++ b/src/workflows/airqo_etl_utils/tests/test_ml_utils.py
@@ -355,6 +355,71 @@ def test_generate_site_daily_forecasts_with_synthetic_data(monkeypatch):
         assert forecasts[column].equals(rounded)
 
 
+def test_generate_site_daily_forecasts_starts_on_requested_date_for_all_sites(
+    monkeypatch,
+):
+    synthetic_history = build_synthetic_site_forecast_history(
+        num_sites=2,
+        num_days=30,
+        seed=13,
+        start_date="2026-04-01",
+    )
+    feature_columns = [
+        "day_of_week",
+        "day_of_year",
+        "month",
+        "pm25_mean_lag_1",
+        "pm25_mean_lag_2",
+        "pm25_mean_lag_3",
+        "pm25_mean_lag_7",
+        "pm25_mean_lag_14",
+        "roll7_mean",
+        "roll7_std",
+        "roll14_mean",
+        "roll14_std",
+        "site_id_code",
+    ]
+    site_mapping = {
+        site_id: idx
+        for idx, site_id in enumerate(sorted(synthetic_history["site_id"].unique()))
+    }
+
+    monkeypatch.setattr(
+        ForecastModelTrainer,
+        "_load_site_forecast_artifacts",
+        staticmethod(
+            lambda: {
+                label: {
+                    "model": DummyForecastModel(offset),
+                    "features": feature_columns,
+                    "site_id_mapping": site_mapping,
+                }
+                for label, offset in {
+                    "mean": 0.5,
+                    "min": -1.0,
+                    "max": 2.0,
+                    "low": -0.5,
+                    "high": 1.5,
+                }.items()
+            }
+        ),
+    )
+
+    forecasts = ForecastModelTrainer.generate_site_daily_forecasts(
+        synthetic_history,
+        horizon=2,
+        forecast_start_date="2026-05-20",
+        include_met_no_weather=False,
+    )
+
+    assert forecasts["site_id"].nunique() == 2
+    assert sorted(forecasts["date"].unique()) == [
+        datetime(2026, 5, 20).date(),
+        datetime(2026, 5, 21).date(),
+    ]
+    assert forecasts.groupby("site_id")["date"].nunique().eq(2).all()
+
+
 def test_fetch_site_prediction_data_includes_execution_day_and_allows_sparse_rows(
     monkeypatch,
 ):

--- a/src/workflows/airqo_etl_utils/tests/test_site_hourly_forecast.py
+++ b/src/workflows/airqo_etl_utils/tests/test_site_hourly_forecast.py
@@ -206,7 +206,6 @@ def test_save_site_hourly_forecasts_to_mongo_replaces_existing_site_rows(monkeyp
     )
 
     mock_collection = MagicMock()
-    mock_collection.find.return_value = []
     mock_collection.delete_many.return_value.deleted_count = 0
 
     mock_db = MagicMock()
@@ -232,36 +231,42 @@ def test_save_site_hourly_forecasts_to_mongo_replaces_existing_site_rows(monkeyp
         lambda *args, **kwargs: mock_client_manager,
     )
 
+    insert_result = MagicMock()
+    insert_result.inserted_ids = [1, 2]
+    mock_collection.insert_many.return_value = insert_result
+
     result = ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(forecasts)
 
-    mock_collection.bulk_write.assert_called_once()
-    assert mock_collection.bulk_write.call_args.kwargs["ordered"] is False
-    bulk_operations = mock_collection.bulk_write.call_args.args[0]
-    assert len(bulk_operations) == 2
-    assert all(operation._upsert for operation in bulk_operations)
-    assert bulk_operations[0]._filter == {
-        "site_id": "site-1",
-        "timestamp": pd.Timestamp("2026-03-04T08:00:00Z").to_pydatetime(),
-    }
-    assert bulk_operations[0]._doc["$set"]["pm2_5_mean"] == 12.1
-    assert bulk_operations[0]._doc["$setOnInsert"] == {
-        "site_name": "Makerere",
-        "site_id": "site-1",
-        "timestamp": pd.Timestamp("2026-03-04T08:00:00Z").to_pydatetime(),
-        "created_at": pd.Timestamp("2026-03-04T08:00:00Z").to_pydatetime(),
-    }
-    mock_collection.delete_many.assert_called_once()
-    delete_filter = mock_collection.delete_many.call_args.args[0]
+    mock_collection.bulk_write.assert_not_called()
+    mock_collection.delete_many.assert_any_call({"site_id": {"$in": ["site-1"]}})
+    mock_collection.insert_many.assert_called_once()
+    assert mock_collection.insert_many.call_args.kwargs["ordered"] is False
+    inserted_documents = mock_collection.insert_many.call_args.args[0]
+    assert len(inserted_documents) == 2
+    assert inserted_documents[0]["site_id"] == "site-1"
+    assert inserted_documents[0]["timestamp"] == pd.Timestamp(
+        "2026-03-04T08:00:00Z"
+    ).to_pydatetime()
+    assert inserted_documents[0]["pm2_5_mean"] == 12.1
+    assert inserted_documents[0]["site_name"] == "Makerere"
+    assert inserted_documents[0]["created_at"] == pd.Timestamp(
+        "2026-03-04T08:00:00Z"
+    ).to_pydatetime()
+    assert mock_collection.delete_many.call_count == 2
+    delete_filter = mock_collection.delete_many.call_args_list[1].args[0]
     assert set(delete_filter.keys()) == {"timestamp"}
     assert set(delete_filter["timestamp"].keys()) == {"$lt"}
-    mock_collection.insert_many.assert_not_called()
-    mock_collection.create_index.assert_not_called()
+    mock_collection.create_index.assert_called_once_with(
+        [("site_id", 1), ("timestamp", 1)],
+        background=True,
+    )
     assert result == {
         "rows": 2,
         "collection": "site_hourly_forecasts",
         "deleted_rows": 0,
-        "bulk_batches": 1,
-        "bulk_batch_size": 500,
+        "inserted_rows": 2,
+        "insert_batches": 1,
+        "bulk_batch_size": 5000,
     }
 
 
@@ -288,7 +293,6 @@ def test_save_site_hourly_forecasts_to_mongo_preserves_existing_met_fields(
     )
 
     mock_collection = MagicMock()
-    mock_collection.find.return_value = []
     mock_collection.delete_many.return_value.deleted_count = 0
 
     mock_db = MagicMock()
@@ -314,16 +318,20 @@ def test_save_site_hourly_forecasts_to_mongo_preserves_existing_met_fields(
         lambda *args, **kwargs: mock_client_manager,
     )
 
+    insert_result = MagicMock()
+    insert_result.inserted_ids = [1]
+    mock_collection.insert_many.return_value = insert_result
+
     ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(forecasts)
 
-    bulk_operations = mock_collection.bulk_write.call_args.args[0]
-    update_doc = bulk_operations[0]._doc
-    assert "air_temperature" not in update_doc["$set"]
-    assert "relative_humidity" not in update_doc["$set"]
-    assert "site_name" not in update_doc["$set"]
-    assert "created_at" not in update_doc["$set"]
-    assert update_doc["$set"]["pm2_5_mean"] == 12.1
-    assert update_doc["$setOnInsert"]["site_name"] == "Makerere"
+    inserted_documents = mock_collection.insert_many.call_args.args[0]
+    assert "air_temperature" not in inserted_documents[0]
+    assert "relative_humidity" not in inserted_documents[0]
+    assert inserted_documents[0]["site_name"] == "Makerere"
+    assert inserted_documents[0]["created_at"] == pd.Timestamp(
+        "2026-03-04T08:00:00Z"
+    ).to_pydatetime()
+    assert inserted_documents[0]["pm2_5_mean"] == 12.1
 
 
 def test_save_site_hourly_forecasts_to_mongo_prunes_old_rows(monkeypatch):
@@ -343,34 +351,18 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_old_rows(monkeypatch):
             }
         ]
     )
-    existing_docs = [
-        {
-            "_id": 1,
-            "site_id": "site-1",
-            "timestamp": pd.Timestamp("2026-03-04T08:00:00Z").to_pydatetime(),
-        },
-        {
-            "_id": 2,
-            "site_id": "site-1",
-            "timestamp": pd.Timestamp("2026-03-04T09:00:00Z").to_pydatetime(),
-        },
-        {
-            "_id": 3,
-            "site_id": "site-1",
-            "timestamp": pd.Timestamp("2026-03-04T10:00:00Z").to_pydatetime(),
-        },
-    ]
-
     mock_collection = MagicMock()
-    mock_collection.find.return_value = existing_docs
     stale_delete_result = MagicMock()
-    stale_delete_result.deleted_count = 1
+    stale_delete_result.deleted_count = 3
     expired_delete_result = MagicMock()
     expired_delete_result.deleted_count = 0
     mock_collection.delete_many.side_effect = [
         stale_delete_result,
         expired_delete_result,
     ]
+    insert_result = MagicMock()
+    insert_result.inserted_ids = [1]
+    mock_collection.insert_many.return_value = insert_result
 
     mock_db = MagicMock()
     mock_db.__getitem__.return_value = mock_collection
@@ -400,9 +392,9 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_old_rows(monkeypatch):
 
     result = ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(forecasts)
 
-    mock_collection.bulk_write.assert_called_once()
+    mock_collection.bulk_write.assert_not_called()
     assert mock_collection.delete_many.call_args_list[0].args[0] == {
-        "_id": {"$in": [1]}
+        "site_id": {"$in": ["site-1"]}
     }
     timestamp_delete_filter = mock_collection.delete_many.call_args_list[1].args[0]
     assert set(timestamp_delete_filter.keys()) == {"timestamp"}
@@ -410,9 +402,10 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_old_rows(monkeypatch):
     assert result == {
         "rows": 1,
         "collection": "site_hourly_forecasts",
-        "deleted_rows": 1,
-        "bulk_batches": 1,
-        "bulk_batch_size": 500,
+        "deleted_rows": 3,
+        "inserted_rows": 1,
+        "insert_batches": 1,
+        "bulk_batch_size": 5000,
     }
 
 
@@ -437,8 +430,10 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_expired_rows_for_absent_site
     )
 
     mock_collection = MagicMock()
-    mock_collection.find.return_value = []
     mock_collection.delete_many.return_value.deleted_count = 4
+    insert_result = MagicMock()
+    insert_result.inserted_ids = [1]
+    mock_collection.insert_many.return_value = insert_result
 
     mock_db = MagicMock()
     mock_db.__getitem__.return_value = mock_collection
@@ -468,16 +463,21 @@ def test_save_site_hourly_forecasts_to_mongo_prunes_expired_rows_for_absent_site
 
     result = ForecastModelTrainer.save_site_hourly_forecasts_to_mongo(forecasts)
 
-    mock_collection.delete_many.assert_called_once()
-    delete_filter = mock_collection.delete_many.call_args.args[0]
+    assert mock_collection.delete_many.call_count == 2
+    site_delete_filter = mock_collection.delete_many.call_args_list[0].args[0]
+    assert site_delete_filter == {
+        "site_id": {"$in": ["site-1"]}
+    }
+    delete_filter = mock_collection.delete_many.call_args_list[1].args[0]
     assert set(delete_filter.keys()) == {"timestamp"}
     assert set(delete_filter["timestamp"].keys()) == {"$lt"}
     assert result == {
         "rows": 1,
         "collection": "site_hourly_forecasts",
-        "deleted_rows": 4,
-        "bulk_batches": 1,
-        "bulk_batch_size": 500,
+        "deleted_rows": 8,
+        "inserted_rows": 1,
+        "insert_batches": 1,
+        "bulk_batch_size": 5000,
     }
 
 

--- a/src/workflows/dags/forecast_prediction_jobs.py
+++ b/src/workflows/dags/forecast_prediction_jobs.py
@@ -213,9 +213,13 @@ def make_site_daily_forecasts():
     def generate_site_forecasts(data):
         """Generate forward site-level daily forecasts without MET enrichment."""
         horizon = int(Config.DAILY_FORECAST_HORIZON or 7)
+        forecast_start_date = DateUtils.date_to_str(
+            datetime.now(timezone.utc), str_format="%Y-%m-%d"
+        )
         return ForecastModelTrainer.generate_site_daily_forecasts(
             data,
             horizon=horizon,
+            forecast_start_date=forecast_start_date,
             include_met_no_weather=False,
         )
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
<!-- Brief summary of the changes -->

`AirQo-site-HOURLY-forecasting-job_Q ` was taking too long in the MongoDB persistence tasks. The hourly save/update flow was doing row-level upserts and extra read/prune work, which made save_site_forecasts_to_mongodb and update_site_forecasts_met_in_mongodb run for 20+ minutes instead of completing quickly.

`AirQo-site-daily-forecasting-job_Q` also needed to guarantee forecasts are generated for today for every eligible site that has data in the configured lookback window.

What

- Updated site daily forecasting so the DAG explicitly starts forecasts on today’s UTC date.

- Fixed the site daily BigQuery fetch so the configured min_hours value is honored instead of being hardcoded.

- Updated site hourly Mongo persistence to delete old forecast rows for incoming sites and insert the new forecast rows in bulk.

- Added/kept a compound Mongo index on site_id,timestamp for faster deletes/inserts.

- Increased hourly Mongo insert batching to at least 5000 rows per batch.

- Updated tests for daily and hourly forecast behavior.

- Replaced deprecated pandas `freq="H"` test fixtures with` freq="h"`.

### Why is this change needed? 

The site hourly forecast DAG was spending too long in the MongoDB save/update tasks because it was using row-level upserts and extra retention reads before pruning old data. This caused `save_site_forecasts_to_mongodb` and `update_site_forecasts_met_in_mongodb` to take much longer than expected.

The site daily forecast DAG also needed to consistently generate forecasts for today for every eligible site that has data within the configured lookback window.

This change improves hourly MongoDB persistence performance and makes daily site forecast coverage more predictable.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Forecasts can now start from a specified date; defaults to the current date.

* **Bug Fixes**
  * Site data filtering now uses the correct hourly record threshold parameter.
  * Improved hourly forecast data persistence with optimized indexing and batch writes.

* **Tests**
  * Added tests validating forecast start date functionality.
  * Updated forecast persistence tests to reflect new write strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->