### PR TITLE
Fix SDK eventType property and scope DB writes to transaction events only

### DIFF
--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -482,9 +482,10 @@ describe("transactions.createCheckoutSession — customer resolution", () => {
 
 describe("transactions.processWebhook — body normalisation", () => {
   let unmarshalStub;
-  // Mirrors the camelCase structure the Paddle Node SDK actually returns
+  // Mirrors the real Paddle Node SDK Event object: eventType (not type) on the
+  // event wrapper; camelCase fields on event.data.
   const fakeEvent = {
-    type: "transaction.completed",
+    eventType: "transaction.completed",
     data: {
       id: "txn_001",
       customerId: "ctm_001",

--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -549,6 +549,20 @@ describe("transactions.processWebhook — body normalisation", () => {
     expect(body.total).to.equal(99);
   });
 
+  it("returns OK and does not call transactions.create for non-transaction events", async () => {
+    unmarshalStub.resolves({
+      eventType: "subscription.activated",
+      data: { id: "sub_001" },
+    });
+    const req = mockWebhookRequest(Buffer.from("{}", "utf8"));
+
+    const result = await transactions.processWebhook(req, () => {});
+
+    sinon.assert.notCalled(transactions.create);
+    expect(result.success).to.equal(true);
+    expect(result.message).to.equal("Event received");
+  });
+
   it("returns an error response when unmarshal throws Invalid webhook signature", async () => {
     unmarshalStub.rejects(new Error("[Paddle] Invalid webhook signature"));
     const req = mockWebhookRequest(Buffer.from("{}", "utf8"));

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -683,34 +683,27 @@ const transactions = {
         ),
       };
 
-      // Only persist a transaction record for financial transaction events.
-      // Non-transaction events (subscription.*, customer.*, etc.) are
-      // acknowledged but do not create a DB record.
-      let result;
+      // Non-transaction events are acknowledged and returned early so
+      // transactions.create is never reached for them.
       switch (event.eventType) {
         case "transaction.completed":
           await transactions.handleCompletedTransaction(
             normalizedTransaction,
             tenant,
           );
-          result = await transactions.create(
-            { body: normalizedTransaction, query: { tenant } },
-            next,
-          );
           break;
         case "transaction.payment_failed":
           await transactions.handleFailedTransaction(normalizedTransaction);
-          result = await transactions.create(
-            { body: normalizedTransaction, query: { tenant } },
-            next,
-          );
           break;
         default:
           logger.info(`Paddle webhook event ${event.eventType} received but not handled`);
-          result = { success: true, message: "Event received", status: httpStatus.OK };
+          return { success: true, message: "Event received", status: httpStatus.OK };
       }
 
-      return result;
+      return await transactions.create(
+        { body: normalizedTransaction, query: { tenant } },
+        next,
+      );
     } catch (error) {
       opsLogger.warn("webhook-debug", {
         bodyType: Buffer.isBuffer(request.body) ? "Buffer" : typeof request.body,

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -668,9 +668,10 @@ const transactions = {
       // Normalise SDK camelCase fields to snake_case once so all downstream
       // callers (handlers, identifyUserFromTransaction, create) use consistent
       // field names without each needing its own camelCase fallback.
+      // SDK exposes eventType (camelCase), not type.
       const normalizedTransaction = {
         ...event.data,
-        type: event.type,
+        type: event.eventType,
         customer_id: event.data.customerId || event.data.customer_id,
         currency: (
           event.data.currencyCode ||
@@ -682,27 +683,32 @@ const transactions = {
         ),
       };
 
-      switch (event.type) {
+      // Only persist a transaction record for financial transaction events.
+      // Non-transaction events (subscription.*, customer.*, etc.) are
+      // acknowledged but do not create a DB record.
+      let result;
+      switch (event.eventType) {
         case "transaction.completed":
           await transactions.handleCompletedTransaction(
             normalizedTransaction,
             tenant,
           );
+          result = await transactions.create(
+            { body: normalizedTransaction, query: { tenant } },
+            next,
+          );
           break;
         case "transaction.payment_failed":
           await transactions.handleFailedTransaction(normalizedTransaction);
+          result = await transactions.create(
+            { body: normalizedTransaction, query: { tenant } },
+            next,
+          );
           break;
         default:
-          logger.warn(`Unhandled event type: ${event.type}`);
+          logger.info(`Paddle webhook event ${event.eventType} received but not handled`);
+          result = { success: true, message: "Event received", status: httpStatus.OK };
       }
-
-      const result = await transactions.create(
-        {
-          body: normalizedTransaction,
-          query: { tenant },
-        },
-        next,
-      );
 
       return result;
     } catch (error) {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes two related bugs in `processWebhook`:

1. **Corrects `event.type` → `event.eventType`** throughout the webhook handler. The Paddle Node SDK's `Event` base class sets `this.eventType` (camelCase), not `this.type`. Reading `event.type` always returned `undefined`.

2. **Scopes `transactions.create` to transaction events only.** Previously `transactions.create` (and therefore the MongoDB write) was called unconditionally after the switch, meaning every Paddle webhook — including `subscription.activated`, `customer.updated`, etc. — attempted to create a transaction record and failed validation.

Also updates the unit test's `fakeEvent` fixture from `{ type: "transaction.completed" }` to `{ eventType: "transaction.completed" }` to match the real SDK shape.

### Why is this change needed?
After the webhook signature fix landed, all events from Paddle began reaching the processing logic. Two cascading failures appeared in production:

- **`paddle_event_type: Path paddle_event_type is required.`** — `event.type` is always `undefined` in the Paddle Node SDK (it uses `event.eventType`). This meant `normalizedTransaction.type` was always `undefined`, Mongoose saw a missing required field, and every single webhook was rejected.

- **`amount: Cast to Number failed for value "NaN"`** — because the switch always fell through to `default` (event type never matched), `transactions.create` was called for non-transaction events like `subscription.activated`. Those events carry subscription data, not `details.totals.total`, so `parseFloat(undefined)` produced `NaN`.

Confirmed by reading the SDK source at `node_modules/@paddle/paddle-node-sdk/dist/cjs/entities/events/event.js`:
```js
class Event {
  constructor(eventData) {
    this.eventType = eventData.event_type; // ← eventType, NOT type
    this.data = eventData.data;
    ...
  }
}
```

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Updated the `processWebhook` unit test fixture from `{ type: "transaction.completed" }` to `{ eventType: "transaction.completed" }` to match the real SDK object. The existing normalisation test (`normalises SDK camelCase fields and passes merged type to transactions.create`) now correctly exercises the `event.eventType` code path and validates `body.type`, `body.customer_id`, `body.currency`, and `body.total`. End-to-end confirmation will come from the next Paddle webhook fired in production.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Webhook routing is now more correct — non-transaction events return `{ success: true }` instead of a Mongoose validation error, which is the expected Paddle webhook response.

---

## :memo: Additional Notes

**Error timeline:**
| Time window | Error | Cause |
|---|---|---|
| Pre-normalization deployment | `paddle_event_type required, paddle_customer_id required, amount required` | Reading snake_case fields on camelCase SDK object |
| Post-normalization, pre-this-fix | `paddle_event_type required` + `amount: NaN` | `event.type` = `undefined`; `create` called for all event types |
| After this fix | Expected: no validation errors | `event.eventType` used; `create` scoped to transaction events |

**Non-transaction events (subscription.*, customer.*, etc.):**
These events are now acknowledged with `{ success: true, message: "Event received" }` and logged at INFO level. No transaction record is written. Paddle requires a 2xx response to consider a webhook delivery successful — returning 200 with this payload satisfies that requirement.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook event handling to correctly identify and process transaction-related events, ensuring non-transaction events are properly acknowledged without creating unwanted transaction records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->