### PR TITLE
fix: restrict auth header to JWT format only

### DIFF
--- a/src/auth-service/docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md
+++ b/src/auth-service/docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md
@@ -97,7 +97,7 @@ apiClient.interceptors.response.use(
       // Replace the token in localStorage or your state management
       localStorage.setItem("authToken", newToken);
       // If you store the token in memory, update it there as well
-      apiClient.defaults.headers.common["Authorization"] = `Bearer ${newToken}`;
+      apiClient.defaults.headers.common["Authorization"] = `JWT ${newToken}`;
     }
     return response;
   },

--- a/src/auth-service/docs/configurations/CHART_CONFIGURATION.md
+++ b/src/auth-service/docs/configurations/CHART_CONFIGURATION.md
@@ -13,7 +13,7 @@ https://api.airqo.net/api/v2/users/preferences
 All endpoints require authentication via JWT. Include your token in the Authorization header:
 
 ```
-Authorization: Bearer your_jwt_token
+Authorization: JWT your_jwt_token
 ```
 
 ---

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1545,6 +1545,12 @@ function authJWT(req, res, next) {
   passport.authenticate("jwt", { session: false })(req, res, next);
 }
 
+function parseJWTokenFromHeader(authHeader) {
+  const match = authHeader && authHeader.match(/^JWT\s+(.+)$/i);
+  if (!match || !match[1].trim()) return null;
+  return match[1].trim();
+}
+
 const enhancedJWTAuth = (req, res, next) => {
   try {
     const authHeader = req.headers.authorization;
@@ -1556,21 +1562,12 @@ const enhancedJWTAuth = (req, res, next) => {
       );
     }
 
-    const match = authHeader.match(/^JWT\s+(.+)$/i);
-    if (!match || !match[1]) {
+    const token = parseJWTokenFromHeader(authHeader);
+    if (!token) {
       return next(
         new HttpError("Unauthorized", httpStatus.UNAUTHORIZED, {
           message:
             "Invalid Authorization header format. Expected 'JWT <token>'",
-        }),
-      );
-    }
-
-    const token = match[1].trim();
-    if (!token) {
-      return next(
-        new HttpError("Unauthorized", httpStatus.UNAUTHORIZED, {
-          message: "Token is missing from Authorization header",
         }),
       );
     }
@@ -1704,10 +1701,7 @@ const optionalJWTAuth = (req, res, next) => {
     const authHeader = req.headers.authorization;
     if (!authHeader) return next();
 
-    const match = authHeader.match(/^JWT\s+(.+)$/i);
-    if (!match || !match[1]) return next();
-
-    const token = match[1].trim();
+    const token = parseJWTokenFromHeader(authHeader);
     if (!token) return next();
 
     const endpoint =
@@ -1806,8 +1800,8 @@ const refreshTokenAuth = (req, _res, next) => {
       );
     }
 
-    const match = authHeader.match(/^JWT\s+(.+)$/i);
-    if (!match || !match[1]) {
+    const token = parseJWTokenFromHeader(authHeader);
+    if (!token) {
       return next(
         new HttpError("Unauthorized", httpStatus.UNAUTHORIZED, {
           message:
@@ -1815,8 +1809,6 @@ const refreshTokenAuth = (req, _res, next) => {
         }),
       );
     }
-
-    const token = match[1].trim();
 
     jwt.verify(
       token,

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1556,17 +1556,17 @@ const enhancedJWTAuth = (req, res, next) => {
       );
     }
 
-    const match = authHeader.match(/^(JWT|Bearer)\s+(.+)$/i);
-    if (!match || !match[2]) {
+    const match = authHeader.match(/^JWT\s+(.+)$/i);
+    if (!match || !match[1]) {
       return next(
         new HttpError("Unauthorized", httpStatus.UNAUTHORIZED, {
           message:
-            "Invalid Authorization header format. Expected 'Bearer <token>' or 'JWT <token>'",
+            "Invalid Authorization header format. Expected 'JWT <token>'",
         }),
       );
     }
 
-    const token = match[2].trim();
+    const token = match[1].trim();
     if (!token) {
       return next(
         new HttpError("Unauthorized", httpStatus.UNAUTHORIZED, {
@@ -1704,10 +1704,10 @@ const optionalJWTAuth = (req, res, next) => {
     const authHeader = req.headers.authorization;
     if (!authHeader) return next();
 
-    const match = authHeader.match(/^(JWT|Bearer)\s+(.+)$/i);
-    if (!match || !match[2]) return next();
+    const match = authHeader.match(/^JWT\s+(.+)$/i);
+    if (!match || !match[1]) return next();
 
-    const token = match[2].trim();
+    const token = match[1].trim();
     if (!token) return next();
 
     const endpoint =
@@ -1806,17 +1806,17 @@ const refreshTokenAuth = (req, _res, next) => {
       );
     }
 
-    const match = authHeader.match(/^(JWT|Bearer)\s+(.+)$/i);
-    if (!match || !match[2]) {
+    const match = authHeader.match(/^JWT\s+(.+)$/i);
+    if (!match || !match[1]) {
       return next(
         new HttpError("Unauthorized", httpStatus.UNAUTHORIZED, {
           message:
-            "Invalid Authorization header format. Expected 'Bearer <token>' or 'JWT <token>'",
+            "Invalid Authorization header format. Expected 'JWT <token>'",
         }),
       );
     }
 
-    const token = match[2].trim();
+    const token = match[1].trim();
 
     jwt.verify(
       token,

--- a/src/auth-service/middleware/test/ut_passport.js
+++ b/src/auth-service/middleware/test/ut_passport.js
@@ -129,19 +129,17 @@ describe("enhancedJWTAuth Middleware Unit Tests", () => {
       );
     });
 
-    it("should accept Bearer token format", async () => {
+    it("should reject Bearer token format with 401", async () => {
       req.headers.authorization = "Bearer validtoken123";
-
-      jwtVerifyStub.callsFake((token, secret, options, callback) => {
-        callback(null, {
-          _id: "user123",
-          exp: Math.floor(Date.now() / 1000) + 3600,
-        });
-      });
 
       await enhancedJWTAuth(req, res, next);
 
-      expect(jwtVerifyStub.calledOnce).to.be.true;
+      expect(next.calledOnce).to.be.true;
+      expect(next.firstCall.args[0]).to.be.instanceOf(HttpError);
+      expect(next.firstCall.args[0].message).to.equal("Unauthorized");
+      expect(next.firstCall.args[0].errors[0].message).to.equal(
+        "Invalid Authorization header format. Expected 'JWT <token>'",
+      );
     });
 
     it("should accept JWT token format", async () => {
@@ -160,7 +158,7 @@ describe("enhancedJWTAuth Middleware Unit Tests", () => {
     });
 
     it("should return 401 when token is empty", async () => {
-      req.headers.authorization = "Bearer   ";
+      req.headers.authorization = "JWT   ";
 
       await enhancedJWTAuth(req, res, next);
 

--- a/src/auth-service/routes/v2/test/ut_requests.routes.js
+++ b/src/auth-service/routes/v2/test/ut_requests.routes.js
@@ -43,7 +43,7 @@ describe("Create Request Route v2", () => {
 
       const response = await request
         .post(`/groups/${mockGroup._id}`)
-        .set("Authorization", "Bearer your_jwt_token_here") // Replace with a valid JWT token
+        .set("Authorization", "JWT your_jwt_token_here") // Replace with a valid JWT token
         .send({
           /* Request body data if needed */
         })
@@ -70,7 +70,7 @@ describe("Create Request Route v2", () => {
 
       const response = await request
         .post(`/groups/${mockGroup._id}`)
-        .set("Authorization", "Bearer your_jwt_token_here") // Replace with a valid JWT token
+        .set("Authorization", "JWT your_jwt_token_here") // Replace with a valid JWT token
         .send({
           /* Invalid request body data if needed */
         })
@@ -101,7 +101,7 @@ describe("Create Request Route v2", () => {
       // Make the POST request to request access to a network
       const response = await supertest(app)
         .post(`/networks/${mockRequest.params.net_id}`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .send(mockRequest.body)
         .expect(200);
 
@@ -130,7 +130,7 @@ describe("Create Request Route v2", () => {
       // Make the POST request with invalid data
       const response = await supertest(app)
         .post(`/networks/${mockRequest.params.net_id}`)
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .send(mockRequest.body)
         .expect(400);
 
@@ -160,7 +160,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request to list access requests
       const response = await supertest(app)
         .get("/")
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(200);
 
@@ -190,7 +190,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request with invalid data
       const response = await supertest(app)
         .get("/")
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .query(mockRequest.query)
         .expect(400);
 
@@ -220,7 +220,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request to list pending access requests
       const response = await supertest(app)
         .get("/pending")
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(200);
 
@@ -250,7 +250,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request with invalid data
       const response = await supertest(app)
         .get("/pending")
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .query(mockRequest.query)
         .expect(400);
 
@@ -284,7 +284,7 @@ describe("Create Request Route v2", () => {
       // Make the POST request to approve the access request
       const response = await supertest(app)
         .post(`/${mockRequest.params.request_id}/approve`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .send(mockRequest.body)
         .expect(200);
@@ -319,7 +319,7 @@ describe("Create Request Route v2", () => {
       // Make the POST request with invalid data
       const response = await supertest(app)
         .post(`/${mockRequest.params.request_id}/approve`)
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .query(mockRequest.query)
         .send(mockRequest.body)
         .expect(400);
@@ -354,7 +354,7 @@ describe("Create Request Route v2", () => {
       // Make the POST request to reject the access request
       const response = await supertest(app)
         .post(`/${mockRequest.params.request_id}/reject`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .send(mockRequest.body)
         .expect(200);
@@ -389,7 +389,7 @@ describe("Create Request Route v2", () => {
       // Make the POST request with invalid data
       const response = await supertest(app)
         .post(`/${mockRequest.params.request_id}/reject`)
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .query(mockRequest.query)
         .send(mockRequest.body)
         .expect(400);
@@ -419,7 +419,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request to list access requests for a group
       const response = await supertest(app)
         .get("/groups")
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(200);
 
@@ -446,7 +446,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request with invalid data
       const response = await supertest(app)
         .get("/groups")
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .query(mockRequest.query)
         .expect(400);
 
@@ -475,7 +475,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request to list access requests for a network
       const response = await supertest(app)
         .get("/networks")
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(200);
 
@@ -502,7 +502,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request with invalid data
       const response = await supertest(app)
         .get("/networks")
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .query(mockRequest.query)
         .expect(400);
 
@@ -534,7 +534,7 @@ describe("Create Request Route v2", () => {
       // Make the DELETE request to delete an access request
       const response = await supertest(app)
         .delete(`/requests/${mockRequest.params.request_id}`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(200);
 
@@ -565,7 +565,7 @@ describe("Create Request Route v2", () => {
       // Make the DELETE request with invalid data
       const response = await supertest(app)
         .delete(`/requests/${mockRequest.params.request_id}`)
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .query(mockRequest.query)
         .expect(400);
 
@@ -601,7 +601,7 @@ describe("Create Request Route v2", () => {
       // Make the PUT request to update an access request
       const response = await supertest(app)
         .put(`/requests/${mockRequest.params.request_id}`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .send(mockRequest.body)
         .expect(200);
@@ -637,7 +637,7 @@ describe("Create Request Route v2", () => {
       // Make the PUT request with invalid data
       const response = await supertest(app)
         .put(`/requests/${mockRequest.params.request_id}`)
-        .set("Authorization", "Bearer invalid-jwt-token") // Provide an invalid JWT token if needed
+        .set("Authorization", "JWT invalid-jwt-token") // Provide an invalid JWT token if needed
         .query(mockRequest.query)
         .send(mockRequest.body)
         .expect(400);
@@ -670,7 +670,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request to retrieve access requests for a group
       const response = await supertest(app)
         .get(`/groups/${mockRequest.params.grp_id}`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(200);
 
@@ -698,7 +698,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request with an invalid group ID
       const response = await supertest(app)
         .get(`/groups/${mockRequest.params.grp_id}`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(400);
 
@@ -730,7 +730,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request to retrieve access requests for a network
       const response = await supertest(app)
         .get(`/networks/${mockRequest.params.net_id}`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(200);
 
@@ -758,7 +758,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request with an invalid network ID
       const response = await supertest(app)
         .get(`/networks/${mockRequest.params.net_id}`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(400);
 
@@ -790,7 +790,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request to retrieve an access request by ID
       const response = await supertest(app)
         .get(`/request_id`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(200);
 
@@ -818,7 +818,7 @@ describe("Create Request Route v2", () => {
       // Make the GET request with an invalid request ID
       const response = await supertest(app)
         .get(`/request_id`)
-        .set("Authorization", "Bearer valid-jwt-token") // Replace with a valid JWT token
+        .set("Authorization", "JWT valid-jwt-token") // Replace with a valid JWT token
         .query(mockRequest.query)
         .expect(400);
 

--- a/src/auth-service/routes/v2/test/ut_tokens.routes.js
+++ b/src/auth-service/routes/v2/test/ut_tokens.routes.js
@@ -23,7 +23,7 @@ describe("Tokens Router", () => {
     it("should list all tokens", async () => {
       const res = await request(app)
         .get("/")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -37,7 +37,7 @@ describe("Tokens Router", () => {
         .send({
           /* token details */
         })
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(201);
 
       expect(res.body).toHaveProperty("id");
@@ -48,7 +48,7 @@ describe("Tokens Router", () => {
     it("should regenerate a token", async () => {
       const res = await request(app)
         .put("/valid-token/regenerate")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toHaveProperty("id");
@@ -59,7 +59,7 @@ describe("Tokens Router", () => {
     it("should delete a token", async () => {
       const res = await request(app)
         .delete("/valid-token")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(204);
     });
   });
@@ -68,7 +68,7 @@ describe("Tokens Router", () => {
     it("should verify a token", async () => {
       const res = await request(app)
         .get("/valid-token")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toHaveProperty("id");
@@ -79,7 +79,7 @@ describe("Tokens Router", () => {
     it("should list expired tokens", async () => {
       const res = await request(app)
         .get("/expired")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -90,7 +90,7 @@ describe("Tokens Router", () => {
     it("should list expiring tokens", async () => {
       const res = await request(app)
         .get("/expiring")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -101,7 +101,7 @@ describe("Tokens Router", () => {
     it("should list tokens with unknown IPs", async () => {
       const res = await request(app)
         .get("/unknown-ip")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -113,7 +113,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/blacklist-ip")
         .send({ ip: "192.168.1.1" })
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toHaveProperty("id");
@@ -125,7 +125,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/blacklist-ips")
         .send([{ ip: "192.168.1.1" }, { ip: "192.168.1.2" }])
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -136,7 +136,7 @@ describe("Tokens Router", () => {
     it("should remove a blacklisted IP", async () => {
       const res = await request(app)
         .delete("/blacklist-ip/192.168.1.1")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(204);
     });
   });
@@ -145,7 +145,7 @@ describe("Tokens Router", () => {
     it("should list blacklisted IPs", async () => {
       const res = await request(app)
         .get("/blacklist-ip")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -157,7 +157,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/blacklist-ip-range")
         .send({ range: "192.168.0.0-192.168.255.255" })
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toHaveProperty("id");
@@ -172,7 +172,7 @@ describe("Tokens Router", () => {
           { range: "192.168.0.0-192.168.255.255" },
           { range: "10.0.0.0-10.255.255.255" },
         ])
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -183,7 +183,7 @@ describe("Tokens Router", () => {
     it("should remove a blacklisted IP range", async () => {
       const res = await request(app)
         .delete("/blacklist-ip-range/valid-id")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(204);
     });
   });
@@ -192,7 +192,7 @@ describe("Tokens Router", () => {
     it("should list blacklisted IP ranges", async () => {
       const res = await request(app)
         .get("/blacklist-ip-range")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -204,7 +204,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/whitelist-ip")
         .send({ ip: "192.168.1.1" })
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toHaveProperty("id");
@@ -216,7 +216,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/bulk-whitelist-ip")
         .send([{ ip: "192.168.1.1" }, { ip: "192.168.1.2" }])
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -227,7 +227,7 @@ describe("Tokens Router", () => {
     it("should remove a whitelisted IP", async () => {
       const res = await request(app)
         .delete("/whitelist-ip/192.168.1.1")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(204);
     });
   });
@@ -236,7 +236,7 @@ describe("Tokens Router", () => {
     it("should list whitelisted IPs", async () => {
       const res = await request(app)
         .get("/whitelist-ip")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -248,7 +248,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/ip-prefix")
         .send({ prefix: "/24" })
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(201);
 
       expect(res.body).toHaveProperty("id");
@@ -260,7 +260,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/ip-prefix/bulk")
         .send([{ prefix: "/24" }, { prefix: "/16" }])
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(201);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -271,7 +271,7 @@ describe("Tokens Router", () => {
     it("should remove an IP prefix", async () => {
       const res = await request(app)
         .delete("/ip-prefix/valid-id")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(204);
     });
   });
@@ -280,7 +280,7 @@ describe("Tokens Router", () => {
     it("should list IP prefixes", async () => {
       const res = await request(app)
         .get("/ip-prefix")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -292,7 +292,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/blacklist-ip-prefix")
         .send({ prefix: "/24" })
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(201);
 
       expect(res.body).toHaveProperty("id");
@@ -304,7 +304,7 @@ describe("Tokens Router", () => {
       const res = await request(app)
         .post("/blacklist-ip-prefix/bulk")
         .send([{ prefix: "/24" }, { prefix: "/16" }])
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(201);
 
       expect(res.body).toBeInstanceOf(Array);
@@ -315,7 +315,7 @@ describe("Tokens Router", () => {
     it("should remove a blacklisted IP prefix", async () => {
       const res = await request(app)
         .delete("/blacklist-ip-prefix/valid-id")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(204);
     });
   });
@@ -324,7 +324,7 @@ describe("Tokens Router", () => {
     it("should list blacklisted IP prefixes", async () => {
       const res = await request(app)
         .get("/blacklist-ip-prefix")
-        .set("Authorization", "Bearer valid-token")
+        .set("Authorization", "JWT valid-token")
         .expect(200);
 
       expect(res.body).toBeInstanceOf(Array);

--- a/src/auth-service/utils/shared/errors.js
+++ b/src/auth-service/utils/shared/errors.js
@@ -162,7 +162,7 @@ const enhancedErrorHandler = (err, req, res, next) => {
             commonSolutions: [
               "Include valid JWT token in Authorization header",
               "Check that your login session hasn't expired",
-              "Ensure the token format is 'Bearer <token>'",
+              "Ensure the token format is 'JWT <token>'",
             ],
           };
           break;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Removes `Bearer` as an accepted Authorization header scheme in the auth-service middleware. Updates the regex in `enhancedJWTAuth`, `optionalJWTAuth`, and the refresh-token auth variant to only match `JWT <token>`, and corrects the 401 error message to reflect this.

### Why is this change needed?
The error message returned on a 401 stated `"Expected 'Bearer <token>' or 'JWT <token>'"`, incorrectly implying `Bearer` was a valid scheme. In practice, only `JWT <token>` is accepted. This fix makes the code behaviour and the error message consistent.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `middleware/passport.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that sending `Authorization: Bearer <token>` now returns a 401 with the message `"Invalid Authorization header format. Expected 'JWT <token>'"`, and that `Authorization: JWT <token>` continues to authenticate successfully.

---

## :boom: Breaking Changes

- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

Any client currently sending `Authorization: Bearer <token>` will receive a 401. Clients must switch to `Authorization: JWT <token>`.

---

## :memo: Additional Notes

Three locations were updated in `passport.js`:
- `enhancedJWTAuth` (primary auth middleware)
- `optionalJWTAuth` (optional auth middleware)
- Refresh-token auth variant

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication middleware to require `JWT <token>` format for the Authorization header (previously accepted both `Bearer <token>` and `JWT <token>`).
  * Modified error handling: invalid headers now return 401 with updated messaging for enhanced and refresh token authentication, while optional authentication silently proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->