### PR TITLE
Fix OAuth CSRF state via cookie store and update LinkedIn scopes

### DIFF
--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const crypto = require("crypto");
 const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const GitHubStrategy = require("passport-github2").Strategy;
 const constants = require("@config/constants");
@@ -9,6 +10,111 @@ const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- passport-strategies`,
 );
+
+/**
+ * Stateless OAuth 2.0 CSRF state store backed by HMAC-signed cookies.
+ *
+ * Replaces passport-oauth2's default session-based StateStore so that
+ * the OAuth redirect round-trip has zero dependence on Redis or MongoDB.
+ * The state is signed with SESSION_SECRET (timing-safe comparison on
+ * verify) and stored in a short-lived HttpOnly cookie. Works correctly
+ * across any number of pods with no shared session store.
+ *
+ * Implements the passport-oauth2 v1.8.0 four-argument store/verify API
+ * (arity-detected by the framework).
+ */
+class CookieStateStore {
+  constructor({ secret, cookieName, ttlSeconds = 600 } = {}) {
+    if (!secret) throw new Error("CookieStateStore: secret is required");
+    this._secret = secret;
+    this._cookieName = cookieName || "_oauth2_state";
+    this._ttl = ttlSeconds;
+  }
+
+  // Called by passport-oauth2 before redirecting to the provider.
+  // Saves the state in a signed cookie so no server-side storage is needed.
+  store(req, state, meta, callback) {
+    const signed = this._sign(state);
+    const res = req.res;
+    if (!res) {
+      return callback(new Error("CookieStateStore: response object unavailable on req.res"));
+    }
+    res.cookie(this._cookieName, signed, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax", // allows cookie on top-level GET from provider redirect
+      maxAge: this._ttl * 1000,
+      path: "/",
+    });
+    callback(null);
+  }
+
+  // Called by passport-oauth2 on the callback to verify CSRF state.
+  verify(req, state, meta, callback) {
+    const signedCookie = req.cookies && req.cookies[this._cookieName];
+    if (!signedCookie) {
+      logger.warn(
+        `[CookieStateStore] state cookie "${this._cookieName}" missing — ` +
+          "possible CSRF attempt or browser cookie policy blocked the cookie",
+      );
+      return callback(null, false, { message: "OAuth state cookie missing" });
+    }
+
+    const storedState = this._unsign(signedCookie);
+    if (!storedState) {
+      return callback(null, false, { message: "OAuth state cookie signature invalid" });
+    }
+
+    // One-time use: clear the cookie immediately after reading.
+    if (req.res) req.res.clearCookie(this._cookieName, { path: "/" });
+
+    // Constant-time comparison guards against timing attacks.
+    if (!this._safeEqual(state, storedState)) {
+      return callback(null, false, { message: "OAuth state mismatch" });
+    }
+
+    callback(null, true);
+  }
+
+  _sign(value) {
+    const sig = crypto
+      .createHmac("sha256", this._secret)
+      .update(value)
+      .digest("base64url");
+    return `${value}.${sig}`;
+  }
+
+  _unsign(signedValue) {
+    const sep = signedValue.lastIndexOf(".");
+    if (sep === -1) return null;
+    const value = signedValue.substring(0, sep);
+    const sig = signedValue.substring(sep + 1);
+    try {
+      const expected = crypto
+        .createHmac("sha256", this._secret)
+        .update(value)
+        .digest("base64url");
+      const sBuf = Buffer.from(sig, "base64url");
+      const eBuf = Buffer.from(expected, "base64url");
+      if (sBuf.length !== eBuf.length) return null;
+      if (!crypto.timingSafeEqual(sBuf, eBuf)) return null;
+      return value;
+    } catch {
+      return null;
+    }
+  }
+
+  _safeEqual(a, b) {
+    try {
+      const aBuf = Buffer.from(a);
+      const bBuf = Buffer.from(b);
+      if (aBuf.length !== bBuf.length) return false;
+      return crypto.timingSafeEqual(aBuf, bBuf);
+    } catch {
+      return false;
+    }
+  }
+}
 
 // ── Strategy registration guard ───────────────────────────────────────────────
 // Strategies are registered once at startup (bin/server.js). This flag
@@ -157,7 +263,10 @@ function configureStrategies(passport, tenant) {
           clientSecret: constants.GOOGLE_CLIENT_SECRET,
           callbackURL: buildCallbackURL("google"),
           passReqToCallback: true,
-          state: true,
+          store: new CookieStateStore({
+            secret: constants.SESSION_SECRET,
+            cookieName: "_oauth2_state_google",
+          }),
         },
         makeStrategyCallback("google"),
       ),
@@ -181,7 +290,10 @@ function configureStrategies(passport, tenant) {
           callbackURL: buildCallbackURL("github"),
           scope: ["user:email"],
           passReqToCallback: true,
-          state: true,
+          store: new CookieStateStore({
+            secret: constants.SESSION_SECRET,
+            cookieName: "_oauth2_state_github",
+          }),
         },
         makeStrategyCallback(
           "github",
@@ -209,9 +321,16 @@ function configureStrategies(passport, tenant) {
             clientID: constants.LINKEDIN_CLIENT_ID,
             clientSecret: constants.LINKEDIN_CLIENT_SECRET,
             callbackURL: buildCallbackURL("linkedin"),
-            scope: ["r_emailaddress", "r_liteprofile"],
+            // OpenID Connect scopes required for "Sign In with LinkedIn using
+            // OpenID Connect" product (Standard Tier). The deprecated v2 Member
+            // Data Portability scopes (r_emailaddress, r_liteprofile) are no
+            // longer accepted on newly created apps.
+            scope: ["openid", "profile", "email"],
             passReqToCallback: true,
-            state: true,
+            store: new CookieStateStore({
+              secret: constants.SESSION_SECRET,
+              cookieName: "_oauth2_state_linkedin",
+            }),
           },
           makeStrategyCallback(
             "linkedin",
@@ -247,7 +366,10 @@ function configureStrategies(passport, tenant) {
             scope: ["user.read"],
             tenant: "common",
             passReqToCallback: true,
-            state: true,
+            store: new CookieStateStore({
+              secret: constants.SESSION_SECRET,
+              cookieName: "_oauth2_state_microsoft",
+            }),
           },
           makeStrategyCallback(
             "microsoft",

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1417,7 +1417,7 @@ const authOAuth = (req, res, next) => {
   const providerScopes = {
     google: ["profile", "email"],
     github: ["user:email"],
-    linkedin: ["r_emailaddress", "r_liteprofile"],
+    linkedin: ["openid", "profile", "email"],
     microsoft: ["user.read"],
   };
 
@@ -1435,17 +1435,45 @@ const authOAuth = (req, res, next) => {
 /**
  * Dynamically handles the OAuth callback for any supported provider.
  * Used by the generic GET /auth/callback/:provider route.
- * Catches InternalOAuthError (e.g. ECONNRESET during token exchange) and
- * redirects to the failure URL rather than propagating a 500.
+ *
+ * All errors — InternalOAuthError (token exchange failures), application-level
+ * errors (e.g. email not returned by provider), and session errors (e.g.
+ * "Failed to find request token in session" in OAuth 1.0a) — redirect to the
+ * failure URL instead of propagating a 500.
+ *
+ * Returning a 500 here was causing a double-request bug in the Twitter OAuth
+ * 1.0a flow: passport-oauth1 destroys the request token from the session
+ * before invoking the verify callback, so any 500 that triggers a load-balancer
+ * or browser retry hits the callback a second time with no session token and
+ * logs a spurious "Failed to find request token in session" error.
+ *
+ * Note: failureRedirect has no effect in callback mode (the third-argument
+ * form of passport.authenticate). All outcomes are handled by the callback.
  */
 const authOAuthCallback = (req, res, next) => {
   const provider = req.oauthProvider || (req.params.provider || "").toLowerCase() || "google";
-  passport.authenticate(provider, {
-    failureRedirect: `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}`,
-    session: false,
-  })(req, res, (err) => {
-    if (err) return handleOAuthCallbackError(err, provider, res, next);
-    next();
+  const failureRedirectUrl = buildOAuthFailureRedirect(
+    constants.GMAIL_VERIFICATION_FAILURE_REDIRECT,
+  );
+  passport.authenticate(provider, { session: false })(req, res, (err) => {
+    if (!err) return next();
+    const safeProvider = SUPPORTED_OAUTH_PROVIDERS.has(provider)
+      ? provider
+      : "unknown";
+    if (err.name === "InternalOAuthError" || err.oauthError) {
+      // Do not log err.message — may contain raw OAuth tokens from provider.
+      logger.error("OAuth token exchange failed", {
+        provider: safeProvider,
+        errorType: err.name || "OAuthError",
+      });
+    } else {
+      logger.error(`[passport] OAuth callback error for ${safeProvider}`, {
+        provider: safeProvider,
+        errorType: err.name || "Error",
+        message: err.message,
+      });
+    }
+    return res.redirect(failureRedirectUrl);
   });
 };
 

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1447,15 +1447,24 @@ const authOAuth = (req, res, next) => {
  * or browser retry hits the callback a second time with no session token and
  * logs a spurious "Failed to find request token in session" error.
  *
- * Note: failureRedirect has no effect in callback mode (the third-argument
- * form of passport.authenticate). All outcomes are handled by the callback.
+ * Note: this is NOT passport's custom-callback form
+ * (passport.authenticate(strategy, callbackFn)). It calls the middleware
+ * returned by passport.authenticate(provider, options) with an overridden
+ * next function. In this form, failureRedirect in options still applies to
+ * authentication failures (cb(null,false) paths such as state mismatch or
+ * user-denied consent) and redirects before the custom next is invoked.
+ * Errors (cb(err) paths) bypass failureRedirect and go through the custom
+ * next, where we redirect them explicitly below.
  */
 const authOAuthCallback = (req, res, next) => {
   const provider = req.oauthProvider || (req.params.provider || "").toLowerCase() || "google";
   const failureRedirectUrl = buildOAuthFailureRedirect(
     constants.GMAIL_VERIFICATION_FAILURE_REDIRECT,
   );
-  passport.authenticate(provider, { session: false })(req, res, (err) => {
+  passport.authenticate(provider, {
+    session: false,
+    failureRedirect: failureRedirectUrl,
+  })(req, res, (err) => {
     if (!err) return next();
     const safeProvider = SUPPORTED_OAUTH_PROVIDERS.has(provider)
       ? provider


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces passport-oauth2's session-based CSRF state store with a stateless `CookieStateStore` backed by HMAC-SHA256 signed cookies for all OAuth 2.0 providers (Google, GitHub, LinkedIn, Microsoft). Updates LinkedIn scopes from the deprecated v2 Member Data Portability API to OpenID Connect. Fixes the Twitter OAuth 1.0a callback error-handling path that was returning 500 responses and triggering a spurious secondary "Failed to find request token in session" error on load-balancer retries.

### Why is this change needed?
Google social login was silently broken in production because `buildSessionStore()` runs synchronously at startup before the async Redis connection establishes, causing the session store to always fall back to MongoDB's deprecated "preconnected" mode. With multiple pods and no guaranteed session affinity, the OAuth `state` CSRF token stored in session during `/auth/google` could not be reliably read back during the `/auth/callback/google` round-trip — passport silently redirected to the login page on every attempt. The `CookieStateStore` is entirely stateless (no Redis or MongoDB needed) and works correctly across any number of pods. LinkedIn's old scopes (`r_emailaddress`, `r_liteprofile`) are rejected by apps on the new "Sign In with LinkedIn using OpenID Connect" product (Standard Tier); migrating to `openid profile email` unblocks LinkedIn login. The Twitter fix eliminates 500 responses on authentication failures, which were triggering nginx ingress retries against already-consumed OAuth 1.0a request tokens in the session.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/auth-service` — `config/passport-strategies.js`, `middleware/passport.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Google social login was already verified working in staging. Production login was consistently failing due to the session/Redis race condition diagnosed from pod startup logs. LinkedIn was blocked by both the mismatched redirect URI (configuration fix required in LinkedIn Developer Console) and the deprecated scopes (code fix in this PR). Twitter callback 500s and the resulting "Failed to find request token in session" secondary errors were confirmed via Slack log analysis and eliminated by making all OAuth callback errors redirect cleanly rather than propagate as 500.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `CookieStateStore` is a drop-in replacement for passport-oauth2's session `StateStore`. Users who are mid-flight through an OAuth redirect at the moment of a rolling deployment will have their state cookie invalidated and will see an "OAuth state cookie missing" failure, redirecting them to the login page to try again — the same behaviour as any existing rolling restart.

---

## :memo: Additional Notes

**LinkedIn OIDC scope migration:** `passport-linkedin-oauth2` v2 accepts OpenID Connect scopes directly. The profile extraction in `social-auth.util.js` already reads `profile._json.email`, `profile._json.given_name`, and `profile._json.family_name`, which are all returned by the OIDC endpoint. No changes to profile handling were needed.

**Session infrastructure retained:** The Redis → MongoDB session fallback is kept for the remaining session uses (`oauthTenant`, `redirect_after` persistence). Only the OAuth CSRF state has moved to signed cookies.

**Outstanding configuration fixes required in provider developer consoles (not in this PR):**
- **Google:** No code changes needed; production callback URL already registered. Fix was the `CookieStateStore` replacing the broken session-based state.
- **GitHub:** Create separate OAuth Apps for staging and production. Each app's Authorization callback URL must be set to `{env-domain}/api/v2/users/auth/callback/github`. Update `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` env vars per environment.
- **LinkedIn:** Register `https://staging-analytics.airqo.net/api/v2/users/auth/callback/linkedin` and `https://analytics.airqo.net/api/v2/users/auth/callback/linkedin` in the LinkedIn app's Auth tab → Authorized redirect URLs.
- **Twitter/X:** Enable "Request email from users" in Twitter Developer Portal → App → User authentication settings → Permissions, then regenerate Consumer Key/Secret. Note: email return is not guaranteed for all X accounts regardless of this setting.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Implemented stateless OAuth state management using signed cookies for improved security and reliability.

* **Updates**
  * Updated LinkedIn OAuth integration to use current OpenID standard scopes.

* **Bug Fixes**
  * Improved OAuth callback error handling and logging for better error visibility and consistency across all OAuth providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->