### PR TITLE
fix: route AirGradient devices to external API for raw online status checks

### DIFF
--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -355,7 +355,7 @@ const processIndividualDevice = async (
   // adapter config is honoured at runtime.
   const externalAdapter =
     device.api_code && device.network && device.network !== "airqo"
-      ? await getNetworkAdapter(device.network)
+      ? await getNetworkAdapter(device.network).catch(() => null)
       : null;
 
   // Route to the external-API path when:

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -164,8 +164,13 @@ const mockNext = (error) => {
 const processDeviceBatch = async (devices, processor) => {
   const CONCURRENCY_LIMIT = 5; // Reduced from 8 to prevent overwhelming ThingSpeak
 
-  // 1. Get all device numbers from the current batch
-  const deviceNumbers = devices.map((d) => d.device_number).filter(Boolean);
+  // 1. Get device numbers for airqo devices only — ThingSpeak channels only
+  // exist for network="airqo". Other networks (airgradient, iqair, etc.) store
+  // their manufacturer location/serial ID in device_number but have no ThingSpeak
+  // channel, so including them here produces wasted DB look-ups.
+  const deviceNumbers = devices
+    .filter((d) => d.network === "airqo" && d.device_number)
+    .map((d) => d.device_number);
 
   // 2. Fetch all necessary device details in a single query with timeout
   let deviceDetailsMap = new Map();
@@ -345,20 +350,21 @@ const processIndividualDevice = async (
     }
   }
 
-  if (!device.device_number) {
+  // Resolve the network adapter once, before any routing decision.
+  // DB record takes precedence over static config so operator-customised
+  // adapter config is honoured at runtime.
+  const externalAdapter =
+    device.api_code && device.network && device.network !== "airqo"
+      ? await getNetworkAdapter(device.network)
+      : null;
+
+  // Route to the external-API path when:
+  //   • the device has no device_number (never had a ThingSpeak channel), OR
+  //   • the adapter declares online_check_via_feed (e.g. AirGradient) —
+  //     these devices may have device_number set to their manufacturer
+  //     location ID, which is NOT a ThingSpeak channel.
+  if (!device.device_number || externalAdapter?.online_check_via_feed) {
     // ── External device path ────────────────────────────────────────────────
-    // If the device has an api_code and its network adapter declares
-    // online_check_via_feed, call the external API to determine live status.
-    // This resolves the historic "no_device_number" skip for non-AirQo devices.
-    //
-    // Devices that still lack api_code (not yet migrated / unknown network)
-    // fall through to the unchanged stale-data fallback below.
-    // Resolve adapter: DB record takes precedence over static config so any
-    // operator-customised adapter config is honoured at runtime.
-    const externalAdapter =
-      device.api_code && device.network && device.network !== "airqo"
-        ? await getNetworkAdapter(device.network)
-        : null;
 
     if (externalAdapter?.online_check_via_feed) {
       try {
@@ -490,6 +496,18 @@ const processIndividualDevice = async (
         },
       },
     };
+  }
+
+  // Warn only when a non-airqo device has an external api_code but its adapter
+  // does not enable online_check_via_feed — that combination is actionable
+  // (the adapter config needs updating). Placeholder networks without api_code
+  // reach this path by design and produce no meaningful warning.
+  if (device.network && device.network !== "airqo" && device.api_code) {
+    logger.warn(
+      `update-raw-online-status-job: device ${device.name} (network: ${device.network}) ` +
+        `has api_code but reached the ThingSpeak path. ` +
+        `Set online_check_via_feed: true in the network adapter config.`,
+    );
   }
 
   // Get the API key from the pre-fetched details

--- a/src/device-registry/utils/common/update-raw-status.util.js
+++ b/src/device-registry/utils/common/update-raw-status.util.js
@@ -65,8 +65,19 @@ const processDevice = async (device) => {
   let lastFeedTime = null;
   let updateReason = "no_device_number";
 
-  // ── AirQo device path ──────────────────────────────────────────────────────
-  if (device.device_number) {
+  // Resolve the network adapter before any routing decision so that networks
+  // with online_check_via_feed (e.g. airgradient) that also carry a
+  // device_number are not incorrectly sent down the ThingSpeak path.
+  const externalAdapter =
+    device.api_code && device.network && device.network !== "airqo"
+      ? await getNetworkAdapter(device.network).catch(() => null)
+      : null;
+
+  // ── ThingSpeak path (airqo-only) ───────────────────────────────────────────
+  // Only enter when device_number is set AND the adapter does NOT declare
+  // online_check_via_feed. Non-airqo devices (airgradient, iqair) store their
+  // manufacturer location ID in device_number but have no ThingSpeak channel.
+  if (device.device_number && !externalAdapter?.online_check_via_feed) {
     let apiKey;
     try {
       const detail = await DeviceModel("airqo")
@@ -145,11 +156,6 @@ const processDevice = async (device) => {
   }
 
   // ── External device path ───────────────────────────────────────────────────
-  const externalAdapter =
-    device.api_code && device.network && device.network !== "airqo"
-      ? await getNetworkAdapter(device.network).catch(() => null)
-      : null;
-
   if (externalAdapter?.online_check_via_feed) {
     try {
       const externalResult = await withTimeout(

--- a/src/device-registry/utils/common/update-raw-status.util.js
+++ b/src/device-registry/utils/common/update-raw-status.util.js
@@ -77,7 +77,7 @@ const processDevice = async (device) => {
   // Only enter when device_number is set AND the adapter does NOT declare
   // online_check_via_feed. Non-airqo devices (airgradient, iqair) store their
   // manufacturer location ID in device_number but have no ThingSpeak channel.
-  if (device.device_number && !externalAdapter?.online_check_via_feed) {
+  if (device.network === "airqo" && device.device_number && !externalAdapter?.online_check_via_feed) {
     let apiKey;
     try {
       const detail = await DeviceModel("airqo")


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a routing gate in both the batch job and the fire-and-forget util so that
non-airqo devices whose network adapter declares `online_check_via_feed`
(e.g. AirGradient) are sent down the external API path instead of the ThingSpeak
path. Also scopes the ThingSpeak `deviceNumbers` pre-fetch in the batch job to
`network: "airqo"` only, avoiding wasted DB queries for other networks.

### Why is this change needed?
AirGradient devices store their manufacturer location ID in `device_number`, but
that ID is **not** a ThingSpeak channel — querying ThingSpeak with it always
fails or returns garbage. Before this fix both the hourly batch job
(`update-raw-online-status-job.js`) and the per-request fire-and-forget util
(`update-raw-status.util.js`) either silently skipped AirGradient devices or
produced incorrect `rawOnlineStatus` values. After this fix, `rawOnlineStatus`
for AirGradient devices will reflect the live AirGradient API response on every
scheduled run.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `bin/jobs/update-raw-online-status-job.js`
- `device-registry` — `utils/common/update-raw-status.util.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that the existing AirQo (ThingSpeak) path is unaffected. AirGradient
devices are now routed to `fetchExternalDeviceData` via the adapter's
`online_check_via_feed` flag. `rawOnlineStatus` will begin updating correctly
for AirGradient devices on the next `:35` cron run after deployment.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- The `deviceNumbers` pre-fetch in the batch job is now filtered to
  `network: "airqo"` only, which also reduces the size of that initial DB query
  when mixed-network devices are processed in the same batch.
- The same routing logic (`device_number && !externalAdapter?.online_check_via_feed`)
  is now consistent between the batch job and the fire-and-forget util.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined device online-status routing logic to direct devices to appropriate status-checking methods based on configuration.
  * Added warning messages for devices with incomplete configurations.

* **Refactor**
  * Streamlined device-batch processing to restrict status lookups to valid devices only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->