### PR TITLE
Downgrade user-cancelled OAuth flows from error to warn

### DIFF
--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1486,7 +1486,7 @@ const authOAuthCallback = (req, res, next) => {
         ).slice(0, 500),
       });
     } else if (err.name === "AuthorizationError") {
-      logger.warn(`[passport] OAuth authorisation declined for ${safeProvider}`, {
+      logger.warn(`[passport] OAuth authorization declined for ${safeProvider}`, {
         provider: safeProvider,
         errorType: err.name,
         message: err.message,

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1485,6 +1485,12 @@ const authOAuthCallback = (req, res, next) => {
               : oauthErr.data ?? "",
         ).slice(0, 500),
       });
+    } else if (err.name === "AuthorizationError") {
+      logger.warn(`[passport] OAuth authorisation declined for ${safeProvider}`, {
+        provider: safeProvider,
+        errorType: err.name,
+        message: err.message,
+      });
     } else {
       logger.error(`[passport] OAuth callback error for ${safeProvider}`, {
         provider: safeProvider,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Changes the log level for `AuthorizationError` OAuth callback events from `ERROR` to `WARN` in the passport middleware. All other OAuth callback errors retain the `ERROR` level.

### Why is this change needed?
An `AuthorizationError` means the user clicked "Cancel" or denied permission on the OAuth provider's consent screen — it is a deliberate user action, not a system fault. Logging it at `ERROR` creates noise in production monitoring and can trigger false alerts. `WARN` is the appropriate level for expected, non-critical user-driven events.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `middleware/passport.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified on staging that cancelling the LinkedIn OAuth consent screen now produces a `WARN` log instead of `ERROR`. Completing the OAuth flow successfully and triggering a genuine token exchange error both continue to log at `ERROR` as expected.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The redirect behaviour on cancellation is unchanged — the user is still sent to the failure redirect URL regardless of log level.
- Only `AuthorizationError` is downgraded. Any other error type in the OAuth callback (e.g. network failures, token exchange errors) continues to log at `ERROR`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
