### PR TITLE
fix: include authMethods in OAuth login and enhanced profile responses

### DIFF
--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -1639,11 +1639,34 @@ UserSchema.methods = {
   },
   async toAuthJSON() {
     const token = await this.createToken();
+    const hasOAuthProvider = !!(
+      this.google_id ||
+      this.github_id ||
+      this.linkedin_id ||
+      this.microsoft_id ||
+      this.twitter_id ||
+      this.facebook_id ||
+      this.apple_id
+    );
+    const hasKnownPassword =
+      this.hasSetPassword === true ||
+      (this.hasSetPassword == null && !!this.password) ||
+      (!hasOAuthProvider && !!this.password);
     return {
       _id: this._id,
       userName: this.userName,
       token: `JWT ${token}`,
       email: this.email,
+      authMethods: {
+        password: hasKnownPassword,
+        google: !!this.google_id,
+        github: !!this.github_id,
+        linkedin: !!this.linkedin_id,
+        microsoft: !!this.microsoft_id,
+        twitter: !!this.twitter_id,
+        facebook: !!this.facebook_id,
+        apple: !!this.apple_id,
+      },
     };
   },
   toJSON() {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -493,10 +493,13 @@ function buildAuthMethods(user) {
     user.facebook_id ||
     user.apple_id
   );
+  // hasSetPassword is authoritative when explicitly true (new accounts / after setPassword).
+  // For legacy accounts created before hasSetPassword existed, fall back to !!user.password
+  // so mixed accounts (email+OAuth) that predate the field are not incorrectly shown as false.
+  const hasKnownPassword =
+    user.hasSetPassword === true || (user.hasSetPassword == null && !!user.password) || (!hasOAuthProvider && !!user.password);
   return {
-    password:
-      user.hasSetPassword === true ||
-      (!!user.password && !hasOAuthProvider),
+    password: hasKnownPassword,
     google: !!user.google_id,
     github: !!user.github_id,
     linkedin: !!user.linkedin_id,
@@ -617,6 +620,7 @@ const createUserModule = {
       const enhancedProfile = {
         ...user,
         ...permissionsResult.data.permissions,
+        authMethods: buildAuthMethods(user),
         profileLastUpdated: new Date().toISOString(),
         hasEnhancedPermissions: true,
         contextSummary: {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -474,14 +474,19 @@ const RATE_LIMIT_WINDOWS = {
 /**
  * Builds the authMethods object for a user document.
  *
- * hasSetPassword is the reliable indicator — it is explicitly set to true
- * during email/password registration and on every password change/reset.
- * Backward-compat fallback: if hasSetPassword was never set (legacy accounts
- * created before the field existed) and the account has no OAuth providers,
- * treat a present password hash as evidence of a user-chosen password.
- * Accounts that have both a hashed password AND OAuth providers are ambiguous
- * (OAuth signup sets a random password), so we rely solely on hasSetPassword
- * for those to avoid false positives.
+ * Priority:
+ *   1. hasSetPassword === true  — explicit signal; set by setPassword,
+ *      updateKnownPassword, and reset-password flows.
+ *   2. hasSetPassword == null (undefined/null) && !!password — legacy accounts
+ *      created before the hasSetPassword field existed. Works for both pure
+ *      email/password accounts and mixed accounts (email+OAuth) because lean()
+ *      queries return undefined for fields absent from the raw document.
+ *   3. !hasOAuthProvider && !!password — accounts where hasSetPassword
+ *      defaulted to false (non-lean Mongoose query) but no OAuth provider is
+ *      linked, safely identifying pure email/password accounts.
+ *
+ * Note: call this function while the password hash is still present on the
+ * user object. Strip the hash from the API response separately.
  */
 function buildAuthMethods(user) {
   const hasOAuthProvider = !!(
@@ -546,10 +551,12 @@ const createUserModule = {
         return permissionsResult;
       }
 
-      // Get basic user data
+      // Fetch password field so buildAuthMethods can compute the legacy fallback
+      // correctly for accounts created before hasSetPassword existed.
+      // Password is stripped from the response before returning.
       const basicUser = await UserModel(tenant)
         .findById(userId)
-        .select("-password -resetPasswordToken -resetPasswordExpires")
+        .select("-resetPasswordToken -resetPasswordExpires")
         .lean();
 
       if (!basicUser) {
@@ -615,12 +622,15 @@ const createUserModule = {
         }
       }
 
-      const user = populatedUser;
+      // Compute authMethods while password hash is still present, then
+      // destructure it out so it is never included in the API response.
+      const computedAuthMethods = buildAuthMethods(populatedUser);
+      const { password: _pw, ...user } = populatedUser;
 
       const enhancedProfile = {
         ...user,
         ...permissionsResult.data.permissions,
-        authMethods: buildAuthMethods(user),
+        authMethods: computedAuthMethods,
         profileLastUpdated: new Date().toISOString(),
         hasEnhancedPermissions: true,
         contextSummary: {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds `authMethods` to `toAuthJSON()` on the User model so it is available on every authentication flow that calls this method, including OAuth callbacks.
- Adds `authMethods` to the `GET /profile/enhanced` response so the frontend can retrieve it after OAuth login without an extra API call.
- Fixes `authMethods.password` returning `false` for legacy mixed accounts (users who signed up with email/password and later linked an OAuth provider). The previous logic incorrectly used `!hasOAuthProvider` as a proxy for "has a real password", which broke for any account with both a password and an OAuth provider linked.

### Why is this change needed?
Two bugs reported by the frontend team:

1. **`authMethods` missing after OAuth login** — The OAuth flow redirects with only a JWT in the URL hash; there is no JSON response body. `authMethods` was only present in the email/password login JSON response. The frontend had no way to read it after OAuth login. Fixed by adding `authMethods` to `toAuthJSON()` (consumed by OAuth callbacks) and to `/profile/enhanced` (which the frontend already calls post-login).

2. **`authMethods.password: false` for users with a real password** — Accounts that were originally created with email/password and later logged in via Google/LinkedIn had `google_id` set. The `buildAuthMethods` logic treated any account with an OAuth provider as having no real password (`!hasOAuthProvider && !!user.password`), returning `false` even though the user genuinely knew their password. Fixed with a more accurate check that uses `hasSetPassword` as the authoritative signal when explicitly `true`, and falls back to `!!user.password` for legacy accounts where the field was never set.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `models/User.js` (`toAuthJSON`)
- `auth-service` — `utils/user.util.js` (`buildAuthMethods`, `_getEnhancedProfile`)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Email/password login → `authMethods` present in response with `password: true` ✓
- Google OAuth login → `authMethods` now present in `toAuthJSON()` output ✓
- `GET /profile/enhanced` → `authMethods` now included in response ✓
- Mixed account (email/password + Google OAuth linked): `authMethods.password` now correctly returns `true` ✓
- Pure OAuth account with no `/setPassword` called: `authMethods.password` correctly returns `false` ✓
- OAuth account after calling `POST /setPassword`: `authMethods.password` correctly returns `true` ✓

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `authMethods` in `toAuthJSON()` is only used in the backend response object — it is not encoded into the JWT itself. This avoids stale values: if a user sets a password after OAuth login, the next call to `/profile/enhanced` always returns the current state without requiring re-login.
- The `buildAuthMethods` logic priority: `hasSetPassword === true` (authoritative) → `hasSetPassword == null && !!password` (legacy accounts where field was never written) → `!hasOAuthProvider && !!password` (pure email/password accounts with default `false`).
- No DB migration required for this fix.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced user profiles to display available authentication methods. The system now detects and reports which authentication options are available for each user, including password authentication and OAuth providers (Google, GitHub, LinkedIn, Microsoft, Twitter, Facebook, Apple).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->