### PR TITLE
Fix webhook signature failure caused by Buffer body passed to unmarshal

### DIFF
--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -193,7 +193,14 @@ app.use((req, res, next) => {
   sessionMiddleware(req, res, next);
 });
 
-app.use(bodyParser.json({ limit: "50mb" })); // JSON body parser
+app.use(
+  bodyParser.json({
+    limit: "50mb",
+    verify: (req, _res, buf) => {
+      req.rawBody = buf;
+    },
+  })
+); // JSON body parser — verify captures raw Buffer for webhook signature checks
 // Other common middlewares: morgan, cookieParser, passport, etc.
 if (isProd) {
   app.use(compression());

--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -445,6 +445,7 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
   });
 
   it("self-heals stale paddle_customer_id: clears cache, resolves fresh customer, retries transaction", async () => {
+
     const staleId = "ctm_stale";
     const req = mockRequest({ paddle_customer_id: staleId });
 
@@ -476,5 +477,65 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
     expect(clearArg.$unset).to.have.property("paddle_customer_id");
     const persistArg = UserModelStub.secondCall.args[1];
     expect(persistArg.$set.paddle_customer_id).to.equal("ctm_fresh");
+  });
+});
+
+describe("transactions.processWebhook — body normalisation", () => {
+  let unmarshalStub;
+  const fakeEvent = {
+    type: "transaction.completed",
+    data: { id: "txn_001", customer_id: "ctm_001" },
+  };
+
+  beforeEach(() => {
+    unmarshalStub = sinon
+      .stub(paddleConfig.paddleClient.webhooks, "unmarshal")
+      .resolves(fakeEvent);
+
+    // Stub handleCompletedTransaction to prevent downstream DB calls
+    sinon.stub(transactions, "handleCompletedTransaction").resolves();
+    // Stub transactions.create to prevent downstream processing
+    sinon.stub(transactions, "create").resolves({ success: true });
+  });
+
+  afterEach(() => sinon.restore());
+
+  const mockWebhookRequest = (rawBody) => ({
+    headers: { "paddle-signature": "ts=1234;h1=abcd" },
+    rawBody,
+    query: { tenant: "airqo" },
+  });
+
+  it("passes a UTF-8 string to unmarshal when rawBody is a Buffer", async () => {
+    const bodyString = JSON.stringify({ id: "txn_001" });
+    const req = mockWebhookRequest(Buffer.from(bodyString, "utf8"));
+
+    await transactions.processWebhook(req, () => {});
+
+    sinon.assert.calledOnce(unmarshalStub);
+    const [bodyArg] = unmarshalStub.firstCall.args;
+    expect(typeof bodyArg).to.equal("string");
+    expect(bodyArg).to.equal(bodyString);
+  });
+
+  it("passes the string through unchanged when rawBody is already a string", async () => {
+    const bodyString = JSON.stringify({ id: "txn_001" });
+    const req = mockWebhookRequest(bodyString);
+
+    await transactions.processWebhook(req, () => {});
+
+    sinon.assert.calledOnce(unmarshalStub);
+    const [bodyArg] = unmarshalStub.firstCall.args;
+    expect(bodyArg).to.equal(bodyString);
+  });
+
+  it("returns an error response when unmarshal throws Invalid webhook signature", async () => {
+    unmarshalStub.rejects(new Error("[Paddle] Invalid webhook signature"));
+    const req = mockWebhookRequest(Buffer.from("{}", "utf8"));
+
+    const result = await transactions.processWebhook(req, () => {});
+
+    expect(result.success).to.equal(false);
+    expect(result.errors.message).to.include("Invalid webhook signature");
   });
 });

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -647,13 +647,15 @@ const transactions = {
     if (!isPaddleConfigured) return PADDLE_NOT_CONFIGURED;
     try {
       const signature = request.headers["paddle-signature"];
-      const { body, query } = request;
+      const { rawBody, query } = request;
       const { tenant } = query;
-      const rawBody = Buffer.isBuffer(body) ? body.toString("utf8") : body;
+      const bodyString = Buffer.isBuffer(rawBody)
+        ? rawBody.toString("utf8")
+        : rawBody;
 
       // Verify webhook authenticity
       const event = await paddleClient.webhooks.unmarshal(
-        rawBody,
+        bodyString,
         signature,
         constants.PADDLE_WEBHOOK_SECRET
       );

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -649,10 +649,11 @@ const transactions = {
       const signature = request.headers["paddle-signature"];
       const { body, query } = request;
       const { tenant } = query;
+      const rawBody = Buffer.isBuffer(body) ? body.toString("utf8") : body;
 
       // Verify webhook authenticity
       const event = await paddleClient.webhooks.unmarshal(
-        body,
+        rawBody,
         signature,
         constants.PADDLE_WEBHOOK_SECRET
       );


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Converts the raw request body from a `Buffer` to a UTF-8 string before passing it to `webhooks.unmarshal` for signature verification.

### Why is this change needed?
`express.raw({ type: "application/json" })` delivers `request.body` as a Node.js `Buffer`. When a `Buffer` is passed directly to the webhook signature validator, JavaScript coerces it to a non-string representation, so the HMAC computed by the SDK never matches the signature Paddle sent. This caused every inbound webhook to fail with `Invalid webhook signature` — on both staging and production — regardless of whether the secret was correct. The fix converts the Buffer to a UTF-8 string before verification, which is what the SDK expects.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified in staging logs that after deployment the `Invalid webhook signature` error no longer appears and webhook events are processed successfully. All existing unit tests pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Restores intended behaviour — no interface or contract changes.

---

## :memo: Additional Notes

**Root cause chain before this fix:**

```
express.raw() → request.body = Buffer
  → Buffer passed to webhooks.unmarshal()
  → HMAC computed on Buffer string representation, not raw bytes
  → signature never matches → Invalid webhook signature thrown
  → (on older deployment) unawaited unmarshal → unhandled rejection
    → cascades into config-database, incomplete-profile-job, bin/server handlers
```

**After this fix:**
```
Buffer.isBuffer(body) ? body.toString("utf8") : body
  → rawBody = valid UTF-8 string
  → HMAC matches Paddle's signature → event unmarshalled successfully
  → webhook processed end-to-end
```

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook data handling for payment verification to ensure consistent signature validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->