### PR TITLE
Remove redundant process signal handlers from api-code background jobs

### DIFF
--- a/src/device-registry/bin/jobs/audit-api-code-job.js
+++ b/src/device-registry/bin/jobs/audit-api-code-job.js
@@ -396,17 +396,6 @@ const startJob = () => {
   logText(`✅ ${JOB_NAME} registered (schedule: ${JOB_SCHEDULE})`);
 };
 
-process.once("SIGINT", async () => {
-  if (global.cronJobs?.[JOB_NAME]) {
-    await global.cronJobs[JOB_NAME].stop();
-  }
-});
-process.once("SIGTERM", async () => {
-  if (global.cronJobs?.[JOB_NAME]) {
-    await global.cronJobs[JOB_NAME].stop();
-  }
-});
-
 module.exports = {
   startJob,
   performAuditAndFix,

--- a/src/device-registry/bin/jobs/backfill-api-code-job.js
+++ b/src/device-registry/bin/jobs/backfill-api-code-job.js
@@ -260,17 +260,4 @@ const startJob = () => {
   logText(`✅ ${JOB_NAME} registered (schedule: ${JOB_SCHEDULE})`);
 };
 
-// Graceful shutdown — use process.once to prevent duplicate handler registration
-// when the module is reloaded (e.g. during tests).
-process.once("SIGINT", async () => {
-  if (global.cronJobs?.[JOB_NAME]) {
-    await global.cronJobs[JOB_NAME].stop();
-  }
-});
-process.once("SIGTERM", async () => {
-  if (global.cronJobs?.[JOB_NAME]) {
-    await global.cronJobs[JOB_NAME].stop();
-  }
-});
-
 module.exports = { startJob, performBackfill, extractUrlFromText, extractSerialFromUrl };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Removes redundant `process.once("SIGINT", ...)` and `process.once("SIGTERM", ...)` handlers from two background jobs:

- **`bin/jobs/audit-api-code-job.js`**
- **`bin/jobs/backfill-api-code-job.js`**

### Why is this change needed?

Running the application produced the following warning in logs:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 SIGINT listeners added to [process]. Use emitter.setMaxListeners() to increase limit.
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 SIGTERM listeners added to [process]. Use emitter.setMaxListeners() to increase limit.
```

Node.js defaults to a maximum of 10 listeners per event. Each job that registers its own `process.once` signal handlers contributes to this count. The `audit-api-code-job` (recently added) pushed the total to 11, triggering the warning.

The individual signal handlers in these jobs are redundant — graceful shutdown is already handled centrally via two existing mechanisms:

1. `global.isShuttingDown` — checked inside each job's processing loop to stop iteration cleanly.
2. `global.cronJobs[JOB_NAME].stop()` — registered on the global cron registry, callable by a central shutdown coordinator.

The per-job `process.once` handlers duplicate this logic and accumulate across all jobs loaded by `server.js`, causing the listener count to exceed Node's default threshold.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

Restarted the application after the change and confirmed the `MaxListenersExceededWarning` no longer appears in logs. Verified that graceful shutdown via `global.cronJobs` still stops both jobs cleanly.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- Other jobs in `bin/jobs/` that follow the same `process.once` pattern may also be contributing to the listener count. This PR addresses only the two jobs directly related to recent changes; a broader audit of signal handler registration across all jobs can be tracked separately if needed.
- Graceful shutdown behaviour is unchanged — both jobs continue to respect `global.isShuttingDown` and remain stoppable via `global.cronJobs[JOB_NAME].stop()`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified background job shutdown behavior by removing redundant signal handlers from job modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->