### PR TITLE
fix: resolve Paddle checkout session failures end to end

### DIFF
--- a/src/auth-service/controllers/transaction.controller.js
+++ b/src/auth-service/controllers/transaction.controller.js
@@ -58,7 +58,7 @@ const transactions = {
             );
             return;
           }
-          resolvedItems = [{ price: priceId, quantity: 1 }];
+          resolvedItems = [{ priceId, quantity: 1 }];
         } else {
           if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) {
             next(
@@ -71,7 +71,7 @@ const transactions = {
           }
           resolvedItems = [
             {
-              price: await transactionsUtil.getDynamicPriceId(
+              priceId: await transactionsUtil.getDynamicPriceId(
                 amount,
                 currency
               ),

--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -433,4 +433,38 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
     expect(sessionArg.customer_id).to.equal("ctm_supplied");
     expect(sessionArg.settings).to.be.undefined;
   });
+
+  it("self-heals stale paddle_customer_id: clears cache, resolves fresh customer, retries transaction", async () => {
+    const staleId = "ctm_stale";
+    const req = mockRequest({ paddle_customer_id: staleId });
+
+    // First transactions.create fails with a Paddle "not found" detail for the stale ID
+    const staleErr = Object.assign(new Error("not found"), {
+      detail: `customer ${staleId} not found.`,
+    });
+    transactionCreateStub.onFirstCall().rejects(staleErr);
+    transactionCreateStub.onSecondCall().resolves({
+      id: "txn_retry",
+      url: "https://pay.paddle.com/checkout/txn_retry",
+    });
+
+    // customers.create succeeds and returns a fresh customer
+    createStub.resolves({ id: "ctm_fresh" });
+
+    const result = await transactions.createCheckoutSession(req, mockSessionData());
+
+    expect(result.success).to.equal(true);
+    // transactions.create must have been called twice
+    sinon.assert.calledTwice(transactionCreateStub);
+    // Second call must use the fresh customer ID
+    const retryArg = transactionCreateStub.secondCall.args[0];
+    expect(retryArg.customer_id).to.equal("ctm_fresh");
+    expect(retryArg.settings).to.be.undefined;
+    // User model must be updated twice: once to clear, once to persist fresh ID
+    sinon.assert.calledTwice(UserModelStub);
+    const clearArg = UserModelStub.firstCall.args[1];
+    expect(clearArg.$unset).to.have.property("paddle_customer_id");
+    const persistArg = UserModelStub.secondCall.args[1];
+    expect(persistArg.$set.paddle_customer_id).to.equal("ctm_fresh");
+  });
 });

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -321,48 +321,51 @@ const transactions = {
       logObject("user.firstName", user.firstName);
       logObject("user.lastName", user.lastName);
 
+      // Shared helper — create or recover a Paddle customer by email.
+      // Handles customer_already_exists by listing and returning the existing ID.
+      const resolveOrCreateCustomer = async () => {
+        try {
+          const customer = await paddleClient.customers.create({
+            email: user.email,
+            name: user.firstName || user.lastName,
+          });
+          return customer.id;
+        } catch (error) {
+          if (error.code === "customer_already_exists") {
+            // customers.list returns an async-iterable Collection; call
+            // next() to fetch the first page before reading .data
+            const collection = paddleClient.customers.list({
+              email: [user.email],
+            });
+            await collection.next();
+            const existingCustomer = collection.data[0];
+            if (existingCustomer) {
+              return existingCustomer.id;
+            }
+            logger.error(
+              `Unable to retrieve existing Paddle customer for email: ${user.email}`
+            );
+            throw error;
+          }
+          logger.error(
+            `Unable to generate the transaction client on Paddle -- ${stringify(
+              error
+            )}`
+          );
+          throw error;
+        }
+      };
+
+      const tenant = (request.query && request.query.tenant) || "airqo";
+
       if (!customerIdentification) {
         if (user.paddle_customer_id) {
           // Reuse the cached Paddle customer ID — no API call needed
           sessionData.customer_id = user.paddle_customer_id;
         } else {
-          let resolvedCustomerId;
-          try {
-            const customer = await paddleClient.customers.create({
-              email: user.email,
-              name: user.firstName || user.lastName,
-            });
-            resolvedCustomerId = customer.id;
-          } catch (error) {
-            if (error.code === "customer_already_exists") {
-              // customers.list returns an async-iterable Collection; call
-              // next() to fetch the first page before reading .data
-              const collection = paddleClient.customers.list({
-                email: [user.email],
-              });
-              await collection.next();
-              const existingCustomer = collection.data[0];
-              if (existingCustomer) {
-                resolvedCustomerId = existingCustomer.id;
-              } else {
-                logger.error(
-                  `Unable to retrieve existing Paddle customer for email: ${user.email}`
-                );
-                throw error;
-              }
-            } else {
-              logger.error(
-                `Unable to generate the transaction client on Paddle -- ${stringify(
-                  error
-                )}`
-              );
-              throw error;
-            }
-          }
+          const resolvedCustomerId = await resolveOrCreateCustomer();
           sessionData.customer_id = resolvedCustomerId;
           // Persist the customer ID so future checkouts skip this lookup
-          const tenant =
-            (request.query && request.query.tenant) || "airqo";
           UserModel(tenant)
             .findByIdAndUpdate(
               user._id,
@@ -398,28 +401,33 @@ const transactions = {
         checkoutSession = await paddleClient.transactions.create(paddlePayload);
       } catch (txnError) {
         // Stale cached paddle_customer_id — customer was deleted or belongs to
-        // a different sandbox. Clear the cache, create a fresh customer, retry.
-        if (
-          txnError.message &&
-          txnError.message.includes("not found") &&
-          paddlePayload.customer_id
-        ) {
-          const tenant = (request.query && request.query.tenant) || "airqo";
+        // a different sandbox. Use detail (structured) to confirm this specific
+        // customer ID is the one Paddle cannot find, then resolve a fresh one.
+        const isStaleCustomer =
+          paddlePayload.customer_id &&
+          txnError.detail &&
+          txnError.detail.includes(paddlePayload.customer_id);
+        if (isStaleCustomer) {
           UserModel(tenant)
             .findByIdAndUpdate(user._id, { $unset: { paddle_customer_id: "" } })
-            .catch(() => {});
-          const freshCustomer = await paddleClient.customers.create({
-            email: user.email,
-            name: user.firstName || user.lastName,
-          });
-          paddlePayload.customer_id = freshCustomer.id;
+            .catch((err) =>
+              logger.error(
+                `Non-critical: failed to clear stale paddle_customer_id for user ${user._id}: ${err.message}`
+              )
+            );
+          const freshCustomerId = await resolveOrCreateCustomer();
+          paddlePayload.customer_id = freshCustomerId;
           UserModel(tenant)
             .findByIdAndUpdate(
               user._id,
-              { $set: { paddle_customer_id: freshCustomer.id } },
+              { $set: { paddle_customer_id: freshCustomerId } },
               { new: false }
             )
-            .catch(() => {});
+            .catch((err) =>
+              logger.error(
+                `Non-critical: failed to persist fresh paddle_customer_id for user ${user._id}: ${err.message}`
+              )
+            );
           checkoutSession = await paddleClient.transactions.create(paddlePayload);
         } else {
           throw txnError;

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -393,9 +393,38 @@ const transactions = {
       // does not accept it (it is a Paddle.js client-side concept only).
       // Redirect URLs are configured in the Paddle dashboard.
       const { settings: _settings, ...paddlePayload } = sessionData;
-      const checkoutSession = await paddleClient.transactions.create(
-        paddlePayload
-      );
+      let checkoutSession;
+      try {
+        checkoutSession = await paddleClient.transactions.create(paddlePayload);
+      } catch (txnError) {
+        // Stale cached paddle_customer_id — customer was deleted or belongs to
+        // a different sandbox. Clear the cache, create a fresh customer, retry.
+        if (
+          txnError.message &&
+          txnError.message.includes("not found") &&
+          paddlePayload.customer_id
+        ) {
+          const tenant = (request.query && request.query.tenant) || "airqo";
+          UserModel(tenant)
+            .findByIdAndUpdate(user._id, { $unset: { paddle_customer_id: "" } })
+            .catch(() => {});
+          const freshCustomer = await paddleClient.customers.create({
+            email: user.email,
+            name: user.firstName || user.lastName,
+          });
+          paddlePayload.customer_id = freshCustomer.id;
+          UserModel(tenant)
+            .findByIdAndUpdate(
+              user._id,
+              { $set: { paddle_customer_id: freshCustomer.id } },
+              { new: false }
+            )
+            .catch(() => {});
+          checkoutSession = await paddleClient.transactions.create(paddlePayload);
+        } else {
+          throw txnError;
+        }
+      }
       return {
         success: true,
         data: {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes a chain of bugs in the Paddle checkout session creation flow, all of which caused `POST /users/transactions/checkout` to return `500 Failed to create payment session`. Changes are confined to `controllers/transaction.controller.js` and `utils/transaction.util.js`.

**Fixes applied (in order of discovery):**

1. **Wrong customer field in session payload** — controller was passing `customer: { id: undefined }` but the util reads `sessionData.customer_id`. Paddle received a malformed object. Fixed by using `...(customerId && { customer_id: customerId })`.

2. **`customer_already_exists` crash on repeat checkout** — `paddleClient.customers.create` threw on a returning user. Fixed by catching `error.code === "customer_already_exists"` and recovering via `customers.list({ email })`.

3. **`settings` field sent to Paddle API** — the `settings` block (`mode`, `success_url`, `cancel_url`) was passed verbatim to `paddleClient.transactions.create`. Paddle's server-side API has no `settings` field — it is Paddle.js-only. Fixed by destructuring `settings` out before the Paddle call.

4. **Wrong item field name** — items were built as `{ price: priceId, quantity: 1 }` but the Paddle Node SDK expects `{ priceId, quantity: 1 }` (camelCase), which it then serialises to `price_id` for the API. `price` as a string is treated as a non-catalog price object and rejected. This was the primary cause of all "Invalid request" errors.

5. **Stale `paddle_customer_id` self-healing** — if the cached `ctm_` ID on the user document no longer exists in Paddle (e.g. after a sandbox reset), `transactions.create` returned "customer not found". The code now catches this, clears the stale cache, creates a fresh Paddle customer, persists the new ID, and retries the transaction automatically.

### Why is this change needed?
The checkout endpoint was completely non-functional — every request to `POST /users/transactions/checkout` returned a 500 error regardless of tier or user state. Collectively these bugs meant no user could initiate a subscription upgrade. The fixes make checkout work end-to-end and self-heal across common failure modes (returning users, sandbox resets, environment changes).

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually tested `POST /users/transactions/checkout` with `{ "tier": "Standard" }` and `{ "tier": "Premium" }` in the development environment. Verified a valid `checkoutUrl` is returned. Verified that a repeat checkout for the same user (already a Paddle customer) succeeds without error. Verified that clearing `paddle_customer_id` from the user document and retrying creates a fresh Paddle customer and caches the new ID. All existing unit tests pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The request and response shapes for `POST /users/transactions/checkout` are unchanged. All fixes are internal to the session creation logic.

---

## :memo: Additional Notes

**Root cause summary:**

The deepest bug was `{ price: priceId }` vs `{ priceId }` in the items array. The Paddle Node SDK's `convertToSnakeCase` helper converts `priceId` → `price_id` (what Paddle API expects). Passing `price` as a string string bypassed this — Paddle interpreted it as a non-catalog price object and rejected every request with "Invalid request."

The `settings` field bug compounded this: even without the `price`/`priceId` issue, Paddle would have rejected any request that included the `settings` block.

**Stale customer recovery flow:**
```
transactions.create → "customer not found"
  → $unset paddle_customer_id on user (fire-and-forget)
  → customers.create → new ctm_ ID
  → $set paddle_customer_id on user (fire-and-forget)
  → transactions.create (retry) → success
```

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved checkout reliability by automatically recovering from stale customer information and retrying transactions
* Ensured consistent pricing identifier handling across all checkout paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->