### PR TITLE
fix: move auth before validation and correct middleware order in setPassword route

### DIFF
--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -637,6 +637,9 @@ router.post(
 
 router.put("/", userValidations.updateUser, userController.update);
 
+router.put("/setPassword", (req, res) =>
+  res.status(405).json({ success: false, message: "Method not allowed. Use POST /setPassword." })
+);
 router.put("/:user_id", userValidations.updateUserById, userController.update);
 
 router.delete(

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -604,8 +604,8 @@ router.post(
 
 router.post(
   "/setPassword",
-  userValidations.setPassword,
   enhancedJWTAuth,
+  userValidations.setPassword,
   userController.setPassword,
 );
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Moves `enhancedJWTAuth` before `userValidations.setPassword` in the `POST /setPassword` route so authentication is enforced before any validation runs.

### Why is this change needed?
The original middleware order ran the request body validator before the JWT auth check. This meant unauthenticated requests received validation error responses (400) instead of an auth rejection (401), leaking information about the endpoint's expected shape to unauthenticated callers. Additionally, a `PUT /setPassword` request was falling through to the generic `PUT /:user_id` route (treating `"setPassword"` as a user ID), producing a misleading ObjectID validation error. Correct order is: auth → validate → handle.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `routes/v2/users.routes.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- `POST /setPassword` without `Authorization` header → 401 (previously leaked 400 validation errors).
- `POST /setPassword` with valid JWT and correct body → 200 password set successfully.
- `PUT /setPassword` with valid JWT → correctly returns 404/method-not-allowed instead of ObjectID validation error.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The correct method for this endpoint is `POST`, not `PUT`. Clients must use `POST /api/v2/users/setPassword?tenant=airqo`.
- This is consistent with all other protected routes in the codebase where `enhancedJWTAuth` precedes validators.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
