### PR TITLE
fix: propagate rawOnlineStatus to sites for external API network devices

### DIFF
--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -500,6 +500,7 @@ const processIndividualDevice = async (
           "external_api_error",
           shouldMarkOfflineFromStaleData,
           hasExistingRawData,
+          siteDataMap,
         );
       }
     }
@@ -620,6 +621,7 @@ const processIndividualDevice = async (
         "decryption_failed",
         shouldMarkOfflineFromStaleData,
         hasExistingRawData,
+        siteDataMap,
       );
     }
     apiKey = decryptResponse.data;
@@ -632,6 +634,7 @@ const processIndividualDevice = async (
       "decryption_error",
       shouldMarkOfflineFromStaleData,
       hasExistingRawData,
+      siteDataMap,
     );
   }
 
@@ -801,6 +804,7 @@ const processIndividualDevice = async (
       "fetch_error",
       shouldMarkOfflineFromStaleData,
       hasExistingRawData,
+      siteDataMap,
     );
   }
 };
@@ -811,6 +815,7 @@ const createFailureUpdate = (
   reason,
   shouldMarkOfflineFromStaleData = false,
   hasExistingRawData = false,
+  siteDataMap = null,
 ) => {
   const isCurrentlyRawOnline = device.rawOnlineStatus;
   // Use stale data check to determine if should be offline
@@ -842,6 +847,18 @@ const createFailureUpdate = (
     updateDoc.$inc = incUpdate;
   }
 
+  const siteUpdates = [];
+  if (siteDataMap) {
+    // No lastFeedTime on failure — propagate only the online/offline decision
+    const siteStatusOp = buildSiteStatusUpdate(
+      device,
+      siteDataMap,
+      isNowRawOnline,
+      null,
+    );
+    if (siteStatusOp) siteUpdates.push(siteStatusOp);
+  }
+
   return {
     deviceUpdate: {
       updateOne: {
@@ -849,6 +866,7 @@ const createFailureUpdate = (
         update: updateDoc,
       },
     },
+    siteUpdates,
   };
 };
 

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -321,6 +321,44 @@ const processDeviceBatch = async (devices, processor) => {
   }
 };
 
