### PR TITLE
fix: scope public metadata to cohort visibility and improve bulk import performance

### DIFF
--- a/src/device-registry/routes/v2/metadata.routes.js
+++ b/src/device-registry/routes/v2/metadata.routes.js
@@ -10,7 +10,7 @@ const metadataValidations = require("@validators/metadata.validators");
 const { headers, pagination } = require("@validators/common");
 
 router.use(headers);
-router.use(metadataValidations.addCategoryQueryParam);
+router.use(metadataValidations.addPublicPathQueryParam);
 
 /** Nearest Locations */
 

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -320,33 +320,51 @@ const createCohort = {
       const sortOrder = order === "asc" ? 1 : -1;
       const sortField = sortBy ? sortBy : "createdAt";
 
-      const pipeline = [
-        { $match: filter },
-        {
-          // Simple array-membership join: MongoDB can use a multikey index on
-          // devices.cohorts with this form, unlike the correlated $expr/$in
-          // pipeline approach. Field trimming is handled downstream by the
-          // $map in COHORTS_INCLUSION_PROJECTION.
-          $lookup: {
-            from: "devices",
-            localField: "_id",
-            foreignField: "cohorts",
-            as: "devices",
-          },
-        },
-        { $project: constants.COHORTS_INCLUSION_PROJECTION },
-        { $project: constants.COHORTS_EXCLUSION_PROJECTION(detailLevel) },
-        {
-          $facet: {
-            paginatedResults: [
-              { $sort: { [sortField]: sortOrder } },
-              { $skip: _skip },
-              { $limit: _limit },
-            ],
-            totalCount: [{ $count: "count" }],
-          },
-        },
-      ];
+      // Public metadata path: return only _id + name, skip the device lookup.
+      const isPublicMetadata = request.query.path === "public";
+
+      const pipeline = isPublicMetadata
+        ? [
+            { $match: filter },
+            { $project: { _id: 1, name: 1 } },
+            {
+              $facet: {
+                paginatedResults: [
+                  { $sort: { [sortField]: sortOrder } },
+                  { $skip: _skip },
+                  { $limit: _limit },
+                ],
+                totalCount: [{ $count: "count" }],
+              },
+            },
+          ]
+        : [
+            { $match: filter },
+            {
+              // Simple array-membership join: MongoDB can use a multikey index on
+              // devices.cohorts with this form, unlike the correlated $expr/$in
+              // pipeline approach. Field trimming is handled downstream by the
+              // $map in COHORTS_INCLUSION_PROJECTION.
+              $lookup: {
+                from: "devices",
+                localField: "_id",
+                foreignField: "cohorts",
+                as: "devices",
+              },
+            },
+            { $project: constants.COHORTS_INCLUSION_PROJECTION },
+            { $project: constants.COHORTS_EXCLUSION_PROJECTION(detailLevel) },
+            {
+              $facet: {
+                paginatedResults: [
+                  { $sort: { [sortField]: sortOrder } },
+                  { $skip: _skip },
+                  { $limit: _limit },
+                ],
+                totalCount: [{ $count: "count" }],
+              },
+            },
+          ];
 
       const results = await CohortModel(tenant)
         .aggregate(pipeline)

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -321,18 +321,24 @@ const createCohort = {
       const sortField = sortBy ? sortBy : "createdAt";
 
       // Public metadata path: return only _id + name, skip the device lookup.
+      // Enforce visibility:true even for /metadata/cohorts/:cohort_id so a
+      // non-public cohort cannot be fetched by ID. Sort before $project so
+      // sortField (e.g. createdAt) is available when ordering results.
       const isPublicMetadata = request.query.path === "public";
+      if (isPublicMetadata) {
+        filter.visibility = true;
+      }
 
       const pipeline = isPublicMetadata
         ? [
             { $match: filter },
-            { $project: { _id: 1, name: 1 } },
+            { $sort: { [sortField]: sortOrder } },
             {
               $facet: {
                 paginatedResults: [
-                  { $sort: { [sortField]: sortOrder } },
                   { $skip: _skip },
                   { $limit: _limit },
+                  { $project: { _id: 1, name: 1 } },
                 ],
                 totalCount: [{ $count: "count" }],
               },

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1173,14 +1173,27 @@ const deviceUtil = {
       // cannot bypass cohort visibility by fetching a non-public device by ID.
       if (request.query.path === "public") {
         delete filter.visibility;
-        const visibleCohorts = await CohortModel(tenant)
-          .find({ visibility: true })
-          .select("_id")
+        const allCohorts = await CohortModel(tenant)
+          .find({}, { _id: 1, visibility: 1 })
           .lean();
-        if (visibleCohorts.length > 0) {
-          filter.cohorts = { $in: visibleCohorts.map((c) => c._id) };
-        } else {
+        const visibleCohortIds = allCohorts
+          .filter((c) => c.visibility === true)
+          .map((c) => c._id);
+        const privateCohortIds = allCohorts
+          .filter((c) => c.visibility !== true)
+          .map((c) => c._id);
+
+        if (visibleCohortIds.length === 0) {
           filter._id = { $in: [] };
+        } else if (privateCohortIds.length === 0) {
+          // All cohorts are public — simple $in is sufficient
+          filter.cohorts = { $in: visibleCohortIds };
+        } else {
+          // Strict rule: device must be in ≥1 public cohort AND in no private cohort
+          filter.$and = (filter.$and || []).concat([
+            { cohorts: { $in: visibleCohortIds } },
+            { cohorts: { $nin: privateCohortIds } },
+          ]);
         }
 
         const publicResults = await DeviceModel(tenant)

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1168,10 +1168,10 @@ const deviceUtil = {
       const sortField = sortBy ? sortBy : "createdAt";
       const filter = generateFilter.devices(request, next);
 
-      // Public metadata path: swap device visibility for cohort visibility.
-      // The device's own visibility field is not the authority here — a device
-      // is "public" when at least one of its cohorts is visible.
-      if (request.query.path === "public" && filter.visibility === true) {
+      // Public metadata path: cohort-scoped, isolated pipeline. Applied for
+      // both list and single-device lookups so /metadata/devices/:device_id
+      // cannot bypass cohort visibility by fetching a non-public device by ID.
+      if (request.query.path === "public") {
         delete filter.visibility;
         const visibleCohorts = await CohortModel(tenant)
           .find({ visibility: true })
@@ -1182,6 +1182,56 @@ const deviceUtil = {
         } else {
           filter._id = { $in: [] };
         }
+
+        const publicResults = await DeviceModel(tenant)
+          .aggregate([
+            { $match: filter },
+            { $sort: { [sortField]: sortOrder } },
+            {
+              $facet: {
+                paginatedResults: [
+                  { $skip: _skip },
+                  { $limit: _limit },
+                  {
+                    $project: {
+                      _id: 1,
+                      name: 1,
+                      long_name: 1,
+                      network: 1,
+                      device_number: 1,
+                    },
+                  },
+                ],
+                totalCount: [{ $count: "count" }],
+              },
+            },
+          ])
+          .option({ maxTimeMS: 15000 });
+
+        const agg =
+          Array.isArray(publicResults) && publicResults[0]
+            ? publicResults[0]
+            : { paginatedResults: [], totalCount: [] };
+        const total =
+          Array.isArray(agg.totalCount) && agg.totalCount[0]
+            ? agg.totalCount[0].count
+            : 0;
+
+        return {
+          success: true,
+          message: "successfully retrieved the device details",
+          data: agg.paginatedResults || [],
+          status: httpStatus.OK,
+          meta: {
+            total,
+            totalResults: (agg.paginatedResults || []).length,
+            limit: _limit,
+            skip: _skip,
+            page: Math.floor(_skip / _limit) + 1,
+            totalPages: Math.ceil(total / _limit),
+            detailLevel,
+          },
+        };
       }
 
       let pipeline = [];
@@ -1189,17 +1239,7 @@ const deviceUtil = {
       // Base match
       pipeline.push({ $match: filter });
 
-      if (request.query.path === "public") {
-        pipeline.push({
-          $project: {
-            _id: 1,
-            name: 1,
-            long_name: 1,
-            network: 1,
-            device_number: 1,
-          },
-        });
-      } else if (detailLevel === "minimal") {
+      if (detailLevel === "minimal") {
         // Minimal data for performance-critical scenarios
         pipeline.push(getDeviceCategoriesAddFieldsStage(), {
           $project: {
@@ -5548,16 +5588,22 @@ const deviceUtil = {
       )
       .lean();
 
-    const existingSerials = new Set(existingDocs.map((d) => d.serial_number));
+    const existingSerials = new Set(
+      existingDocs.map((d) => d.serial_number).filter(Boolean),
+    );
     const existingNames = new Set(existingDocs.map((d) => d.name));
 
-    const hasNewDevices = devices.some(
-      (d) =>
-        !existingSerials.has(d.serial_number) &&
-        !existingNames.has(
-          (d.long_name || d.name || "").replace(/[^a-zA-Z0-9]/g, "_").slice(0, 41).trim().toLowerCase(),
-        ),
-    );
+    const hasNewDevices = devices.some((d) => {
+      const serial = d.serial_number;
+      const sanitized = (d.long_name || d.name || "")
+        .replace(/[^a-zA-Z0-9]/g, "_")
+        .slice(0, 41)
+        .trim()
+        .toLowerCase();
+      const isDuplicate =
+        (serial && existingSerials.has(serial)) || existingNames.has(sanitized);
+      return !isDuplicate;
+    });
 
     // One shared Kafka producer for the whole batch avoids N connect/disconnect
     // cycles. Skip entirely when pre-flight shows no new devices to save.

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1168,12 +1168,38 @@ const deviceUtil = {
       const sortField = sortBy ? sortBy : "createdAt";
       const filter = generateFilter.devices(request, next);
 
+      // Public metadata path: swap device visibility for cohort visibility.
+      // The device's own visibility field is not the authority here — a device
+      // is "public" when at least one of its cohorts is visible.
+      if (request.query.path === "public" && filter.visibility === true) {
+        delete filter.visibility;
+        const visibleCohorts = await CohortModel(tenant)
+          .find({ visibility: true })
+          .select("_id")
+          .lean();
+        if (visibleCohorts.length > 0) {
+          filter.cohorts = { $in: visibleCohorts.map((c) => c._id) };
+        } else {
+          filter._id = { $in: [] };
+        }
+      }
+
       let pipeline = [];
 
       // Base match
       pipeline.push({ $match: filter });
 
-      if (detailLevel === "minimal") {
+      if (request.query.path === "public") {
+        pipeline.push({
+          $project: {
+            _id: 1,
+            name: 1,
+            long_name: 1,
+            network: 1,
+            device_number: 1,
+          },
+        });
+      } else if (detailLevel === "minimal") {
         // Minimal data for performance-critical scenarios
         pipeline.push(getDeviceCategoriesAddFieldsStage(), {
           $project: {
@@ -1924,6 +1950,7 @@ const deviceUtil = {
           const sharedProducer = request._sharedKafkaProducer || null;
           const kafkaProducer = sharedProducer || kafka.producer({
             groupId: constants.UNIQUE_PRODUCER_GROUP,
+            retry: { retries: 1, initialRetryTime: 100 },
           });
           if (!sharedProducer) await kafkaProducer.connect();
           let deviceDataString = responseFromRegisterDevice.data
@@ -5506,17 +5533,48 @@ const deviceUtil = {
       );
     }
 
+    // Pre-flight: identify already-existing devices with one bulk query so we
+    // can (a) skip Kafka entirely when nothing will be created, and (b) return
+    // fast failures without attempting individual saves.
+    const serialNumbers = devices.map((d) => d.serial_number).filter(Boolean);
+    const sanitizedNames = devices
+      .map((d) => (d.long_name || d.name || "").replace(/[^a-zA-Z0-9]/g, "_").slice(0, 41).trim().toLowerCase())
+      .filter(Boolean);
+
+    const existingDocs = await DeviceModel(tenant)
+      .find(
+        { $or: [{ serial_number: { $in: serialNumbers } }, { name: { $in: sanitizedNames } }] },
+        { serial_number: 1, name: 1 },
+      )
+      .lean();
+
+    const existingSerials = new Set(existingDocs.map((d) => d.serial_number));
+    const existingNames = new Set(existingDocs.map((d) => d.name));
+
+    const hasNewDevices = devices.some(
+      (d) =>
+        !existingSerials.has(d.serial_number) &&
+        !existingNames.has(
+          (d.long_name || d.name || "").replace(/[^a-zA-Z0-9]/g, "_").slice(0, 41).trim().toLowerCase(),
+        ),
+    );
+
     // One shared Kafka producer for the whole batch avoids N connect/disconnect
-    // cycles. Falls back to null so createOnPlatform manages its own lifecycle.
+    // cycles. Skip entirely when pre-flight shows no new devices to save.
     let sharedProducer = null;
-    try {
-      sharedProducer = kafka.producer({ groupId: constants.UNIQUE_PRODUCER_GROUP });
-      await sharedProducer.connect();
-    } catch (kafkaErr) {
-      logger.warn(
-        `createDevicesBatch: could not connect shared Kafka producer: ${kafkaErr.message}. Per-device fallback will be used.`,
-      );
-      sharedProducer = null;
+    if (hasNewDevices) {
+      try {
+        sharedProducer = kafka.producer({
+          groupId: constants.UNIQUE_PRODUCER_GROUP,
+          retry: { retries: 1, initialRetryTime: 100 },
+        });
+        await sharedProducer.connect();
+      } catch (kafkaErr) {
+        logger.warn(
+          `createDevicesBatch: could not connect shared Kafka producer: ${kafkaErr.message}. Per-device fallback will be used.`,
+        );
+        sharedProducer = null;
+      }
     }
 
     try {
@@ -5556,9 +5614,9 @@ const deviceUtil = {
               return {
                 success: false,
                 message: capturedError.message || "Device creation failed",
-                ...(capturedError.details &&
-                  Object.keys(capturedError.details).length > 0 && {
-                    details: capturedError.details,
+                ...(capturedError.errors &&
+                  Object.keys(capturedError.errors).length > 0 && {
+                    details: capturedError.errors,
                   }),
               };
             }
@@ -5586,6 +5644,10 @@ const deviceUtil = {
                 long_name: deviceRow.long_name,
                 success: false,
                 error: outcome?.message || "Device creation failed",
+                ...(outcome?.details &&
+                  Object.keys(outcome.details).length > 0 && {
+                    details: outcome.details,
+                  }),
               });
             }
           } else {

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -967,27 +967,29 @@ const createGrid = {
       }
 
       // Public metadata path: lightweight pipeline — no site lookups, no caching.
-      // Grids default to visibility=true so the filter already covers all public grids.
+      // Enforce visibility:true explicitly so /metadata/grids/:grid_id cannot
+      // return a non-public grid by ID. Sort happens before $project so
+      // sortField (e.g. createdAt) is available regardless of the projection.
       if (request.query.path === "public") {
         const results = await GridModel(normalizedTenant)
           .aggregate([
-            { $match: filter },
-            {
-              $project: {
-                _id: 1,
-                visibility: 1,
-                name: 1,
-                admin_level: 1,
-                long_name: 1,
-                flag_url: 1,
-              },
-            },
+            { $match: { ...filter, visibility: true } },
+            { $sort: { [sortField]: sortOrder } },
             {
               $facet: {
                 paginatedResults: [
-                  { $sort: { [sortField]: sortOrder } },
                   { $skip: _skip },
                   { $limit: _limit },
+                  {
+                    $project: {
+                      _id: 1,
+                      visibility: 1,
+                      name: 1,
+                      admin_level: 1,
+                      long_name: 1,
+                      flag_url: 1,
+                    },
+                  },
                 ],
                 totalCount: [{ $count: "count" }],
               },

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -966,6 +966,52 @@ const createGrid = {
         };
       }
 
+      // Public metadata path: lightweight pipeline — no site lookups, no caching.
+      // Grids default to visibility=true so the filter already covers all public grids.
+      if (request.query.path === "public") {
+        const results = await GridModel(normalizedTenant)
+          .aggregate([
+            { $match: filter },
+            {
+              $project: {
+                _id: 1,
+                visibility: 1,
+                name: 1,
+                admin_level: 1,
+                long_name: 1,
+                flag_url: 1,
+              },
+            },
+            {
+              $facet: {
+                paginatedResults: [
+                  { $sort: { [sortField]: sortOrder } },
+                  { $skip: _skip },
+                  { $limit: _limit },
+                ],
+                totalCount: [{ $count: "count" }],
+              },
+            },
+          ])
+          .option({ maxTimeMS: 15000 });
+
+        const agg =
+          Array.isArray(results) && results[0]
+            ? results[0]
+            : { paginatedResults: [], totalCount: [] };
+        const total =
+          Array.isArray(agg.totalCount) && agg.totalCount[0]
+            ? agg.totalCount[0].count
+            : 0;
+        return {
+          success: true,
+          message: "Successfully retrieved grids",
+          data: agg.paginatedResults || [],
+          status: httpStatus.OK,
+          meta: buildGridListMeta({ total, _skip, _limit, request }),
+        };
+      }
+
       // Use cached helper — avoids a full Cohort→Device join on every request.
       // Cache is per-tenant with a 5-minute TTL (see getPrivateSiteIds above).
       const privateSiteIds = await getPrivateSiteIds(normalizedTenant);

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1580,12 +1580,52 @@ const createSite = {
       const filter = generateFilter.sites(request, next);
       filter.lat_long = { $ne: "4_4" };
 
+      // Public metadata path: a site is "public" when it has at least one
+      // device that belongs to a visible cohort — not by the site's own visibility.
+      if (request.query.path === "public" && filter.visibility === true) {
+        delete filter.visibility;
+        const visibleCohorts = await CohortModel(tenant)
+          .find({ visibility: true })
+          .select("_id")
+          .lean();
+        if (visibleCohorts.length === 0) {
+          filter._id = { $in: [] };
+        } else {
+          const devicesInCohorts = await DeviceModel(tenant)
+            .find(
+              {
+                cohorts: { $in: visibleCohorts.map((c) => c._id) },
+                site_id: { $exists: true, $ne: null },
+              },
+              { site_id: 1 },
+            )
+            .lean();
+          const siteIds = [
+            ...new Set(devicesInCohorts.map((d) => d.site_id.toString())),
+          ];
+          filter._id =
+            siteIds.length > 0
+              ? { $in: siteIds.map((id) => ObjectId(id)) }
+              : { $in: [] };
+        }
+      }
+
       let pipeline = [];
 
       // Base match
       pipeline.push({ $match: filter });
 
-      if (detailLevel === "minimal") {
+      if (request.query.path === "public") {
+        pipeline.push({
+          $project: {
+            _id: 1,
+            name: 1,
+            long_name: 1,
+            generated_name: 1,
+            formatted_name: 1,
+          },
+        });
+      } else if (detailLevel === "minimal") {
         pipeline.push({
           $project: {
             _id: 1,

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1585,17 +1585,32 @@ const createSite = {
       // /metadata/sites/:site_id cannot bypass cohort visibility by ID.
       if (request.query.path === "public") {
         delete filter.visibility;
-        const visibleCohorts = await CohortModel(tenant)
-          .find({ visibility: true })
-          .select("_id")
+        const allCohorts = await CohortModel(tenant)
+          .find({}, { _id: 1, visibility: 1 })
           .lean();
+        const visibleCohortIds = allCohorts
+          .filter((c) => c.visibility === true)
+          .map((c) => c._id);
+        const privateCohortIds = allCohorts
+          .filter((c) => c.visibility !== true)
+          .map((c) => c._id);
 
         let allowedSiteIds = [];
-        if (visibleCohorts.length > 0) {
-          allowedSiteIds = await DeviceModel(tenant).distinct("site_id", {
-            cohorts: { $in: visibleCohorts.map((c) => c._id) },
-            site_id: { $ne: null },
-          });
+        if (visibleCohortIds.length > 0) {
+          const deviceFilter = { site_id: { $ne: null } };
+          if (privateCohortIds.length === 0) {
+            deviceFilter.cohorts = { $in: visibleCohortIds };
+          } else {
+            // Strict rule: device must be in ≥1 public cohort AND in no private cohort
+            deviceFilter.$and = [
+              { cohorts: { $in: visibleCohortIds } },
+              { cohorts: { $nin: privateCohortIds } },
+            ];
+          }
+          allowedSiteIds = await DeviceModel(tenant).distinct(
+            "site_id",
+            deviceFilter,
+          );
         }
 
         if (filter._id !== undefined) {

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1580,34 +1580,88 @@ const createSite = {
       const filter = generateFilter.sites(request, next);
       filter.lat_long = { $ne: "4_4" };
 
-      // Public metadata path: a site is "public" when it has at least one
-      // device that belongs to a visible cohort — not by the site's own visibility.
-      if (request.query.path === "public" && filter.visibility === true) {
+      // Public metadata path: a site is "public" when it has a device in a
+      // visible cohort. Applied for both list and single-site lookups so
+      // /metadata/sites/:site_id cannot bypass cohort visibility by ID.
+      if (request.query.path === "public") {
         delete filter.visibility;
         const visibleCohorts = await CohortModel(tenant)
           .find({ visibility: true })
           .select("_id")
           .lean();
-        if (visibleCohorts.length === 0) {
-          filter._id = { $in: [] };
+
+        let allowedSiteIds = [];
+        if (visibleCohorts.length > 0) {
+          allowedSiteIds = await DeviceModel(tenant).distinct("site_id", {
+            cohorts: { $in: visibleCohorts.map((c) => c._id) },
+            site_id: { $ne: null },
+          });
+        }
+
+        if (filter._id !== undefined) {
+          // Single-site lookup: verify this site is in the allowed set
+          const allowedSet = new Set(
+            allowedSiteIds.map((id) => id.toString()),
+          );
+          filter._id = allowedSet.has(filter._id.toString())
+            ? filter._id
+            : { $in: [] };
         } else {
-          const devicesInCohorts = await DeviceModel(tenant)
-            .find(
-              {
-                cohorts: { $in: visibleCohorts.map((c) => c._id) },
-                site_id: { $exists: true, $ne: null },
-              },
-              { site_id: 1 },
-            )
-            .lean();
-          const siteIds = [
-            ...new Set(devicesInCohorts.map((d) => d.site_id.toString())),
-          ];
           filter._id =
-            siteIds.length > 0
-              ? { $in: siteIds.map((id) => ObjectId(id)) }
+            allowedSiteIds.length > 0
+              ? { $in: allowedSiteIds }
               : { $in: [] };
         }
+
+        const publicResults = await SiteModel(tenant)
+          .aggregate([
+            { $match: filter },
+            { $sort: { [sortField]: sortOrder } },
+            {
+              $facet: {
+                paginatedResults: [
+                  { $skip: _skip },
+                  { $limit: _limit },
+                  {
+                    $project: {
+                      _id: 1,
+                      name: 1,
+                      long_name: 1,
+                      generated_name: 1,
+                      formatted_name: 1,
+                    },
+                  },
+                ],
+                totalCount: [{ $count: "count" }],
+              },
+            },
+          ])
+          .option({ maxTimeMS: 15000 });
+
+        const agg =
+          Array.isArray(publicResults) && publicResults[0]
+            ? publicResults[0]
+            : { paginatedResults: [], totalCount: [] };
+        const total =
+          Array.isArray(agg.totalCount) && agg.totalCount[0]
+            ? agg.totalCount[0].count
+            : 0;
+
+        return {
+          success: true,
+          message: "successfully retrieved the sites",
+          data: agg.paginatedResults || [],
+          status: httpStatus.OK,
+          meta: {
+            total,
+            totalResults: (agg.paginatedResults || []).length,
+            limit: _limit,
+            skip: _skip,
+            page: Math.floor(_skip / _limit) + 1,
+            totalPages: Math.ceil(total / _limit),
+            detailLevel,
+          },
+        };
       }
 
       let pipeline = [];
@@ -1615,17 +1669,7 @@ const createSite = {
       // Base match
       pipeline.push({ $match: filter });
 
-      if (request.query.path === "public") {
-        pipeline.push({
-          $project: {
-            _id: 1,
-            name: 1,
-            long_name: 1,
-            generated_name: 1,
-            formatted_name: 1,
-          },
-        });
-      } else if (detailLevel === "minimal") {
+      if (detailLevel === "minimal") {
         pipeline.push({
           $project: {
             _id: 1,

--- a/src/device-registry/validators/metadata.validators.js
+++ b/src/device-registry/validators/metadata.validators.js
@@ -274,7 +274,7 @@ const metadataValidations = {
 module.exports = {
   ...metadataValidations,
   pagination: commonValidations.pagination,
-  addCategoryQueryParam: (req, res, next) => {
+  addPublicPathQueryParam: (req, res, next) => {
     req.query.path = "public";
     next();
   },

--- a/src/device-registry/validators/metadata.validators.js
+++ b/src/device-registry/validators/metadata.validators.js
@@ -276,7 +276,6 @@ module.exports = {
   pagination: commonValidations.pagination,
   addCategoryQueryParam: (req, res, next) => {
     req.query.path = "public";
-    req.query.category = "public";
     next();
   },
 };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Three groups of changes, all in `device-registry`:

**1. Public metadata endpoint — cohort-based visibility scoping**
- `/metadata/devices`: filter replaced from `device.visibility = true` to `cohorts: { $in: <visible cohort IDs> }`. A device is public when at least one of its cohorts has `visibility = true`.
- `/metadata/sites`: filter replaced from `site.visibility = true` to a two-step lookup — visible cohort IDs → devices in those cohorts → site IDs of those devices. A site is public when it hosts a device that belongs to a visible cohort.
- `/metadata/grids`: lightweight pipeline returning only `_id`, `visibility`, `name`, `admin_level`, `long_name`, `flag_url`. Skips site lookups and caching entirely.
- `/metadata/cohorts`: skips the expensive `$lookup` on devices, returns only `_id` and `name` for cohorts where `visibility = true`.
- Removed erroneous `req.query.category = "public"` from `addCategoryQueryParam` that was causing all metadata endpoints to return zero results.
- Restored the `path === "public" → filter.visibility = true` blocks in `generate-filter.js` for devices and sites that were accidentally dropped.

**2. Bulk import — `details` field now surfaced in failure results**
- `capturedError.details` was being computed correctly but silently dropped when constructing the per-device entry in `chunkOutcomes.forEach`. The spread is now forwarded so callers see the exact duplicate field names.

**3. Bulk import — performance improvements**
- Pre-flight duplicate check: one bulk `find` query before Kafka connect identifies already-existing devices. If all devices in the batch are duplicates, Kafka connect is skipped entirely.
- Kafka retry config tightened on the shared producer: `retries: 1, initialRetryTime: 100ms` (was KafkaJS default of 5 retries / 300ms, which caused ~9s timeout on unreachable brokers).

### Why is this change needed?
- Public metadata endpoints were returning zero results because `category = "public"` was being applied as a MongoDB filter — no entity uses "public" as a category value.
- Devices and sites on the public metadata routes were previously gated by their own `visibility` field (default `false`), meaning no results were ever returned. The correct authority is cohort visibility.
- Bulk import callers had no way to know which specific fields caused a conflict — the `details` object was computed but never reached the API response.
- Bulk import on a local machine with Kafka unavailable was taking ~10s because the default KafkaJS retry policy waited ~9s before giving up. All-duplicate batches wasted this time even though no Kafka publish was needed.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
- `GET /metadata/grids` — confirmed all grids returned with only the 6 specified fields.
- `GET /metadata/cohorts` — confirmed only cohorts with `visibility = true` are returned, with `_id` and `name` only.
- `GET /metadata/devices` — confirmed only devices belonging to visible cohorts are returned, with minimal fields.
- `GET /metadata/sites` — confirmed only sites hosting devices in visible cohorts are returned, with minimal fields.
- Bulk import — clean batch of 3 devices created successfully. Second run (all duplicates) returns `"error": "Validation errors for some of the provided fields"` with `details` listing each duplicate field. Response time dropped from ~10s to ~400ms on an unreachable Kafka broker.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `details` field on bulk import failure results is only present when field-level conflict information is available. Simple failures (missing required fields, server errors) omit it.
- The pre-flight duplicate check uses the same `sanitizeName` logic as the Device model (`/[^a-zA-Z0-9]/g → "_"`, slice 41, lowercase) to match accurately.
- Kafka retry config is scoped only to the shared batch producer and the per-device fallback producer in `createOnPlatform`. The recall-flow producers are intentionally left unchanged.
- Fields returned by metadata endpoints: grids (`_id`, `visibility`, `name`, `admin_level`, `long_name`, `flag_url`), cohorts (`_id`, `name`), devices (`_id`, `name`, `long_name`, `network`, `device_number`), sites (`_id`, `name`, `long_name`, `generated_name`, `formatted_name`).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a public metadata mode across APIs to return only public-facing fields with optimized, paginated queries
  * Added pre-flight deduplication for bulk device creation to skip duplicates before creation
* **Improvements**
  * Added retry behavior for message publishing during device operations
  * Improved error detail reporting for per-device failures in bulk creation workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->