### PR TITLE
fix: re-fetch user from DB in getSubscriptionStatus to avoid stale JWT

### DIFF
--- a/src/auth-service/controllers/transaction.controller.js
+++ b/src/auth-service/controllers/transaction.controller.js
@@ -15,7 +15,6 @@ const logger = log4js.getLogger(
 const transactionsUtil = require("@utils/transaction.util");
 const tokenUtil = require("@utils/token.util");
 const { paddleClient, isPaddleConfigured } = require("@config/paddle");
-const UserModel = require("@models/User");
 
 const transactions = {
   createCheckoutSession: async (req, res, next) => {
@@ -631,56 +630,12 @@ const transactions = {
         return;
       }
 
-      if (!isPaddleConfigured) {
-        return res.status(httpStatus.SERVICE_UNAVAILABLE).json({
-          success: false,
-          message:
-            "Payment service is not configured. Please try again later.",
-        });
-      }
-
-      if (!req.user) {
-        return res.status(httpStatus.UNAUTHORIZED).json({
-          success: false,
-          message: "Authentication required",
-        });
-      }
-
-      // Re-fetch from DB: req.user comes from the JWT and may predate the
-      // webhook that set currentSubscriptionId on the user document.
-      const tenant = (req.query && req.query.tenant) || "airqo";
-      const freshUser = await UserModel(tenant)
-        .findById(req.user._id)
-        .select("currentSubscriptionId subscriptionStatus")
-        .lean();
-
-      if (!freshUser || !freshUser.currentSubscriptionId) {
-        return res.status(httpStatus.BAD_REQUEST).json({
-          success: false,
-          message: "No active subscription found",
-          errors: { message: "User has no subscription ID" },
-        });
-      }
-
-      const subscriptionStatus = await paddleClient.subscriptions.get(
-        freshUser.currentSubscriptionId
-      );
-
-      await UserModel("airqo").findByIdAndUpdate(req.user._id, {
-        $set: {
-          subscriptionStatus: subscriptionStatus.status,
-          lastSubscriptionCheck: new Date(),
-        },
-      });
-
-      return res.status(httpStatus.OK).json({
-        success: true,
-        message: "Subscription status retrieved successfully",
-        data: {
-          status: subscriptionStatus.status,
-          lastChecked: new Date(),
-          subscriptionId: freshUser.currentSubscriptionId,
-        },
+      const result = await transactionsUtil.getSubscriptionStatus(req);
+      return res.status(result.status).json({
+        success: result.success,
+        message: result.message,
+        ...(result.data && { data: result.data }),
+        ...(result.errors && { errors: result.errors }),
       });
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
@@ -688,9 +643,7 @@ const transactions = {
         new HttpError(
           "Internal Server Error",
           httpStatus.INTERNAL_SERVER_ERROR,
-          {
-            message: error.message,
-          }
+          { message: error.message }
         )
       );
       return;

--- a/src/auth-service/controllers/transaction.controller.js
+++ b/src/auth-service/controllers/transaction.controller.js
@@ -639,7 +639,22 @@ const transactions = {
         });
       }
 
-      if (!req.user || !req.user.currentSubscriptionId) {
+      if (!req.user) {
+        return res.status(httpStatus.UNAUTHORIZED).json({
+          success: false,
+          message: "Authentication required",
+        });
+      }
+
+      // Re-fetch from DB: req.user comes from the JWT and may predate the
+      // webhook that set currentSubscriptionId on the user document.
+      const tenant = (req.query && req.query.tenant) || "airqo";
+      const freshUser = await UserModel(tenant)
+        .findById(req.user._id)
+        .select("currentSubscriptionId subscriptionStatus")
+        .lean();
+
+      if (!freshUser || !freshUser.currentSubscriptionId) {
         return res.status(httpStatus.BAD_REQUEST).json({
           success: false,
           message: "No active subscription found",
@@ -648,7 +663,7 @@ const transactions = {
       }
 
       const subscriptionStatus = await paddleClient.subscriptions.get(
-        req.user.currentSubscriptionId
+        freshUser.currentSubscriptionId
       );
 
       await UserModel("airqo").findByIdAndUpdate(req.user._id, {
@@ -664,7 +679,7 @@ const transactions = {
         data: {
           status: subscriptionStatus.status,
           lastChecked: new Date(),
-          subscriptionId: req.user.currentSubscriptionId,
+          subscriptionId: freshUser.currentSubscriptionId,
         },
       });
     } catch (error) {

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -1369,6 +1369,62 @@ const transactions = {
    * @param {Object} request - Express request object (user populated by auth middleware)
    * @returns {Promise<Object>}
    */
+  getSubscriptionStatus: async (request) => {
+    if (!isPaddleConfigured) return PADDLE_NOT_CONFIGURED;
+    try {
+      const tenant =
+        (request.query && request.query.tenant) ||
+        constants.DEFAULT_TENANT ||
+        "airqo";
+
+      // Re-fetch from DB: request.user is decoded from the JWT and may predate
+      // the webhook that wrote currentSubscriptionId onto the user document.
+      const freshUser = await UserModel(tenant)
+        .findById(request.user._id)
+        .select("currentSubscriptionId subscriptionStatus")
+        .lean();
+
+      if (!freshUser || !freshUser.currentSubscriptionId) {
+        return {
+          success: false,
+          message: "No active subscription found",
+          status: httpStatus.BAD_REQUEST,
+          errors: { message: "User has no subscription ID" },
+        };
+      }
+
+      const subscriptionStatus = await paddleClient.subscriptions.get(
+        freshUser.currentSubscriptionId,
+      );
+
+      await UserModel(tenant).findByIdAndUpdate(request.user._id, {
+        $set: {
+          subscriptionStatus: subscriptionStatus.status,
+          lastSubscriptionCheck: new Date(),
+        },
+      });
+
+      return {
+        success: true,
+        message: "Subscription status retrieved successfully",
+        status: httpStatus.OK,
+        data: {
+          status: subscriptionStatus.status,
+          lastChecked: new Date(),
+          subscriptionId: freshUser.currentSubscriptionId,
+        },
+      };
+    } catch (error) {
+      logger.error(`getSubscriptionStatus error --- ${stringify(error)}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
   disableAutoRenewal: async (request) => {
     try {
       const user = request.user;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces the stale `req.user.currentSubscriptionId` check in `getSubscriptionStatus` with a fresh database lookup using `findById`, selecting only the fields needed (`currentSubscriptionId`, `subscriptionStatus`).

### Why is this change needed?
`req.user` is decoded from the JWT token issued at login. If the Paddle webhook that sets `currentSubscriptionId` on the user document fired after the user's last login, the JWT will never carry that field — causing the endpoint to always return a 400 "User has no subscription ID" even for paying users. Reading directly from the database ensures the endpoint always reflects the current persisted state regardless of when the user last logged in.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `controllers/transaction.controller.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Tested against staging with a user who had completed a Paddle payment (webhook already fired and set `currentSubscriptionId` on the DB document). Before this fix the endpoint returned 400; after the fix it returns 200 with the correct subscription status from Paddle.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The DB lookup selects only `currentSubscriptionId` and `subscriptionStatus` to keep the query lightweight.
- Tenant is resolved from `req.query.tenant` with a fallback to `"airqo"`, consistent with the rest of the codebase.
- The `UserModel("airqo")` hard-code in the subsequent `findByIdAndUpdate` call (subscription status sync after Paddle fetch) is left unchanged as a separate concern.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
