### PR TITLE
feat: add setPassword endpoint for OAuth users to configure email login

### DIFF
--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -784,14 +784,9 @@ const userController = {
 
   setPassword: async (req, res, next) => {
     try {
-      const errors = extractErrorsFromRequest(req);
-      if (errors) {
-        next(
-          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors),
-        );
-        return;
-      }
-      const result = await userUtil.setPassword(req, next);
+      const request = handleRequest(req, next);
+      if (!request) return;
+      const result = await userUtil.setPassword(request, next);
       if (result) {
         res.status(result.status).json({
           success: result.success,

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -782,6 +782,28 @@ const userController = {
     }
   },
 
+  setPassword: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors),
+        );
+        return;
+      }
+      const result = await userUtil.setPassword(req, next);
+      if (result) {
+        res.status(result.status).json({
+          success: result.success,
+          message: result.message,
+        });
+      }
+    } catch (error) {
+      logObject("error in controller", error);
+      handleError(error, next);
+    }
+  },
+
   registerMobileUser: async (req, res, next) => {
     try {
       const errors = extractErrorsFromRequest(req);

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -358,6 +358,10 @@ const UserSchema = new Schema(
     facebook_id: { type: String, trim: true },
     apple_id: { type: String, trim: true },
     // ── OAuth provider IDs end ────────────────────────────────────────────────────
+    // True only when the user has explicitly set their own password.
+    // OAuth users are created with a random unknown password, so !!password
+    // alone cannot distinguish "user knows their password" from "system-generated".
+    hasSetPassword: { type: Boolean, default: false },
     timezone: { type: String, trim: true },
     preferredTokenStrategy: {
       type: String,

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -603,6 +603,13 @@ router.post(
 );
 
 router.post(
+  "/setPassword",
+  userValidations.setPassword,
+  enhancedJWTAuth,
+  userController.setPassword,
+);
+
+router.post(
   "/reset-password/:token",
   userValidations.resetPassword,
   userController.resetPassword,

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -4947,6 +4947,77 @@ const createUserModule = {
     }
   },
 
+  setPassword: async (request, next) => {
+    try {
+      const { password, confirmPassword } = request.body;
+      const tenant =
+        isEmpty(request.query.tenant)
+          ? constants.DEFAULT_TENANT || "airqo"
+          : request.query.tenant;
+
+      if (password !== confirmPassword) {
+        return next(
+          new HttpError("Passwords do not match", httpStatus.BAD_REQUEST, {
+            message: "password and confirmPassword must be identical",
+          }),
+        );
+      }
+
+      const validationResult = createUserModule._validatePassword(password);
+      if (!validationResult.isValid) {
+        return next(validationResult.error);
+      }
+
+      // Re-fetch from DB to check current hasSetPassword state.
+      const user = await UserModel(tenant)
+        .findById(request.user._id)
+        .select("hasSetPassword")
+        .lean();
+
+      if (!user) {
+        return next(
+          new HttpError("User not found", httpStatus.NOT_FOUND, {
+            message: "Authenticated user record could not be found",
+          }),
+        );
+      }
+
+      if (user.hasSetPassword) {
+        return next(
+          new HttpError(
+            "Password already set",
+            httpStatus.BAD_REQUEST,
+            {
+              message:
+                "A password is already configured for this account. Use the change password flow instead.",
+            },
+          ),
+        );
+      }
+
+      await UserModel(tenant).findByIdAndUpdate(
+        request.user._id,
+        { $set: { password, hasSetPassword: true } },
+        { context: "query" },
+      );
+
+      return {
+        success: true,
+        message: "Password set successfully. You can now log in with your email and password.",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
   resetPassword: async ({ token, password, tenant }, next) => {
     try {
       // 1. Manually validate the new password
@@ -6574,7 +6645,7 @@ const createUserModule = {
 
         // Auth methods — which login providers this account has connected
         authMethods: {
-          password: !!user.password,
+          password: !!user.hasSetPassword,
           google: !!user.google_id,
           github: !!user.github_id,
           linkedin: !!user.linkedin_id,

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -4603,6 +4603,7 @@ const createUserModule = {
         {
           $set: {
             password: password, // pre-hook will hash this
+            hasSetPassword: true,
             resetPasswordToken: null,
             resetPasswordExpires: null,
           },
@@ -4717,6 +4718,7 @@ const createUserModule = {
         {
           $set: {
             password: new_password, // pre-hook will hash this
+            hasSetPassword: true,
             resetPasswordToken: null,
             resetPasswordExpires: null,
           },
@@ -4968,38 +4970,33 @@ const createUserModule = {
         return next(validationResult.error);
       }
 
-      // Re-fetch from DB to check current hasSetPassword state.
-      const user = await UserModel(tenant)
-        .findById(request.user._id)
-        .select("hasSetPassword")
-        .lean();
+      // Atomic conditional update: only matches when hasSetPassword is not true.
+      // Prevents both the TOCTOU race and existing-password bypass in one query.
+      const updated = await UserModel(tenant).findOneAndUpdate(
+        { _id: request.user._id, hasSetPassword: { $ne: true } },
+        { $set: { password, hasSetPassword: true } },
+        { new: false, context: "query" },
+      );
 
-      if (!user) {
+      if (!updated) {
+        // Either the user doesn't exist or hasSetPassword was already true.
+        const exists = await UserModel(tenant)
+          .exists({ _id: request.user._id })
+          .lean();
+        if (!exists) {
+          return next(
+            new HttpError("User not found", httpStatus.NOT_FOUND, {
+              message: "Authenticated user record could not be found",
+            }),
+          );
+        }
         return next(
-          new HttpError("User not found", httpStatus.NOT_FOUND, {
-            message: "Authenticated user record could not be found",
+          new HttpError("Password already set", httpStatus.BAD_REQUEST, {
+            message:
+              "A password is already configured for this account. Use the change password flow instead.",
           }),
         );
       }
-
-      if (user.hasSetPassword) {
-        return next(
-          new HttpError(
-            "Password already set",
-            httpStatus.BAD_REQUEST,
-            {
-              message:
-                "A password is already configured for this account. Use the change password flow instead.",
-            },
-          ),
-        );
-      }
-
-      await UserModel(tenant).findByIdAndUpdate(
-        request.user._id,
-        { $set: { password, hasSetPassword: true } },
-        { context: "query" },
-      );
 
       return {
         success: true,
@@ -5040,6 +5037,7 @@ const createUserModule = {
         {
           $set: {
             password: password, // pre-hook will hash this
+            hasSetPassword: true,
             resetPasswordToken: null,
             resetPasswordExpires: null,
           },
@@ -6645,7 +6643,10 @@ const createUserModule = {
 
         // Auth methods — which login providers this account has connected
         authMethods: {
-          password: !!user.hasSetPassword,
+          password:
+            user.hasSetPassword != null
+              ? !!user.hasSetPassword
+              : !!user.password,
           google: !!user.google_id,
           github: !!user.github_id,
           linkedin: !!user.linkedin_id,

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1047,20 +1047,23 @@ const setPassword = [
     .exists()
     .withMessage("password is required")
     .bail()
-    .isLength({ min: 6 })
-    .withMessage("password must be at least 6 characters long")
-    .trim(),
+    .trim()
+    .isLength({ min: 6, max: 30 })
+    .withMessage("Password must be between 6 and 30 characters long")
+    .bail()
+    .matches(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d@#?!$%^&*,.]{6,}$/)
+    .withMessage("Password must contain at least one letter and one number"),
   body("confirmPassword")
     .exists()
     .withMessage("confirmPassword is required")
     .bail()
+    .trim()
     .custom((value, { req }) => {
-      if (value.trim() !== (req.body.password || "").trim()) {
+      if (value !== (req.body.password || "").trim()) {
         throw new Error("Passwords do not match");
       }
       return true;
-    })
-    .trim(),
+    }),
 ];
 
 const resetPassword = [

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1055,7 +1055,7 @@ const setPassword = [
     .withMessage("confirmPassword is required")
     .bail()
     .custom((value, { req }) => {
-      if (value !== req.body.password) {
+      if (value.trim() !== (req.body.password || "").trim()) {
         throw new Error("Passwords do not match");
       }
       return true;

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1042,6 +1042,27 @@ const resetPasswordRequest = [
   //Potentially add tenant validation here as well, using the oneOf approach if necessary
 ];
 
+const setPassword = [
+  body("password")
+    .exists()
+    .withMessage("password is required")
+    .bail()
+    .isLength({ min: 6 })
+    .withMessage("password must be at least 6 characters long")
+    .trim(),
+  body("confirmPassword")
+    .exists()
+    .withMessage("confirmPassword is required")
+    .bail()
+    .custom((value, { req }) => {
+      if (value !== req.body.password) {
+        throw new Error("Passwords do not match");
+      }
+      return true;
+    })
+    .trim(),
+];
+
 const resetPassword = [
   param("token")
     .exists()
@@ -1609,6 +1630,7 @@ module.exports = {
   getEnhancedProfileForUser,
   resetPasswordRequest,
   resetPassword,
+  setPassword,
   verifyMobileEmail,
   getOrganizationBySlug,
   registerViaOrgSlug,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a `POST /api/v2/users/setPassword` endpoint that allows users who signed up via a third-party OAuth provider (Google, GitHub, LinkedIn, etc.) to set a password on their account so they can also log in via email and password.

Introduces a `hasSetPassword` boolean field on the User schema to reliably distinguish users who have explicitly set their own password from OAuth users who hold a system-generated random password. Updates `authMethods.password` in the login response to reflect this distinction accurately.

### Why is this change needed?
OAuth users are created with a randomly generated password they never know. Without this endpoint, if their OAuth provider has an outage or they lose access to that provider account, they have no fallback login method. The existing `authMethods.password: true` in the login response was also misleading — it returned `true` for all users including OAuth users with unknown system passwords. Both issues are resolved here.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `models/User.js`
- `auth-service` — `utils/user.util.js`
- `auth-service` — `controllers/user.controller.js`
- `auth-service` — `validators/users.validators.js`
- `auth-service` — `routes/v2/users.routes.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- OAuth user (no previously set password): `POST /setPassword` with matching passwords returns 200.
- OAuth user calls endpoint a second time: returns 400 `"Password already set"`.
- Mismatched `password` / `confirmPassword`: returns 400 `"Passwords do not match"`.
- Email/password user (already has `hasSetPassword: true`): returns 400 `"Password already set"`.
- Missing auth header: returns 401.
- After setting password, user can log in via `POST /login` with email + new password.
- `authMethods.password` in login response now correctly returns `false` for OAuth users who have not yet set a password, and `true` after they do.

---

## :boom: Breaking Changes

- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

**`authMethods.password` value change:**
Previously `authMethods.password` returned `true` for all users (including OAuth users with unknown system-generated passwords). It now returns `false` for OAuth users who have not explicitly set a password via this endpoint.

**Frontend action required:** If the frontend currently uses `authMethods.password === true` to gate any UI, it should be updated to handle `false` for OAuth-only accounts and prompt those users to set a password instead.

**Migration:** Existing email/password users are unaffected — their `hasSetPassword` field defaults to `false` on the schema, but the `findByIdAndUpdate` in `setPassword` only blocks users where `hasSetPassword` is explicitly `true`. To backfill existing email/password users so their `authMethods.password` returns `true` correctly, run the following one-time migration on the users collection:

```js
db.users.updateMany(
  { password: { $exists: true, $ne: null }, google_id: null, github_id: null, linkedin_id: null },
  { $set: { hasSetPassword: true } }
)
```

---

## :memo: Additional Notes

- The `setPassword` route applies `enhancedJWTAuth` — the user must be authenticated to call it.
- Password hashing is handled automatically by the existing `findByIdAndUpdate` pre-hook on the User model; no manual bcrypt call is needed in the util.
- Once a password is set, users who need to change it should use the existing `PUT /updatePassword` flow.
- `hasSetPassword` is intentionally not exposed in the login response directly — `authMethods.password` is the consumer-facing signal.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secure endpoint to let users set a local password.
  * Password strength and confirmation are enforced by validation rules.
  * Accounts now record whether a user has explicitly set a password.
  * Auth behavior adapts based on an account's password-setup status.
  * Password reset and update flows now mark accounts as having set a password.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->