### PR TITLE
Fix site network and data_provider mismatch on device deployment and recall

### DIFF
--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -256,6 +256,21 @@ const syncSiteNetworkMismatches = async (tenant) => {
           deviceNetworks: { $addToSet: "$network" },
         },
       },
+      // Sort deviceNetworks alphabetically so the winner is deterministic
+      // regardless of $addToSet insertion order, then derive networkWinner as
+      // the first element of that sorted array.
+      {
+        $set: {
+          deviceNetworks: {
+            $sortArray: { input: "$deviceNetworks", sortBy: 1 },
+          },
+        },
+      },
+      {
+        $set: {
+          networkWinner: { $arrayElemAt: ["$deviceNetworks", 0] },
+        },
+      },
       {
         $lookup: {
           from: "sites",
@@ -266,18 +281,19 @@ const syncSiteNetworkMismatches = async (tenant) => {
         },
       },
       { $unwind: "$site" },
-      // Keep only sites where site.network is not among the device networks.
-      // If site.network already matches any active device's network the site is
-      // already correct and can be skipped.
+      // Keep only sites where site.network differs from the deterministic winner.
+      // Comparing against the winner (not membership) catches sites whose
+      // network matches a non-winning active-device network.
       {
         $match: {
-          $expr: { $not: { $in: ["$site.network", "$deviceNetworks"] } },
+          $expr: { $ne: ["$site.network", "$networkWinner"] },
         },
       },
       {
         $project: {
           _id: 1, // site_id
           deviceNetworks: 1,
+          networkWinner: 1,
           currentSiteNetwork: "$site.network",
         },
       },
@@ -289,16 +305,13 @@ const syncSiteNetworkMismatches = async (tenant) => {
       return { synced: 0, failed: 0 };
     }
 
-    // Build bulk ops: sort device networks for determinism, pick the first.
-    const bulkOps = mismatchedSites.map(({ _id: siteId, deviceNetworks }) => {
-      const networkToSet = [...deviceNetworks].sort()[0];
-      return {
-        updateOne: {
-          filter: { _id: siteId },
-          update: { $set: { network: networkToSet } },
-        },
-      };
-    });
+    // networkWinner is already computed deterministically in the pipeline.
+    const bulkOps = mismatchedSites.map(({ _id: siteId, networkWinner }) => ({
+      updateOne: {
+        filter: { _id: siteId },
+        update: { $set: { network: networkWinner } },
+      },
+    }));
 
     try {
       await SiteModel(tenant).bulkWrite(bulkOps, { ordered: false });

--- a/src/device-registry/bin/jobs/backfill-site-metadata-job.js
+++ b/src/device-registry/bin/jobs/backfill-site-metadata-job.js
@@ -1,5 +1,6 @@
 const cron = require("node-cron");
 const SiteModel = require("@models/Site");
+const DeviceModel = require("@models/Device");
 const JobLockModel = require("@models/JobLock");
 const constants = require("@config/constants");
 const log4js = require("log4js");
@@ -24,6 +25,9 @@ const BATCH_SIZE = 30;
 // Hard cap on total geocoding attempts per run. Sites are processed in
 // BATCH_SIZE chunks; the job stops once this many have been attempted.
 const MAX_GEOCODING_ATTEMPTS_PER_RUN = 300;
+// Hard cap on sites whose site.network is synced from devices per run.
+// Keeps each of the 3 daily runs short while draining the historical backlog.
+const MAX_NETWORK_SYNC_PER_RUN = 500;
 // After this many consecutive altitude failures for a single site, the job
 // skips the getAltitude API call for that site rather than burning credits
 // on coordinates that repeatedly return nothing. The counter resets to 0
@@ -206,6 +210,120 @@ const GEOCODED_FIELDS = [
 const NON_ALTITUDE_GEOCODED_FIELDS = GEOCODED_FIELDS.filter(
   (f) => f !== "altitude",
 );
+
+/**
+ * Phase 2 of the backfill job.
+ *
+ * Finds deployed sites where site.network does not match any of their active
+ * devices' networks and corrects both site.network (bulk write) and
+ * data_provider (via refreshSiteDataProvider fire-and-forget).
+ *
+ * The query works from the Device side so it only touches sites that actually
+ * have at least one active deployed device — idle / recalled sites are skipped
+ * automatically. Capped at MAX_NETWORK_SYNC_PER_RUN per run so the job stays
+ * short regardless of historical backlog size.
+ *
+ * Selection criterion:
+ *   site.network ∉ {network values of all active devices at that site}
+ *
+ * Network to apply:
+ *   deviceNetworks is deduplicated by $addToSet. We sort it and take the first
+ *   element so the result is deterministic across runs even for the rare
+ *   multi-network site. refreshSiteDataProvider then derives the correct
+ *   joined data_provider label from all active devices.
+ *
+ * @param {string} tenant
+ * @returns {Promise<{synced: number, failed: number}>}
+ */
+const syncSiteNetworkMismatches = async (tenant) => {
+  let synced = 0;
+  let failed = 0;
+
+  try {
+    // Aggregate from the Device collection: group active deployed devices by
+    // site_id, collect unique networks, then join to Site to find mismatches.
+    const mismatchedSites = await DeviceModel(tenant).aggregate([
+      {
+        $match: {
+          isActive: true,
+          site_id: { $exists: true, $ne: null },
+        },
+      },
+      {
+        $group: {
+          _id: "$site_id",
+          // Collect the distinct networks of all active devices at this site.
+          deviceNetworks: { $addToSet: "$network" },
+        },
+      },
+      {
+        $lookup: {
+          from: "sites",
+          localField: "_id",
+          foreignField: "_id",
+          as: "site",
+          pipeline: [{ $project: { network: 1 } }],
+        },
+      },
+      { $unwind: "$site" },
+      // Keep only sites where site.network is not among the device networks.
+      // If site.network already matches any active device's network the site is
+      // already correct and can be skipped.
+      {
+        $match: {
+          $expr: { $not: { $in: ["$site.network", "$deviceNetworks"] } },
+        },
+      },
+      {
+        $project: {
+          _id: 1, // site_id
+          deviceNetworks: 1,
+          currentSiteNetwork: "$site.network",
+        },
+      },
+      { $limit: MAX_NETWORK_SYNC_PER_RUN },
+    ]);
+
+    if (mismatchedSites.length === 0) {
+      logger.info(`[${POD_ID}] syncSiteNetworkMismatches: no mismatches found.`);
+      return { synced: 0, failed: 0 };
+    }
+
+    // Build bulk ops: sort device networks for determinism, pick the first.
+    const bulkOps = mismatchedSites.map(({ _id: siteId, deviceNetworks }) => {
+      const networkToSet = [...deviceNetworks].sort()[0];
+      return {
+        updateOne: {
+          filter: { _id: siteId },
+          update: { $set: { network: networkToSet } },
+        },
+      };
+    });
+
+    try {
+      await SiteModel(tenant).bulkWrite(bulkOps, { ordered: false });
+      synced = bulkOps.length;
+    } catch (bulkErr) {
+      logger.error(
+        `[${POD_ID}] syncSiteNetworkMismatches: bulkWrite failed: ${bulkErr.message}`,
+      );
+      failed = bulkOps.length;
+    }
+
+    // Refresh data_provider for every site whose network was (or was attempted
+    // to be) updated — fire-and-forget, errors are logged inside the util.
+    mismatchedSites.forEach(({ _id: siteId }) => {
+      createSiteUtil.refreshSiteDataProvider(tenant, siteId.toString());
+    });
+  } catch (error) {
+    logger.error(
+      `[${POD_ID}] syncSiteNetworkMismatches: aggregation failed: ${error.message}`,
+    );
+    failed = -1; // signal structural failure
+  }
+
+  return { synced, failed };
+};
 
 const backfillSiteMetadata = async (tenant) => {
   const jobName = `backfill-site-metadata-${tenant}`;
@@ -452,11 +570,28 @@ const backfillSiteMetadata = async (tenant) => {
 
     if (sitesFailedCount > 0) {
       jobLogger.warn(
-        `[${POD_ID}] ${jobName} finished. Updated: ${sitesProcessed}, Failed: ${sitesFailedCount}.`,
+        `[${POD_ID}] ${jobName} phase-1 finished. Updated: ${sitesProcessed}, Failed: ${sitesFailedCount}.`,
       );
     } else {
       jobLogger.info(
-        `[${POD_ID}] ${jobName} finished. Updated: ${sitesProcessed}.`,
+        `[${POD_ID}] ${jobName} phase-1 finished. Updated: ${sitesProcessed}.`,
+      );
+    }
+
+    // Phase 2: Fix historical site.network / data_provider mismatches.
+    // Runs every invocation after phase-1 completes so each of the 3 daily
+    // runs chips away at the backlog. Capped at MAX_NETWORK_SYNC_PER_RUN so
+    // it can't blow the lock TTL even on a large backlog.
+    const { synced: networkSynced, failed: networkFailed } =
+      await syncSiteNetworkMismatches(tenant);
+
+    if (networkFailed > 0) {
+      jobLogger.warn(
+        `[${POD_ID}] ${jobName} phase-2 (network sync) finished. Synced: ${networkSynced}, Failed: ${networkFailed}.`,
+      );
+    } else {
+      jobLogger.info(
+        `[${POD_ID}] ${jobName} phase-2 (network sync) finished. Synced: ${networkSynced}.`,
       );
     }
   } catch (error) {

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -1073,13 +1073,25 @@ const createActivity = {
             next,
           );
 
-          // **STEP 5**: Refresh site data_provider (fire and forget)
-          // Runs after the device is deployed, so it picks up the new device's network.
-          if (activityBody.site_id) {
-            createSiteUtil.refreshSiteDataProvider(
-              tenant,
-              activityBody.site_id,
-            );
+          // **STEP 5**: Sync site.network and data_provider to the deployed device's network.
+          // site.network must match device.network so that the fallback in
+          // computeSiteDataProvider (no-active-devices case) stays consistent with the
+          // deployed device. data_provider is a derived display label and is refreshed
+          // separately below.
+          if (activityBody.site_id && existingDevice.network) {
+            try {
+              await SiteModel(tenant).findByIdAndUpdate(
+                activityBody.site_id,
+                { $set: { network: existingDevice.network } },
+                { new: false },
+              );
+            } catch (siteNetworkErr) {
+              logger.error(
+                `Failed to sync site.network for site ${activityBody.site_id}: ${siteNetworkErr.message}`,
+              );
+            }
+            // Refresh data_provider now that site.network is up to date.
+            createSiteUtil.refreshSiteDataProvider(tenant, activityBody.site_id);
           }
 
           const data = {
@@ -2231,17 +2243,43 @@ const createActivity = {
         }
       });
 
-      // Refresh data_provider for each newly deployed site (fire-and-forget).
-      // Deduplicate site_ids so we call once per site regardless of how many
-      // devices were deployed to it in this batch.
-      // NOTE: mirrors the single-deploy refresh in _processDeployment (Step 5).
-      const deployedSiteIds = [
-        ...new Set(
-          createdActivities
-            .filter((a) => a.site_id)
-            .map((a) => a.site_id.toString()),
-        ),
-      ];
+      // Sync site.network to device.network for every successfully deployed
+      // static site, then refresh data_provider. site.network must stay in
+      // sync with the deployed device so the no-active-devices fallback inside
+      // computeSiteDataProvider stays consistent (mirrors _processDeployment STEP 5).
+      //
+      // When multiple devices with different networks land on the same site in one
+      // batch, site.network is set to the last-winning device's network.
+      // data_provider handles the multi-network case correctly via refreshSiteDataProvider.
+      const siteNetworkMap = new Map(); // site_id (string) -> device.network
+      for (const activity of createdActivities) {
+        if (!activity.site_id) continue;
+        const dev = deviceUpdateMap.get(activity.device);
+        if (dev && dev.network) {
+          siteNetworkMap.set(activity.site_id.toString(), dev.network);
+        }
+      }
+
+      if (siteNetworkMap.size > 0) {
+        const siteBulkOps = [...siteNetworkMap.entries()].map(
+          ([siteId, network]) => ({
+            updateOne: {
+              filter: { _id: ObjectId(siteId) },
+              update: { $set: { network } },
+            },
+          }),
+        );
+        SiteModel(tenant)
+          .bulkWrite(siteBulkOps, { ordered: false })
+          .catch((err) =>
+            logger.error(
+              `Batch deploy: failed to sync site.network fields: ${err.message}`,
+            ),
+          );
+      }
+
+      // Deduplicate site_ids then refresh data_provider (fire-and-forget).
+      const deployedSiteIds = [...siteNetworkMap.keys()];
       deployedSiteIds.forEach((siteId) => {
         createSiteUtil.refreshSiteDataProvider(tenant, siteId);
       });
@@ -2483,10 +2521,35 @@ const createActivity = {
         });
       });
 
-      // Refresh site data_provider now that a device has been removed.
-      // Use the site_id captured before the device was recalled.
+      // After recall: re-sync site.network from remaining active devices, then
+      // refresh data_provider. If no devices remain at the site, site.network
+      // reverts to DEFAULT_NETWORK so the no-active-devices fallback in
+      // computeSiteDataProvider stays consistent with the platform default.
       if (device.site_id) {
-        createSiteUtil.refreshSiteDataProvider(tenant, device.site_id);
+        (async () => {
+          try {
+            const remainingDevices = await DeviceModel(tenant)
+              .find({ site_id: device.site_id, isActive: true })
+              .select("network")
+              .lean();
+
+            const networkToSet =
+              remainingDevices.length > 0
+                ? remainingDevices[0].network
+                : constants.DEFAULT_NETWORK || "airqo";
+
+            await SiteModel(tenant).findByIdAndUpdate(
+              device.site_id,
+              { $set: { network: networkToSet } },
+              { new: false },
+            );
+          } catch (err) {
+            logger.error(
+              `Failed to sync site.network after recall for site ${device.site_id}: ${err.message}`,
+            );
+          }
+          createSiteUtil.refreshSiteDataProvider(tenant, device.site_id);
+        })();
       }
 
       // Use toObject() on both Mongoose documents to ensure clean

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -2249,14 +2249,19 @@ const createActivity = {
       // computeSiteDataProvider stays consistent (mirrors _processDeployment STEP 5).
       //
       // When multiple devices with different networks land on the same site in one
-      // batch, site.network is set to the last-winning device's network.
+      // batch, site.network is set to the alphabetically first network value so the
+      // result is deterministic across runs.
       // data_provider handles the multi-network case correctly via refreshSiteDataProvider.
       const siteNetworkMap = new Map(); // site_id (string) -> device.network
       for (const activity of createdActivities) {
         if (!activity.site_id) continue;
         const dev = deviceUpdateMap.get(activity.device);
         if (dev && dev.network) {
-          siteNetworkMap.set(activity.site_id.toString(), dev.network);
+          const siteId = activity.site_id.toString();
+          const current = siteNetworkMap.get(siteId);
+          if (!current || dev.network < current) {
+            siteNetworkMap.set(siteId, dev.network);
+          }
         }
       }
 
@@ -2269,16 +2274,18 @@ const createActivity = {
             },
           }),
         );