+// Builds the rawOnlineStatus bulk-write op for a site driven by a primary device.
+// Returns a single updateOne op object, or null if the device is not eligible or
+// the site is not found in the pre-fetched siteDataMap.
+const buildSiteStatusUpdate = (device, siteDataMap, isRawOnline, lastFeedTime) => {
+  if (!device.site_id || !device.isPrimaryInLocation) return null;
+
+  const currentSite = siteDataMap.get(device.site_id.toString());
+  if (!currentSite) {
+    logger.warn(
+      `Site ${device.site_id} not found for device ${device.name}, skipping site update`,
+    );
+    return null;
+  }
+
+  const { setUpdate: siteSetUpdate, incUpdate: siteIncUpdate } =
+    getUptimeAccuracyUpdateObject({
+      isCurrentlyOnline: currentSite.rawOnlineStatus,
+      isNowOnline: isRawOnline,
+      currentStats: currentSite.onlineStatusAccuracy,
+      reason: isRawOnline ? "online_raw_site" : "offline_raw_site",
+    });
+
+  const siteUpdateFields = { rawOnlineStatus: isRawOnline };
+  if (lastFeedTime) {
+    siteUpdateFields.lastRawData = new Date(lastFeedTime);
+  }
+
+  return {
+    updateOne: {
+      filter: { _id: device.site_id },
+      update: {
+        $set: { ...siteUpdateFields, ...siteSetUpdate },
+        ...(siteIncUpdate && { $inc: siteIncUpdate }),
+      },
+    },
+  };
+};
+
 // Extracted individual device processing function - FIXED VERSION
 const processIndividualDevice = async (
   device,
@@ -435,6 +473,15 @@ const processIndividualDevice = async (
           updateDoc.$inc = incUpdate;
         }
 
+        const siteUpdates = [];
+        const siteStatusOp = buildSiteStatusUpdate(
+          device,
+          siteDataMap,
+          isRawOnline,
+          lastFeedTime,
+        );
+        if (siteStatusOp) siteUpdates.push(siteStatusOp);
+
         return {
           deviceUpdate: {
             updateOne: {
@@ -442,6 +489,7 @@ const processIndividualDevice = async (
               update: updateDoc,
             },
           },
+          siteUpdates,
         };
       } catch (externalError) {
         logger.error(
@@ -710,62 +758,32 @@ const processIndividualDevice = async (
       };
     }
 
-    // Prepare site update if PM2.5 is valid and device is primary for its site
+    // Build site rawOnlineStatus update (shared with external-API path)
     const siteUpdates = [];
-    if (device.site_id && device.isPrimaryInLocation) {
-      // Fetch current site to get its rawOnlineStatus for accuracy check
-      const currentSite = siteDataMap.get(device.site_id.toString());
-
-      if (!currentSite) {
-        logger.warn(
-          `Site ${device.site_id} not found for device ${device.name}, skipping site update`,
-        );
-      } else {
-        const {
-          setUpdate: siteSetUpdate,
-          incUpdate: siteIncUpdate,
-        } = getUptimeAccuracyUpdateObject({
-          isCurrentlyOnline: currentSite.rawOnlineStatus,
-          isNowOnline: isRawOnline,
-          currentStats: currentSite.onlineStatusAccuracy,
-          reason: isRawOnline ? "online_raw_site" : "offline_raw_site",
-        });
-
-        const siteUpdateFields = {
-          rawOnlineStatus: isRawOnline,
-        };
-        if (lastFeedTime) {
-          siteUpdateFields.lastRawData = new Date(lastFeedTime);
-        }
-
-        // Unconditional status update for the site
+    const siteStatusOp = buildSiteStatusUpdate(
+      device,
+      siteDataMap,
+      isRawOnline,
+      lastFeedTime,
+    );
+    if (siteStatusOp) {
+      siteUpdates.push(siteStatusOp);
+      // Conditional PM2.5 update for the site (ThingSpeak path only)
+      if (latestRawPm25) {
         siteUpdates.push({
           updateOne: {
-            filter: { _id: device.site_id },
+            filter: {
+              _id: device.site_id,
+              $or: [
+                { "latest_pm2_5.raw.time": { $lt: latestRawPm25.time } },
+                { "latest_pm2_5.raw.time": { $exists: false } },
+              ],
+            },
             update: {
-              $set: { ...siteUpdateFields, ...siteSetUpdate },
-              ...(siteIncUpdate && { $inc: siteIncUpdate }),
+              $set: { "latest_pm2_5.raw": latestRawPm25 },
             },
           },
         });
-
-        // Conditional PM2.5 update for the site
-        if (latestRawPm25) {
-          siteUpdates.push({
-            updateOne: {
-              filter: {
-                _id: device.site_id,
-                $or: [
-                  { "latest_pm2_5.raw.time": { $lt: latestRawPm25.time } },
-                  { "latest_pm2_5.raw.time": { $exists: false } },
-                ],
-              },
-              update: {
-                $set: { "latest_pm2_5.raw": latestRawPm25 },
-              },
-            },
-          });
-        }
       }
     }
 

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -594,6 +594,15 @@ const processIndividualDevice = async (
       updateDoc.$inc = incUpdate;
     }
 
+    const siteUpdates = [];
+    const siteStatusOp = buildSiteStatusUpdate(
+      device,
+      siteDataMap,
+      isNowRawOnline,
+      null,
+    );
+    if (siteStatusOp) siteUpdates.push(siteStatusOp);
+
     return {
       deviceUpdate: {
         updateOne: {
@@ -601,6 +610,7 @@ const processIndividualDevice = async (
           update: updateDoc,
         },
       },
+      siteUpdates,
     };
   }
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Extracts site `rawOnlineStatus` propagation into a shared helper (`buildSiteStatusUpdate`) and calls it from the external API code path inside `processIndividualDevice` in `update-raw-online-status-job.js`. Previously, only the ThingSpeak path (airqo devices) updated the parent site's `rawOnlineStatus` and `lastRawData`; the external API path (airgradient, iqair, and other non-airqo networks) returned early with no site update at all.

### Why is this change needed?
Sites whose only deployed device belongs to a non-airqo network (e.g. airgradient) permanently show **"Data Available"** (`isOnline: true`, `rawOnlineStatus: false`) even when the device is actively transmitting and correctly shows **"Operational"** (`isOnline: true`, `rawOnlineStatus: true`). The root cause is that `processIndividualDevice` has two code paths and the site-update block lived exclusively in the ThingSpeak path. Every external-API device silently skipped the site write, leaving `site.rawOnlineStatus = false` and `site.lastRawData = null` indefinitely.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/bin/jobs/update-raw-online-status-job.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Confirmed the bug via direct DB inspection of site `6a05bda30c37890013723d43` (Saint Louis, Ecole Goxu Mbacc 2): device `ag_168389` had `rawOnlineStatus: true` and `lastRawData: 2026-05-31T18:22:19Z` while the site had `rawOnlineStatus: false` and `lastRawData: null` despite the device having `isPrimaryInLocation: true` set for 17 days. The fix ensures the next job run at `:35` will write the correct `rawOnlineStatus` and `lastRawData` to the site document.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The ThingSpeak path is unchanged in behaviour; it now delegates the status-only op to `buildSiteStatusUpdate` and appends the ThingSpeak-specific conditional PM2.5 site update separately.
- The external API path now returns `siteUpdates` alongside `deviceUpdate`, matching the shape expected by `processDeviceBatch` which already handles `result.siteUpdates` via bulk write.
- No schema changes, no new dependencies.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated device and site status update logic for consistent handling of raw online status and PM2.5 across data sources.
* **Bug Fixes**
  * Prevented site updates when site data is missing and only set last-raw-data when a valid feed time exists.
  * Ensured failure handling can emit corresponding site updates based on computed online/offline decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->