### PR TITLE
Fix CookieStateStore to self-generate state and return it via callback

### DIFF
--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -459,4 +459,4 @@ function configureStrategies(passport, tenant) {
   );
 }
 
-module.exports = { configureStrategies, buildCallbackURL };
+module.exports = { configureStrategies, buildCallbackURL, CookieStateStore };

--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -32,9 +32,13 @@ class CookieStateStore {
   }
 
   // Called by passport-oauth2 before redirecting to the provider.
-  // Saves the state in a signed cookie so no server-side storage is needed.
+  // The store is responsible for generating the state value — passport-oauth2
+  // passes state=undefined here (it only pre-generates state when options.state
+  // is an explicit string). The generated value must be returned via
+  // callback(null, value) so passport-oauth2 can include it in the redirect URL.
   store(req, state, meta, callback) {
-    const signed = this._sign(state);
+    const value = crypto.randomBytes(12).toString("hex");
+    const signed = this._sign(value);
     const res = req.res;
     if (!res) {
       return callback(new Error("CookieStateStore: response object unavailable on req.res"));
@@ -46,7 +50,7 @@ class CookieStateStore {
       maxAge: this._ttl * 1000,
       path: "/",
     });
-    callback(null);
+    callback(null, value);
   }
 
   // Called by passport-oauth2 on the callback to verify CSRF state.

