### PR TITLE
Fix authMethods password flag for legacy accounts with OAuth linked

### DIFF
--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -3042,6 +3042,30 @@ describe("create-user-util", function () {
       });
       expect(result.$set.verified).to.be.undefined;
     });
+
+    it("stamps hasSetPassword when stampHasSetPassword is true and flag not already set", function () {
+      const legacy = { verified: true, preferredTokenStrategy: null, hasSetPassword: false };
+      const result = createUser._constructLoginUpdate(legacy, null, {
+        stampHasSetPassword: true,
+      });
+      expect(result.$set.hasSetPassword).to.equal(true);
+    });
+
+    it("does not stamp hasSetPassword when stampHasSetPassword is false (OAuth/JWT callers)", function () {
+      const oauthUser = { verified: true, preferredTokenStrategy: null, hasSetPassword: false };
+      const result = createUser._constructLoginUpdate(oauthUser, null, {
+        stampHasSetPassword: false,
+      });
+      expect(result.$set.hasSetPassword).to.be.undefined;
+    });
+
+    it("does not stamp hasSetPassword when already true", function () {
+      const alreadyStamped = { verified: true, preferredTokenStrategy: null, hasSetPassword: true };
+      const result = createUser._constructLoginUpdate(alreadyStamped, null, {
+        stampHasSetPassword: true,
+      });
+      expect(result.$set.hasSetPassword).to.be.undefined;
+    });
   });
 });
 

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -6244,6 +6244,13 @@ const createUserModule = {
       updatePayload.$set.verified = true;
     }
 
+    // Self-healing migration: stamp hasSetPassword on any account that
+    // successfully authenticates via password but was created before the flag
+    // existed (or before create() was fixed to set it).
+    if (user.hasSetPassword !== true) {
+      updatePayload.$set.hasSetPassword = true;
+    }
+
     // Handle one-time token strategy migration (only for enhanced login)
     if (
       strategy &&
@@ -6580,7 +6587,12 @@ const createUserModule = {
         // Enhanced authentication
         token: `JWT ${token}`,
 
-        authMethods: buildAuthMethods(user),
+        authMethods: {
+          ...buildAuthMethods(user),
+          // Always true here — we verified the password above to reach this point.
+          // Also covers legacy accounts whose hasSetPassword was never stamped.
+          password: true,
+        },
 
         // --- REMOVED FOR SCALABILITY ---
         // The following large data fields are removed to prevent oversized login responses

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -6228,7 +6228,7 @@ const createUserModule = {
   _constructLoginUpdate: (
     user,
     strategy = null,
-    { autoVerify = false } = {},
+    { autoVerify = false, stampHasSetPassword = false } = {},
   ) => {
     const currentDate = new Date();
     const updatePayload = {
@@ -6244,10 +6244,10 @@ const createUserModule = {
       updatePayload.$set.verified = true;
     }
 
-    // Self-healing migration: stamp hasSetPassword on any account that
-    // successfully authenticates via password but was created before the flag
-    // existed (or before create() was fixed to set it).
-    if (user.hasSetPassword !== true) {
+    // Self-healing migration: only stamp hasSetPassword when called from a
+    // verified password-login flow. OAuth and JWT callers pass the default
+    // false so they never incorrectly mark OAuth-only accounts.
+    if (stampHasSetPassword && user.hasSetPassword !== true) {
       updatePayload.$set.hasSetPassword = true;
     }
 
@@ -6475,7 +6475,7 @@ const createUserModule = {
           const updatePayload = createUserModule._constructLoginUpdate(
             user,
             strategy,
-            { autoVerify: shouldAutoVerify },
+            { autoVerify: shouldAutoVerify, stampHasSetPassword: true },
           );
           const updatedUser = await UserModel(dbTenant).findOneAndUpdate(
             { _id: user._id },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes `authMethods.password` incorrectly returning `false` for accounts that have a real user-chosen password but also have an OAuth provider linked. The fix has two layers:

1. **Immediate response**: `loginWithEnhancedTokens` now always returns `authMethods.password: true` since reaching that point means the password was just successfully verified.
2. **Self-healing migration**: `_constructLoginUpdate` now stamps `hasSetPassword: true` on the user document during any successful password login where the flag was not already set. This corrects legacy accounts in-place as users log in, making all subsequent `authMethods` lookups (e.g. profile endpoints) accurate without a bulk migration script.

Also adds `hasSetPassword: true` to the email/password registration path (`create()`) so all newly registered accounts are stamped correctly from the start.

### Why is this change needed?
Accounts that existed before the `hasSetPassword` field was introduced and later linked a social provider were stuck showing `authMethods.password: false` indefinitely, even after logging in multiple times via email/password. The root cause: `hasSetPassword` defaults to `false` (not `null`), and the backward-compat fallback in `buildAuthMethods` only fires when no OAuth provider is linked. Once Google (or any provider) was linked, the fallback was blocked and `password` always evaluated to `false`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `utils/user.util.js`

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
All 5 existing `buildAuthMethods` unit tests pass. Verified on staging that an account with a real password and Google linked now correctly returns `authMethods.password: true` immediately on first login after deployment. Subsequent logins also return `true` as `hasSetPassword` is now stamped on the document.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`authMethods.password` will change from `false` to `true` for affected accounts after their first password login post-deployment. This is a correction, not a breaking change.

---

## :memo: Additional Notes

- **No migration script needed.** The self-healing approach in `_constructLoginUpdate` corrects each account the first time the user logs in via password after deployment. Accounts that only ever use OAuth are unaffected — they never reach `loginWithEnhancedTokens`.
- **OAuth-created accounts are unaffected.** Auto-generated passwords set during OAuth signup do not trigger `hasSetPassword: true` — that flag is only stamped on explicit user-chosen password flows (registration, password reset, change password, `setPassword` endpoint, and now successful password login).
- A deliberate decision was made **not** to auto-stamp `hasSetPassword` in the Mongoose pre-save/pre-update hooks, because those hooks cannot distinguish a user-chosen password from an OAuth-user's auto-generated one.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account reliability with automatic password flag restoration during login for accounts that successfully authenticate but lack proper state tracking.
  * Enhanced password authentication status tracking for improved login security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->