### PR TITLE
feat: auto-CC admins on system emails sent to registered application accounts

### DIFF
--- a/src/auth-service/controllers/application-email-config.controller.js
+++ b/src/auth-service/controllers/application-email-config.controller.js
@@ -1,0 +1,158 @@
+const applicationEmailConfigUtil = require("@utils/application-email-config.util");
+const { logObject, HttpError, extractErrorsFromRequest } = require("@utils/shared");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+const httpStatus = require("http-status");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- application-email-config-controller`
+);
+
+const applicationEmailConfig = {
+  create: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+
+      const result = await applicationEmailConfigUtil.create(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+
+      if (result.success === true) {
+        const status = result.status || httpStatus.CREATED;
+        return res.status(status).json({
+          success: true,
+          message: result.message || "",
+          applicationEmailConfiguration: result.data || {},
+        });
+      } else {
+        const status = result.status || httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message || "",
+          errors: result.errors || { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  list: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+
+      const result = await applicationEmailConfigUtil.list(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+
+      if (result.success === true) {
+        const status = result.status || httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message || "",
+          applicationEmailConfigurations: result.data || [],
+          total: result.totalCount,
+        });
+      } else {
+        const status = result.status || httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message || "",
+          errors: result.errors || { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  update: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+
+      const result = await applicationEmailConfigUtil.update(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+
+      if (result.success === true) {
+        const status = result.status || httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message || "",
+          applicationEmailConfiguration: result.data || {},
+        });
+      } else {
+        const status = result.status || httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message || "",
+          errors: result.errors || { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  delete: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+
+      const result = await applicationEmailConfigUtil.remove(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+
+      if (result.success === true) {
+        const status = result.status || httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message || "",
+          applicationEmailConfiguration: result.data || {},
+        });
+      } else {
+        const status = result.status || httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message || "",
+          errors: result.errors || { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+module.exports = applicationEmailConfig;

--- a/src/auth-service/models/ApplicationEmailConfiguration.js
+++ b/src/auth-service/models/ApplicationEmailConfiguration.js
@@ -69,20 +69,23 @@ ApplicationEmailConfigurationSchema.statics = {
       logObject("the error", err);
       logger.error(`🐛🐛 Internal Server Error -- ${err.message}`);
       let errors = {};
+      let message;
+      let status;
       if (err.code === 11000) {
         errors["tenant"] =
           "An application email configuration for this tenant already exists";
+        message = "Validation errors for some of the provided fields";
+        status = httpStatus.CONFLICT;
       } else if (err.errors) {
         Object.entries(err.errors).forEach(([k, v]) => (errors[k] = v.message));
+        message = "Validation errors for some of the provided fields";
+        status = httpStatus.UNPROCESSABLE_ENTITY;
       } else {
         errors = { message: err.message };
+        message = "Internal Server Error";
+        status = httpStatus.INTERNAL_SERVER_ERROR;
       }
-      return {
-        success: false,
-        message: "Validation errors for some of the provided fields",
-        status: httpStatus.CONFLICT,
-        errors,
-      };
+      return { success: false, message, status, errors };
     }
   },
 

--- a/src/auth-service/models/ApplicationEmailConfiguration.js
+++ b/src/auth-service/models/ApplicationEmailConfiguration.js
@@ -1,0 +1,197 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+const { getModelByTenant } = require("@config/database");
+const httpStatus = require("http-status");
+const { HttpError, logObject } = require("@utils/shared");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- application-email-configuration-model`
+);
+
+const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+const ApplicationEmailConfigurationSchema = new Schema(
+  {
+    tenant: { type: String, required: true, unique: true, lowercase: true },
+    // Emails belonging to applications (not real people). When system-generated
+    // emails are sent to any of these addresses, admin CC emails are added automatically.
+    applicationEmails: {
+      type: [String],
+      default: [],
+      set: (emails) => [...new Set(emails.map((e) => e.toLowerCase().trim()))],
+      validate: {
+        validator: (emails) => emails.every(isValidEmail),
+        message: "One or more application emails are invalid",
+      },
+    },
+    // Comma-separated list of admin email addresses to CC whenever an email
+    // lands on one of the applicationEmails above.
+    adminCCEmails: {
+      type: String,
+      default: "",
+      trim: true,
+      validate: {
+        validator: (val) => {
+          if (!val) return true;
+          return val
+            .split(",")
+            .map((e) => e.trim())
+            .filter(Boolean)
+            .every(isValidEmail);
+        },
+        message: "One or more admin CC emails are invalid",
+      },
+    },
+  },
+  { timestamps: true }
+);
+
+ApplicationEmailConfigurationSchema.statics = {
+  async register(args, next) {
+    try {
+      const created = await this.create({ ...args });
+      if (!isEmpty(created)) {
+        return {
+          success: true,
+          message: "Application email configuration created successfully",
+          data: created,
+          status: httpStatus.CREATED,
+        };
+      }
+      return {
+        success: false,
+        message: "Operation successful but configuration not created",
+        status: httpStatus.OK,
+      };
+    } catch (err) {
+      logObject("the error", err);
+      logger.error(`🐛🐛 Internal Server Error -- ${err.message}`);
+      let errors = {};
+      if (err.code === 11000) {
+        errors["tenant"] =
+          "An application email configuration for this tenant already exists";
+      } else if (err.errors) {
+        Object.entries(err.errors).forEach(([k, v]) => (errors[k] = v.message));
+      } else {
+        errors = { message: err.message };
+      }
+      return {
+        success: false,
+        message: "Validation errors for some of the provided fields",
+        status: httpStatus.CONFLICT,
+        errors,
+      };
+    }
+  },
+
+  async list({ skip = 0, limit = 100, filter = {} } = {}, next) {
+    try {
+      const totalCount = await this.countDocuments(filter).exec();
+      const data = await this.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(parseInt(skip))
+        .limit(parseInt(limit))
+        .exec();
+      return {
+        success: true,
+        message: data.length
+          ? "Successfully retrieved application email configurations"
+          : "No application email configurations exist",
+        data,
+        totalCount,
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
+  async modify({ filter = {}, update = {} } = {}, next) {
+    try {
+      const options = { new: true, runValidators: true };
+      const updated = await this.findOneAndUpdate(
+        filter,
+        update,
+        options
+      ).exec();
+      if (!isEmpty(updated)) {
+        return {
+          success: true,
+          message: "Successfully modified the application email configuration",
+          data: updated,
+          status: httpStatus.OK,
+        };
+      }
+      return {
+        success: false,
+        message: "Application email configuration not found",
+        status: httpStatus.NOT_FOUND,
+        errors: {
+          message: "Configuration does not exist, please crosscheck",
+        },
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      if (error instanceof HttpError) return error;
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
+  async remove({ filter = {} } = {}, next) {
+    try {
+      const removed = await this.findOneAndRemove(filter).exec();
+      if (!isEmpty(removed)) {
+        return {
+          success: true,
+          message: "Successfully removed the application email configuration",
+          data: removed,
+          status: httpStatus.OK,
+        };
+      }
+      return {
+        success: false,
+        message: "Application email configuration not found",
+        status: httpStatus.NOT_FOUND,
+        errors: { message: "Configuration does not exist" },
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      if (error instanceof HttpError) return error;
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+};
+
+const ApplicationEmailConfigurationModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("application_email_configuration");
+  } catch (error) {
+    return getModelByTenant(
+      dbTenant,
+      "application_email_configuration",
+      ApplicationEmailConfigurationSchema
+    );
+  }
+};
+
+module.exports = ApplicationEmailConfigurationModel;

--- a/src/auth-service/models/ApplicationEmailConfiguration.js
+++ b/src/auth-service/models/ApplicationEmailConfiguration.js
@@ -183,15 +183,11 @@ ApplicationEmailConfigurationSchema.statics = {
 const ApplicationEmailConfigurationModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
-  try {
-    return mongoose.model("application_email_configuration");
-  } catch (error) {
-    return getModelByTenant(
-      dbTenant,
-      "application_email_configuration",
-      ApplicationEmailConfigurationSchema
-    );
-  }
+  return getModelByTenant(
+    dbTenant,
+    "application_email_configuration",
+    ApplicationEmailConfigurationSchema
+  );
 };
 
 module.exports = ApplicationEmailConfigurationModel;

--- a/src/auth-service/routes/v2/application-email-configs.routes.js
+++ b/src/auth-service/routes/v2/application-email-configs.routes.js
@@ -1,0 +1,18 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("@controllers/application-email-config.controller");
+const validators = require("@validators/application-email-config.validators");
+const { enhancedJWTAuth } = require("@middleware/passport");
+const { headers } = require("@validators/common");
+
+router.use(headers);
+
+router.get("/", validators.list, enhancedJWTAuth, controller.list);
+
+router.post("/", validators.create, enhancedJWTAuth, controller.create);
+
+router.put("/:id", validators.update, enhancedJWTAuth, controller.update);
+
+router.delete("/:id", validators.delete, enhancedJWTAuth, controller.delete);
+
+module.exports = router;

--- a/src/auth-service/routes/v2/application-email-configs.routes.js
+++ b/src/auth-service/routes/v2/application-email-configs.routes.js
@@ -3,16 +3,20 @@ const router = express.Router();
 const controller = require("@controllers/application-email-config.controller");
 const validators = require("@validators/application-email-config.validators");
 const { enhancedJWTAuth } = require("@middleware/passport");
+const { requirePermissions } = require("@middleware/permissionAuth");
+const constants = require("@config/constants");
 const { headers } = require("@validators/common");
 
 router.use(headers);
 
-router.get("/", validators.list, enhancedJWTAuth, controller.list);
+const requireSuperAdmin = requirePermissions([constants.SUPER_ADMIN]);
 
-router.post("/", validators.create, enhancedJWTAuth, controller.create);
+router.get("/", validators.list, enhancedJWTAuth, requireSuperAdmin, controller.list);
 
-router.put("/:id", validators.update, enhancedJWTAuth, controller.update);
+router.post("/", validators.create, enhancedJWTAuth, requireSuperAdmin, controller.create);
 
-router.delete("/:id", validators.delete, enhancedJWTAuth, controller.delete);
+router.put("/:id", validators.update, enhancedJWTAuth, requireSuperAdmin, controller.update);
+
+router.delete("/:id", validators.delete, enhancedJWTAuth, requireSuperAdmin, controller.delete);
 
 module.exports = router;

--- a/src/auth-service/routes/v2/index.js
+++ b/src/auth-service/routes/v2/index.js
@@ -275,6 +275,12 @@ const authRoutes = [
     description: "Multi-tenant settings management",
   },
   {
+    path: "/application-email-configs",
+    route: "@routes/v2/application-email-configs.routes",
+    name: "application-email-configs",
+    description: "Application email CC configuration — auto-CCs admins when system emails target app inboxes",
+  },
+  {
     path: "/privacy",
     route: "@routes/v2/privacy.routes",
     name: "privacy",

--- a/src/auth-service/utils/application-email-config.util.js
+++ b/src/auth-service/utils/application-email-config.util.js
@@ -1,0 +1,158 @@
+const ApplicationEmailConfigurationModel = require("@models/ApplicationEmailConfiguration");
+const httpStatus = require("http-status");
+const { logObject, HttpError } = require("@utils/shared");
+const isEmpty = require("is-empty");
+const mongoose = require("mongoose");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- application-email-config-util`
+);
+
+const applicationEmailConfig = {
+  create: async (request, next) => {
+    try {
+      const { body } = request;
+      const tenant = (
+        body.tenant ||
+        request.query.tenant ||
+        constants.DEFAULT_TENANT ||
+        "airqo"
+      ).toLowerCase();
+
+      const response = await ApplicationEmailConfigurationModel(tenant).register(
+        { ...body, tenant },
+        next
+      );
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  list: async (request, next) => {
+    try {
+      const { query, params } = request;
+      const tenant = (
+        query.tenant ||
+        constants.DEFAULT_TENANT ||
+        "airqo"
+      ).toLowerCase();
+      const { limit = 100, skip = 0 } = query;
+
+      const filter = {};
+      if (params.id) {
+        filter._id = mongoose.Types.ObjectId(params.id);
+      }
+      if (query.tenant) {
+        filter.tenant = tenant;
+      }
+
+      const response = await ApplicationEmailConfigurationModel(tenant).list(
+        { skip, limit, filter },
+        next
+      );
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  update: async (request, next) => {
+    try {
+      const { query, body, params } = request;
+      const tenant = (
+        query.tenant ||
+        constants.DEFAULT_TENANT ||
+        "airqo"
+      ).toLowerCase();
+
+      const filter = { _id: mongoose.Types.ObjectId(params.id) };
+      const update = {};
+
+      // Replace the entire applicationEmails list
+      if (body.applicationEmails !== undefined) {
+        update.applicationEmails = body.applicationEmails;
+      }
+
+      // Replace the adminCCEmails string
+      if (body.adminCCEmails !== undefined) {
+        update.adminCCEmails = body.adminCCEmails;
+      }
+
+      // Fine-grained: add specific emails without sending the full list
+      if (!isEmpty(body.addApplicationEmails)) {
+        update.$addToSet = {
+          applicationEmails: { $each: body.addApplicationEmails },
+        };
+      }
+
+      // Fine-grained: remove specific emails from the list
+      if (!isEmpty(body.removeApplicationEmails)) {
+        update.$pull = {
+          applicationEmails: { $in: body.removeApplicationEmails },
+        };
+      }
+
+      if (isEmpty(update)) {
+        return {
+          success: false,
+          message: "No update fields provided",
+          status: httpStatus.BAD_REQUEST,
+          errors: { message: "Provide at least one field to update" },
+        };
+      }
+
+      const response = await ApplicationEmailConfigurationModel(tenant).modify(
+        { filter, update },
+        next
+      );
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  remove: async (request, next) => {
+    try {
+      const { query, params } = request;
+      const tenant = (
+        query.tenant ||
+        constants.DEFAULT_TENANT ||
+        "airqo"
+      ).toLowerCase();
+
+      const filter = { _id: mongoose.Types.ObjectId(params.id) };
+
+      const response = await ApplicationEmailConfigurationModel(tenant).remove(
+        { filter },
+        next
+      );
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+module.exports = applicationEmailConfig;

--- a/src/auth-service/utils/application-email-config.util.js
+++ b/src/auth-service/utils/application-email-config.util.js
@@ -78,30 +78,44 @@ const applicationEmailConfig = {
       ).toLowerCase();
 
       const filter = { _id: mongoose.Types.ObjectId(params.id) };
-      const update = {};
 
-      // Replace the entire applicationEmails list
-      if (body.applicationEmails !== undefined) {
-        update.applicationEmails = body.applicationEmails;
+      const hasReplacement = body.applicationEmails !== undefined;
+      const hasAddRemove =
+        !isEmpty(body.addApplicationEmails) ||
+        !isEmpty(body.removeApplicationEmails);
+
+      if (hasReplacement && hasAddRemove) {
+        return {
+          success: false,
+          message:
+            "Cannot combine applicationEmails replacement with addApplicationEmails or removeApplicationEmails in the same request",
+          status: httpStatus.BAD_REQUEST,
+          errors: {
+            message:
+              "Use applicationEmails to replace the full list, or use addApplicationEmails/removeApplicationEmails for partial updates — not both at once",
+          },
+        };
       }
 
-      // Replace the adminCCEmails string
+      const update = {};
+
       if (body.adminCCEmails !== undefined) {
         update.adminCCEmails = body.adminCCEmails;
       }
 
-      // Fine-grained: add specific emails without sending the full list
-      if (!isEmpty(body.addApplicationEmails)) {
-        update.$addToSet = {
-          applicationEmails: { $each: body.addApplicationEmails },
-        };
-      }
-
-      // Fine-grained: remove specific emails from the list
-      if (!isEmpty(body.removeApplicationEmails)) {
-        update.$pull = {
-          applicationEmails: { $in: body.removeApplicationEmails },
-        };
+      if (hasReplacement) {
+        update.applicationEmails = body.applicationEmails;
+      } else {
+        if (!isEmpty(body.addApplicationEmails)) {
+          update.$addToSet = {
+            applicationEmails: { $each: body.addApplicationEmails },
+          };
+        }
+        if (!isEmpty(body.removeApplicationEmails)) {
+          update.$pull = {
+            applicationEmails: { $in: body.removeApplicationEmails },
+          };
+        }
       }
 
       if (isEmpty(update)) {

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -15,6 +15,7 @@ const path = require("path");
 const EmailQueueModel = require("@models/EmailQueue");
 const EmailLogModel = require("@models/EmailLog");
 const AdminAlertCounterModel = require("@models/AdminAlertCounter");
+const ApplicationEmailConfigurationModel = require("@models/ApplicationEmailConfiguration");
 const { emailDeduplicator } = require("./email-deduplication.util");
 const {
   logObject,
@@ -169,6 +170,56 @@ const stopEmailQueue = () => {
     clearInterval(queueIntervalId);
     queueIntervalId = null;
     logger.info("Email queue processor has been stopped.");
+  }
+};
+
+// Cache for application email configs — keyed by tenant, 5-minute TTL.
+// Avoids a DB round-trip on every email send while staying reasonably fresh.
+const _appEmailConfigCache = new Map();
+const _APP_EMAIL_CONFIG_TTL_MS = 5 * 60 * 1000;
+
+const _getApplicationEmailConfig = async (tenant) => {
+  const cached = _appEmailConfigCache.get(tenant);
+  if (cached && Date.now() - cached.fetchedAt < _APP_EMAIL_CONFIG_TTL_MS) {
+    return cached.data;
+  }
+  try {
+    const config = await ApplicationEmailConfigurationModel(tenant)
+      .findOne({ tenant: tenant.toLowerCase() })
+      .lean();
+    _appEmailConfigCache.set(tenant, { data: config, fetchedAt: Date.now() });
+    return config;
+  } catch (error) {
+    logger.warn(
+      `Failed to fetch application email config for tenant ${tenant}: ${error.message}`
+    );
+    return null;
+  }
+};
+
+// Returns the adminCCEmails string if `email` is a registered application
+// email address, otherwise returns null.
+const _resolveAdminCCForApplicationEmail = async (email, tenant) => {
+  try {
+    const config = await _getApplicationEmailConfig(tenant);
+    if (
+      !config ||
+      !config.adminCCEmails ||
+      !Array.isArray(config.applicationEmails) ||
+      config.applicationEmails.length === 0
+    ) {
+      return null;
+    }
+    const normalized = email.toLowerCase().trim();
+    const isAppEmail = config.applicationEmails.some(
+      (e) => e.toLowerCase().trim() === normalized
+    );
+    return isAppEmail ? config.adminCCEmails : null;
+  } catch (error) {
+    logger.warn(
+      `Failed to resolve admin CC for ${email}: ${error.message}`
+    );
+    return null;
   }
 };
 
@@ -432,6 +483,27 @@ const createMailerFunction = (
       const mailOptions = customMailOptionsModifier
         ? customMailOptionsModifier(baseMailOptions, { email, ...otherParams })
         : baseMailOptions;
+
+      // ✅ STEP 4c-CC: If the recipient is a registered application email address,
+      // add admin CC so the right people are notified about system-generated emails
+      // (e.g. token expiry, security alerts) that would otherwise go unnoticed.
+      try {
+        const adminCC = await _resolveAdminCCForApplicationEmail(
+          mailOptions.to,
+          tenant
+        );
+        if (adminCC) {
+          mailOptions.cc = adminCC;
+          logger.info(
+            `Admin CC applied for application email ${mailOptions.to} on tenant ${tenant}`
+          );
+        }
+      } catch (ccError) {
+        // Non-fatal — proceed without CC rather than blocking the primary email.
+        logger.warn(
+          `Admin CC resolution failed for ${mailOptions.to}: ${ccError.message}`
+        );
+      }
 
       // ✅ STEP 4d: DB-backed deduplication check before queuing
       let emailResult;
@@ -1016,6 +1088,21 @@ const createSecurityEmailFunction = (
         html: emailMessageFunction({ email, ...otherParams }),
         attachments: attachments,
       };
+
+      // ✅ STEP 4-CC: Add admin CC for registered application email addresses.
+      try {
+        const adminCC = await _resolveAdminCCForApplicationEmail(email, tenant);
+        if (adminCC) {
+          baseMailOptions.cc = adminCC;
+          logger.info(
+            `Admin CC applied for application email ${email} on tenant ${tenant}`
+          );
+        }
+      } catch (ccError) {
+        logger.warn(
+          `Admin CC resolution failed for ${email}: ${ccError.message}`
+        );
+      }
 
       // ✅ STEP 5: DB-backed deduplication check before queuing
       let emailResult;

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -179,19 +179,20 @@ const _appEmailConfigCache = new Map();
 const _APP_EMAIL_CONFIG_TTL_MS = 5 * 60 * 1000;
 
 const _getApplicationEmailConfig = async (tenant) => {
-  const cached = _appEmailConfigCache.get(tenant);
+  const normalizedTenant = (tenant || "").toLowerCase();
+  const cached = _appEmailConfigCache.get(normalizedTenant);
   if (cached && Date.now() - cached.fetchedAt < _APP_EMAIL_CONFIG_TTL_MS) {
     return cached.data;
   }
   try {
-    const config = await ApplicationEmailConfigurationModel(tenant)
-      .findOne({ tenant: tenant.toLowerCase() })
+    const config = await ApplicationEmailConfigurationModel(normalizedTenant)
+      .findOne({ tenant: normalizedTenant })
       .lean();
-    _appEmailConfigCache.set(tenant, { data: config, fetchedAt: Date.now() });
+    _appEmailConfigCache.set(normalizedTenant, { data: config, fetchedAt: Date.now() });
     return config;
   } catch (error) {
     logger.warn(
-      `Failed to fetch application email config for tenant ${tenant}: ${error.message}`
+      `Failed to fetch application email config for tenant ${normalizedTenant}: ${error.message}`
     );
     return null;
   }
@@ -485,15 +486,22 @@ const createMailerFunction = (
         : baseMailOptions;
 
       // ✅ STEP 4c-CC: If the recipient is a registered application email address,
-      // add admin CC so the right people are notified about system-generated emails
-      // (e.g. token expiry, security alerts) that would otherwise go unnoticed.
+      // merge admin CC into any existing cc set by customMailOptionsModifier.
       try {
         const adminCC = await _resolveAdminCCForApplicationEmail(
           mailOptions.to,
           tenant
         );
         if (adminCC) {
-          mailOptions.cc = adminCC;
+          const existing = mailOptions.cc
+            ? (Array.isArray(mailOptions.cc)
+                ? mailOptions.cc
+                : String(mailOptions.cc).split(",").map((e) => e.trim())
+              ).filter(Boolean)
+            : [];
+          const incoming = adminCC.split(",").map((e) => e.trim()).filter(Boolean);
+          const merged = [...new Set([...existing, ...incoming])];
+          mailOptions.cc = merged.join(",");
           logger.info(
             `Admin CC applied for application email ${mailOptions.to} on tenant ${tenant}`
           );

--- a/src/auth-service/validators/application-email-config.validators.js
+++ b/src/auth-service/validators/application-email-config.validators.js
@@ -1,0 +1,128 @@
+const { query, body, param, oneOf } = require("express-validator");
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Types.ObjectId;
+const constants = require("@config/constants");
+
+const isValidEmail = (val) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val);
+
+const validateTenant = oneOf([
+  query("tenant")
+    .optional()
+    .notEmpty()
+    .withMessage("tenant should not be empty if provided")
+    .trim()
+    .toLowerCase()
+    .bail()
+    .isIn(constants.TENANTS)
+    .withMessage("the tenant value is not among the expected ones"),
+]);
+
+const validateIdParam = oneOf([
+  param("id")
+    .exists()
+    .withMessage("the id param is missing in the request")
+    .bail()
+    .notEmpty()
+    .withMessage("id cannot be empty")
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage("id must be an object ID")
+    .bail()
+    .customSanitizer((value) => ObjectId(value)),
+]);
+
+const list = [validateTenant];
+
+const create = [
+  validateTenant,
+  body("tenant")
+    .optional()
+    .trim()
+    .toLowerCase()
+    .isIn(constants.TENANTS || ["airqo", "kcca"])
+    .withMessage("the tenant value is not among the expected ones"),
+  body("adminCCEmails")
+    .exists()
+    .withMessage("adminCCEmails is required")
+    .bail()
+    .notEmpty()
+    .withMessage("adminCCEmails cannot be empty")
+    .bail()
+    .isString()
+    .withMessage("adminCCEmails must be a comma-separated string of email addresses")
+    .bail()
+    .custom((val) => {
+      const emails = val.split(",").map((e) => e.trim()).filter(Boolean);
+      if (emails.length === 0) throw new Error("adminCCEmails must contain at least one email");
+      if (!emails.every(isValidEmail))
+        throw new Error("One or more admin CC email addresses are invalid");
+      return true;
+    }),
+  body("applicationEmails")
+    .optional()
+    .isArray()
+    .withMessage("applicationEmails must be an array")
+    .bail()
+    .custom((emails) => {
+      if (!emails.every(isValidEmail))
+        throw new Error("One or more application email addresses are invalid");
+      return true;
+    }),
+];
+
+const update = [
+  validateTenant,
+  validateIdParam,
+  body("adminCCEmails")
+    .optional()
+    .isString()
+    .withMessage("adminCCEmails must be a comma-separated string")
+    .bail()
+    .custom((val) => {
+      if (!val) return true;
+      const emails = val.split(",").map((e) => e.trim()).filter(Boolean);
+      if (!emails.every(isValidEmail))
+        throw new Error("One or more admin CC email addresses are invalid");
+      return true;
+    }),
+  body("applicationEmails")
+    .optional()
+    .isArray()
+    .withMessage("applicationEmails must be an array")
+    .bail()
+    .custom((emails) => {
+      if (!emails.every(isValidEmail))
+        throw new Error("One or more application email addresses are invalid");
+      return true;
+    }),
+  body("addApplicationEmails")
+    .optional()
+    .isArray()
+    .withMessage("addApplicationEmails must be an array")
+    .bail()
+    .custom((emails) => {
+      if (!emails.every(isValidEmail))
+        throw new Error("One or more emails in addApplicationEmails are invalid");
+      return true;
+    }),
+  body("removeApplicationEmails")
+    .optional()
+    .isArray()
+    .withMessage("removeApplicationEmails must be an array")
+    .bail()
+    .custom((emails) => {
+      if (!emails.every(isValidEmail))
+        throw new Error("One or more emails in removeApplicationEmails are invalid");
+      return true;
+    }),
+];
+
+const deleteConfig = [validateTenant, validateIdParam];
+
+module.exports = {
+  list,
+  create,
+  update,
+  delete: deleteConfig,
+};


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Introduces a DB-backed `ApplicationEmailConfiguration` collection that stores two things per tenant: a list of email addresses belonging to application accounts, and a comma-separated list of admin emails to CC. Any system-generated email (token expiry, security alerts, etc.) whose recipient matches a registered application email automatically CCs the configured admins. A 5-minute in-memory cache avoids a DB round-trip on every send.

New CRUD API at `POST/GET/PUT/DELETE /api/v2/application-email-configs` allows admins to manage both the application email list and the CC list at runtime, with fine-grained options to append or remove individual emails without replacing the full list.

### Why is this change needed?

Several AirQo accounts belong to applications rather than real people. When system emails — such as API token expiry warnings or security compromise alerts — are sent to these inboxes, nobody sees them because no human monitors those addresses. This change ensures the right admins are automatically looped in without requiring any changes to how emails are sent today.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

The CC injection is fail-open at both injection points in `mailer.util.js`. If no `ApplicationEmailConfiguration` document exists for a tenant (the case for all existing tenants on deploy), `_resolveAdminCCForApplicationEmail` returns `null` and the email sends exactly as before — no CC, no change. If the DB lookup throws for any reason, the `try/catch` logs a warning and the primary email still goes out. Existing email flows are therefore unaffected until an admin explicitly creates a configuration.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The implementation is fully backward compatible. The new collection is additive, no existing models were changed, and both injection points in the mailer are fail-open by design. Deploying to production with no configuration created is equivalent to deploying nothing.

---

## :memo: Additional Notes

- The application email list is intentionally separate from the User model. Application accounts are set up as normal AirQo accounts with no distinguishing flag, so a side-maintained list is the correct mechanism to identify them.
- The in-memory cache has a 5-minute TTL per tenant. Adding a new application email to the config takes effect within 5 minutes of the update.
- `adminCCEmails` is a comma-separated string (e.g. `"admin1@airqo.net,admin2@airqo.net"`) consistent with how `HARDWARE_AND_DS_EMAILS` and `REQUEST_ACCESS_EMAILS` are handled elsewhere in the mailer.
- The `PUT /:id` endpoint supports three update modes in a single request: replace the full `applicationEmails` array, append via `addApplicationEmails`, or remove via `removeApplicationEmails`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email configuration management with per-tenant settings support.
  * Introduced admin CC email functionality for registered application email recipients.
  * Provided REST API endpoints to create, list, update, and delete application email configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->