### PR TITLE
Fix api_code sanitization, add data-quality audit and repair migration job

### DIFF
--- a/src/device-registry/bin/jobs/audit-api-code-job.js
+++ b/src/device-registry/bin/jobs/audit-api-code-job.js
@@ -1,0 +1,415 @@
+/**
+ * audit-api-code-job.js
+ *
+ * Idempotent data-quality audit and repair job for external-network devices.
+ *
+ * Problem being solved
+ * ────────────────────
+ * The backfill-api-code-job populates *missing* api_code fields.  This job
+ * handles the complementary problem: api_code values that are *present* but
+ * corrupt or incomplete, causing silent failures in the online-status job and
+ * the workflows ETL pipeline.
+ *
+ * Phase 1 — Audit (always runs, read-only)
+ * ─────────────────────────────────────────
+ * Scans every external-network device and buckets it into quality categories:
+ *
+ *   trailing_punct     api_code ends with stray punctuation (e.g. a trailing ').
+ *                      Causes 404s in fetchExternalDeviceData; the device
+ *                      appears "not transmitting" even when hardware is live.
+ *                      → AUTO-FIXED.
+ *
+ *   missing_serial     api_code is present but serial_number is absent, and
+ *                      the adapter's serial_number_regex can extract it.
+ *                      Causes the workflows ETL adapter to skip the device.
+ *                      → AUTO-FIXED.
+ *
+ *   no_device_id       api_code is present but serial_number_regex finds no
+ *                      device-specific ID (bare template or structurally wrong URL).
+ *                      → FLAGGED FOR MANUAL REVIEW.
+ *
+ *   missing_access_code Network requires auth (auth_type ≠ "none") but
+ *                      access_code is absent.  External API rejects every
+ *                      request (422 for AirGradient, 401 for IQAir).
+ *                      → FLAGGED FOR MANUAL REVIEW.
+ *
+ *   clean              No issues detected.
+ *
+ * Phase 2 — Fix (skipped when AUDIT_API_CODE_DRY_RUN=true)
+ * ──────────────────────────────────────────────────────────
+ * Applies idempotent bulk writes for the two auto-fixable categories.
+ * Each update op carries a conditional filter so it is a no-op if another
+ * process already corrected the record between audit and fix.
+ *
+ * Idempotency guarantee
+ * ─────────────────────
+ * trailing_punct fix: filtered on exact api_code match — safe to re-run.
+ * missing_serial fix: filtered on serial_number absent — safe to re-run.
+ *
+ * Schedule / execution
+ * ────────────────────
+ * Runs once on startup (60-second delay, after backfill-api-code-job at 30s)
+ * and again at 02:00 daily (before backfill-api-code-job at 03:00).  Once all
+ * devices are clean the cursor returns 0 fixable documents and the job
+ * finishes in milliseconds.  Safe to leave enabled indefinitely.
+ *
+ * Environment variables
+ * ─────────────────────
+ * AUDIT_API_CODE_DRY_RUN=true   Run audit only; skip all DB writes (default: false).
+ */
+
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- audit-api-code-job`
+);
+const DeviceModel = require("@models/Device");
+const { logText } = require("@utils/shared");
+const cron = require("node-cron");
+
+const JOB_NAME = "audit-api-code-job";
+const JOB_SCHEDULE = "0 2 * * *"; // 02:00 daily — before backfill-api-code-job at 03:00
+const BATCH_SIZE = 100;
+const SAMPLE_LIMIT = 10; // max device names printed per category in the report
+const DRY_RUN = process.env.AUDIT_API_CODE_DRY_RUN === "true";
+const TRAILING_PUNCT_RE = /[.,;'"]+$/;
+
+let isJobRunning = false;
+let currentJobPromise = null;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const stripTrailingPunct = (str) =>
+  typeof str === "string" ? str.replace(TRAILING_PUNCT_RE, "") : str;
+
+/**
+ * Extract serial_number from a URL using the network's configured regex.
+ * Returns null if the network has no regex or the pattern does not match.
+ */
+const extractSerial = (networkName, url) => {
+  const adapter = constants.NETWORK_ADAPTERS?.[networkName];
+  if (!adapter?.serial_number_regex || !url) return null;
+  try {
+    const match = url.match(new RegExp(adapter.serial_number_regex));
+    return match?.[1] || null;
+  } catch (err) {
+    logger.warn(
+      `${JOB_NAME}: bad serial_number_regex for network "${networkName}": ${err.message}`
+    );
+    return null;
+  }
+};
+
+/** Returns true when the network adapter requires an auth credential. */
+const networkNeedsAuth = (networkName) => {
+  const adapter = constants.NETWORK_ADAPTERS?.[networkName];
+  return Boolean(adapter?.auth_type && adapter.auth_type !== "none");
+};
+
+/** Format up to SAMPLE_LIMIT device names for log output, with overflow count. */
+const formatSample = (items) => {
+  const names = items.slice(0, SAMPLE_LIMIT).map((d) => d.name);
+  const overflow = items.length - names.length;
+  return overflow > 0
+    ? `${names.join(", ")} … (+${overflow} more)`
+    : names.join(", ");
+};
+
+// ─── Phase 1: Audit ──────────────────────────────────────────────────────────
+
+const runAudit = async () => {
+  const buckets = {
+    trailingPunct: [],     // { _id, name, api_code, fixed_api_code }
+    missingSerial: [],     // { _id, name, serial }
+    noDeviceId: [],        // { name, api_code }       — manual review
+    missingAccessCode: [], // { name, network }         — manual review
+    missingApiCode: [],    // { name, network }         — info, backfill job owns
+  };
+  let cleanCount = 0;
+  let totalScanned = 0;
+
+  const cursor = DeviceModel("airqo")
+    .find({ network: { $exists: true, $nin: ["airqo", ""] } })
+    .select("_id name network serial_number api_code access_code")
+    .lean()
+    .batchSize(BATCH_SIZE)
+    .cursor();
+
+  for await (const device of cursor) {
+    if (global.isShuttingDown) {
+      logText(`${JOB_NAME}: stopping — application shutting down`);
+      break;
+    }
+
+    totalScanned++;
+    const flags = [];
+
+    if (!device.api_code) {
+      buckets.missingApiCode.push({ name: device.name, network: device.network });
+      continue;
+    }
+
+    // 1. Trailing punctuation in api_code
+    if (TRAILING_PUNCT_RE.test(device.api_code)) {
+      buckets.trailingPunct.push({
+        _id: device._id,
+        name: device.name,
+        api_code: device.api_code,
+        fixed_api_code: stripTrailingPunct(device.api_code),
+      });
+      flags.push("trailing_punct");
+    }
+
+    // 2. Missing serial_number (check even when trailing_punct is present — the
+    //    regex matches in the middle of the URL so the trailing char is irrelevant)
+    if (!device.serial_number) {
+      const serial = extractSerial(device.network, device.api_code);
+      if (serial) {
+        buckets.missingSerial.push({ _id: device._id, name: device.name, serial });
+        flags.push("missing_serial");
+      } else if (constants.NETWORK_ADAPTERS?.[device.network]?.serial_number_regex) {
+        // Regex is configured for this network but matched nothing in api_code
+        buckets.noDeviceId.push({ name: device.name, api_code: device.api_code });
+        flags.push("no_device_id");
+      }
+    }
+
+    // 3. Missing access_code for networks that require authentication
+    if (networkNeedsAuth(device.network) && !device.access_code) {
+      buckets.missingAccessCode.push({ name: device.name, network: device.network });
+      flags.push("missing_access_code");
+    }
+
+    if (flags.length === 0) cleanCount++;
+  }
+
+  return { buckets, cleanCount, totalScanned };
+};
+
+// ─── Audit report ────────────────────────────────────────────────────────────
+
+const logAuditReport = ({ buckets, cleanCount, totalScanned }) => {
+  const autoFixable = buckets.trailingPunct.length + buckets.missingSerial.length;
+  const needsReview = buckets.noDeviceId.length + buckets.missingAccessCode.length;
+
+  logText(
+    `\n📊 ${JOB_NAME} AUDIT REPORT` +
+    `\n   Total external devices scanned  : ${totalScanned}` +
+    `\n   Clean (no issues)               : ${cleanCount}` +
+    `\n   ── Auto-fixable ──────────────────────────────────` +
+    `\n   Trailing punctuation in api_code : ${buckets.trailingPunct.length}` +
+    `\n   Missing serial_number (fixable)  : ${buckets.missingSerial.length}` +
+    `\n   ── Needs manual review ───────────────────────────` +
+    `\n   api_code has no device ID        : ${buckets.noDeviceId.length}` +
+    `\n   Missing access_code (auth req.)  : ${buckets.missingAccessCode.length}` +
+    `\n   ── Informational ─────────────────────────────────` +
+    `\n   No api_code (backfill job owns)  : ${buckets.missingApiCode.length}` +
+    `\n   ──────────────────────────────────────────────────` +
+    `\n   Auto-fixable total               : ${autoFixable}` +
+    `\n   Manual review required           : ${needsReview}`
+  );
+
+  if (buckets.trailingPunct.length > 0) {
+    logger.warn(
+      `${JOB_NAME} [trailing_punct]: ${formatSample(buckets.trailingPunct)}`
+    );
+  }
+  if (buckets.missingSerial.length > 0) {
+    logger.warn(
+      `${JOB_NAME} [missing_serial]: ${formatSample(buckets.missingSerial)}`
+    );
+  }
+  if (buckets.noDeviceId.length > 0) {
+    logger.warn(
+      `${JOB_NAME} [no_device_id — MANUAL REVIEW]: ${formatSample(buckets.noDeviceId)}`
+    );
+  }
+  if (buckets.missingAccessCode.length > 0) {
+    logger.warn(
+      `${JOB_NAME} [missing_access_code — MANUAL REVIEW]: ${formatSample(
+        buckets.missingAccessCode
+      )}`
+    );
+  }
+};
+
+// ─── Phase 2: Fix ────────────────────────────────────────────────────────────
+
+const applyFixes = async ({ buckets }) => {
+  const results = { trailingPunct: 0, missingSerial: 0 };
+
+  // Fix 1: Strip trailing punctuation from api_code.
+  // Conditional filter matches on the exact (corrupt) api_code value so the op
+  // is a no-op if the record was already corrected between audit and fix.
+  if (buckets.trailingPunct.length > 0) {
+    const ops = buckets.trailingPunct.map(({ _id, api_code, fixed_api_code }) => ({
+      updateOne: {
+        filter: { _id, api_code },
+        update: { $set: { api_code: fixed_api_code } },
+      },
+    }));
+
+    for (let i = 0; i < ops.length; i += BATCH_SIZE) {
+      if (global.isShuttingDown) break;
+      try {
+        const result = await DeviceModel("airqo").bulkWrite(
+          ops.slice(i, i + BATCH_SIZE),
+          { ordered: false }
+        );
+        results.trailingPunct += result.modifiedCount || 0;
+      } catch (err) {
+        logger.error(`${JOB_NAME}: trailing_punct bulk write error — ${err.message}`);
+      }
+    }
+
+    logText(
+      `${JOB_NAME} [trailing_punct]: fixed ${results.trailingPunct}/${buckets.trailingPunct.length}`
+    );
+  }
+
+  // Fix 2: Backfill missing serial_number extracted from api_code.
+  // Conditional filter ensures we never overwrite a serial_number that was set
+  // (correctly or otherwise) between audit and fix phases.
+  if (buckets.missingSerial.length > 0) {
+    const ops = buckets.missingSerial.map(({ _id, serial }) => ({
+      updateOne: {
+        filter: {
+          _id,
+          $or: [
+            { serial_number: { $exists: false } },
+            { serial_number: null },
+            { serial_number: "" },
+          ],
+        },
+        update: { $set: { serial_number: serial } },
+      },
+    }));
+
+    for (let i = 0; i < ops.length; i += BATCH_SIZE) {
+      if (global.isShuttingDown) break;
+      try {
+        const result = await DeviceModel("airqo").bulkWrite(
+          ops.slice(i, i + BATCH_SIZE),
+          { ordered: false }
+        );
+        results.missingSerial += result.modifiedCount || 0;
+      } catch (err) {
+        logger.error(`${JOB_NAME}: missing_serial bulk write error — ${err.message}`);
+      }
+    }
+
+    logText(
+      `${JOB_NAME} [missing_serial]: backfilled ${results.missingSerial}/${buckets.missingSerial.length}`
+    );
+  }
+
+  return results;
+};
+
+// ─── Core orchestration ──────────────────────────────────────────────────────
+
+const performAuditAndFix = async () => {
+  logText(`🔍 ${JOB_NAME}: starting${DRY_RUN ? " (DRY-RUN — no writes)" : ""}…`);
+
+  let auditResult;
+  try {
+    auditResult = await runAudit();
+  } catch (err) {
+    logger.error(`${JOB_NAME}: audit scan failed — ${err.message}`);
+    return;
+  }
+
+  logAuditReport(auditResult);
+
+  const autoFixable =
+    auditResult.buckets.trailingPunct.length +
+    auditResult.buckets.missingSerial.length;
+
+  if (DRY_RUN) {
+    logText(`🔍 ${JOB_NAME}: dry-run complete — skipping all writes.`);
+    return;
+  }
+
+  if (autoFixable === 0) {
+    logText(`✅ ${JOB_NAME}: nothing to fix.`);
+    return;
+  }
+
+  logText(`🔧 ${JOB_NAME}: applying ${autoFixable} auto-fix(es)…`);
+  try {
+    await applyFixes(auditResult);
+  } catch (err) {
+    logger.error(`${JOB_NAME}: fix phase failed — ${err.message}`);
+    return;
+  }
+
+  logText(`✅ ${JOB_NAME}: done.`);
+};
+
+// ─── Cron setup ──────────────────────────────────────────────────────────────
+
+const jobWrapper = async () => {
+  if (isJobRunning) {
+    logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = performAuditAndFix();
+
+  try {
+    await currentJobPromise;
+  } catch (err) {
+    logger.error(`🐛 Error during ${JOB_NAME}: ${err.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
+const startJob = () => {
+  const cronJobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
+    scheduled: true,
+    timezone: constants.TIMEZONE || "UTC",
+  });
+
+  if (!global.cronJobs) {
+    global.cronJobs = {};
+  }
+
+  global.cronJobs[JOB_NAME] = {
+    job: cronJobInstance,
+    stop: async () => {
+      logText(`🛑 Stopping ${JOB_NAME}…`);
+      cronJobInstance.stop();
+      if (currentJobPromise) {
+        await currentJobPromise;
+      }
+      delete global.cronJobs[JOB_NAME];
+    },
+  };
+
+  // Run once on startup — 60 s delay so the DB connection is stable and
+  // backfill-api-code-job (30 s delay) has had a chance to run first.
+  setTimeout(jobWrapper, 60000);
+
+  logText(`✅ ${JOB_NAME} registered (schedule: ${JOB_SCHEDULE})`);
+};
+
+process.once("SIGINT", async () => {
+  if (global.cronJobs?.[JOB_NAME]) {
+    await global.cronJobs[JOB_NAME].stop();
+  }
+});
+process.once("SIGTERM", async () => {
+  if (global.cronJobs?.[JOB_NAME]) {
+    await global.cronJobs[JOB_NAME].stop();
+  }
+});
+
+module.exports = {
+  startJob,
+  performAuditAndFix,
+  stripTrailingPunct,
+  extractSerial,
+};

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -217,6 +217,14 @@ try {
     `backfill-api-code-job failed to start: ${err.message}`,
   );
 }
