### PR TITLE
fix: downgrade non-actionable OAuth and JWT errors to WARN

### DIFF
--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1491,6 +1491,26 @@ const authOAuthCallback = (req, res, next) => {
         errorType: err.name,
         message: err.message,
       });
+    } else if (
+      err.message &&
+      err.message.includes("Failed to find request token in session")
+    ) {
+      // OAuth 1.0a session expiry — not actionable; occurs when the session
+      // expires between request-token and callback (pod restart, sticky-session
+      // miss, or browser back-button replay).
+      logger.warn(`[passport] OAuth session expired for ${safeProvider}`, {
+        provider: safeProvider,
+        errorType: err.name || "Error",
+        message: err.message,
+      });
+    } else if (err.name === "TokenError" && err.code === "invalid_grant") {
+      // Authorization code expired or already used — user-triggered (slow
+      // browser, back-button replay, or double-submit). Not a code bug.
+      logger.warn(`[passport] OAuth code rejected by ${safeProvider}`, {
+        provider: safeProvider,
+        errorType: err.name,
+        code: err.code,
+      });
     } else {
       logger.error(`[passport] OAuth callback error for ${safeProvider}`, {
         provider: safeProvider,
@@ -1625,7 +1645,10 @@ const enhancedJWTAuth = (req, res, next) => {
                 res.set("Access-Control-Expose-Headers", "X-Access-Token");
               }
             } catch (refreshError) {
-              logger.error(
+              // Best-effort background refresh — the existing token is still
+              // valid, so the request proceeds. A persistent failure here will
+              // surface through DB health alerts rather than per-request noise.
+              logger.warn(
                 `Failed to refresh token for user ${decoded.id || decoded._id}: ${refreshError.message}`,
               );
             }


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Downgrades four non-actionable log events in `src/auth-service/middleware/passport.js` from `ERROR` to `WARN`:

1. **Twitter OAuth 1.0a session expiry** — `"Failed to find request token in session"` fires when the OAuth 1.0a session is lost between the request-token and callback steps (pod restart, sticky-session miss, or browser back-button replay).
2. **User-declined OAuth consent** — `AuthorizationError` fires when the user explicitly clicks "Deny" on the provider consent screen.
3. **Expired/reused authorization code** — `TokenError` with `invalid_grant` fires when the OAuth code expires before exchange or the user double-submits the callback (back-button or browser retry). Configuration errors (`invalid_client`, `redirect_uri_mismatch`) remain at `ERROR`.
4. **Background token refresh failure** in `enhancedJWTAuth` — a best-effort optimisation that silently attaches a refreshed token to the response header. The user is fully authenticated and their request proceeds regardless.

### Why is this change needed?
All four events fire due to transient user behaviour or normal operational conditions — not code bugs or infrastructure failures. Logging them at `ERROR` floods on-call alerts with noise that engineers cannot act on, making it harder to spot genuinely actionable errors in the same log stream.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `middleware/passport.js` (log level changes only)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Log-level-only changes — no logic altered, no new code paths introduced. Verified by reproducing each scenario (user-denied consent, back-button callback replay, Twitter session expiry) on staging and confirming the events now appear as `WARN` in the log output without affecting the redirect behaviour or authentication result.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The `invalid_grant` guard on `TokenError` is intentional: other `TokenError` codes (`invalid_client`, `redirect_uri_mismatch`) indicate misconfiguration that needs immediate investigation and are deliberately left at `ERROR`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for OAuth authentication failures with more specific error messages for session and token exchange issues.
  * Improved token refresh resilience by treating refresh errors as best-effort conditions, allowing the request flow to continue gracefully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->