### PR TITLE
fix: log device duplicate ValidationErrors as warn to silence Slack noise

### DIFF
--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -982,26 +982,32 @@ deviceSchema.statics = {
       };
     } catch (error) {
       logObject("The error in the Device Model", error);
-      logger.error(`🐛🐛 Internal Server Error -- ${stringify(error)}`);
 
       let response = {};
       let message = "Validation errors for some of the provided fields";
 
-      // Check if the error is an instance of HttpError
       if (error instanceof HttpError) {
-        // Log the HTTP error details
         logger.error(
           `HTTP Error: ${error.message}, Status: ${error.statusCode}`,
         );
-        response.message = error.message; // Use the message from HttpError
-        response.details = error.details || {}; // Capture additional details if available
+        response.message = error.message;
+        response.details = error.details || {};
+      } else if (error.name === "ValidationError") {
+        // Mongoose unique/validation constraint — an expected business conflict,
+        // not an internal failure. Log at WARN so Slack stays clean.
+        logger.warn(`🐛 Device validation conflict -- ${stringify(error)}`);
+        if (error.errors) {
+          Object.entries(error.errors).forEach(([key, value]) => {
+            response[key] = value.message;
+          });
+        }
       } else if (error.errors) {
-        // Handle validation errors
+        logger.error(`🐛🐛 Internal Server Error -- ${stringify(error)}`);
         Object.entries(error.errors).forEach(([key, value]) => {
-          response[key] = value.message; // Capture specific field errors
+          response[key] = value.message;
         });
       } else {
-        // Fallback for unexpected errors
+        logger.error(`🐛🐛 Internal Server Error -- ${stringify(error)}`);
         response.message = "An unexpected error occurred.";
       }
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Downgrades Mongoose `ValidationError` logging in `Device.register()` from `logger.error` to `logger.warn`, and removes a duplicate `logger.error` call that was firing for `HttpError` instances. The API response (409 Conflict with field-level details) is unchanged.

### Why is this change needed?
Bulk device creation jobs were flooding the Slack notifications channel with `[ERROR] Internal Server Error` messages every time a device with a duplicate `name`, `long_name`, or `serial_number` was encountered. These are expected business conflicts — not genuine server failures — and were being mislabelled and misrouted. Since the `log4js` config routes only `ERROR` and above to Slack, downgrading to `WARN` silences the noise while keeping the conflicts visible in the file log. Genuinely unexpected errors still alert Slack.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `models/Device.js` (`register` static method catch block)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified via the existing Slack logs that the errors originate from `ValidationError` (Mongoose unique constraint on `name`, `long_name`, `serial_number`). The `register()` return value is untouched — callers still receive a 409 Conflict with the same field-level error map. No schema or route changes were made.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `logger.warn` writes to the file log (`log/app.log`) but is filtered out of the Slack appender by `log4js`'s `logLevelFilter` (level: `ERROR`), so these conflicts are not silently dropped — they remain auditable.
- The duplicate `logger.error` that previously fired a second Slack alert for `HttpError` instances caught in this block has also been removed.
- No changes to the `ops-alerts` category or any other logger category.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error response handling for registration operations, now providing more structured and detailed error messages.
  * Enhanced field-level error reporting to clearly identify which inputs failed validation.
  * Refined error logging for better troubleshooting visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->