--- a/src/auth-service/config/test/ut_passport-strategies.js
+++ b/src/auth-service/config/test/ut_passport-strategies.js
@@ -1,0 +1,140 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const { CookieStateStore } = require("@config/passport-strategies");
+
+const SECRET = "test-secret-for-unit-tests-32bytes!!";
+const COOKIE_NAME = "_oauth2_state_test";
+
+describe("CookieStateStore", () => {
+  let store;
+
+  beforeEach(() => {
+    store = new CookieStateStore({ secret: SECRET, cookieName: COOKIE_NAME });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function makeReq(cookies = {}) {
+    return {
+      cookies,
+      res: {
+        cookie: sinon.spy(),
+        clearCookie: sinon.spy(),
+      },
+    };
+  }
+
+  // ── store() ─────────────────────────────────────────────────────────────────
+
+  describe("store()", () => {
+    it("generates a non-empty state and returns it via callback(null, state)", (done) => {
+      const req = makeReq();
+      store.store(req, undefined, {}, (err, state) => {
+        expect(err).to.be.null;
+        expect(state).to.be.a("string").with.length.greaterThan(0);
+        done();
+      });
+    });
+
+    it("sets the signed cookie whose value starts with the returned state", (done) => {
+      const req = makeReq();
+      store.store(req, undefined, {}, (err, state) => {
+        expect(req.res.cookie.calledOnce).to.be.true;
+        const [name, value] = req.res.cookie.firstCall.args;
+        expect(name).to.equal(COOKIE_NAME);
+        // Signed format is "state.hmac_signature" — value begins with the state
+        expect(value).to.satisfy((v) => v.startsWith(state + "."));
+        done();
+      });
+    });
+
+    it("sets the cookie with httpOnly, sameSite=lax, and a positive maxAge", (done) => {
+      const req = makeReq();
+      store.store(req, undefined, {}, () => {
+        const opts = req.res.cookie.firstCall.args[2];
+        expect(opts.httpOnly).to.be.true;
+        expect(opts.sameSite).to.equal("lax");
+        expect(opts.maxAge).to.be.a("number").greaterThan(0);
+        done();
+      });
+    });
+
+    it("produces a different state on each call", (done) => {
+      const req1 = makeReq();
+      const req2 = makeReq();
+      store.store(req1, undefined, {}, (err, state1) => {
+        store.store(req2, undefined, {}, (err2, state2) => {
+          expect(state1).to.not.equal(state2);
+          done();
+        });
+      });
+    });
+
+    it("calls back with an error when req.res is absent", (done) => {
+      const req = { cookies: {} };
+      store.store(req, undefined, {}, (err) => {
+        expect(err).to.be.an("error");
+        expect(err.message).to.include("response object unavailable");
+        done();
+      });
+    });
+  });
+
+  // ── verify() ────────────────────────────────────────────────────────────────
+
+  describe("verify()", () => {
+    // Helper: run store() against a fresh req and hand back the generated
+    // state + the raw signed cookie value for use in verify() tests.
+    function runStore(cb) {
+      const req = makeReq();
+      store.store(req, undefined, {}, (err, state) => {
+        const [, signedCookie] = req.res.cookie.firstCall.args;
+        cb(state, signedCookie);
+      });
+    }
+
+    it("calls back with true and clears the cookie for a valid matching state", (done) => {
+      runStore((state, signedCookie) => {
+        const req = makeReq({ [COOKIE_NAME]: signedCookie });
+        store.verify(req, state, {}, (err, ok) => {
+          expect(err).to.be.null;
+          expect(ok).to.be.true;
+          expect(req.res.clearCookie.calledOnce).to.be.true;
+          done();
+        });
+      });
+    });
+
+    it("calls back with false when the state cookie is missing", (done) => {
+      store.verify(makeReq(), "any-state", {}, (err, ok, info) => {
+        expect(err).to.be.null;
+        expect(ok).to.be.false;
+        expect(info).to.have.property("message");
+        done();
+      });
+    });
+
+    it("calls back with false when the cookie signature has been tampered with", (done) => {
+      const req = makeReq({ [COOKIE_NAME]: "legitimate-state.invalidsignatureXXX" });
+      store.verify(req, "legitimate-state", {}, (err, ok) => {
+        expect(err).to.be.null;
+        expect(ok).to.be.false;
+        done();
+      });
+    });
+
+    it("calls back with false when the URL state does not match the cookie state", (done) => {
+      runStore((state, signedCookie) => {
+        const req = makeReq({ [COOKIE_NAME]: signedCookie });
+        store.verify(req, state + "-tampered", {}, (err, ok) => {
+          expect(err).to.be.null;
+          expect(ok).to.be.false;
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes `CookieStateStore.store()` in `config/passport-strategies.js` to generate its own random state value using `crypto.randomBytes`, sign it into the response cookie, and return it to passport-oauth2 via `callback(null, value)`. Previously the method tried to sign the `state` parameter passed in by passport-oauth2 and called `callback(null)` with no state returned.

### Why is this change needed?
The `fix-oauth-csrf` branch introduced `CookieStateStore` as a stateless replacement for passport-oauth2's session-based state store. However, the `store()` method was written under the wrong assumption that passport-oauth2 pre-generates the state and passes it in. In reality, passport-oauth2 always passes `state = undefined` to the store (it only pre-generates state when `options.state` is an explicit string, which our `authOAuth` calls never set). The store is responsible for generating the state itself — exactly as the built-in `SessionStore` does with `uid(24)`. As a result, Google, GitHub, and LinkedIn OAuth initiation all crashed with `TypeError: The "data" argument must be of type string or an instance of Buffer. Received undefined` because `crypto.createHmac().update(undefined)` throws. Additionally, `callback(null)` with no state meant passport-oauth2's redirect builder never received the state value to append to the provider URL, so even if signing had succeeded no `state` query parameter would have been included in the redirect.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/auth-service` — `config/passport-strategies.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually verified on staging that clicking Google, GitHub, and LinkedIn login buttons now successfully redirects to the respective provider consent screens instead of returning a 500 Internal Server Error. The `verify()` path was confirmed correct — it reads the signed cookie and compares against the `state` query parameter returned by the provider on callback.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Root cause detail:** `passport-oauth2` v1.8.0 detects store arity to determine calling convention. With our 4-argument `store(req, state, meta, callback)`, passport calls it as `store(req, undefined, meta, stored)` where `undefined` is `options.state` (never set). The store must generate the value itself — identical to how the built-in `SessionStore` (arity=2) calls `uid(24)` internally before calling `callback(null, state)`. The `verify()` method was unaffected: for arity=4, passport-oauth2 correctly passes the provider-returned state URL parameter as the second argument, which our method reads, unsigns from the cookie, and compares.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
