### PR TITLE
fix: await webhook unmarshal and pass next to processWebhook

### DIFF
--- a/src/auth-service/controllers/transaction.controller.js
+++ b/src/auth-service/controllers/transaction.controller.js
@@ -208,7 +208,7 @@ const transactions = {
         : req.query.tenant;
 
       // Verify and process webhook
-      const result = await transactionsUtil.processWebhook(request);
+      const result = await transactionsUtil.processWebhook(request, next);
 
       if (isEmpty(result) || res.headersSent) {
         return;

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -623,7 +623,7 @@ const transactions = {
       const { tenant } = query;
 
       // Verify webhook authenticity
-      const event = paddleClient.webhooks.unmarshal(
+      const event = await paddleClient.webhooks.unmarshal(
         body,
         signature,
         constants.PADDLE_WEBHOOK_SECRET

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -555,6 +555,34 @@ const transactions = {
       logger.error("Failed to send admin notification", notificationError);
     }
   },
+  handleFailedTransaction: async (eventData) => {
+    try {
+      logObject("Failed Transaction Event", eventData);
+
+      if (!eventData || !eventData.id || !eventData.customer_id) {
+        logger.warn("Invalid transaction data received for payment_failed event");
+        return;
+      }
+
+      logger.warn(`Payment failed for transaction: ${eventData.id}`, {
+        customerId: eventData.customer_id,
+        amount: eventData.total,
+        currency: eventData.currency,
+      });
+
+      await transactions.notifyAdminOfTransactionError(
+        new Error(`Payment failed for transaction ${eventData.id}`),
+        eventData
+      );
+    } catch (error) {
+      logger.error("Failed transaction processing error", {
+        errorMessage: error.message,
+        transactionId: eventData?.id,
+        stack: error.stack,
+      });
+    }
+  },
+
   handleCompletedTransaction: async (eventData) => {
     try {
       // Log the incoming event data for debugging
@@ -634,7 +662,7 @@ const transactions = {
           await transactions.handleCompletedTransaction(event.data);
           break;
         case "transaction.payment_failed":
-          await handleFailedTransaction(event.data);
+          await transactions.handleFailedTransaction(event.data);
           break;
         // Add more event handlers
         default:


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes two bugs in the webhook handling flow:

1. **Missing `await` on `webhooks.unmarshal`** — `paddleClient.webhooks.unmarshal()` is async. Without `await`, `event` was a Promise object rather than the resolved event. Every downstream access to `event.data` returned `undefined`, causing `identifyUserFromTransaction` to crash with `TypeError: Cannot read properties of undefined (reading 'customer_id')`. The unresolved Promise then rejected in the background as an unhandled rejection, propagating the "Invalid webhook signature" error across multiple process-level handlers.

2. **`next` not passed from controller to `processWebhook`** — `handleWebhook` called `transactionsUtil.processWebhook(request)` without passing `next`. Inside `transactions.create`, the error handler calls `next(new HttpError(...))`, but with `next` being `undefined`, this threw a secondary `TypeError: next is not a function` that masked the root error.

### Why is this change needed?
Every incoming webhook from the payment provider caused three cascading errors: a TypeError on undefined transaction data, a TypeError on `next`, and an unhandled Promise rejection that surfaced in unrelated process-level handlers (including the incomplete-profile background job). No webhook event was being processed successfully — subscription upgrades triggered by completed payments were silently dropped.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that incoming webhook requests no longer produce unhandled Promise rejections or `next is not a function` errors in staging logs. The webhook handler now correctly awaits signature verification before processing event data. All existing unit tests pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Both fixes restore the intended behaviour — no interface or contract changes.

---

## :memo: Additional Notes

**Error chain before this fix:**

```
webhooks.unmarshal() → not awaited → event = Promise (not event object)
  → event.data = undefined
  → identifyUserFromTransaction(undefined) → TypeError: Cannot read properties of undefined
  → transactions.create error handler calls next() → next is undefined → TypeError: next is not a function
  → unmarshal Promise rejects in background → unhandled rejection in process + background jobs
```

**After this fix:**
```
await webhooks.unmarshal() → event = resolved event object
  → event.data = valid transaction data
  → processWebhook(request, next) → next is Express's error handler
  → any error correctly forwarded to Express error middleware
```

Note: a valid webhook secret (`PADDLE_WEBHOOK_SECRET`) matching the one configured in the payment provider's sandbox dashboard is still required for signature verification to pass. This is a separate infrastructure configuration step.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction webhook processing reliability with enhanced error handling and proper asynchronous operation execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->