### PR TITLE
Fix duplicate adminLevel names triggering false Internal Server Error alerts

### DIFF
--- a/src/device-registry/models/AdminLevel.js
+++ b/src/device-registry/models/AdminLevel.js
@@ -91,7 +91,14 @@ adminLevelSchema.statics.register = async function(args, next) {
     } else {
       response.errors = { message: error.message };
     }
-    logger.warn(`⚠️ Conflict -- duplicate adminLevel name: ${error.message}`);
+    const isDuplicate =
+      !isEmpty(error.errors) &&
+      Object.values(error.errors).some((e) => e.kind === "unique");
+    if (isDuplicate) {
+      logger.warn(`⚠️ Conflict -- duplicate adminLevel name: ${error.message}`);
+    } else {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    }
     next(new HttpError(response.message, response.status, response.errors));
   }
 };

--- a/src/device-registry/models/AdminLevel.js
+++ b/src/device-registry/models/AdminLevel.js
@@ -91,7 +91,7 @@ adminLevelSchema.statics.register = async function(args, next) {
     } else {
       response.errors = { message: error.message };
     }
-    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    logger.warn(`⚠️ Conflict -- duplicate adminLevel name: ${error.message}`);
     next(new HttpError(response.message, response.status, response.errors));
   }
 };

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -1352,7 +1352,8 @@ const createGrid = {
       const { tenant } = request.query;
       const { name } = request.body;
 
-      const existing = await AdminLevelModel(tenant).findOne({ name }).lean();
+      const AdminLevel = AdminLevelModel(tenant);
+      const existing = await AdminLevel.findOne({ name }, { _id: 1 }).lean();
       if (existing) {
         next(
           new HttpError("Conflict", httpStatus.CONFLICT, {
@@ -1363,9 +1364,10 @@ const createGrid = {
         return;
       }
 
-      const responseFromCreateAdminLevel = await AdminLevelModel(
-        tenant
-      ).register(request.body, next);
+      const responseFromCreateAdminLevel = await AdminLevel.register(
+        request.body,
+        next
+      );
       return responseFromCreateAdminLevel;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -1350,6 +1350,19 @@ const createGrid = {
   createAdminLevel: async (request, next) => {
     try {
       const { tenant } = request.query;
+      const { name } = request.body;
+
+      const existing = await AdminLevelModel(tenant).findOne({ name }).lean();
+      if (existing) {
+        next(
+          new HttpError("Conflict", httpStatus.CONFLICT, {
+            message: `adminLevel with name "${name}" already exists`,
+            name: `${name} is a duplicate value!`,
+          })
+        );
+        return;
+      }
+
       const responseFromCreateAdminLevel = await AdminLevelModel(
         tenant
       ).register(request.body, next);

--- a/src/device-registry/utils/test/ut_grid.util.js
+++ b/src/device-registry/utils/test/ut_grid.util.js
@@ -465,6 +465,60 @@ describe("Grid Util", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // createAdminLevel
+  // ---------------------------------------------------------------------------
+  describe("createAdminLevel", () => {
+    let adminLevelModelStub;
+    let findOneStub;
+    let registerStub;
+    let nextSpy;
+
+    beforeEach(() => {
+      findOneStub = { lean: sandbox.stub() };
+      registerStub = sandbox.stub();
+      adminLevelModelStub = {
+        findOne: sandbox.stub().returns(findOneStub),
+        register: registerStub,
+      };
+      sandbox.stub(AdminLevelModel, "call").returns(adminLevelModelStub);
+      nextSpy = sandbox.spy();
+    });
+
+    it("returns 409 and calls next(HttpError) when name already exists", async () => {
+      findOneStub.lean.resolves({ _id: "existing-id" });
+
+      const request = {
+        query: { tenant: "airqo" },
+        body: { name: "town" },
+      };
+
+      await gridUtil.createAdminLevel(request, nextSpy);
+
+      expect(nextSpy.calledOnce).to.be.true;
+      const err = nextSpy.firstCall.args[0];
+      expect(err.status).to.equal(httpStatus.CONFLICT);
+      expect(registerStub.called).to.be.false;
+    });
+
+    it("calls register() and returns its result when name is unique", async () => {
+      findOneStub.lean.resolves(null);
+      const mockResponse = { success: true, status: httpStatus.OK };
+      registerStub.resolves(mockResponse);
+
+      const request = {
+        query: { tenant: "airqo" },
+        body: { name: "district" },
+      };
+
+      const result = await gridUtil.createAdminLevel(request, nextSpy);
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(result).to.deep.equal(mockResponse);
+      expect(nextSpy.called).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // getPrivateSiteIds — two-level cache (L1 in-memory + L2 MongoDB)
   // ---------------------------------------------------------------------------
   describe("getPrivateSiteIds", () => {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Changes `logger.error` to `logger.warn` in `AdminLevel.register()` for duplicate name validation errors, so these no longer fire as bug alerts in Slack.
- Adds a `findOne` existence check in `createAdminLevel` (grid.util.js) that short-circuits with a clean HTTP 409 before the request ever hits the DB unique constraint.

### Why is this change needed?
Repeated attempts to create an adminLevel with a duplicate `name` were being logged at `ERROR` severity and surfaced as `🐛🐛 Internal Server Error` alerts in Slack. These are expected client-side 409 Conflict responses, not server faults, and should not trigger bug alerts. The fix prevents alert fatigue and ensures error severity accurately reflects actual system health.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`
  - `src/device-registry/models/AdminLevel.js`
  - `src/device-registry/utils/grid.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that posting a duplicate adminLevel name returns HTTP 409 with a descriptive conflict message and no longer emits an ERROR-level log entry. Unique names continue to be created successfully with HTTP 200.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The `logger.warn` in `AdminLevel.register()` now serves as a last-resort safety net (e.g. if the pre-check races under concurrent writes). Under normal single-request conditions, duplicates are caught by the `findOne` guard in `createAdminLevel` before reaching the model layer.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
