### PR TITLE
fix: log LinkedIn OAuth token-exchange provider error body for diagnostics

### DIFF
--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1470,10 +1470,16 @@ const authOAuthCallback = (req, res, next) => {
       ? provider
       : "unknown";
     if (err.name === "InternalOAuthError" || err.oauthError) {
-      // Do not log err.message — may contain raw OAuth tokens from provider.
+      // Log the underlying provider error body (statusCode + data) to diagnose
+      // OAuth rejections. Avoid logging err.message which may contain tokens.
+      const oauthErr = err.oauthError || {};
       logger.error("OAuth token exchange failed", {
         provider: safeProvider,
         errorType: err.name || "OAuthError",
+        oauthStatusCode: oauthErr.statusCode,
+        oauthData: typeof oauthErr.data === "string"
+          ? oauthErr.data.slice(0, 500)
+          : oauthErr.data,
       });
     } else {
       logger.error(`[passport] OAuth callback error for ${safeProvider}`, {

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1477,9 +1477,13 @@ const authOAuthCallback = (req, res, next) => {
         provider: safeProvider,
         errorType: err.name || "OAuthError",
         oauthStatusCode: oauthErr.statusCode,
-        oauthData: typeof oauthErr.data === "string"
-          ? oauthErr.data.slice(0, 500)
-          : oauthErr.data,
+        oauthData: String(
+          Buffer.isBuffer(oauthErr.data)
+            ? oauthErr.data.toString()
+            : typeof oauthErr.data === "object" && oauthErr.data !== null
+              ? JSON.stringify(oauthErr.data)
+              : oauthErr.data ?? "",
+        ).slice(0, 500),
       });
     } else {
       logger.error(`[passport] OAuth callback error for ${safeProvider}`, {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Extends the `InternalOAuthError` handler in `authOAuthCallback` middleware to log the underlying OAuth provider error body (`oauthStatusCode` and `oauthData`) when a token exchange fails.

### Why is this change needed?
LinkedIn OAuth was failing with `InternalOAuthError` at the token exchange step, but the existing error handler deliberately skipped logging `err.message` (to avoid leaking tokens). This also omitted `err.oauthError`, which contains the actual HTTP status code and raw response body returned by LinkedIn's token endpoint. Without this, diagnosing the root cause (e.g. `invalid_grant`, `unauthorized_client`, `invalid_scope`) was impossible from logs alone. The new logging captures only the safe diagnostic fields, truncated to 500 characters.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `middleware/passport.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Deployed to staging and triggered a LinkedIn OAuth flow. The new log fields (`oauthStatusCode`, `oauthData`) are emitted when LinkedIn rejects the token exchange, making the provider's error code visible in logs without exposing sensitive token values.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `oauthData` is truncated to 500 characters to avoid bloating log entries with large provider responses.
- Only `err.oauthError.statusCode` and `err.oauthError.data` are logged — `err.message` is still intentionally omitted as it may contain raw OAuth tokens.
- This change is diagnostic only; no logic paths are altered.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging for OAuth authentication failures to enhance debugging and issue tracking capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->