### PR TITLE
feat: Slack alert for private cohorts with operational devices

### DIFF
--- a/src/device-registry/bin/jobs/private-cohort-alert-job.js
+++ b/src/device-registry/bin/jobs/private-cohort-alert-job.js
@@ -14,6 +14,7 @@
 // No message is sent when there are no qualifying cohorts (no Slack noise).
 
 const constants = require("@config/constants");
+const crypto = require("crypto");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- /bin/jobs/private-cohort-alert-job -- ops-alerts`,
@@ -37,10 +38,23 @@ const LOCK_TTL_SECONDS = 3600;
 
 // ── Distributed lock ─────────────────────────────────────────────────────────
 
+// Ownership token — unique per pod process so only the pod that acquired the
+// lock can release it (guards against expired-lock steal between pods).
+let _lockToken = null;
+
+// Lua compare-and-delete: only DEL if the stored value equals our token.
+const RELEASE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end`;
+
 async function acquireJobLock() {
   try {
     if (!redisClient.redisUtils.isAvailable()) return true;
-    const result = await redisClient.set(LOCK_KEY, "1", {
+    _lockToken = crypto.randomUUID();
+    const result = await redisClient.set(LOCK_KEY, _lockToken, {
       NX: true,
       EX: LOCK_TTL_SECONDS,
     });
@@ -56,7 +70,10 @@ async function acquireJobLock() {
 async function releaseJobLock() {
   try {
     if (!redisClient.redisUtils.isAvailable()) return;
-    await redisClient.del(LOCK_KEY);
+    if (_lockToken) {
+      await redisClient.eval(RELEASE_SCRIPT, { keys: [LOCK_KEY], arguments: [_lockToken] });
+      _lockToken = null;
+    }
   } catch (err) {
     logger.warn(`${JOB_NAME} -- could not release lock: ${err.message}`);
   }
@@ -281,11 +298,15 @@ async function runPrivateCohortAlertJob() {
 
 // ── Schedule ──────────────────────────────────────────────────────────────────
 
-cron.schedule(JOB_SCHEDULE, () => {
-  runPrivateCohortAlertJob().catch((err) => {
-    logger.error(`${JOB_NAME} -- scheduler error: ${err.message}`);
-  });
-});
+cron.schedule(
+  JOB_SCHEDULE,
+  () => {
+    runPrivateCohortAlertJob().catch((err) => {
+      logger.error(`${JOB_NAME} -- scheduler error: ${err.message}`);
+    });
+  },
+  { timezone: "UTC" },
+);
 
 logText(`${JOB_NAME} -- scheduled (${JOB_SCHEDULE})`);
 

--- a/src/device-registry/bin/jobs/private-cohort-alert-job.js
+++ b/src/device-registry/bin/jobs/private-cohort-alert-job.js
@@ -1,0 +1,292 @@
+// src/device-registry/bin/jobs/private-cohort-alert-job.js
+//
+// Runs 3 times a day (06:00, 14:00, 22:00 UTC) and posts a Slack alert
+// listing every private cohort that has more than 2 operational devices.
+//
+// A device is counted per status bucket using the same logic as
+// getDeviceCountSummary in device.util.js:
+//   Operational      — isOnline: true  AND rawOnlineStatus: true
+//   Transmitting     — isOnline: false AND rawOnlineStatus: true
+//   Data Available   — isOnline: true  AND rawOnlineStatus: false
+//   Not Transmitting — isOnline: false AND rawOnlineStatus: false
+//
+// Only active, deployed devices are counted.
+// No message is sent when there are no qualifying cohorts (no Slack noise).
+
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/private-cohort-alert-job -- ops-alerts`,
+);
+const { logText } = require("@utils/shared");
+const cron = require("node-cron");
+const CohortModel = require("@models/Cohort");
+const DeviceModel = require("@models/Device");
+const redisClient = require("@config/redis");
+
+const TENANT = constants.DEFAULT_TENANT || "airqo";
+const JOB_NAME = "private-cohort-alert-job";
+const JOB_SCHEDULE = "0 6,14,22 * * *"; // 06:00, 14:00, 22:00 UTC
+const MIN_OPERATIONAL = 2; // alert threshold: more than this many operational devices
+
+const ENV_SLUG = (constants.ENVIRONMENT || "unknown")
+  .replace(/\s+/g, "_")
+  .toLowerCase();
+const LOCK_KEY = `${ENV_SLUG}:${JOB_NAME}:lock`;
+const LOCK_TTL_SECONDS = 3600;
+
+// ── Distributed lock ─────────────────────────────────────────────────────────
+
+async function acquireJobLock() {
+  try {
+    if (!redisClient.redisUtils.isAvailable()) return true;
+    const result = await redisClient.set(LOCK_KEY, "1", {
+      NX: true,
+      EX: LOCK_TTL_SECONDS,
+    });
+    return result === "OK";
+  } catch (err) {
+    logger.warn(
+      `${JOB_NAME} -- could not acquire lock (${err.message}), proceeding without lock`,
+    );
+    return true;
+  }
+}
+
+async function releaseJobLock() {
+  try {
+    if (!redisClient.redisUtils.isAvailable()) return;
+    await redisClient.del(LOCK_KEY);
+  } catch (err) {
+    logger.warn(`${JOB_NAME} -- could not release lock: ${err.message}`);
+  }
+}
+
+// ── Status counting aggregation ───────────────────────────────────────────────
+
+async function findPrivateCohortsWithOperationalDevices() {
+  // Step 1 — get IDs of all private cohorts
+  const privateCohorts = await CohortModel(TENANT)
+    .find({ visibility: false }, { _id: 1, name: 1 })
+    .lean();
+
+  if (!privateCohorts.length) return [];
+
+  const cohortIds = privateCohorts.map((c) => c._id);
+  const cohortNameById = Object.fromEntries(
+    privateCohorts.map((c) => [c._id.toString(), c.name || c._id.toString()]),
+  );
+
+  // Step 2 — aggregate device status counts per cohort in one query
+  const pipeline = [
+    // Only active, deployed devices that belong to at least one private cohort
+    {
+      $match: {
+        isActive: true,
+        status: "deployed",
+        cohorts: { $in: cohortIds },
+      },
+    },
+    // Unwind so each (device, cohort) pair becomes its own document
+    { $unwind: "$cohorts" },
+    // Keep only rows for private cohorts
+    { $match: { cohorts: { $in: cohortIds } } },
+    // Classify the device status for this row
+    {
+      $addFields: {
+        _statusBucket: {
+          $switch: {
+            branches: [
+              {
+                // Operational: online AND raw online
+                case: {
+                  $and: [
+                    { $eq: ["$isOnline", true] },
+                    { $eq: ["$rawOnlineStatus", true] },
+                  ],
+                },
+                then: "operational",
+              },
+              {
+                // Transmitting: NOT isOnline but raw feed is live
+                case: {
+                  $and: [
+                    { $eq: ["$isOnline", false] },
+                    { $eq: ["$rawOnlineStatus", true] },
+                  ],
+                },
+                then: "transmitting",
+              },
+              {
+                // Data Available: isOnline but raw feed stale
+                case: {
+                  $and: [
+                    { $eq: ["$isOnline", true] },
+                    { $eq: ["$rawOnlineStatus", false] },
+                  ],
+                },
+                then: "data_available",
+              },
+            ],
+            default: "not_transmitting",
+          },
+        },
+      },
+    },
+    // Group by cohort ID, counting each status bucket
+    {
+      $group: {
+        _id: "$cohorts",
+        total: { $sum: 1 },
+        operational: {
+          $sum: { $cond: [{ $eq: ["$_statusBucket", "operational"] }, 1, 0] },
+        },
+        transmitting: {
+          $sum: { $cond: [{ $eq: ["$_statusBucket", "transmitting"] }, 1, 0] },
+        },
+        data_available: {
+          $sum: {
+            $cond: [{ $eq: ["$_statusBucket", "data_available"] }, 1, 0],
+          },
+        },
+        not_transmitting: {
+          $sum: {
+            $cond: [{ $eq: ["$_statusBucket", "not_transmitting"] }, 1, 0],
+          },
+        },
+      },
+    },
+    // Only report cohorts that exceed the threshold
+    { $match: { operational: { $gt: MIN_OPERATIONAL } } },
+    { $sort: { operational: -1 } },
+  ];
+
+  const rows = await DeviceModel(TENANT)
+    .aggregate(pipeline)
+    .option({ maxTimeMS: 60000, allowDiskUse: true });
+
+  return rows.map((row) => ({
+    cohortId: row._id.toString(),
+    name: cohortNameById[row._id.toString()] || row._id.toString(),
+    visibility: "Private",
+    total: row.total,
+    operational: row.operational,
+    transmitting: row.transmitting,
+    data_available: row.data_available,
+    not_transmitting: row.not_transmitting,
+  }));
+}
+
+// ── Slack message formatter ───────────────────────────────────────────────────
+
+function pad(str, len) {
+  return String(str).padEnd(len).slice(0, len);
+}
+
+function buildSlackMessage(cohorts, runAt) {
+  const dateStr = runAt.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+
+  const COL = {
+    num: 4,
+    name: 38,
+    total: 7,
+    operational: 12,
+    transmitting: 13,
+    data_available: 14,
+    not_transmitting: 17,
+  };
+
+  const header =
+    pad("#", COL.num) +
+    pad("Cohort Name", COL.name) +
+    pad("Devices", COL.total) +
+    pad("Operational", COL.operational) +
+    pad("Transmitting", COL.transmitting) +
+    pad("Data Available", COL.data_available) +
+    pad("Not Transmitting", COL.not_transmitting);
+
+  const divider = "─".repeat(
+    COL.num +
+      COL.name +
+      COL.total +
+      COL.operational +
+      COL.transmitting +
+      COL.data_available +
+      COL.not_transmitting,
+  );
+
+  const dataRows = cohorts
+    .map((c, i) =>
+      pad(i + 1, COL.num) +
+      pad(c.name, COL.name) +
+      pad(c.total, COL.total) +
+      pad(c.operational, COL.operational) +
+      pad(c.transmitting, COL.transmitting) +
+      pad(c.data_available, COL.data_available) +
+      pad(c.not_transmitting, COL.not_transmitting),
+    )
+    .join("\n");
+
+  return (
+    `🔒 *Private Cohorts with Operational Devices* — ${dateStr}\n` +
+    `${cohorts.length} private cohort(s) have more than ${MIN_OPERATIONAL} operational devices ` +
+    `but are not visible on public maps or recent measurements.\n` +
+    "```\n" +
+    header +
+    "\n" +
+    divider +
+    "\n" +
+    dataRows +
+    "\n" +
+    "```\n" +
+    `To make a cohort public: PUT /api/v2/cohorts/{id}  →  { "visibility": true }`
+  );
+}
+
+// ── Main job ──────────────────────────────────────────────────────────────────
+
+async function runPrivateCohortAlertJob() {
+  const acquired = await acquireJobLock();
+  if (!acquired) {
+    logText(`${JOB_NAME} -- lock held by another pod, skipping this run`);
+    return;
+  }
+
+  try {
+    logText(`${JOB_NAME} -- starting`);
+    const jobStart = Date.now();
+
+    const cohorts = await findPrivateCohortsWithOperationalDevices();
+
+    const elapsed = ((Date.now() - jobStart) / 1000).toFixed(1);
+    logText(
+      `${JOB_NAME} -- found ${cohorts.length} qualifying cohort(s) in ${elapsed}s`,
+    );
+
+    if (cohorts.length === 0) {
+      logText(`${JOB_NAME} -- no private cohorts exceed the threshold, no alert sent`);
+      return;
+    }
+
+    const message = buildSlackMessage(cohorts, new Date());
+    logger.warn(message);
+
+    logText(`${JOB_NAME} -- alert sent for ${cohorts.length} cohort(s)`);
+  } catch (error) {
+    logger.error(`${JOB_NAME} -- unhandled error: ${error.message}`);
+  } finally {
+    await releaseJobLock();
+  }
+}
+
+// ── Schedule ──────────────────────────────────────────────────────────────────
+
+cron.schedule(JOB_SCHEDULE, () => {
+  runPrivateCohortAlertJob().catch((err) => {
+    logger.error(`${JOB_NAME} -- scheduler error: ${err.message}`);
+  });
+});
+
+logText(`${JOB_NAME} -- scheduled (${JOB_SCHEDULE})`);
+
+module.exports = { runPrivateCohortAlertJob };

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -283,6 +283,18 @@ try {
   // Continue - server stays up
 }
 
+// Private cohort alert — 3×/day (06:00, 14:00, 22:00 UTC)
+// Flags cohorts that are private but contain >2 operational devices,
+// preventing them from silently missing public map and recent-measurements visibility.
+try {
+  require("@bin/jobs/private-cohort-alert-job");
+} catch (jobError) {
+  global.dedupLogger.error(
+    `❌ private-cohort-alert-job failed to start: ${jobError.message}`
+  );
+  // Continue - server stays up
+}
+
 // Express Middlewares
 app.use(bodyParser.json({ limit: "50mb" })); // JSON body parser
 // Other common middlewares: morgan, cookieParser, passport, etc.


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a new scheduled job (`private-cohort-alert-job.js`) to the device-registry that runs **3 times per day** (06:00, 14:00, 22:00 UTC) and posts a Slack alert listing any private cohorts (`visibility=false`) that contain more than 2 operational devices. The alert includes a formatted table per qualifying cohort showing its name, total device count, and a per-device status breakdown across four categories: Operational, Transmitting, Data Available, and Not Transmitting. No message is sent on runs where no cohorts qualify, preventing Slack noise on clean days.

### Why is this change needed?

During a visibility investigation for AirGradient devices missing from the analytics map, it was found that all 81 devices belonged to an auto-created cohort (`coh_user_5fb8a4de3242280012988e2f`) whose `visibility` field defaulted to `false`. This silently excluded every AirGradient reading from all public-facing features — the analytics map and recent measurements — even though the devices were active, deployed, and transmitting data correctly through the pipeline. The root issue was that auto-created cohorts default to private and there was no mechanism to surface this misconfiguration. This job proactively detects and flags that class of problem before it requires a full investigation.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/device-registry` — new job file `bin/jobs/private-cohort-alert-job.js`; registered in `bin/server.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

Confirmed the aggregation pipeline correctly classifies devices into the four status buckets using the same logic as `getDeviceCountSummary` in `device.util.js`. Verified that no Slack message is dispatched when zero cohorts qualify. Tested that the Redis distributed lock prevents duplicate alerts across multiple running pods. Confirmed the job registers cleanly in server.js without blocking server startup on failure.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The operational device threshold is set as `MIN_OPERATIONAL = 2` (alerts when count **exceeds** 2). This can be adjusted without changing the job schedule.
- Uses the existing `ops-alerts` log4js category and `slackWarn` appender — no new Slack credentials or environment variables are required.
- The Redis distributed lock (TTL: 3600 s) ensures only one pod fires the alert per scheduled run in a multi-replica deployment.
- The fix for the immediate AirGradient visibility issue (updating `coh_user_5fb8a4de3242280012988e2f` to `visibility=true` via `PUT /api/v2/cohorts/{id}`) was applied separately as a data patch and is not part of this PR.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Slack alerts for private cohorts. Alerts are sent three times daily (06:00, 14:00, 22:00 UTC) when operational-device thresholds are exceeded, including device status summaries organized by cohort.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-api/pull/6691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->