### PR TITLE
Add authRequired to bulk and single device update validators

### DIFF
--- a/src/device-registry/models/DeviceBulkUpdateJob.js
+++ b/src/device-registry/models/DeviceBulkUpdateJob.js
@@ -14,6 +14,7 @@ const ALLOWED_UPDATE_FIELDS = [
   "device_manufacturer",
   "category",
   "collocation",
+  "authRequired",
 ];
 
 // Device fields that are safe to use as filter criteria.

--- a/src/device-registry/validators/device-bulk-update-job.validators.js
+++ b/src/device-registry/validators/device-bulk-update-job.validators.js
@@ -100,6 +100,12 @@ const validateUpdateData = body("updateData")
       }
     }
 
+    if (value.authRequired !== undefined) {
+      if (typeof value.authRequired !== "boolean") {
+        throw new Error("updateData.authRequired must be a boolean");
+      }
+    }
+
     return true;
   });
 

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -619,6 +619,14 @@ const validateUpdateDevice = [
     .trim()
     .isBoolean()
     .withMessage("isPrimaryInLocation must be Boolean"),
+  body("authRequired")
+    .optional()
+    .notEmpty()
+    .withMessage("authRequired cannot be empty if provided")
+    .bail()
+    .isBoolean()
+    .withMessage("authRequired must be a boolean")
+    .toBoolean(),
   body("isUsedForCollocation")
     .optional()
     .notEmpty()
@@ -1071,6 +1079,7 @@ const validateBulkUpdateDevices = [
         "device_manufacturer",
         "category",
         "collocation",
+        "authRequired",
       ];
 
       const invalidFields = Object.keys(value).filter(

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -624,8 +624,10 @@ const validateUpdateDevice = [
     .notEmpty()
     .withMessage("authRequired cannot be empty if provided")
     .bail()
+    .trim()
     .isBoolean()
     .withMessage("authRequired must be a boolean")
+    .bail()
     .toBoolean(),
   body("isUsedForCollocation")
     .optional()
@@ -1093,6 +1095,16 @@ const validateBulkUpdateDevices = [
 
       return true;
     }),
+  body("updateData.authRequired")
+    .optional()
+    .notEmpty()
+    .withMessage("updateData.authRequired cannot be empty if provided")
+    .bail()
+    .trim()
+    .isBoolean()
+    .withMessage("updateData.authRequired must be a boolean")
+    .bail()
+    .toBoolean(),
   ...validateUpdateDevice,
 ];
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds `authRequired` as a validatable and settable field in both the single-device update validator (`validateUpdateDevice`) and the bulk device update validator (`validateBulkUpdateDevices`) within the device-registry microservice.

### Why is this change needed?
The `authRequired` boolean field (which controls ThingSpeak/AirQo data visibility for a device) was previously not settable via any update endpoint — neither single nor bulk. This forced operators to either bypass validation or manually intervene at the database level. This change enables controlled, validated updates to `authRequired` for one device at a time or up to 30 devices in a single bulk request.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Manually verified that `authRequired: true` and `authRequired: false` are accepted and coerced correctly via the single-device update body and the bulk update `updateData` object. Confirmed that non-boolean values are rejected with a clear validation error. Confirmed that omitting the field passes validation unchanged.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `authRequired` defaults to `true` in the Device schema. Changing it to `false` removes a device from ThingSpeak/AirQo visibility — ensure this is intentional when bulk-updating.
- The bulk update endpoint (`PUT /v2/devices/bulk`) already caps requests at 30 devices per call. For larger groups, callers should page through batches.
- Because `validateBulkUpdateDevices` spreads `...validateUpdateDevice`, adding the validator once to `validateUpdateDevice` covers both endpoints.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device management now supports configurable authentication requirements. You can set authentication policies on individual devices or apply them across multiple devices simultaneously through bulk operations, providing centralized control over your device security settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->