### PR TITLE
Add authMethods field to login response to show connected providers

### DIFF
--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -570,6 +570,7 @@ const userController = {
             interestsDescription: data.interestsDescription,
             verified: data.verified,
             isActive: data.isActive,
+            authMethods: data.authMethods,
           };
           return res.status(httpStatus.OK).json(userResponse);
         } else {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -6572,6 +6572,18 @@ const createUserModule = {
         // Enhanced authentication
         token: `JWT ${token}`,
 
+        // Auth methods — which login providers this account has connected
+        authMethods: {
+          password: !!user.password,
+          google: !!user.google_id,
+          github: !!user.github_id,
+          linkedin: !!user.linkedin_id,
+          microsoft: !!user.microsoft_id,
+          twitter: !!user.twitter_id,
+          facebook: !!user.facebook_id,
+          apple: !!user.apple_id,
+        },
+
         // --- REMOVED FOR SCALABILITY ---
         // The following large data fields are removed to prevent oversized login responses
         // which can cause 502 Bad Gateway errors. Clients should fetch this data


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds an `authMethods` object to the login API response, indicating which authentication providers a user has connected to their AirQo account.

Example response shape:
```json
"authMethods": {
  "password": true,
  "google": true,
  "github": false,
  "linkedin": false,
  "microsoft": false,
  "twitter": false,
  "facebook": false,
  "apple": false
}
```

The field is populated in `loginWithEnhancedTokens()` (the shared login utility) and forwarded in the `login()` controller response. Endpoints that already return the full enhanced data object (`loginWithDetails`, `loginEnhanced`) get the field automatically.

### Why is this change needed?
The frontend has no way to know which login providers a user has set up without making a separate API call. With `authMethods` in the login response, the frontend can immediately render the correct UI — for example, showing a "Connect Google" or "Disconnect Google" button on the account settings page — without an extra round-trip. This was identified as the high-value, low-effort part of a broader account-linking suggestion.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `utils/user.util.js`, `controllers/user.controller.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that the `authMethods` field appears in the login response for both password-only users and users with OAuth providers linked. Boolean values correctly reflect the presence of `password`, `google_id`, `github_id`, and other provider ID fields on the user document.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `authMethods` field is additive — no existing fields were modified or removed. Clients that do not read the field are unaffected.

---

## :memo: Additional Notes

- `authMethods` is derived entirely from fields already stored on the user document (`google_id`, `github_id`, `linkedin_id`, `microsoft_id`, `twitter_id`, `facebook_id`, `apple_id`, `password`). No schema changes or new DB queries are required.
- Link/unlink endpoints (allowing users to add or remove a provider from their account) were considered but deferred. The `authMethods` field in the response covers the immediate frontend need and unblocks UI work without the added complexity.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login responses now display which authentication methods are connected to your account, giving you visibility into your available login options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->