-        SiteModel(tenant)
-          .bulkWrite(siteBulkOps, { ordered: false })
-          .catch((err) =>
-            logger.error(
-              `Batch deploy: failed to sync site.network fields: ${err.message}`,
-            ),
+        try {
+          await SiteModel(tenant).bulkWrite(siteBulkOps, { ordered: false });
+        } catch (err) {
+          logger.error(
+            `Batch deploy: failed to sync site.network fields: ${err.message}`,
           );
+        }
       }
 
-      // Deduplicate site_ids then refresh data_provider (fire-and-forget).
+      // Refresh data_provider only after site.network bulkWrite completes
+      // (success or handled error) so refreshSiteDataProvider always reads the
+      // correct site.network when it falls back to it.
       const deployedSiteIds = [...siteNetworkMap.keys()];
       deployedSiteIds.forEach((siteId) => {
         createSiteUtil.refreshSiteDataProvider(tenant, siteId);
@@ -2528,27 +2535,36 @@ const createActivity = {
       if (device.site_id) {
         (async () => {
           try {
-            const remainingDevices = await DeviceModel(tenant)
-              .find({ site_id: device.site_id, isActive: true })
-              .select("network")
-              .lean();
+            const remainingNetworks = await DeviceModel(tenant).distinct(
+              "network",
+              { site_id: device.site_id, isActive: true },
+            );
+            const sortedNetworks = (remainingNetworks || [])
+              .map((n) => (typeof n === "string" ? n.trim() : n))
+              .filter((n) => typeof n === "string" && n.length > 0)
+              .sort();
 
             const networkToSet =
-              remainingDevices.length > 0
-                ? remainingDevices[0].network
+              sortedNetworks.length > 0
+                ? sortedNetworks[0]
                 : constants.DEFAULT_NETWORK || "airqo";
 
-            await SiteModel(tenant).findByIdAndUpdate(
+            const updateResult = await SiteModel(tenant).findByIdAndUpdate(
               device.site_id,
               { $set: { network: networkToSet } },
               { new: false },
             );
+
+            // Only refresh data_provider after a confirmed successful write so
+            // refreshSiteDataProvider always reads the already-correct site.network.
+            if (updateResult) {
+              createSiteUtil.refreshSiteDataProvider(tenant, device.site_id);
+            }
           } catch (err) {
             logger.error(
               `Failed to sync site.network after recall for site ${device.site_id}: ${err.message}`,
             );
           }
-          createSiteUtil.refreshSiteDataProvider(tenant, device.site_id);
         })();
       }
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

- Syncs `site.network` to the deployed device's `network` during single static deployment (`_processDeployment`) — previously the site's `network` field was never updated during deployment.
- Extends `batchDeployWithCoordinates` to bulk-update `site.network` for every site that receives a device in a batch run, using the deployed device's network.
- Resets `site.network` after a device recall — re-derives it from the remaining active devices at the site, or falls back to `DEFAULT_NETWORK` if no devices remain.
- Ensures `refreshSiteDataProvider` always runs **after** `site.network` is already correct, so `data_provider` is computed from an up-to-date base.
- Adds **Phase 2** (`syncSiteNetworkMismatches`) to the existing `backfill-site-metadata-job` to repair historical mismatches — finds all deployed sites where `site.network ∉ {active device networks}`, bulk-corrects `site.network`, and refreshes `data_provider`. Capped at 500 sites per run across 3 daily executions.

### Why is this change needed?

`site.network` was set once at site-creation time (always defaulting to `DEFAULT_NETWORK = "airqo"`) and was never updated when a device was deployed or recalled. This caused a permanent mismatch between `site.network` and `device.network` for any non-AirQo device (e.g., AirGradient). Because `computeSiteDataProvider` falls back to `site.network` when no active devices are present, this also caused `site.data_provider` to show the wrong provider after a recall. All three deployment paths (`deploy`, `deployWithOwnership`, `batchDeployWithCoordinates`) shared this gap.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `device-registry`
  - `src/device-registry/utils/activity.util.js` — deployment and recall sync logic
  - `src/device-registry/bin/jobs/backfill-site-metadata-job.js` — Phase 2 historical repair

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Verified via the `GET /api/v2/devices/sites/:site_id` and `GET /api/v2/devices/:device_id` endpoints that after deployment, `site.network` matches `device.network` and `site.data_provider` reflects the correct provider label. Confirmed that after recall, `site.network` reverts to the remaining active device's network (or `DEFAULT_NETWORK` when no devices remain). The Phase 2 backfill aggregation was validated by querying active devices with a differing site network before and after a dry run.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `_deployOwnedStatic` and `_deployOwnedMobile` inherit the fix automatically — both delegate to `_deployStatic` / `_deployMobile` → `_processDeployment`.
- Phase 2 of the backfill job runs on every invocation of `backfillSiteMetadata` (3× daily at 02:00, 10:00, 18:00 Nairobi time), sharing the existing distributed lock and 90-minute TTL. The 500-site-per-run cap ensures it cannot blow the TTL even on a large historical backlog.
- For sites with multiple active devices from different networks, `site.network` is set to the alphabetically first network value; `data_provider` correctly joins all networks via `refreshSiteDataProvider` regardless.
- The `backfill-site-metadata-job` Phase 1 log lines were relabelled `phase-1` to distinguish them from the new `phase-2 (network sync)` summary line.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced site network synchronization to automatically keep site metadata aligned with active device deployments during deployment, recall, and backfill operations, ensuring data consistency and accuracy across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->