### PR TITLE
fix: log Grid and AirQloud no-sites conditions as warn not error

### DIFF
--- a/src/device-registry/controllers/event.controller.js
+++ b/src/device-registry/controllers/event.controller.js
@@ -335,8 +335,8 @@ const processGridIds = async (grid_ids, request) => {
         );
         return responseFromGetSitesOfGrid;
       } else if (isEmpty(responseFromGetSitesOfGrid.data)) {
-        logger.error(
-          `🐛🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`,
+        logger.warn(
+          `🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`,
         );
         return {
           success: false,
@@ -361,7 +361,7 @@ const processGridIds = async (grid_ids, request) => {
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
-    logger.error(
+    logger.warn(
       `🙅🏼🙅🏼 Bad Request Error --- ${JSON.stringify(invalidSiteIdResults)}`,
     );
   }
@@ -466,8 +466,8 @@ const processAirQloudIds = async (airqloud_ids, request) => {
         );
         return responseFromGetSitesOfAirQloud;
       } else if (isEmpty(responseFromGetSitesOfAirQloud.data)) {
-        logger.error(
-          `🐛🐛 The provided AirQloud ID ${airqloud_id} does not have any associated Site IDs`,
+        logger.warn(
+          `🐛 The provided AirQloud ID ${airqloud_id} does not have any associated Site IDs`,
         );
         return {
           success: false,
@@ -497,7 +497,7 @@ const processAirQloudIds = async (airqloud_ids, request) => {
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
-    logger.error(
+    logger.warn(
       `🙅🏼🙅🏼 Bad Request Error --- ${JSON.stringify(invalidSiteIdResults)}`,
     );
   }

--- a/src/device-registry/controllers/reading.controller.js
+++ b/src/device-registry/controllers/reading.controller.js
@@ -121,8 +121,8 @@ const processGridIds = async (grid_ids, request) => {
         // Grid is private — treat as empty site set, not an error
         return null;
       } else if (isEmpty(responseFromGetSitesOfGrid.data)) {
-        logger.error(
-          `🐛🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`
+        logger.warn(
+          `🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`
         );
         return {
           success: false,
@@ -155,7 +155,7 @@ const processGridIds = async (grid_ids, request) => {
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
-    logger.error(
+    logger.warn(
       `🙅🏼🙅🏼 Bad Request Error --- ${JSON.stringify(invalidSiteIdResults)}`
     );
   }

--- a/src/device-registry/controllers/signal.controller.js
+++ b/src/device-registry/controllers/signal.controller.js
@@ -165,7 +165,7 @@ const processGridIds = async (grid_ids, request) => {
   logObject("siteIdResults", siteIdResults);
 
   const invalidSiteIdResults = siteIdResults.filter(
-    (result) => result.success === false
+    (result) => result != null && result.success === false
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
@@ -176,7 +176,7 @@ const processGridIds = async (grid_ids, request) => {
   logObject("invalidSiteIdResults", invalidSiteIdResults);
 
   const validSiteIdResults = siteIdResults.filter(
-    (result) => !(result.success === false)
+    (result) => result != null && result.success !== false
   );
 
   logObject("validSiteIdResults", validSiteIdResults);

--- a/src/device-registry/controllers/signal.controller.js
+++ b/src/device-registry/controllers/signal.controller.js
@@ -136,8 +136,8 @@ const processGridIds = async (grid_ids, request) => {
         );
         return responseFromGetSitesOfGrid;
       } else if (isEmpty(responseFromGetSitesOfGrid.data)) {
-        logger.error(
-          `🐛🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`
+        logger.warn(
+          `🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`
         );
         return {
           success: false,
@@ -169,7 +169,7 @@ const processGridIds = async (grid_ids, request) => {
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
-    logger.error(
+    logger.warn(
       `🙅🏼🙅🏼 Bad Request Error --- ${JSON.stringify(invalidSiteIdResults)}`
     );
   }

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -903,8 +903,8 @@ const processGridIds = async (grid_ids, request) => {
         // Grid is private — treat as empty site set, not an error
         return null;
       } else if (isEmpty(responseFromGetSitesOfGrid.data)) {
-        logger.error(
-          `🐛🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`,
+        logger.warn(
+          `🐛 The provided Grid ID ${grid_id} does not have any associated Site IDs`,
         );
         return {
           success: false,
@@ -935,7 +935,7 @@ const processGridIds = async (grid_ids, request) => {
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
-    logger.error(
+    logger.warn(
       `🙅🏼🙅🏼 Bad Request Error --- ${JSON.stringify(invalidSiteIdResults)}`,
     );
   }
@@ -1070,8 +1070,8 @@ const processAirQloudIds = async (airqloud_ids, request) => {
         );
         return responseFromGetSitesOfAirQloud;
       } else if (isEmpty(responseFromGetSitesOfAirQloud.data)) {
-        logger.error(
-          `🐛🐛 The provided AirQloud ID ${airqloud_id} does not have any associated Site IDs`,
+        logger.warn(
+          `🐛 The provided AirQloud ID ${airqloud_id} does not have any associated Site IDs`,
         );
         return {
           success: false,
@@ -1102,7 +1102,7 @@ const processAirQloudIds = async (airqloud_ids, request) => {
   );
 
   if (!isEmpty(invalidSiteIdResults)) {
-    logger.error(
+    logger.warn(
       `🙅🏼🙅🏼 Bad Request Error --- ${JSON.stringify(invalidSiteIdResults)}`,
     );
   }


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Downgrades 10 `logger.error` calls to `logger.warn` across `event.controller.js`, `event.util.js`, `reading.controller.js`, and `signal.controller.js` — specifically for the "Grid/AirQloud ID has no associated Site IDs" condition and its corresponding batch summary log.

### Why is this change needed?
A Grid or AirQloud having no associated sites is a **400 Bad Request** data condition, not an internal server failure. These were being logged at `ERROR` level, which routes to Slack via the `logLevelFilter` appender, causing two Slack alerts per request (one per grid_id, one for the batch summary). Downgrading to `WARN` keeps these auditable in the file log while eliminating false-positive Slack noise. The API response to callers is unchanged.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `controllers/event.controller.js`
- `device-registry` — `utils/event.util.js`
- `device-registry` — `controllers/reading.controller.js`
- `device-registry` — `controllers/signal.controller.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Confirmed via Slack logs that both the per-item (`🐛🐛 The provided Grid ID ... does not have any associated Site IDs`) and batch summary (`🙅🏼🙅🏼 Bad Request Error ---`) log lines originate from these paths. Only the log level changes — no logic, response structure, or error propagation was modified. The `success === false` branches (where `getSitesFromGrid` itself fails with a genuine server error) remain at `logger.error` and will continue to alert Slack.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- Each "no sites" event previously generated **two** Slack alerts (per-item log + batch summary log). Both are now `WARN`, so neither reaches Slack.
- Genuinely unexpected `getSitesFromGrid` failures (`success === false` path) are intentionally left as `logger.error` and will still page Slack.
- The same pattern exists for both Grid IDs and AirQloud IDs — both were fixed consistently across all four files.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined logging severity for device registry operations handling Grid and AirQloud identifiers. Scenarios with missing or empty site associations, previously reported as errors, are now logged as warnings. This adjustment improves system error reporting accuracy and distinguishes between genuine failures and informational concerns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->