### PR TITLE
fix: propagate device rawOnlineStatus to sites in raw online status job

### DIFF
--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -327,25 +327,33 @@ const processDeviceBatch = async (devices, processor) => {
 const buildSiteStatusUpdate = (device, siteDataMap, isRawOnline, lastFeedTime) => {
   if (!device.site_id || !device.isPrimaryInLocation) return null;
 
-  const currentSite = siteDataMap.get(device.site_id.toString());
+  const currentSite = siteDataMap
+    ? siteDataMap.get(device.site_id.toString())
+    : null;
+
   if (!currentSite) {
     logger.warn(
-      `Site ${device.site_id} not found for device ${device.name}, skipping site update`,
+      `Site ${device.site_id} not found in prefetch for device ${device.name}; ` +
+        `updating rawOnlineStatus without accuracy tracking`,
     );
-    return null;
   }
 
-  const { setUpdate: siteSetUpdate, incUpdate: siteIncUpdate } =
-    getUptimeAccuracyUpdateObject({
+  const siteUpdateFields = { rawOnlineStatus: isRawOnline };
+  if (lastFeedTime) {
+    siteUpdateFields.lastRawData = new Date(lastFeedTime);
+  }
+
+  let siteSetUpdate = {};
+  let siteIncUpdate = null;
+  if (currentSite) {
+    const accuracyResult = getUptimeAccuracyUpdateObject({
       isCurrentlyOnline: currentSite.rawOnlineStatus,
       isNowOnline: isRawOnline,
       currentStats: currentSite.onlineStatusAccuracy,
       reason: isRawOnline ? "online_raw_site" : "offline_raw_site",
     });
-
-  const siteUpdateFields = { rawOnlineStatus: isRawOnline };
-  if (lastFeedTime) {
-    siteUpdateFields.lastRawData = new Date(lastFeedTime);
+    siteSetUpdate = accuracyResult.setUpdate;
+    siteIncUpdate = accuracyResult.incUpdate;
   }
 
   return {

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -322,8 +322,11 @@ const processDeviceBatch = async (devices, processor) => {
 };
 
 // Builds the rawOnlineStatus bulk-write op for a site driven by a primary device.
-// Returns a single updateOne op object, or null if the device is not eligible or
-// the site is not found in the pre-fetched siteDataMap.
+// Returns a single updateOne op object, or null only when the device itself is
+// ineligible (missing site_id or isPrimaryInLocation is false).
+// When siteDataMap lacks the site entry, buildSiteStatusUpdate still emits a
+// site write op for rawOnlineStatus/lastRawData but skips accuracy tracking
+// (onlineStatusAccuracy counters) since the current site state is unavailable.
 const buildSiteStatusUpdate = (device, siteDataMap, isRawOnline, lastFeedTime) => {
   if (!device.site_id || !device.isPrimaryInLocation) return null;
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes `rawOnlineStatus` not being propagated from primary devices to their parent sites in `update-raw-online-status-job.js`. Introduces a shared `buildSiteStatusUpdate` helper and wires it into all four previously broken paths: the external API (airgradient) success path, the no-readKey ThingSpeak path, and all four `createFailureUpdate` call sites.

### Why is this change needed?
Sites with a deployed `isPrimaryInLocation: true` device were permanently stuck at `rawOnlineStatus: false` / `lastRawData: null` even when the device itself reported `rawOnlineStatus: true`. This caused sites to display as **"Data Available"** instead of **"Operational"** in the dashboard. Root causes:
1. The external API path returned `{ deviceUpdate }` only — no `siteUpdates`.
2. `createFailureUpdate` never built a site write op, so all failure paths (API error, decryption failure, fetch error) silently dropped the site update.
3. The no-readKey ThingSpeak path also skipped the site write.
4. `buildSiteStatusUpdate` returned `null` on a `siteDataMap` pre-fetch miss, silently dropping the entire site write even when the map was populated.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `bin/jobs/update-raw-online-status-job.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified against two affected devices (`ag_167976`, `ag_168389`) whose sites had `rawOnlineStatus: false` and `lastRawData: null` despite the device holding `rawOnlineStatus: true` and `isPrimaryInLocation: true`. Confirmed via DB field inspection that the `:35` job had never written to the site — `onlineStatusAccuracy.lastCheck` contained only `:45` timestamps (online-status job), never `:35` (raw-status job).

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `update-online-status-job.js` (`:45` job) is unaffected; `isOnline` propagation to sites was confirmed working correctly from observed data.
- `buildSiteStatusUpdate` now writes `rawOnlineStatus` and `lastRawData` unconditionally and only skips accuracy counter updates on a `siteDataMap` pre-fetch miss — ensuring the status write is never silently dropped.
- No changes were made to `activity.util.js` or any other file outside the raw online status job.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device status update reliability by ensuring updates are processed even when certain supporting data is temporarily unavailable.
  * Enhanced error logging to better diagnose status update issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->