### PR TITLE
fix: read checkout URL from transaction.checkout.url not transaction.url

### DIFF
--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -363,7 +363,7 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
 
     transactionCreateStub = sinon
       .stub(paddleConfig.paddleClient.transactions, "create")
-      .resolves({ id: "txn_001", url: "https://pay.paddle.com/checkout/txn_001" });
+      .resolves({ id: "txn_001", checkout: { url: "https://pay.paddle.com/checkout/txn_001" } });
 
     const UserModel = require("@models/User");
     UserModelStub = sinon
@@ -380,9 +380,19 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
     sinon.assert.notCalled(createStub);
     sinon.assert.notCalled(listStub);
     expect(result.success).to.equal(true);
+    expect(result.data.url).to.equal("https://pay.paddle.com/checkout/txn_001");
     const sessionArg = transactionCreateStub.firstCall.args[0];
     expect(sessionArg.customer_id).to.equal("ctm_cached");
     expect(sessionArg.settings).to.be.undefined;
+  });
+
+  it("returns undefined url without error when Paddle returns checkout: null", async () => {
+    transactionCreateStub.resolves({ id: "txn_null", checkout: null });
+    const req = mockRequest({ paddle_customer_id: "ctm_cached" });
+    const result = await transactions.createCheckoutSession(req, mockSessionData());
+
+    expect(result.success).to.equal(true);
+    expect(result.data.url).to.be.undefined;
   });
 
   it("creates a new Paddle customer when none is cached and persists the ID", async () => {
@@ -445,7 +455,7 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
     transactionCreateStub.onFirstCall().rejects(staleErr);
     transactionCreateStub.onSecondCall().resolves({
       id: "txn_retry",
-      url: "https://pay.paddle.com/checkout/txn_retry",
+      checkout: { url: "https://pay.paddle.com/checkout/txn_retry" },
     });
 
     // customers.create succeeds and returns a fresh customer

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -437,7 +437,7 @@ const transactions = {
         success: true,
         data: {
           id: checkoutSession.id,
-          url: checkoutSession.url,
+          url: checkoutSession.checkout?.url,
         },
         status: httpStatus.CREATED,
       };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the field path used to extract the checkout URL from Paddle's `transactions.create` response. Changes `checkoutSession.url` to `checkoutSession.checkout?.url` in `utils/transaction.util.js`.

### Why is this change needed?
The Paddle Node SDK's `Transaction` entity has no top-level `url` property. The checkout URL lives at `transaction.checkout.url` (`TransactionCheckout.url`). Reading `checkoutSession.url` always returned `undefined`, causing the controller to return `checkoutUrl: undefined` — which the frontend reported as "Checkout session did not return a redirect URL". The checkout session was being created successfully on Paddle's side but the URL was silently dropped before reaching the client.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually tested `POST /users/transactions/checkout` with `{ "tier": "Standard" }` in the development environment. Confirmed the response now includes a populated `checkoutUrl` (`https://<domain>?_ptxn=txn_xxx`) instead of `undefined`. All existing unit tests pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `checkoutUrl` field was previously always `undefined` — returning a real URL is a fix, not a breaking change.

---

## :memo: Additional Notes

**Paddle SDK Transaction shape:**

```
Transaction
├── id               string
├── checkout         TransactionCheckout | null
│   └── url          string | null   ← correct field
├── status           TransactionStatus
└── ...              (no top-level `url` property)
```

The one-character path change (`checkoutSession.url` → `checkoutSession.checkout?.url`) is the entire diff. The optional chaining (`?.`) guards against the case where Paddle returns `checkout: null` on certain transaction states.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkout session URL retrieval to ensure payment flows work correctly with updated response structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->