### PR TITLE
Fix site count summary endpoint to honour cohort_id filter parameter

### DIFF
--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -39,8 +39,27 @@ const ObjectId = mongoose.Types.ObjectId;
 
 const getSiteCountSummary = async (request, next) => {
   try {
-    const { tenant } = request.query;
+    const { tenant, cohort_id } = request.query;
     const filter = generateFilter.sites(request, next);
+
+    if (cohort_id) {
+      const cohortObjectIds = cohort_id
+        .split(",")
+        .map((id) => id.trim())
+        .filter((id) => isValidObjectId(id))
+        .map((id) => ObjectId(id));
+
+      if (cohortObjectIds.length > 0) {
+        const snapshots = await CohortSiteSnapshotModel(tenant)
+          .distinct("site_id", {
+            cohort_id: { $in: cohortObjectIds },
+            tenant,
+          })
+          .maxTimeMS(10000);
+
+        filter._id = { $in: snapshots };
+      }
+    }
 
     const pipeline = [
       { $match: filter },

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -49,7 +49,9 @@ const getSiteCountSummary = async (request, next) => {
         .filter((id) => isValidObjectId(id))
         .map((id) => ObjectId(id));
 
-      if (cohortObjectIds.length > 0) {
+      if (cohortObjectIds.length === 0) {
+        filter._id = { $in: [] };
+      } else {
         const snapshots = await CohortSiteSnapshotModel(tenant)
           .distinct("site_id", {
             cohort_id: { $in: cohortObjectIds },
@@ -57,7 +59,21 @@ const getSiteCountSummary = async (request, next) => {
           })
           .maxTimeMS(10000);
 
-        filter._id = { $in: snapshots };
+        const snapshotStrings = new Set(snapshots.map((id) => id.toString()));
+
+        const existing = filter._id;
+        if (!existing) {
+          filter._id = { $in: snapshots };
+        } else if (existing.$in) {
+          filter._id = {
+            $in: existing.$in.filter((id) => snapshotStrings.has(id.toString())),
+          };
+        } else {
+          // plain ObjectId from generateFilter.sites (id / _id / site_id param)
+          filter._id = {
+            $in: snapshotStrings.has(existing.toString()) ? [existing] : [],
+          };
+        }
       }
     }
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes `GET /api/v2/devices/sites/summary/count` so that the `cohort_id` query parameter actually scopes the counts to the sites belonging to the specified cohort(s).

Previously, passing `?cohort_id=<id>` returned identical results to calling the endpoint with no parameters — the filter was silently ignored end-to-end. The endpoint now:

1. Reads `cohort_id` (supports a single value or comma-separated list) from the query string inside `getSiteCountSummary`.
2. Looks up the matching `site_id`s from the `CohortSiteSnapshot` collection (the pre-computed cohort→site mapping).
3. Injects `_id: { $in: [...siteIds] }` into the aggregation `$match` filter so that `total_sites`, `operational`, `transmitting`, `data_available`, and `not_transmitting` counts are all scoped to that cohort's sites.

### Why is this change needed?

The endpoint was announced to the frontend team as supporting cohort-scoped site health summaries. In production the `cohort_id` parameter had no effect — every request returned global counts regardless of what cohort was passed. This was reported directly by Belinda (frontend) after testing the endpoint.

The miss was a three-layer gap:
- The **validator** (`validateGetSiteCountSummary`) correctly accepted and validated `cohort_id`.
- `generateFilter.sites` never destructured or applied `cohort_id` — it was dropped silently.
- Even if `generateFilter.sites` had tried to apply it, `Site` documents hold no `cohort_id` field — membership lives in `CohortSiteSnapshot`, requiring an indirect lookup.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`
  - `utils/site.util.js` — `getSiteCountSummary` now resolves cohort site membership and scopes the aggregation accordingly

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Called `GET /api/v2/devices/sites/summary/count` without `cohort_id` — returns global counts (unchanged behaviour).
- Called `GET /api/v2/devices/sites/summary/count?cohort_id=69bbe61f0c2b8d0013b6a003` — returns counts scoped only to the sites in that cohort (previously returned global counts).
- Called with a comma-separated list of cohort IDs — counts reflect the union of sites across all provided cohorts.
- Called with an invalid/unknown cohort ID — returns all-zero counts rather than crashing.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Callers that previously passed `cohort_id` and received (incorrect) global counts will now receive the correct cohort-scoped counts. No existing query parameters are removed or renamed. Callers that do not pass `cohort_id` see identical behaviour.

---

## :memo: Additional Notes

- The fix deliberately routes through `CohortSiteSnapshot` (the pre-computed flat collection) rather than performing a live aggregation join — this keeps the query fast and consistent with how `listCachedSites` resolves cohort membership.
- The `isValidObjectId` guard ensures malformed IDs in a comma-separated list are skipped rather than throwing.
- `generateFilter.sites` was intentionally left unchanged — it is a shared filter builder and adding cohort resolution there would have broader, untested side-effects on other site endpoints.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cohort-based filtering for site count summaries. Users can now filter site counts by specifying cohort IDs as query parameters. The feature supports multiple comma-separated cohort IDs for batch filtering, enabling more detailed analysis of site distribution across different cohort groupings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->