### PR TITLE
Fix SMTP rate-limiting via connection pooling and staggered cron jobs

### DIFF
--- a/src/auth-service/bin/jobs/subscription-renewal-job.js
+++ b/src/auth-service/bin/jobs/subscription-renewal-job.js
@@ -184,7 +184,7 @@ const subscriptionRenewalUtils = {
 };
 
 // Schedule jobs
-const renewalSchedule = "0 2 * * *"; // every day at 2 AM
+const renewalSchedule = "15 2 * * *"; // every day at 2:15 AM (staggered from inactive-users-job at 2:00 AM)
 cron.schedule(
   renewalSchedule,
   subscriptionRenewalUtils.processAutomaticRenewal,

--- a/src/auth-service/config/mailer.config.js
+++ b/src/auth-service/config/mailer.config.js
@@ -14,13 +14,19 @@ const directTransporter = nodemailer.createTransport({
   socketTimeout: 15000, // 15 seconds
 });
 
-// Transporter for background queue processing (longer timeout for resilience)
+// Transporter for background queue processing.
+// pool:true keeps one authenticated SMTP connection alive and reuses it across
+// sends, preventing repeated AUTH commands that trigger Google's rate-limit
+// ("Too many login attempts") when multiple pods drain the queue simultaneously.
 const queueTransporter = nodemailer.createTransport({
   service: "gmail",
   auth: {
     user: `${process.env.MAIL_USER}`,
     pass: `${process.env.MAIL_PASS}`,
   },
+  pool: true,
+  maxConnections: 1,
+  maxMessages: Infinity,
   connectionTimeout: 20000, // 20 seconds
   socketTimeout: 20000, // 20 seconds
 });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Enables SMTP connection pooling (`pool: true`, `maxConnections: 1`) on the `queueTransporter` in `mailer.config.js` so each pod keeps one authenticated Gmail SMTP session alive and reuses it across all queued sends.
- Staggeres the `subscription-renewal-job` cron from `0 2 * * *` to `15 2 * * *` (2:15 AM) so it no longer fires at the exact same moment as the `inactive-users-job`.

### Why is this change needed?
At 2:00 AM Africa/Nairobi, both the `inactive-users-job` and `subscription-renewal-job` fire simultaneously, dumping a large batch of emails into the MongoDB queue. In production, multiple pods each run an independent queue processor. Without connection pooling, every pod re-authenticates to Google SMTP for every single email it sends. Multiple pods hammering SMTP auth concurrently triggered Google's `454 4.7.0 Too many login attempts` rate-limit, causing a flood of `mailer-util` errors and preventing any emails from being delivered for the duration of the lockout.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `config/mailer.config.js`, `bin/jobs/subscription-renewal-job.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that the `queueTransporter` config change is backward-compatible — nodemailer's pooled transport exposes the same `sendMail` API. The staggered cron schedule was verified against the `node-cron` expression parser. The 2 AM flood scenario can be reproduced locally by seeding the email queue with many records and running multiple processes simultaneously; with pooling enabled, only one SMTP AUTH handshake occurs per process lifetime.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `directTransporter` (used for high-priority sends) is intentionally left without pooling — it is used for one-off immediate sends where a fresh connection is acceptable and connection reuse is not needed.
- If the team later migrates away from Gmail SMTP app passwords to OAuth2 or a dedicated email service (SendGrid, SES), the `pool` option will still be valid and beneficial.
- The `subscription-renewal-job` is now at **2:15 AM Africa/Nairobi** — any runbook or monitoring alert referencing the old 2:00 AM schedule should be updated.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Adjusted subscription renewal job timing for improved system performance
  * Enhanced email delivery configuration to improve reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->