### PR TITLE
Fix authMethods password flag always returning false

### DIFF
--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -3044,3 +3044,71 @@ describe("create-user-util", function () {
     });
   });
 });
+
+// ── buildAuthMethods ─────────────────────────────────────────────────────────
+
+describe("buildAuthMethods()", () => {
+  const { buildAuthMethods } = require("@utils/user.util");
+
+  it("returns password:true for an email/password-only account with hasSetPassword:true", () => {
+    const user = { password: "hashed", hasSetPassword: true };
+    const result = buildAuthMethods(user);
+    expect(result.password).to.equal(true);
+    expect(result.google).to.equal(false);
+  });
+
+  it("returns password:false for an OAuth-only account with system-generated password", () => {
+    const user = {
+      password: "generated-random-hash",
+      hasSetPassword: false,
+      google_id: "google-123",
+    };
+    const result = buildAuthMethods(user);
+    expect(result.password).to.equal(false);
+    expect(result.google).to.equal(true);
+  });
+
+  it("returns password:true for an OAuth account that later used setPassword", () => {
+    const user = {
+      password: "user-chosen-hash",
+      hasSetPassword: true,
+      google_id: "google-123",
+      github_id: "gh-456",
+    };
+    const result = buildAuthMethods(user);
+    expect(result.password).to.equal(true);
+    expect(result.google).to.equal(true);
+    expect(result.github).to.equal(true);
+  });
+
+  it("backward-compat: returns password:true for legacy email/password account with no OAuth and no hasSetPassword flag", () => {
+    const user = { password: "legacy-hash", hasSetPassword: false };
+    const result = buildAuthMethods(user);
+    expect(result.password).to.equal(true);
+  });
+
+  it("returns all provider flags correctly", () => {
+    const user = {
+      hasSetPassword: true,
+      password: "h",
+      google_id: "g",
+      github_id: "gh",
+      linkedin_id: "li",
+      microsoft_id: "ms",
+      twitter_id: "tw",
+      facebook_id: "fb",
+      apple_id: "ap",
+    };
+    const result = buildAuthMethods(user);
+    expect(result).to.deep.equal({
+      password: true,
+      google: true,
+      github: true,
+      linkedin: true,
+      microsoft: true,
+      twitter: true,
+      facebook: true,
+      apple: true,
+    });
+  });
+});

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -6643,10 +6643,7 @@ const createUserModule = {
 
         // Auth methods — which login providers this account has connected
         authMethods: {
-          password:
-            user.hasSetPassword != null
-              ? !!user.hasSetPassword
-              : !!user.password,
+          password: !!user.password,
           google: !!user.google_id,
           github: !!user.github_id,
           linkedin: !!user.linkedin_id,

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -471,6 +471,42 @@ const RATE_LIMIT_WINDOWS = {
   MOBILE_EMAIL_VERIFY_ATTEMPT_MS: 3 * 60 * 1000, // 3 minutes per attempt
 };
 
+/**
+ * Builds the authMethods object for a user document.
+ *
+ * hasSetPassword is the reliable indicator — it is explicitly set to true
+ * during email/password registration and on every password change/reset.
+ * Backward-compat fallback: if hasSetPassword was never set (legacy accounts
+ * created before the field existed) and the account has no OAuth providers,
+ * treat a present password hash as evidence of a user-chosen password.
+ * Accounts that have both a hashed password AND OAuth providers are ambiguous
+ * (OAuth signup sets a random password), so we rely solely on hasSetPassword
+ * for those to avoid false positives.
+ */
+function buildAuthMethods(user) {
+  const hasOAuthProvider = !!(
+    user.google_id ||
+    user.github_id ||
+    user.linkedin_id ||
+    user.microsoft_id ||
+    user.twitter_id ||
+    user.facebook_id ||
+    user.apple_id
+  );
+  return {
+    password:
+      user.hasSetPassword === true ||
+      (!!user.password && !hasOAuthProvider),
+    google: !!user.google_id,
+    github: !!user.github_id,
+    linkedin: !!user.linkedin_id,
+    microsoft: !!user.microsoft_id,
+    twitter: !!user.twitter_id,
+    facebook: !!user.facebook_id,
+    apple: !!user.apple_id,
+  };
+}
+
 const createUserModule = {
   _validatePassword: (password) => {
     if (!password || !constants.PASSWORD_REGEX.test(password)) {
@@ -4022,6 +4058,7 @@ const createUserModule = {
         {
           userName: normalizedEmail,
           password,
+          hasSetPassword: true,
           analyticsVersion: 3,
           ...(userBody.interests && { interests: userBody.interests }),
           ...(userBody.interestsDescription && {
@@ -6641,17 +6678,7 @@ const createUserModule = {
         // Enhanced authentication
         token: `JWT ${token}`,
 
-        // Auth methods — which login providers this account has connected
-        authMethods: {
-          password: !!user.password,
-          google: !!user.google_id,
-          github: !!user.github_id,
-          linkedin: !!user.linkedin_id,
-          microsoft: !!user.microsoft_id,
-          twitter: !!user.twitter_id,
-          facebook: !!user.facebook_id,
-          apple: !!user.apple_id,
-        },
+        authMethods: buildAuthMethods(user),
 
         // --- REMOVED FOR SCALABILITY ---
         // The following large data fields are removed to prevent oversized login responses
@@ -7949,4 +7976,5 @@ module.exports = {
   ...feedbackUtil,
   generateNumericToken,
   ensureDefaultAirqoRole: createUserModule.ensureDefaultAirqoRole,
+  buildAuthMethods,
 };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the `authMethods.password` field in the login response, which was always returning `false` even for accounts that have a password set.

### Why is this change needed?
The `password` flag was being derived from a `hasSetPassword` field that defaults to `false` on every user document. Since this default is always present, the fallback to the actual `password` field was never reached — making `authMethods.password: false` for all users regardless of whether they genuinely have a password. The fix uses `!!user.password` directly, which is the correct and reliable source of truth.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `utils/user.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified on staging that an account with a password now correctly returns `authMethods.password: true`, and an OAuth-only account (no password set) correctly returns `authMethods.password: false`.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

This is a bug fix — the field now returns the correct value it was always intended to return.

---

## :memo: Additional Notes

- This fix is a follow-up to the `auth-methods` PR that introduced the `authMethods` field to the login response.
- The `hasSetPassword` field remains on the user document and is still used by the `setPassword` endpoint flow; this change only affects how `authMethods.password` is computed in the login response.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated password authentication method detection in login responses to use consistent credential validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->