### PR TITLE
feat: add cohort_id filter to groups list endpoint

### DIFF
--- a/src/auth-service/utils/common/generate-filter.util.js
+++ b/src/auth-service/utils/common/generate-filter.util.js
@@ -1083,7 +1083,7 @@ const filter = {
   },
   groups: (req, next) => {
     try {
-      const { grp_title, grp_status, category, grp_id } = {
+      const { grp_title, grp_status, category, grp_id, cohort_id } = {
         ...req.query,
         ...req.params,
       };
@@ -1098,9 +1098,11 @@ const filter = {
       if (grp_title) {
         filter["grp_title"] = grp_title;
       }
-
       if (category) {
         filter["category"] = category;
+      }
+      if (cohort_id) {
+        filter["cohorts"] = ObjectId(cohort_id);
       }
       logObject("the filter we are sending", filter);
       return filter;

--- a/src/auth-service/utils/common/test/ut_generate-filter.util.js
+++ b/src/auth-service/utils/common/test/ut_generate-filter.util.js
@@ -610,6 +610,19 @@ describe("generate-filter util", function () {
       expect(filter).to.deep.equal({});
     });
 
+    it("should filter by cohort_id when provided", () => {
+      const cohortId = "507f1f77bcf86cd799439011";
+      const req = {
+        query: { cohort_id: cohortId },
+        params: {},
+      };
+
+      const filter = generateFilter.groups(req);
+
+      expect(filter).to.have.property("cohorts");
+      expect(filter.cohorts.toString()).to.equal(cohortId);
+    });
+
     it("should handle an error and return an error response", () => {
       const req = {
         query: {

--- a/src/auth-service/validators/groups.validators.js
+++ b/src/auth-service/validators/groups.validators.js
@@ -154,38 +154,40 @@ const updateName = [
 
 const list = [
   validateTenant,
-  oneOf([
-    query("grp_id")
-      .optional()
-      .isMongoId()
-      .withMessage("grp_id must be an object ID IF provided")
-      .bail()
-      .customSanitizer((value) => {
-        return ObjectId(value);
-      }),
-    query("grp_title")
-      .optional()
-      .trim()
-      .notEmpty()
-      .withMessage("grp_title should not be empty IF provided")
-      .bail(),
-    query("grp_status")
-      .optional()
-      .trim()
-      .notEmpty()
-      .withMessage("grp_status should not be empty IF provided")
-      .bail()
-      .trim()
-      .toUpperCase()
-      .isIn(["INACTIVE", "ACTIVE"])
-      .withMessage(
-        "the grp_status value is not among the expected ones, use ACTIVE or INACTIVE",
-      ),
-    query("cohort_id")
-      .optional()
-      .isMongoId()
-      .withMessage("cohort_id must be a valid ObjectId IF provided"),
-  ]),
+  query("grp_id")
+    .optional()
+    .isMongoId()
+    .withMessage("grp_id must be an object ID IF provided")
+    .bail()
+    .customSanitizer((value) => {
+      return ObjectId(value);
+    }),
+  query("grp_title")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("grp_title should not be empty IF provided")
+    .bail(),
+  query("grp_status")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("grp_status should not be empty IF provided")
+    .bail()
+    .trim()
+    .toUpperCase()
+    .isIn(["INACTIVE", "ACTIVE"])
+    .withMessage(
+      "the grp_status value is not among the expected ones, use ACTIVE or INACTIVE",
+    ),
+  query("cohort_id")
+    .optional()
+    .isMongoId()
+    .withMessage("cohort_id must be a valid ObjectId IF provided")
+    .bail()
+    .customSanitizer((value) => {
+      return ObjectId(value);
+    }),
 ];
 
 const create = [

--- a/src/auth-service/validators/groups.validators.js
+++ b/src/auth-service/validators/groups.validators.js
@@ -181,6 +181,10 @@ const list = [
       .withMessage(
         "the grp_status value is not among the expected ones, use ACTIVE or INACTIVE",
       ),
+    query("cohort_id")
+      .optional()
+      .isMongoId()
+      .withMessage("cohort_id must be a valid ObjectId IF provided"),
   ]),
 ];
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds support for filtering groups by `cohort_id` via the existing `GET /api/v2/users/groups` and `GET /api/v3/users/groups` list endpoints. Passing `?cohort_id=<id>` as a query parameter returns only the groups/organizations that contain the specified cohort in their `cohorts` array.

### Why is this change needed?

Admins managing 100+ organizations need a reliable way to determine which organizations a given cohort is linked to — for example, to assign or unassign a cohort from an organization via the admin panel. Since group-cohort assignments are managed entirely within auth-service (`Group.cohorts[]`), querying from here guarantees accurate, real-time results without any cross-service data inconsistency.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

- `GET /api/v2/users/groups?cohort_id=<valid_mongo_id>` returns only groups whose `cohorts` array contains that ID.
- `GET /api/v2/users/groups?cohort_id=<invalid_id>` returns a `400 Bad Request` from the validator.
- `GET /api/v2/users/groups` with no `cohort_id` param behaves exactly as before — no regression on existing filters (`grp_id`, `grp_title`, `grp_status`).

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `cohort_id` query parameter is fully optional. All existing group list behaviour is unchanged.

---

## :memo: Additional Notes

- No new routes were added. The filter is applied within the existing `generateFilter.groups()` utility, keeping the change minimal and consistent with the existing filter pattern.
- This endpoint requires the caller to have `GROUP_VIEW` permission (enforced by the existing route middleware).
- The companion reverse endpoint — `GET /api/v2/users/groups/:grp_id/cohorts` — already exists for the opposite lookup (cohorts belonging to a group).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added cohort ID filtering for group operations. Users can now filter groups by cohort to retrieve groups associated with specific cohorts. Input validation ensures cohort ID is properly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->