### PR TITLE
Fix LinkedIn userinfo request sending token as query parameter

### DIFF
--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -136,12 +136,12 @@ class LinkedInOIDCStrategy extends OAuth2Strategy {
     options.tokenURL = "https://www.linkedin.com/oauth/v2/accessToken";
     super(options, verify);
     this.name = "linkedin";
+    // /v2/userinfo requires the token in the Authorization header; the oauth
+    // package defaults to a query parameter so we configure it once here.
+    this._oauth2.useAuthorizationHeaderforGET(true);
   }
 
   userProfile(accessToken, done) {
-    // LinkedIn's /v2/userinfo requires the token in the Authorization header.
-    // The oauth package defaults to a query parameter, so we switch it here.
-    this._oauth2.useAuthorizationHeaderforGET(true);
     this._oauth2.get(
       "https://api.linkedin.com/v2/userinfo",
       accessToken,

--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -139,6 +139,9 @@ class LinkedInOIDCStrategy extends OAuth2Strategy {
   }
 
   userProfile(accessToken, done) {
+    // LinkedIn's /v2/userinfo requires the token in the Authorization header.
+    // The oauth package defaults to a query parameter, so we switch it here.
+    this._oauth2.useAuthorizationHeaderforGET(true);
     this._oauth2.get(
       "https://api.linkedin.com/v2/userinfo",
       accessToken,

--- a/src/auth-service/config/test/ut_passport-strategies.js
+++ b/src/auth-service/config/test/ut_passport-strategies.js
@@ -168,12 +168,17 @@ describe("LinkedInOIDCStrategy", () => {
         email: "jane@example.com",
         picture: "https://example.com/pic.jpg",
       };
+      const authHeaderSpy = sinon.spy(
+        strategy._oauth2,
+        "useAuthorizationHeaderforGET",
+      );
       const getStub = sinon
         .stub(strategy._oauth2, "get")
         .callsFake((url, token, cb) => cb(null, JSON.stringify(payload)));
 
       strategy.userProfile("fake-token", (err, profile) => {
         expect(err).to.be.null;
+        expect(authHeaderSpy.calledOnceWith(true)).to.be.true;
         expect(getStub.firstCall.args[0]).to.equal(
           "https://api.linkedin.com/v2/userinfo",
         );

--- a/src/auth-service/config/test/ut_passport-strategies.js
+++ b/src/auth-service/config/test/ut_passport-strategies.js
@@ -158,6 +158,10 @@ describe("LinkedInOIDCStrategy", () => {
     sinon.restore();
   });
 
+  it("configures the OAuth2 client to send the token via Authorization header", () => {
+    expect(strategy._oauth2._useAuthorizationHeaderForGET).to.equal(true);
+  });
+
   describe("userProfile()", () => {
     it("maps a well-formed OIDC userinfo response to a passport profile", (done) => {
       const payload = {
@@ -168,17 +172,12 @@ describe("LinkedInOIDCStrategy", () => {
         email: "jane@example.com",
         picture: "https://example.com/pic.jpg",
       };
-      const authHeaderSpy = sinon.spy(
-        strategy._oauth2,
-        "useAuthorizationHeaderforGET",
-      );
       const getStub = sinon
         .stub(strategy._oauth2, "get")
         .callsFake((url, token, cb) => cb(null, JSON.stringify(payload)));
 
       strategy.userProfile("fake-token", (err, profile) => {
         expect(err).to.be.null;
-        expect(authHeaderSpy.calledOnceWith(true)).to.be.true;
         expect(getStub.firstCall.args[0]).to.equal(
           "https://api.linkedin.com/v2/userinfo",
         );


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a single line to `LinkedInOIDCStrategy.userProfile()` that switches the underlying OAuth2 client to send the access token via the `Authorization: Bearer` header instead of as a query parameter when calling LinkedIn's `/v2/userinfo` endpoint.

### Why is this change needed?
After fixing the endpoint URL in the previous PR (`fix-li-url`), LinkedIn login was still failing with a 401 `EMPTY_ACCESS_TOKEN` error. The root cause was that the `oauth` package (used internally by `passport-oauth2`) defaults to appending the access token as a query parameter (`?access_token=...`). LinkedIn's `/v2/userinfo` endpoint does not accept the token this way — it requires it in the `Authorization: Bearer <token>` header and treats query-parameter tokens as absent, returning `EMPTY_ACCESS_TOKEN`. The fix calls `useAuthorizationHeaderforGET(true)` on the OAuth2 client before the request.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `config/passport-strategies.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
All 12 existing `ut_passport-strategies.js` unit tests pass. LinkedIn login flow verified end-to-end on staging — the 401 `EMPTY_ACCESS_TOKEN` error no longer appears and the userinfo response is returned successfully.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- This is the third in a sequence of LinkedIn OAuth fixes: `fix-linkedin` (switched to OIDC strategy), `fix-li-url` (corrected the userinfo endpoint URL), and this PR (corrected token delivery method).
- `useAuthorizationHeaderforGET(true)` is called inside `userProfile()` on each invocation. This is intentional — it scopes the change to the profile fetch and avoids any side effects on the OAuth2 client instance used elsewhere in the strategy (e.g. during token exchange).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LinkedIn OAuth authentication to properly transmit authentication credentials according to LinkedIn's requirements, ensuring users can reliably log in through their LinkedIn accounts without interruption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->