### PR TITLE
Fix LinkedIn OAuth by switching to OIDC userinfo endpoint

### DIFF
--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -315,20 +315,75 @@ function configureStrategies(passport, tenant) {
   }
 
   // ── LinkedIn ─────────────────────────────────────────────────────────────
+  // passport-linkedin-oauth2 v2 calls the deprecated /v2/me and /v2/emailAddress
+  // endpoints (Member Data Portability API) which require r_liteprofile /
+  // r_emailaddress scopes. LinkedIn's Standard Tier only grants OpenID Connect
+  // scopes (openid profile email). We use passport-oauth2 directly and call the
+  // OIDC userinfo endpoint (/oidc/v2/userinfo) which works with OIDC tokens.
   if (constants.LINKEDIN_CLIENT_ID && constants.LINKEDIN_CLIENT_SECRET) {
     try {
-      const LinkedInStrategy = require("passport-linkedin-oauth2").Strategy;
+      const { Strategy: OAuth2Strategy, InternalOAuthError } =
+        require("passport-oauth2");
+
+      class LinkedInOIDCStrategy extends OAuth2Strategy {
+        constructor(options, verify) {
+          options.authorizationURL =
+            "https://www.linkedin.com/oauth/v2/authorization";
+          options.tokenURL =
+            "https://www.linkedin.com/oauth/v2/accessToken";
+          super(options, verify);
+          this.name = "linkedin";
+        }
+
+        userProfile(accessToken, done) {
+          this._oauth2.get(
+            "https://api.linkedin.com/oidc/v2/userinfo",
+            accessToken,
+            (err, body) => {
+              if (err) {
+                return done(
+                  new InternalOAuthError(
+                    "failed to fetch LinkedIn userinfo",
+                    err,
+                  ),
+                );
+              }
+              try {
+                const json = JSON.parse(body);
+                const profile = {
+                  provider: "linkedin",
+                  id: json.sub,
+                  displayName: json.name || "",
+                  name: {
+                    givenName: json.given_name || "",
+                    familyName: json.family_name || "",
+                  },
+                  emails: json.email ? [{ value: json.email }] : [],
+                  photos: json.picture ? [{ value: json.picture }] : [],
+                  _raw: body,
+                  _json: json,
+                };
+                done(null, profile);
+              } catch (e) {
+                done(
+                  new InternalOAuthError(
+                    "failed to parse LinkedIn userinfo response",
+                    e,
+                  ),
+                );
+              }
+            },
+          );
+        }
+      }
+
       passport.use(
         "linkedin",
-        new LinkedInStrategy(
+        new LinkedInOIDCStrategy(
           {
             clientID: constants.LINKEDIN_CLIENT_ID,
             clientSecret: constants.LINKEDIN_CLIENT_SECRET,
             callbackURL: buildCallbackURL("linkedin"),
-            // OpenID Connect scopes required for "Sign In with LinkedIn using
-            // OpenID Connect" product (Standard Tier). The deprecated v2 Member
-            // Data Portability scopes (r_emailaddress, r_liteprofile) are no
-            // longer accepted on newly created apps.
             scope: ["openid", "profile", "email"],
             passReqToCallback: true,
             store: new CookieStateStore({
@@ -343,10 +398,10 @@ function configureStrategies(passport, tenant) {
           ),
         ),
       );
-      logger.info("✅ LinkedIn OAuth strategy configured");
+      logger.info("✅ LinkedIn OIDC strategy configured");
     } catch (e) {
       logger.warn(
-        `⚠️  LinkedIn OAuth strategy skipped: failed to load passport-linkedin-oauth2 — ${e.message}`,
+        `⚠️  LinkedIn OAuth strategy skipped: ${e.message}`,
       );
     }
   } else {

--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -3,6 +3,10 @@
 const crypto = require("crypto");
 const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const GitHubStrategy = require("passport-github2").Strategy;
+const {
+  Strategy: OAuth2Strategy,
+  InternalOAuthError,
+} = require("passport-oauth2");
 const constants = require("@config/constants");
 const { handleOAuthProfile } = require("@utils/social-auth.util");
 const { logObject } = require("@utils/shared");
@@ -117,6 +121,59 @@ class CookieStateStore {
     } catch {
       return false;
     }
+  }
+}
+
+// ── LinkedIn OIDC Strategy ────────────────────────────────────────────────────
+// passport-linkedin-oauth2 v2 calls the deprecated /v2/me and /v2/emailAddress
+// endpoints which require r_liteprofile / r_emailaddress scopes. LinkedIn's
+// Standard Tier only grants OIDC scopes (openid profile email). This class
+// uses passport-oauth2 directly and calls /oidc/v2/userinfo instead.
+class LinkedInOIDCStrategy extends OAuth2Strategy {
+  constructor(options, verify) {
+    options.authorizationURL =
+      "https://www.linkedin.com/oauth/v2/authorization";
+    options.tokenURL = "https://www.linkedin.com/oauth/v2/accessToken";
+    super(options, verify);
+    this.name = "linkedin";
+  }
+
+  userProfile(accessToken, done) {
+    this._oauth2.get(
+      "https://api.linkedin.com/oidc/v2/userinfo",
+      accessToken,
+      (err, body) => {
+        if (err) {
+          return done(
+            new InternalOAuthError("failed to fetch LinkedIn userinfo", err),
+          );
+        }
+        try {
+          const json = JSON.parse(body);
+          const profile = {
+            provider: "linkedin",
+            id: json.sub,
+            displayName: json.name || "",
+            name: {
+              givenName: json.given_name || "",
+              familyName: json.family_name || "",
+            },
+            emails: json.email ? [{ value: json.email }] : [],
+            photos: json.picture ? [{ value: json.picture }] : [],
+            _raw: body,
+            _json: json,
+          };
+          done(null, profile);
+        } catch (e) {
+          done(
+            new InternalOAuthError(
+              "failed to parse LinkedIn userinfo response",
+              e,
+            ),
+          );
+        }
+      },
+    );
   }
 }
 
@@ -315,68 +372,8 @@ function configureStrategies(passport, tenant) {
   }
 
   // ── LinkedIn ─────────────────────────────────────────────────────────────
-  // passport-linkedin-oauth2 v2 calls the deprecated /v2/me and /v2/emailAddress
-  // endpoints (Member Data Portability API) which require r_liteprofile /
-  // r_emailaddress scopes. LinkedIn's Standard Tier only grants OpenID Connect
-  // scopes (openid profile email). We use passport-oauth2 directly and call the
-  // OIDC userinfo endpoint (/oidc/v2/userinfo) which works with OIDC tokens.
   if (constants.LINKEDIN_CLIENT_ID && constants.LINKEDIN_CLIENT_SECRET) {
     try {
-      const { Strategy: OAuth2Strategy, InternalOAuthError } =
-        require("passport-oauth2");
-
-      class LinkedInOIDCStrategy extends OAuth2Strategy {
-        constructor(options, verify) {
-          options.authorizationURL =
-            "https://www.linkedin.com/oauth/v2/authorization";
-          options.tokenURL =
-            "https://www.linkedin.com/oauth/v2/accessToken";
-          super(options, verify);
-          this.name = "linkedin";
-        }
-
-        userProfile(accessToken, done) {
-          this._oauth2.get(
-            "https://api.linkedin.com/oidc/v2/userinfo",
-            accessToken,
-            (err, body) => {
-              if (err) {
-                return done(
-                  new InternalOAuthError(
-                    "failed to fetch LinkedIn userinfo",
-                    err,
-                  ),
-                );
-              }
-              try {
-                const json = JSON.parse(body);
-                const profile = {
-                  provider: "linkedin",
-                  id: json.sub,
-                  displayName: json.name || "",
-                  name: {
-                    givenName: json.given_name || "",
-                    familyName: json.family_name || "",
-                  },
-                  emails: json.email ? [{ value: json.email }] : [],
-                  photos: json.picture ? [{ value: json.picture }] : [],
-                  _raw: body,
-                  _json: json,
-                };
-                done(null, profile);
-              } catch (e) {
-                done(
-                  new InternalOAuthError(
-                    "failed to parse LinkedIn userinfo response",
-                    e,
-                  ),
-                );
-              }
-            },
-          );
-        }
-      }
-
       passport.use(
         "linkedin",
         new LinkedInOIDCStrategy(
@@ -401,7 +398,7 @@ function configureStrategies(passport, tenant) {
       logger.info("✅ LinkedIn OIDC strategy configured");
     } catch (e) {
       logger.warn(
-        `⚠️  LinkedIn OAuth strategy skipped: ${e.message}`,
+        `⚠️  LinkedIn OIDC strategy skipped: failed to configure — ${e.message}`,
       );
     }
   } else {
@@ -514,4 +511,9 @@ function configureStrategies(passport, tenant) {
   );
 }
 
-module.exports = { configureStrategies, buildCallbackURL, CookieStateStore };
+module.exports = {
+  configureStrategies,
+  buildCallbackURL,
+  CookieStateStore,
+  LinkedInOIDCStrategy,
+};

--- a/src/auth-service/config/test/ut_passport-strategies.js
+++ b/src/auth-service/config/test/ut_passport-strategies.js
@@ -1,7 +1,10 @@
 require("module-alias/register");
 const { expect } = require("chai");
 const sinon = require("sinon");
-const { CookieStateStore } = require("@config/passport-strategies");
+const {
+  CookieStateStore,
+  LinkedInOIDCStrategy,
+} = require("@config/passport-strategies");
 
 const SECRET = "test-secret-for-unit-tests-32bytes!!";
 const COOKIE_NAME = "_oauth2_state_test";
@@ -134,6 +137,79 @@ describe("CookieStateStore", () => {
           expect(ok).to.be.false;
           done();
         });
+      });
+    });
+  });
+});
+
+// ── LinkedInOIDCStrategy ─────────────────────────────────────────────────────
+
+describe("LinkedInOIDCStrategy", () => {
+  let strategy;
+
+  beforeEach(() => {
+    strategy = new LinkedInOIDCStrategy(
+      { clientID: "test-id", clientSecret: "test-secret" },
+      () => {},
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("userProfile()", () => {
+    it("maps a well-formed OIDC userinfo response to a passport profile", (done) => {
+      const payload = {
+        sub: "abc123",
+        name: "Jane Doe",
+        given_name: "Jane",
+        family_name: "Doe",
+        email: "jane@example.com",
+        picture: "https://example.com/pic.jpg",
+      };
+      sinon
+        .stub(strategy._oauth2, "get")
+        .callsFake((url, token, cb) => cb(null, JSON.stringify(payload)));
+
+      strategy.userProfile("fake-token", (err, profile) => {
+        expect(err).to.be.null;
+        expect(profile.provider).to.equal("linkedin");
+        expect(profile.id).to.equal("abc123");
+        expect(profile.displayName).to.equal("Jane Doe");
+        expect(profile.name.givenName).to.equal("Jane");
+        expect(profile.name.familyName).to.equal("Doe");
+        expect(profile.emails[0].value).to.equal("jane@example.com");
+        expect(profile.photos[0].value).to.equal("https://example.com/pic.jpg");
+        done();
+      });
+    });
+
+    it("calls back with InternalOAuthError when the HTTP request fails", (done) => {
+      sinon
+        .stub(strategy._oauth2, "get")
+        .callsFake((url, token, cb) => cb(new Error("connection refused")));
+
+      strategy.userProfile("fake-token", (err) => {
+        expect(err).to.be.instanceof(Error);
+        expect(err.name).to.equal("InternalOAuthError");
+        expect(err.message).to.include("failed to fetch LinkedIn userinfo");
+        done();
+      });
+    });
+
+    it("calls back with InternalOAuthError when the response body is invalid JSON", (done) => {
+      sinon
+        .stub(strategy._oauth2, "get")
+        .callsFake((url, token, cb) => cb(null, "not-valid-json{{"));
+
+      strategy.userProfile("fake-token", (err) => {
+        expect(err).to.be.instanceof(Error);
+        expect(err.name).to.equal("InternalOAuthError");
+        expect(err.message).to.include(
+          "failed to parse LinkedIn userinfo response",
+        );
+        done();
       });
     });
   });

--- a/src/auth-service/package.json
+++ b/src/auth-service/package.json
@@ -113,6 +113,7 @@
     "passport-linkedin-oauth2": "^2.0.0",
     "passport-local": "^1.0.0",
     "passport-microsoft": "^2.1.0",
+    "passport-oauth2": "^1.8.0",
     "passport-twitter": "^1.0.4",
     "posthog-node": "^5.11.2",
     "rate-limit-redis": "^4.2.1",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces `passport-linkedin-oauth2` (v2.0.0) with a custom `LinkedInOIDCStrategy` class that extends `passport-oauth2` directly. The new strategy calls LinkedIn's OIDC UserInfo endpoint (`/oidc/v2/userinfo`) to fetch the user's profile and email in a single request, instead of the old `/v2/me` and `/v2/emailAddress` Member Data Portability API endpoints.

### Why is this change needed?
`passport-linkedin-oauth2` v2 was built for LinkedIn's deprecated Member Data Portability API which requires `r_liteprofile` and `r_emailaddress` scopes. LinkedIn's Standard Tier (required for "Sign In with LinkedIn using OpenID Connect") no longer grants those scopes — it only grants `openid`, `profile`, and `email`. When our access token was issued under OIDC scopes, LinkedIn returned a 403 on every `/v2/me` call, causing an `InternalOAuthError` on every LinkedIn login attempt. The OIDC UserInfo endpoint is the correct API for OIDC-scoped tokens and returns `sub`, `name`, `given_name`, `family_name`, `email`, and `picture` in a single response.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `config/passport-strategies.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
LinkedIn OAuth login flow tested end-to-end in staging. The OIDC UserInfo endpoint returns a valid profile with `email` populated, resolving the `InternalOAuthError` that previously blocked all LinkedIn sign-ins. Existing `CookieStateStore` unit tests (`ut_passport-strategies.js`) continue to pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `passport-linkedin-oauth2` remains listed in `package.json` but is no longer used by the LinkedIn strategy. It can be removed in a follow-up cleanup PR.
- No new npm packages are introduced — `passport-oauth2` is already a transitive dependency in node_modules.
- The `LinkedInOIDCStrategy` class lives inline in `passport-strategies.js` alongside the other strategy registrations, consistent with the existing pattern.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated LinkedIn authentication infrastructure to use modern industry-standard authentication protocols for improved security and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->