### PR TITLE
Fix webhook signature by capturing raw body before JSON parser runs

### DIFF
--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -193,14 +193,13 @@ app.use((req, res, next) => {
   sessionMiddleware(req, res, next);
 });
 
+// Must be before bodyParser.json() — preserves raw Buffer in req.body for webhook signature verification
 app.use(
-  bodyParser.json({
-    limit: "50mb",
-    verify: (req, _res, buf) => {
-      req.rawBody = buf;
-    },
-  })
-); // JSON body parser — verify captures raw Buffer for webhook signature checks
+  "/api/v2/users/transactions/webhook",
+  express.raw({ type: "*/*" })
+);
+
+app.use(bodyParser.json({ limit: "50mb" })); // JSON body parser
 // Other common middlewares: morgan, cookieParser, passport, etc.
 if (isProd) {
   app.use(compression());

--- a/src/auth-service/routes/v2/transactions.routes.js
+++ b/src/auth-service/routes/v2/transactions.routes.js
@@ -19,7 +19,6 @@ router.post(
 router.post(
   "/webhook",
   transactionValidations.tenantOperation,
-  express.raw({ type: "application/json" }),
   TransactionController.handleWebhook
 );
 

--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -500,9 +500,9 @@ describe("transactions.processWebhook — body normalisation", () => {
 
   afterEach(() => sinon.restore());
 
-  const mockWebhookRequest = (rawBody) => ({
+  const mockWebhookRequest = (body) => ({
     headers: { "paddle-signature": "ts=1234;h1=abcd" },
-    rawBody,
+    body,
     query: { tenant: "airqo" },
   });
 

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -647,11 +647,11 @@ const transactions = {
     if (!isPaddleConfigured) return PADDLE_NOT_CONFIGURED;
     try {
       const signature = request.headers["paddle-signature"];
-      const { rawBody, query } = request;
+      const { body, query } = request;
       const { tenant } = query;
-      const bodyString = Buffer.isBuffer(rawBody)
-        ? rawBody.toString("utf8")
-        : rawBody;
+      const bodyString = Buffer.isBuffer(body)
+        ? body.toString("utf8")
+        : body;
 
       // Verify webhook authenticity
       const event = await paddleClient.webhooks.unmarshal(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Mounts `express.raw({ type: "*/*" })` for the webhook path in `bin/server.js` **before** the global `bodyParser.json()` middleware, so `req.body` is always a raw `Buffer` when the webhook handler runs. `processWebhook` then converts that Buffer to a UTF-8 string before passing it to the signature verifier. The now-redundant `express.raw()` in the webhook route definition is also removed.

### Why is this change needed?
`bodyParser.json()` is registered globally and runs before any route handlers. When a webhook request arrives, it parses the body into a JavaScript object and marks the request as consumed (`req._body = true`). The route-level `express.raw()` sees the body is already consumed and skips — so the signature verifier never received the raw bytes. A previous attempt used `bodyParser.json()`'s `verify` callback to capture `req.rawBody`, but that callback is only invoked when body-parser actually processes the request, which fails silently if the Content-Type doesn't match exactly. Mounting `express.raw()` on the specific path before the JSON parser is the only reliable way to guarantee the raw Buffer is preserved.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Three unit tests cover body normalisation in `processWebhook`: Buffer input is converted to a UTF-8 string, string input passes through unchanged, and a signature failure returns a structured error response. Verified in staging logs that `Invalid webhook signature` errors no longer appear after deployment.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Restores intended webhook behaviour — no interface or contract changes.

---

## :memo: Additional Notes

**Why the `verify` callback approach failed:**

```
bodyParser.json({ verify: (req, res, buf) => { req.rawBody = buf } })
  → verify only runs when body-parser processes the request
  → if Content-Type doesn't match or body-parser skips for any reason
  → req.rawBody = undefined
  → unmarshal receives undefined → signature always fails
```

**How this fix works:**

```
app.use("/api/v2/users/transactions/webhook", express.raw({ type: "*/*" }))
  → runs before bodyParser.json() for the webhook path
  → req.body = raw Buffer, req._body = true
app.use(bodyParser.json(...))
  → sees req._body = true → skips webhook requests
processWebhook:
  → req.body is a Buffer → toString("utf8") → valid string
  → unmarshal receives correct raw bytes → HMAC matches → signature passes
```

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized webhook request handling infrastructure for improved processing efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->