### PR TITLE
Fix UserModel tenant factory call in webhook user identification

### DIFF
--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -539,3 +539,73 @@ describe("transactions.processWebhook — body normalisation", () => {
     expect(result.errors.message).to.include("Invalid webhook signature");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// identifyUserFromTransaction — tenant factory + user resolution
+// ─────────────────────────────────────────────────────────────────────────────
+describe("transactions.identifyUserFromTransaction", () => {
+  let findOneStub;
+  let createStub;
+
+  beforeEach(() => {
+    sinon.restore();
+    const UserModel = require("@models/User");
+    findOneStub = sinon.stub(UserModel("airqo"), "findOne");
+    createStub = sinon.stub(UserModel("airqo"), "create");
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("returns existing user and isNewUser: false when paddle_customer_id matches", async () => {
+    findOneStub.resolves({ _id: "user123" });
+
+    const result = await transactions.identifyUserFromTransaction(
+      { customer_id: "ctm_001" },
+      "airqo",
+    );
+
+    sinon.assert.calledOnce(findOneStub);
+    sinon.assert.notCalled(createStub);
+    expect(result.userId).to.equal("user123");
+    expect(result.isNewUser).to.equal(false);
+  });
+
+  it("creates a new user and returns isNewUser: true when no match is found", async () => {
+    findOneStub.resolves(null);
+    createStub.resolves({ _id: "user_new" });
+
+    const result = await transactions.identifyUserFromTransaction(
+      { customer_id: "ctm_002", email: "new@example.com" },
+      "airqo",
+    );
+
+    sinon.assert.calledOnce(createStub);
+    expect(result.userId).to.equal("user_new");
+    expect(result.isNewUser).to.equal(true);
+  });
+
+  it("defaults to airqo tenant when none is provided", async () => {
+    findOneStub.resolves({ _id: "user_default" });
+
+    const result = await transactions.identifyUserFromTransaction({
+      customer_id: "ctm_003",
+    });
+
+    sinon.assert.calledOnce(findOneStub);
+    expect(result.userId).to.equal("user_default");
+  });
+
+  it("throws 'Could not identify or create user' when the DB call fails", async () => {
+    findOneStub.rejects(new Error("DB connection lost"));
+
+    try {
+      await transactions.identifyUserFromTransaction(
+        { customer_id: "ctm_004" },
+        "airqo",
+      );
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(error.message).to.equal("Could not identify or create user");
+    }
+  });
+});

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -590,7 +590,7 @@ const transactions = {
     }
   },
 
-  handleCompletedTransaction: async (eventData) => {
+  handleCompletedTransaction: async (eventData, tenant) => {
     try {
       // Log the incoming event data for debugging
       logObject("Completed Transaction Event", eventData);
@@ -603,10 +603,7 @@ const transactions = {
 
       // Attempt to identify or create user associated with the transaction
       const userIdentification =
-        await transactions.identifyUserFromTransaction(
-          eventData,
-          constants.DEFAULT_TENANT || "airqo",
-        );
+        await transactions.identifyUserFromTransaction(eventData, tenant);
 
       // Prepare detailed transaction metadata
       const transactionMetadata = {
@@ -669,7 +666,7 @@ const transactions = {
 
       switch (event.type) {
         case "transaction.completed":
-          await transactions.handleCompletedTransaction(event.data);
+          await transactions.handleCompletedTransaction(event.data, tenant);
           break;
         case "transaction.payment_failed":
           await transactions.handleFailedTransaction(event.data);
@@ -715,6 +712,7 @@ const transactions = {
   /**
    * Attempt to identify user from transaction data
    * @param {Object} transactionData - Paddle transaction data
+   * @param {string} [tenant] - Tenant identifier; defaults to constants.DEFAULT_TENANT or "airqo"
    * @returns {Promise<Object>} User identification result
    */
   identifyUserFromTransaction: async (transactionData, tenant) => {

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -116,7 +116,7 @@ const transactions = {
 
       // Attempt to find or create associated user
       const userIdentification =
-        await transactions.identifyUserFromTransaction(paddleEventData);
+        await transactions.identifyUserFromTransaction(paddleEventData, tenant);
 
       // Prepare transaction creation body
       const creationBody = {
@@ -603,7 +603,10 @@ const transactions = {
 
       // Attempt to identify or create user associated with the transaction
       const userIdentification =
-        await transactions.identifyUserFromTransaction(eventData);
+        await transactions.identifyUserFromTransaction(
+          eventData,
+          constants.DEFAULT_TENANT || "airqo",
+        );
 
       // Prepare detailed transaction metadata
       const transactionMetadata = {
@@ -714,11 +717,10 @@ const transactions = {
    * @param {Object} transactionData - Paddle transaction data
    * @returns {Promise<Object>} User identification result
    */
-  identifyUserFromTransaction: async (transactionData) => {
+  identifyUserFromTransaction: async (transactionData, tenant) => {
+    const resolvedTenant = tenant || constants.DEFAULT_TENANT || "airqo";
     try {
-      // Logic to find or create user based on Paddle customer ID
-      // Try to find existing user by Paddle customer ID
-      const existingUser = await UserModel.findOne({
+      const existingUser = await UserModel(resolvedTenant).findOne({
         paddle_customer_id: transactionData.customer_id,
       });
 
@@ -729,12 +731,10 @@ const transactions = {
         };
       }
 
-      // If no existing user, create a new one
-      const newUser = await UserModel.create({
+      const newUser = await UserModel(resolvedTenant).create({
         paddle_customer_id: transactionData.customer_id,
         email: transactionData.email || null,
         name: transactionData.customer_name || null,
-        // Add any other relevant user creation fields
       });
 
       return {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes `identifyUserFromTransaction` to call `UserModel` as a tenant factory (`UserModel(tenant).findOne/create`) instead of calling Mongoose static methods directly on the factory function. Also passes `tenant` explicitly from both call sites (`create` and `handleCompletedTransaction`), falling back to `constants.DEFAULT_TENANT` where no tenant is available in scope.

### Why is this change needed?
After the webhook signature fix landed, webhooks began passing verification and reaching `identifyUserFromTransaction` for the first time in production. The function immediately threw `TypeError: UserModel.findOne is not a function` because `UserModel` in this codebase is a factory that must be invoked with a tenant string before Mongoose model methods are available. Every webhook that completed signature verification was silently failing at user resolution, so no transactions were being recorded.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Bug was confirmed from live production logs (`TypeError: UserModel.findOne is not a function` at `transaction.util.js:721`). Fix aligns with the existing tenant-factory pattern used throughout the file (e.g. `UserModel(defaultTenant).findByIdAndUpdate` in `performAdditionalBusinessLogic`). Existing unit tests pass; the affected code path requires a live Paddle webhook to exercise end-to-end.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely a correctness fix. No interface or contract changes.

---

## :memo: Additional Notes

**Root cause timeline:**
- Webhook signature verification was failing for an unrelated reason (wrong `unmarshal` argument order + body not preserved as Buffer).
- Once those were fixed, webhooks started reaching `identifyUserFromTransaction` — exposing this pre-existing bug that had been masked by the earlier failure.

**Pattern used elsewhere in this file:**
```js
// performAdditionalBusinessLogic — correct pattern this fix follows:
const defaultTenant = constants.DEFAULT_TENANT || "airqo";
await UserModel(defaultTenant).findByIdAndUpdate(user_id, { ... });
```

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced transaction handling to properly resolve user identification across different tenant contexts, improving reliability of account matching during transaction processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->