### PR TITLE
fix: remove broken auth-service call in kafka group handler

### DIFF
--- a/src/device-registry/bin/jobs/kafka-consumer.js
+++ b/src/device-registry/bin/jobs/kafka-consumer.js
@@ -464,18 +464,32 @@ const handleGroupCreated = async (payload) => {
       return;
     }
 
-    // 2. Create the default cohort
-    const network = tenant;
-
-    await CohortModel(tenant).create({
-      name: cohortName,
-      description: cohortDescription,
-      network: network,
-      grp_id: groupId, // Link the cohort to the group
+    // 2. Create the default cohort via util so COHORT_TOPIC is published
+    const request = {
+      body: {
+        name: cohortName,
+        description: cohortDescription,
+        network: tenant,
+        grp_id: groupId,
+      },
+      query: { tenant },
+    };
+    const result = await createCohortUtil.create(request, (err) => {
+      if (err)
+        logger.error(
+          `KAFKA-CONSUMER: Error creating cohort for group ${groupId}: ${err.message}`
+        );
     });
 
+    if (result && result.success === false) {
+      logger.error(
+        `KAFKA-CONSUMER: Failed to create cohort for group ${groupId}: ${result.message}`
+      );
+      return;
+    }
+
     logger.info(
-      `KAFKA-CONSUMER: Successfully created default cohort '${cohortName}' for group ID ${groupId} in network '${network}'.`
+      `KAFKA-CONSUMER: Successfully created default cohort '${cohortName}' for group ID ${groupId} in tenant '${tenant}'.`
     );
   } catch (error) {
     logger.error(

--- a/src/device-registry/bin/jobs/kafka-consumer.js
+++ b/src/device-registry/bin/jobs/kafka-consumer.js
@@ -13,7 +13,6 @@ const { jsonrepair } = require("jsonrepair");
 const cleanDeep = require("clean-deep");
 const isEmpty = require("is-empty");
 const CohortModel = require("@models/Cohort");
-const axios = require("axios");
 const createCohortUtil = require("@utils/cohort.util");
 
 const { stringify } = require("@utils/common");
@@ -450,36 +449,10 @@ const handleGroupCreated = async (payload) => {
       return;
     }
 
-    // 1. Validate that the group actually exists in the auth-service
-    let groupDetails;
-    try {
-      const response = await axios.get(
-        `${constants.AUTH_SERVICE_URL}/groups/${groupId}`,
-        {
-          headers: { "x-api-key": constants.INTER_SERVICE_TOKEN },
-          params: { tenant },
-        }
-      );
-      groupDetails = response.data.data;
-      if (isEmpty(groupDetails)) {
-        logger.warn(
-          `KAFKA-CONSUMER: Group with ID ${groupId} not found in auth-service for tenant ${tenant}. Skipping cohort creation.`
-        );
-        return;
-      }
-    } catch (error) {
-      logger.error(
-        `KAFKA-CONSUMER: Error fetching group details for ID ${groupId} from auth-service: ${error.message}`,
-        payload
-      );
-      // Stop processing if we can't verify the group
-      return;
-    }
-
     const cohortName = `coh_group_${groupId}`;
     const cohortDescription = `Default cohort for organization: ${groupName}`;
 
-    // 2. Check for idempotency: if a cohort with this name already exists, skip.
+    // 1. Check for idempotency: if a cohort with this name already exists, skip.
     const existingCohort = await CohortModel(tenant).findOne({
       name: cohortName,
     });
@@ -491,9 +464,8 @@ const handleGroupCreated = async (payload) => {
       return;
     }
 
-    // 3. Create the default cohort
-    // Derive network from group data, fall back to tenant if not present
-    const network = groupDetails.network || tenant;
+    // 2. Create the default cohort
+    const network = tenant;
 
     await CohortModel(tenant).create({
       name: cohortName,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Removes the HTTP call to the auth-service inside `handleGroupCreated` in the device-registry Kafka consumer. Also removes the now-unused `axios` import.

### Why is this change needed?
The Kafka consumer was calling `GET /groups/:grp_id` on the auth-service using an `x-api-key` header (`INTER_SERVICE_TOKEN`), but that endpoint requires JWT authentication (`enhancedJWTAuth`). This caused consistent `401 Unauthorized` errors in staging whenever a `group.created` event was received, blocking default cohort creation for every new organisation.

Additionally, the only field fetched from that response was `groupDetails.network`, which the `Group` model does not define — so the code always fell back to `tenant` anyway. The HTTP call was both broken and redundant.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [x] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `bin/jobs/kafka-consumer.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified against staging logs — the 401 errors were traced to the auth-service call. The fix eliminates the call entirely; cohort creation now proceeds directly from the trusted Kafka event payload using `tenant` as the network value, which was always the effective outcome.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
The `group.created` Kafka event payload (published by auth-service) already contains all fields needed for cohort creation (`groupId`, `groupName`, `tenant`). Trusting the event directly is both correct and consistent with how other Kafka handlers in this consumer work. If group validation is ever needed in future, the auth-service `/groups/:grp_id` route would first need to support inter-service API key authentication.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- Optimized group creation event handling by removing an external authentication service dependency check, which improves overall event processing speed and eliminates an additional failure point in the system.
- Simplified cohort network configuration logic to use the tenant identifier directly as the default value instead of deriving it from group metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->