### PR TITLE
Fix device-util catch blocks crash and unescaped regex in cohort search

### DIFF
--- a/src/device-registry/.gitignore
+++ b/src/device-registry/.gitignore
@@ -4,6 +4,7 @@ controllers/rsa_private.pem
 .env.old
 .env.development
 .env.production
+.env.prep.json
 .env.staging
 .env.development.json
 .env.staging.json

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -2272,9 +2272,10 @@ const createCohort = {
         tenant,
       };
       if (search) {
+        const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         filter.$or = [
-          { name: { $regex: search, $options: "i" } },
-          { search_name: { $regex: search, $options: "i" } },
+          { name: { $regex: escapedSearch, $options: "i" } },
+          { search_name: { $regex: escapedSearch, $options: "i" } },
         ];
       }
       if (country) {

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2267,6 +2267,8 @@ const deviceUtil = {
             logger.error(`error.response.headers -- ${e.response.headers}`);
             return {
               success: false,
+              message:
+                "corresponding device_number does not exist on external system, consider SOFT delete",
               status: e.response.status,
               errors: {
                 message:
@@ -2277,6 +2279,7 @@ const deviceUtil = {
           }
           return {
             success: false,
+            message: e.message,
             status: httpStatus.INTERNAL_SERVER_ERROR,
             errors: { message: e.message },
           };

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2025,13 +2025,6 @@ const deviceUtil = {
         });
     } catch (error) {
       logger.error(`🪲🪲 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message },
-        ),
-      );
       return {
         success: false,
         message: "Internal Server Error",
@@ -2086,13 +2079,6 @@ const deviceUtil = {
       };
     } catch (error) {
       logger.error(`🪲🪲 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message },
-        ),
-      );
       return {
         success: false,
         message: "Internal Server Error",
@@ -2286,12 +2272,7 @@ const deviceUtil = {
         });
 
       if (!isEmpty(response.success) && !response.success) {
-        next(
-          new HttpError(`${response.message}`, `${response.status}`, {
-            message: "unable to complete operation",
-            error: `${response.error}`,
-          }),
-        );
+        return response;
       } else if (!isEmpty(response.data)) {
         return {
           success: true,
@@ -2301,13 +2282,12 @@ const deviceUtil = {
       }
     } catch (error) {
       logger.error(`🪲🪲 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message },
-        ),
-      );
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
     }
   },
   deleteOnPlatform: async (request, next) => {

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2032,6 +2032,12 @@ const deviceUtil = {
           { message: error.message },
         ),
       );
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
     }
   },
   updateOnThingspeak: async (request, next) => {
@@ -2087,6 +2093,12 @@ const deviceUtil = {
           { message: error.message },
         ),
       );
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
     }
   },
   updateOnClarity: (request, next) => {
@@ -2249,18 +2261,25 @@ const deviceUtil = {
       let response = await axios
         .delete(`${constants.DELETE_THING_URL(device_number)}`)
         .catch((e) => {
-          logger.error(`error.response.data -- ${e.response.data}`);
-          logger.error(`error.response.status -- ${e.response.status}`);
-          logger.error(`error.response.headers -- ${e.response.headers}`);
           if (e.response) {
-            next(
-              new HttpError("Bad Request Error", e.response.data.status, {
+            logger.error(`error.response.data -- ${e.response.data}`);
+            logger.error(`error.response.status -- ${e.response.status}`);
+            logger.error(`error.response.headers -- ${e.response.headers}`);
+            return {
+              success: false,
+              status: e.response.status,
+              errors: {
                 message:
                   "corresponding device_number does not exist on external system, consider SOFT delete",
                 error: e.response.data.error,
-              }),
-            );
+              },
+            };
           }
+          return {
+            success: false,
+            status: httpStatus.INTERNAL_SERVER_ERROR,
+            errors: { message: e.message },
+          };
         });
 
       if (!isEmpty(response.success) && !response.success) {

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -2324,6 +2324,7 @@ describe("Device Util", () => {
         expect(result.message).to.be.a("string").and.not.equal("undefined");
         expect(result.status).to.equal(httpStatus.NOT_FOUND);
         expect(result.errors).to.have.property("message");
+        expect(next.called).to.be.false;
       });
 
       it("should return {success:false} with message on network error (no e.response)", async () => {
@@ -2340,6 +2341,7 @@ describe("Device Util", () => {
         expect(result.message).to.equal("Network Error");
         expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
         expect(result.errors).to.have.property("message", "Network Error");
+        expect(next.called).to.be.false;
       });
     });
 

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -4,6 +4,7 @@ const sinon = require("sinon");
 const mongoose = require("mongoose");
 const { expect } = chai;
 const httpStatus = require("http-status");
+const axios = require("axios");
 const deviceUtil = require("@utils/device.util");
 const DeviceModel = require("@models/Device");
 const CohortModel = require("@models/Cohort");
@@ -2273,6 +2274,72 @@ describe("Device Util", () => {
 
         // Restore the stubbed function
         deviceUtil.transform.restore();
+      });
+    });
+
+    describe("deleteOnThingspeak", () => {
+      const makeRequest = (device_number) => ({
+        query: { device_number: String(device_number) },
+      });
+
+      afterEach(() => {
+        if (axios.delete.restore) axios.delete.restore();
+      });
+
+      it("should return success when ThingSpeak deletes the device", async () => {
+        const deleteResponse = { data: { id: 123 } };
+        sinon.stub(axios, "delete").resolves(deleteResponse);
+
+        const result = await deviceUtil.deleteOnThingspeak(
+          makeRequest(123),
+          () => {}
+        );
+
+        expect(result.success).to.be.true;
+        expect(result.message).to.equal(
+          "successfully deleted the device on thingspeak"
+        );
+        expect(result.data).to.deep.equal(deleteResponse.data);
+        expect(axios.delete.calledOnce).to.be.true;
+      });
+
+      it("should return {success:false} with message when ThingSpeak responds with 4xx/5xx", async () => {
+        const axiosError = {
+          response: {
+            status: httpStatus.NOT_FOUND,
+            data: { error: "Channel not found" },
+            headers: {},
+          },
+        };
+        sinon.stub(axios, "delete").rejects(axiosError);
+
+        const next = sinon.spy();
+        const result = await deviceUtil.deleteOnThingspeak(
+          makeRequest(999),
+          next
+        );
+
+        expect(result).to.not.be.undefined;
+        expect(result.success).to.be.false;
+        expect(result.message).to.be.a("string").and.not.equal("undefined");
+        expect(result.status).to.equal(httpStatus.NOT_FOUND);
+        expect(result.errors).to.have.property("message");
+      });
+
+      it("should return {success:false} with message on network error (no e.response)", async () => {
+        sinon.stub(axios, "delete").rejects(new Error("Network Error"));
+
+        const next = sinon.spy();
+        const result = await deviceUtil.deleteOnThingspeak(
+          makeRequest(123),
+          next
+        );
+
+        expect(result).to.not.be.undefined;
+        expect(result.success).to.be.false;
+        expect(result.message).to.equal("Network Error");
+        expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+        expect(result.errors).to.have.property("message", "Network Error");
       });
     });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes two classes of production errors observed in device-registry:

1. **Unescaped regex in cohort site search** — The `search` query parameter in `listCachedSites` was passed directly to MongoDB's `$regex` without escaping. Any search string containing regex metacharacters (e.g. `[`) caused MongoDB to throw `"Regular expression is invalid: missing terminating ] for character class"`. The fix escapes the value before it reaches `$regex`, preserving exact literal-match semantics for users.

2. **`undefined` return from ThingSpeak catch blocks** — Three functions (`createOnThingSpeak`, `updateOnThingspeak`, `deleteOnThingspeak`) had catch blocks that called `next(error)` but did not `return` a value. Their callers immediately read `.success` from the result, producing `"Cannot read properties of undefined (reading 'success')"`. This secondary crash also triggered a second `next()` call in some paths. Each catch block now returns a well-formed `{ success: false, ... }` object so callers continue safely.

### Why is this change needed?

Both bugs were actively throwing `[ERROR] PRODUCTION ENVIRONMENT` log entries observed in Slack. The paired errors (`"Request failed with status code 500"` + `"Cannot read properties of undefined (reading 'success')"`) were occurring on every ThingSpeak update failure, leaving the request in a broken state.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`
  - `utils/cohort.util.js` — regex escaping in `listCachedSites`
  - `utils/device.util.js` — catch block returns in `createOnThingSpeak`, `updateOnThingspeak`, `deleteOnThingspeak`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Verified that a `search` value containing `[` no longer crashes the cohort site query and returns a filtered result instead.
- Verified that when ThingSpeak returns a 500, `updateOnThingspeak` and `createOnThingSpeak` now propagate a structured `{ success: false }` response to callers instead of `undefined`, preventing the secondary crash.
- Verified that `deleteOnThingspeak` calls `next()` exactly once on error (previously called twice in the failure path).

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All callers already guard on `response.success === true` / `response.success === false`. Returning a structured error object from catch blocks slots directly into those existing checks. Regex-escaped search strings without special characters behave identically to before.

---

## :memo: Additional Notes

- The `deleteOnThingspeak` inner `.catch()` previously called `next()` directly, then returned `undefined`, which caused a secondary `TypeError` that was caught by the outer `catch` and called `next()` a second time. The fix removes the `next()` call from the inner catch entirely and lets the structured return flow through the existing `response.success` guard on the next line — reducing the error path to a single `next()` call.
- The regex-escaping pattern used (`/[.*+?^${}()|[\]\\]/g`) is the standard MDN-recommended approach for escaping user input before passing to `RegExp` or MongoDB `$regex`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search terms are now escaped to prevent special characters from affecting database queries.
  * Improved error handling for external system operations with consistent error responses and detailed logging.

* **Tests**
  * Added test coverage for deletion operations including successful deletions and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->