### PR TITLE
Fix double response in forgotPassword user not found path

### DIFF
--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -1539,8 +1539,29 @@ describe("create-user-util", function () {
       });
     });
 
+    it("should call next with a 400 error and not invoke modify or mailer when user does not exist", async () => {
+      const request = {
+        body: {},
+        query: { tenant: "your-tenant" },
+      };
+      const next = sinon.spy();
+
+      sinon.stub(generateFilter, "users").returns({ email: "unknown@example.com" });
+      sinon.stub(UserModel("your-tenant"), "exists").resolves(false);
+      const modifyStub = sinon.stub(UserModel("your-tenant"), "modify").resolves({});
+      sinon.stub(mailer, "forgot").resolves({});
+
+      await forgotPassword(request, next);
+
+      sinon.assert.calledOnce(next);
+      const errorArg = next.firstCall.args[0];
+      expect(errorArg).to.be.instanceOf(Error);
+      expect(errorArg.statusCode).to.equal(httpStatus.BAD_REQUEST);
+      sinon.assert.notCalled(modifyStub);
+    });
+
     // Add more test cases to cover other scenarios
-    // For example, when the user does not exist, when generating the reset token fails, when modifying the user fails, etc.
+    // For example, when generating the reset token fails, when modifying the user fails, etc.
   });
   describe("updateForgottenPassword", () => {
     afterEach(() => {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -4497,7 +4497,7 @@ const createUserModule = {
       const userExists = await UserModel(tenant).exists(filter);
 
       if (!userExists) {
-        next(
+        return next(
           new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
             message:
               "Sorry, the provided email or username does not belong to a registered user. Please make sure you have entered the correct information or sign up for a new account.",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a `return` before `next()` in the user-not-found guard inside `forgotPassword` (`utils/user.util.js`), preventing execution from continuing into `generateResetToken()` and `UserModel.modify()` after the error has already been dispatched.

**Before:**
```js
if (!userExists) {
  next(
    new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, { message: "..." }),
  );
  // ← no return; execution falls through
}
const responseFromGenerateResetToken = createUserModule.generateResetToken();
```

**After:**
```js
if (!userExists) {
  return next(
    new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, { message: "..." }),
  );
}
const responseFromGenerateResetToken = createUserModule.generateResetToken();
```

### Why is this change needed?
When a user submitted a forgot-password request with an unrecognised email or username, `next(error)` was called to send a 400 response, but the function continued executing. The subsequent `UserModel.modify()` call also invoked `next`, which attempted to send a second response on an already-closed connection — producing the Slack error `HTTP response already sent to the client`. Confirmed from production logs at `2026-05-24T09:00:49`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Bug confirmed from production log: `Error: Bad Request Error` at `user.util.js:4501` preceded by `HTTP response already sent to the client`. Fix is a one-line guard (`return next(...)`). Existing tests pass. Manual verification: submitting a forgot-password request with an unknown email should return a single 400 response with the user-not-found message and no double-send error in Slack.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The 400 response content is identical to before. Only the execution flow changes — the function now exits immediately after dispatching the error.

---

## :memo: Additional Notes

This pattern (`next(error)` without `return`) is a common source of double-response bugs in Express middleware. The fix follows the standard Express idiom of `return next(error)` to make the early-exit intent explicit.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the forgot password flow where error handling was not properly preventing further code execution when a user account was not found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->