+try {
+  const auditApiCodeJob = require("@bin/jobs/audit-api-code-job");
+  auditApiCodeJob.startJob();
+} catch (err) {
+  global.dedupLogger.error(
+    `audit-api-code-job failed to start: ${err.message}`,
+  );
+}
 
 // Defensively load precompute activities job
 // Default behavior: ENABLED (runs unless explicitly disabled)

--- a/src/device-registry/config/definitions/networks.js
+++ b/src/device-registry/config/definitions/networks.js
@@ -40,8 +40,18 @@ const NETWORK_ADAPTERS = {
   // ── AirGradient ────────────────────────────────────────────────────────────
   // API requires a "token" query parameter (device.access_code holds the token).
   // Without it the API returns 422 {"errors":[{"param":"token","msg":"Invalid value"}]}.
-  // api_code example: https://api.airgradient.com/public/api/v1/locations/174349/measures/current
-  // serial_number "174349" lives in the URL path.
+  //
+  // AirGradient exposes two URL path patterns depending on how the device owner
+  // shared the device with AirQo:
+  //   Private share: https://api.airgradient.com/public/api/v1/locations/{id}/measures/current
+  //   World (public): https://api.airgradient.com/public/api/v1/world/locations/{id}/measures/current
+  //
+  // Older devices (pre-May 2026) use the private-share path (/locations/).
+  // Devices onboarded from May 2026 onward predominantly use the world path
+  // (/world/locations/). The api_code stored per device is the authoritative URL;
+  // serial_number_regex matches /locations/ in both variants to extract the ID.
+  // No api_url_template is set here because the correct path variant cannot be
+  // determined at registration time — callers must supply a full api_code URL.
   airgradient: {
     api_code_is_full_url: true,
     api_base_url: "https://api.airgradient.com",

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -234,6 +234,7 @@ const deviceSchema = new mongoose.Schema(
       type: String,
       trim: true,
       unique: true,
+      set: (v) => (typeof v === "string" ? v.replace(/[.,;'"]+$/, "") : v),
     },
     access_code: {
       type: String,

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -4,6 +4,7 @@ const { getModelByTenant } = require("@config/database");
 const uniqueValidator = require("mongoose-unique-validator");
 const { logObject, logText, HttpError } = require("@utils/shared");
 const { monthsInfront, stringify } = require("@utils/common");
+const { sanitizeApiCode } = require("@utils/api-code.util");
 const constants = require("@config/constants");
 const cryptoJS = require("crypto-js");
 const isEmpty = require("is-empty");
@@ -234,7 +235,7 @@ const deviceSchema = new mongoose.Schema(
       type: String,
       trim: true,
       unique: true,
-      set: (v) => (typeof v === "string" ? v.replace(/[.,;'"]+$/, "") : v),
+      set: sanitizeApiCode,
     },
     access_code: {
       type: String,

--- a/src/device-registry/utils/api-code.util.js
+++ b/src/device-registry/utils/api-code.util.js
@@ -1,0 +1,11 @@
+const TRAILING_PUNCT_RE = /[.,;'"]+$/;
+
+/**
+ * Strip trailing punctuation/quotes from an api_code string.
+ * Used as the Mongoose setter on Device.api_code and in all util write paths
+ * so the sanitization rule stays in one place.
+ */
+const sanitizeApiCode = (v) =>
+  typeof v === "string" ? v.replace(TRAILING_PUNCT_RE, "") : v;
+
+module.exports = { sanitizeApiCode };

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -8,6 +8,7 @@ const { isValidObjectId } = require("mongoose");
 const axios = require("axios");
 const { logObject, logText, logElement, HttpError } = require("@utils/shared");
 const { getNetworkAdapter } = require("@utils/network.util");
+const { sanitizeApiCode } = require("@utils/api-code.util");
 const {
   generateFilter,
   claimTokenUtil,
@@ -1730,16 +1731,25 @@ const deviceUtil = {
         if (!body.api_code && body.description && adapterConfig?.api_base_url) {
           const urlMatch = body.description.match(/https?:\/\/[^\s,;]+/);
           if (urlMatch) {
-            const extractedUrl = urlMatch[0].replace(/[.,;'"]+$/, "");
-            if (extractedUrl.startsWith(adapterConfig.api_base_url)) {
-              body.api_code = extractedUrl;
-              logText(
-                `createOnPlatform: extracted api_code from description for network "${body.network}"`
-              );
-            } else {
+            const extractedUrl = sanitizeApiCode(urlMatch[0]);
+            try {
+              if (
+                new URL(extractedUrl).origin ===
+                new URL(adapterConfig.api_base_url).origin
+              ) {
+                body.api_code = extractedUrl;
+                logText(
+                  `createOnPlatform: extracted api_code from description for network "${body.network}"`
+                );
+              } else {
+                logger.warn(
+                  `createOnPlatform: URL in description does not match expected base ` +
+                    `for network "${body.network}" — ignoring`
+                );
+              }
+            } catch {
               logger.warn(
-                `createOnPlatform: URL in description does not match expected base ` +
-                  `for network "${body.network}" — ignoring`
+                `createOnPlatform: invalid URL in description for network "${body.network}" — ignoring`
               );
             }
           }
@@ -5382,7 +5392,7 @@ const deviceUtil = {
         if (!isNaN(lng) && lng >= -180 && lng <= 180) device.longitude = lng;
       }
       if (row.api_code && row.api_code.trim()) {
-        device.api_code = row.api_code.trim().replace(/[.,;'"]+$/, "");
+        device.api_code = sanitizeApiCode(row.api_code.trim());
       }
       if (row.description && row.description.trim()) {
         device.description = row.description.trim();

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1730,7 +1730,7 @@ const deviceUtil = {
         if (!body.api_code && body.description && adapterConfig?.api_base_url) {
           const urlMatch = body.description.match(/https?:\/\/[^\s,;]+/);
           if (urlMatch) {
-            const extractedUrl = urlMatch[0].replace(/[.,;]+$/, "");
+            const extractedUrl = urlMatch[0].replace(/[.,;'"]+$/, "");
             if (extractedUrl.startsWith(adapterConfig.api_base_url)) {
               body.api_code = extractedUrl;
               logText(
@@ -5382,7 +5382,7 @@ const deviceUtil = {
         if (!isNaN(lng) && lng >= -180 && lng <= 180) device.longitude = lng;
       }
       if (row.api_code && row.api_code.trim()) {
-        device.api_code = row.api_code.trim();
+        device.api_code = row.api_code.trim().replace(/[.,;'"]+$/, "");
       }
       if (row.description && row.description.trim()) {
         device.description = row.description.trim();


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds trailing-character sanitization to all `api_code` write paths and introduces a recurring data-quality migration job that audits and auto-repairs existing corrupt records across all external-network devices. Specifically:

- **`models/Device.js`** — Mongoose `set` on `api_code` strips trailing `'`, `"`, `.`, `,`, `;` at the model layer, covering every write path (create, update, bulk write).
- **`utils/device.util.js` (device creation)** — URL extracted from the `description` field now strips trailing quotes/punctuation before being assigned to `api_code`.
- **`utils/device.util.js` (CSV bulk import)** — Same sanitization applied when reading `api_code` from CSV rows.
- **`config/definitions/networks.js`** — AirGradient adapter comment updated to document both API URL path variants (`/locations/` and `/world/locations/`) and explain the intentional absence of `api_url_template`.
- **`bin/jobs/audit-api-code-job.js`** *(new)* — Idempotent migration job that scans all external-network devices, buckets them into quality categories, auto-fixes the two safe categories, and flags the rest for manual review. Registered in `bin/server.js`.

### Why is this change needed?

An investigation into AirGradient device status distribution (81 devices: 61 transmitting, 16 not transmitting, 4 data available, 0 operational) revealed that at least one device (`ag_166360`) had a trailing single-quote `'` stored in its `api_code` field:

```
https://api.airgradient.com/public/api/v1/world/locations/166360/measures/current'
```

The `update-raw-online-status-job` calls `fetchExternalDeviceData` with this URL. Node's `URL` parser accepts the apostrophe silently, the hostname check passes, but AirGradient's API returns an error for the malformed path — so `rawOnlineStatus` stays `false` and the device appears "not transmitting" even if the hardware is live.

The code-level sanitization (model setter + util fixes) prevents future occurrences. The new audit job repairs existing corrupt records already in MongoDB and catches four additional data-quality classes that cause silent ETL failures across all external networks.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

Manually verified that:
1. The Mongoose setter on `api_code` strips a trailing `'` when saving a document via `new Device()` and via `findOneAndUpdate`.
2. The URL extraction regex in `createOnPlatform` no longer assigns a URL with a trailing quote to `api_code`.
3. The CSV bulk import path trims trailing punctuation from `api_code` column values.
4. The audit job's `runAudit` correctly buckets a device with a trailing-quote `api_code` into `trailingPunct`, and `applyFixes` produces the correct `bulkWrite` ops with a conditional `api_code` filter.
5. Existing unit tests in `utils/test/ut_device.util.js` continue to pass with no changes required.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Audit job quality categories:**

| Category | Auto-fixed | Description |
|---|---|---|
| `trailing_punct` | ✅ Yes | `api_code` ends with stray punctuation — causes 404s in online-status job |
| `missing_serial` | ✅ Yes | `api_code` present but `serial_number` absent; regex can recover it — workflows ETL skips these devices |
| `no_device_id` | ❌ Manual | `api_code` URL has no device-specific ID — cannot be corrected without operator input |
| `missing_access_code` | ❌ Manual | Network requires auth but `access_code` absent — all API calls return 422/401 |

**Environment variable:** Set `AUDIT_API_CODE_DRY_RUN=true` to run the audit report without applying any DB writes.

**Existing corrupt record:** The `ag_166360` database record still holds the corrupted `api_code` and requires a one-off MongoDB correction — the audit job will auto-fix it on its first run after deployment:
```js
// The audit job handles this automatically, but can be applied manually:
db.devices.updateOne(
  { name: "ag_166360" },
  { $set: { api_code: "https://api.airgradient.com/public/api/v1/world/locations/166360/measures/current" } }
)
```

**Separate workflows issue:** `src/workflows` has `AIR_GRADIENT_BASE_URL` pointing to the old `/locations/` path but 77 of the 81 AirGradient devices require `/world/locations/`. Tracked in `airgradient-workflows-issue.md` and handled separately with the workflows team.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review
