### PR TITLE
fix: remove settings field causing Paddle checkout invalid request errors

### DIFF
--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -382,6 +382,7 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
     expect(result.success).to.equal(true);
     const sessionArg = transactionCreateStub.firstCall.args[0];
     expect(sessionArg.customer_id).to.equal("ctm_cached");
+    expect(sessionArg.settings).to.be.undefined;
   });
 
   it("creates a new Paddle customer when none is cached and persists the ID", async () => {
@@ -393,6 +394,7 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
     expect(result.success).to.equal(true);
     const sessionArg = transactionCreateStub.firstCall.args[0];
     expect(sessionArg.customer_id).to.equal("ctm_new");
+    expect(sessionArg.settings).to.be.undefined;
     // paddle_customer_id should be persisted fire-and-forget
     sinon.assert.calledOnce(UserModelStub);
     const updateArg = UserModelStub.firstCall.args[1];
@@ -412,6 +414,7 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
     expect(result.success).to.equal(true);
     const sessionArg = transactionCreateStub.firstCall.args[0];
     expect(sessionArg.customer_id).to.equal("ctm_existing");
+    expect(sessionArg.settings).to.be.undefined;
     sinon.assert.calledOnce(UserModelStub);
     const updateArg = UserModelStub.firstCall.args[1];
     expect(updateArg.$set.paddle_customer_id).to.equal("ctm_existing");
@@ -428,5 +431,6 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
     expect(result.success).to.equal(true);
     const sessionArg = transactionCreateStub.firstCall.args[0];
     expect(sessionArg.customer_id).to.equal("ctm_supplied");
+    expect(sessionArg.settings).to.be.undefined;
   });
 });

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -379,8 +379,8 @@ const transactions = {
 
       // Ensure required fields are present
       if (
-        !sessionData.settings.success_url ||
-        !sessionData.settings.cancel_url
+        !sessionData.settings?.success_url ||
+        !sessionData.settings?.cancel_url
       ) {
         throw new Error("success_url and cancel_url are required in settings");
       }
@@ -389,8 +389,12 @@ const transactions = {
         throw new Error("items array with at least one item is required");
       }
 
+      // Strip internal-only `settings` key — Paddle's transactions.create API
+      // does not accept it (it is a Paddle.js client-side concept only).
+      // Redirect URLs are configured in the Paddle dashboard.
+      const { settings: _settings, ...paddlePayload } = sessionData;
       const checkoutSession = await paddleClient.transactions.create(
-        sessionData
+        paddlePayload
       );
       return {
         success: true,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Strips the internal `settings` object (`mode`, `success_url`, `cancel_url`) from the payload sent to `paddleClient.transactions.create()` before it reaches the Paddle API. The `settings` block is still used locally to validate that the redirect URL environment variables are configured, then discarded before the Paddle call.

### Why is this change needed?
The Paddle Billing server-side `POST /transactions` API does not accept a `settings` field — that is a Paddle.js client-side overlay concept. Every checkout attempt was sending `settings: { mode: "transaction", success_url, cancel_url }` directly to Paddle, which rejected the entire request with `"Invalid request."` This caused a `500 Failed to create payment session` error for all users attempting to subscribe, regardless of tier. Redirect URLs after payment are configured in the Paddle dashboard and do not need to be in the server-side API call.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that `POST /users/transactions/checkout` with `{ tier: "Standard" }` no longer returns `"Invalid request"` from Paddle. The checkout URL is returned successfully and the user can be redirected to complete payment. All existing unit tests pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The API request and response shapes are unchanged. The `settings` field was never documented as part of the checkout request contract — it was an internal artefact passed incorrectly to Paddle.

---

## :memo: Additional Notes

**Root cause in detail:**

In `utils/transaction.util.js`, `createCheckoutSession` received a `sessionData` object from the controller that included:

```js
settings: {
  mode: "transaction",
  success_url: process.env.PADDLE_SUCCESS_REDIRECT_URL,
  cancel_url: process.env.PADDLE_CANCEL_REDIRECT_URL,
}
```

This was passed verbatim to `paddleClient.transactions.create(sessionData)`. Paddle's `POST /transactions` endpoint has no `settings` field and rejected every request.

**Fix:** destructure `settings` out before the Paddle call:

```js
const { settings: _settings, ...paddlePayload } = sessionData;
const checkoutSession = await paddleClient.transactions.create(paddlePayload);
```

The `settings` block is still validated above this line (guards against missing env vars), then discarded. Post-payment redirect URLs are handled by the Paddle dashboard configuration.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety of checkout session configuration validation.
  * Updated payment provider integration to send properly formatted requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->