### PR TITLE
Add scheduled job to fix transaction amounts stored in cents

### DIFF
--- a/src/auth-service/bin/jobs/transaction-amount-fix-job.js
+++ b/src/auth-service/bin/jobs/transaction-amount-fix-job.js
@@ -69,7 +69,7 @@ const fixTransactionAmounts = async () => {
       const ids = batch.map((doc) => doc._id);
 
       const result = await TransactionModel(TENANT).updateMany(
-        { _id: { $in: ids } },
+        { _id: { $in: ids }, amount: { $gte: 1000 } },
         [{ $set: { amount: { $divide: ["$amount", 100] } } }]
       );
 

--- a/src/auth-service/bin/jobs/transaction-amount-fix-job.js
+++ b/src/auth-service/bin/jobs/transaction-amount-fix-job.js
@@ -11,10 +11,15 @@ const logger = log4js.getLogger(
 const TENANT = constants.DEFAULT_TENANT || "airqo";
 const BATCH_SIZE = 500;
 
-// Records stored in smallest currency unit (cents) before the /100 fix was
-// deployed. Legitimate major-unit amounts for Standard ($50) and Premium ($150)
-// will never reach 1000, making this a safe discriminator.
-const DIRTY_FILTER = { amount: { $gte: 1000 } };
+// Date the webhook /100 normalization fix was deployed. Only records created
+// before this boundary can be dirty; records on or after are always correct.
+// Keeping amount >= 1000 as a secondary guard makes each batch idempotent —
+// already-corrected records (e.g. amount: 50) are never re-touched.
+const CUTOFF_DATE = new Date("2026-05-25T00:00:00.000Z");
+const DIRTY_FILTER = {
+  createdAt: { $lt: CUTOFF_DATE },
+  amount: { $gte: 1000 },
+};
 
 let isJobRunning = false;
 
@@ -46,6 +51,13 @@ const fixTransactionAmounts = async () => {
 
     // Process in batches to avoid locking large portions of the collection.
     while (true) {
+      if (global.isShuttingDown) {
+        logger.info(
+          `transaction-amount-fix-job: shutdown signal received — stopping after ${totalFixed} record(s) fixed`
+        );
+        break;
+      }
+
       const batch = await TransactionModel(TENANT)
         .find(DIRTY_FILTER)
         .select("_id")

--- a/src/auth-service/bin/jobs/transaction-amount-fix-job.js
+++ b/src/auth-service/bin/jobs/transaction-amount-fix-job.js
@@ -1,0 +1,95 @@
+const cron = require("node-cron");
+const TransactionModel = require("@models/Transaction");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const { stringify } = require("@utils/common");
+
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- transaction-amount-fix-job`
+);
+
+const TENANT = constants.DEFAULT_TENANT || "airqo";
+const BATCH_SIZE = 500;
+
+// Records stored in smallest currency unit (cents) before the /100 fix was
+// deployed. Legitimate major-unit amounts for Standard ($50) and Premium ($150)
+// will never reach 1000, making this a safe discriminator.
+const DIRTY_FILTER = { amount: { $gte: 1000 } };
+
+let isJobRunning = false;
+
+const fixTransactionAmounts = async () => {
+  if (isJobRunning) {
+    logger.warn("transaction-amount-fix-job already running — skipping tick");
+    return;
+  }
+  isJobRunning = true;
+
+  try {
+    // Fast pre-check: exit immediately if there is nothing to fix.
+    const dirtyCount = await TransactionModel(TENANT).countDocuments(
+      DIRTY_FILTER
+    );
+
+    if (dirtyCount === 0) {
+      logger.info(
+        "transaction-amount-fix-job: all records clean — nothing to do"
+      );
+      return;
+    }
+
+    logger.info(
+      `transaction-amount-fix-job: ${dirtyCount} dirty record(s) found — starting fix`
+    );
+
+    let totalFixed = 0;
+
+    // Process in batches to avoid locking large portions of the collection.
+    while (true) {
+      const batch = await TransactionModel(TENANT)
+        .find(DIRTY_FILTER)
+        .select("_id")
+        .limit(BATCH_SIZE)
+        .lean();
+
+      if (batch.length === 0) break;
+
+      const ids = batch.map((doc) => doc._id);
+
+      const result = await TransactionModel(TENANT).updateMany(
+        { _id: { $in: ids } },
+        [{ $set: { amount: { $divide: ["$amount", 100] } } }]
+      );
+
+      const fixed =
+        typeof result.modifiedCount === "number"
+          ? result.modifiedCount
+          : result.nModified || 0;
+
+      totalFixed += fixed;
+      logger.debug(`Batch done: ${fixed} record(s) fixed`);
+    }
+
+    logger.info(
+      `transaction-amount-fix-job: complete — ${totalFixed} record(s) fixed`
+    );
+  } catch (error) {
+    logger.error(
+      `transaction-amount-fix-job error --- ${stringify(error)}`
+    );
+  } finally {
+    isJobRunning = false;
+  }
+};
+
+// Run at 06:00 and 18:00 Nairobi time.
+const schedule = "0 6,18 * * *";
+const jobName = "transaction-amount-fix-job";
+
+global.cronJobs = global.cronJobs || {};
+global.cronJobs[jobName] = cron.schedule(schedule, fixTransactionAmounts, {
+  scheduled: true,
+  timezone: "Africa/Nairobi",
+});
+
+module.exports = { fixTransactionAmounts };

--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -111,6 +111,7 @@ const jobs = [
   "@bin/jobs/daily-compromise-summary-job",
   "@bin/jobs/unknown-ip-cleanup-job",
   "@bin/jobs/feedback-screenshot-cleanup-job",
+  "@bin/jobs/transaction-amount-fix-job",
 ];
 
 // Initialize log4js with SAFE configuration


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a background job (`bin/jobs/transaction-amount-fix-job.js`) that runs twice daily and corrects historical transaction records where `amount` was stored in the smallest currency unit (cents) instead of major units (dollars).

- Performs a fast pre-check on each tick — if no dirty records exist, exits immediately with no writes
- Processes dirty records in batches of 500 to avoid locking the collection
- Registered in the server's cron job registry and participates in graceful shutdown
- Self-limiting: once all records are clean, each tick costs only one lightweight count query

### Why is this change needed?
The billing webhook was previously storing raw amounts from the payment provider (e.g. `5000` for a $50 Standard plan, `15000` for a $150 Premium plan) without converting to major currency units. A normalization fix (dividing by 100) was later applied to the webhook handler and correctly handles all new incoming records — but existing records in the database were never back-filled. As a result, the frontend transaction history page displayed inflated values (e.g. $5000 instead of $50). This job corrects those historical records automatically, without requiring a one-off manual script or a deployment window.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `bin/jobs/transaction-amount-fix-job.js` (new job)
- `auth-service` — `bin/server.js` (job registered in startup list)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Confirmed on staging that pre-fix records have `amount: 5000` and post-fix records have `amount: 50` — matching the exact split visible in the transaction list response
- Verified the dirty-record filter (`amount >= 1000`) correctly identifies only the historical records; no valid major-unit subscription amount ($50 Standard, $150 Premium) can reach 1000
- Verified the job exits immediately with a log when no dirty records are present
- Verified batch processing completes and modifiedCount is reported correctly per batch

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The dirty-record filter `amount >= 1000` is safe because no legitimate subscription amount in major units (Standard: $50, Premium: $150) can reach $1,000 — eliminating any risk of double-dividing already-correct records
- The `isJobRunning` in-memory flag prevents a slow run from stacking with the next scheduled tick
- Schedule: 06:00 and 18:00 Nairobi time (`0 6,18 * * *`)
- The `metadata.total` field inside embedded transaction metadata is intentionally left uncorrected — it is a raw audit snapshot of the original billing event and is not read by the frontend
- Once all records are corrected the job becomes a permanent no-op (one count query per tick) and can be removed in a future cleanup PR when the team is confident no new dirty records can appear

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated background job that corrects historical transaction amounts (scales stored values to restore accuracy); runs twice daily in Africa/Nairobi and logs progress.

* **Chores**
  * Server startup now registers and loads the new background job; job processes records in batches, avoids overlapping runs, exits early when no work is found, and supports graceful shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->