### PR TITLE
fix: auto-assign primary device on deploy and add primary health check job

### DIFF
--- a/src/device-registry/bin/jobs/check-primary-device-job.js
+++ b/src/device-registry/bin/jobs/check-primary-device-job.js
@@ -1,0 +1,256 @@
+// src/device-registry/bin/jobs/check-primary-device-job.js
+//
+// Runs daily at 02:00 UTC. Finds all sites where no deployed device carries
+// isPrimaryInLocation: true and takes one of two actions:
+//
+//   1-device site  → auto-fix: set isPrimaryInLocation=true on that device so
+//                    update-raw-online-status-job can propagate rawOnlineStatus
+//                    to the site without any manual intervention.
+//
+//   Multi-device site → Slack alert listing the site and its devices so the
+//                       team can decide which device should be primary.
+//
+// Also detects sites where more than one device is primary and alerts, since
+// the system has no write-time guard against that condition.
+
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/check-primary-device-job -- ops-alerts`,
+);
+const { logText } = require("@utils/shared");
+const cron = require("node-cron");
+const DeviceModel = require("@models/Device");
+const crypto = require("crypto");
+const redisClient = require("@config/redis");
+
+const TENANT = constants.DEFAULT_TENANT || "airqo";
+const JOB_NAME = "check-primary-device-job";
+const JOB_SCHEDULE = "0 2 * * *"; // daily at 02:00 UTC
+
+const ENV_SLUG = (constants.ENVIRONMENT || "unknown")
+  .replace(/\s+/g, "_")
+  .toLowerCase();
+const LOCK_KEY = `${ENV_SLUG}:${JOB_NAME}:lock`;
+const LOCK_TTL_SECONDS = 3600;
+
+// ── Distributed lock ──────────────────────────────────────────────────────────
+
+let _lockToken = null;
+
+const RELEASE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end`;
+
+async function acquireJobLock() {
+  try {
+    if (!redisClient.redisUtils.isAvailable()) return true;
+    _lockToken = crypto.randomUUID();
+    const result = await redisClient.set(LOCK_KEY, _lockToken, {
+      NX: true,
+      EX: LOCK_TTL_SECONDS,
+    });
+    return result === "OK";
+  } catch (err) {
+    logger.warn(
+      `${JOB_NAME} -- could not acquire lock (${err.message}), proceeding without lock`,
+    );
+    return true;
+  }
+}
+
+async function releaseJobLock() {
+  try {
+    if (!redisClient.redisUtils.isAvailable()) return;
+    if (_lockToken) {
+      await redisClient.eval(RELEASE_SCRIPT, {
+        keys: [LOCK_KEY],
+        arguments: [_lockToken],
+      });
+      _lockToken = null;
+    }
+  } catch (err) {
+    logger.warn(`${JOB_NAME} -- could not release lock: ${err.message}`);
+  }
+}
+
+// ── Aggregation ───────────────────────────────────────────────────────────────
+
+async function findSitesWithPrimaryIssues() {
+  // Group all active, deployed devices with a site_id by site, collecting the
+  // list of device names and how many are primary.
+  const pipeline = [
+    {
+      $match: {
+        isActive: true,
+        status: "deployed",
+        site_id: { $exists: true, $ne: null },
+      },
+    },
+    {
+      $group: {
+        _id: "$site_id",
+        totalDevices: { $sum: 1 },
+        primaryCount: {
+          $sum: { $cond: [{ $eq: ["$isPrimaryInLocation", true] }, 1, 0] },
+        },
+        devices: {
+          $push: { name: "$name", isPrimary: "$isPrimaryInLocation", id: "$_id" },
+        },
+      },
+    },
+    {
+      $match: {
+        $or: [
+          { primaryCount: 0 },      // no primary — needs fix or alert
+          { primaryCount: { $gt: 1 } }, // multiple primaries — alert
+        ],
+      },
+    },
+  ];
+
+  return DeviceModel(TENANT)
+    .aggregate(pipeline)
+    .option({ maxTimeMS: 120000, allowDiskUse: true });
+}
+
+// ── Auto-fix: single-device sites ────────────────────────────────────────────
+
+async function autoFixSingleDeviceSites(noPrimarySites) {
+  const singleDeviceSites = noPrimarySites.filter((s) => s.totalDevices === 1);
+  if (singleDeviceSites.length === 0) return 0;
+
+  const bulkOps = singleDeviceSites.map((site) => ({
+    updateOne: {
+      filter: { _id: site.devices[0].id },
+      update: { $set: { isPrimaryInLocation: true } },
+    },
+  }));
+
+  const result = await DeviceModel(TENANT).bulkWrite(bulkOps, { ordered: false });
+  return result.modifiedCount;
+}
+
+// ── Slack message builders ────────────────────────────────────────────────────
+
+function buildNoPrimaryMultiDeviceMessage(sites, runAt) {
+  const dateStr = runAt.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+  const rows = sites
+    .map((s, i) => {
+      const deviceList = s.devices
+        .map((d) => d.name)
+        .join(", ");
+      return `  ${i + 1}. Site ${s._id} — ${s.totalDevices} devices: ${deviceList}`;
+    })
+    .join("\n");
+
+  return (
+    `⚠️ *Sites with no primary device (multiple devices)* — ${dateStr}\n` +
+    `${sites.length} site(s) have multiple deployed devices but none is marked isPrimaryInLocation=true.\n` +
+    `rawOnlineStatus will not propagate to these sites until a primary is assigned.\n` +
+    "```\n" +
+    rows +
+    "\n```\n" +
+    `Fix: PUT /api/v2/devices/{name}  →  { "isPrimaryInLocation": true }`
+  );
+}
+
+function buildMultiplePrimaryMessage(sites, runAt) {
+  const dateStr = runAt.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+  const rows = sites
+    .map((s, i) => {
+      const primaries = s.devices
+        .filter((d) => d.isPrimary)
+        .map((d) => d.name)
+        .join(", ");
+      return `  ${i + 1}. Site ${s._id} — ${s.primaryCount} primaries: ${primaries}`;
+    })
+    .join("\n");
+
+  return (
+    `⚠️ *Sites with multiple primary devices* — ${dateStr}\n` +
+    `${sites.length} site(s) have more than one device with isPrimaryInLocation=true.\n` +
+    `Only one primary is expected; this may cause duplicate site status updates.\n` +
+    "```\n" +
+    rows +
+    "\n```\n" +
+    `Fix: PUT /api/v2/devices/{name}  →  { "isPrimaryInLocation": false } on all but one.`
+  );
+}
+
+// ── Main job ──────────────────────────────────────────────────────────────────
+
+async function runCheckPrimaryDeviceJob() {
+  const acquired = await acquireJobLock();
+  if (!acquired) {
+    logText(`${JOB_NAME} -- lock held by another pod, skipping`);
+    return;
+  }
+
+  try {
+    logText(`${JOB_NAME} -- starting`);
+    const jobStart = Date.now();
+
+    const problemSites = await findSitesWithPrimaryIssues();
+
+    const noPrimarySites = problemSites.filter((s) => s.primaryCount === 0);
+    const multiPrimarySites = problemSites.filter((s) => s.primaryCount > 1);
+
+    const singleDeviceNoPrimary = noPrimarySites.filter((s) => s.totalDevices === 1);
+    const multiDeviceNoPrimary = noPrimarySites.filter((s) => s.totalDevices > 1);
+
+    // Auto-fix single-device sites
+    if (singleDeviceNoPrimary.length > 0) {
+      const fixed = await autoFixSingleDeviceSites(singleDeviceNoPrimary);
+      const deviceNames = singleDeviceNoPrimary
+        .map((s) => s.devices[0].name)
+        .join(", ");
+      logText(
+        `${JOB_NAME} -- auto-fixed ${fixed} single-device site(s): ${deviceNames}`,
+      );
+      logger.info(
+        `${JOB_NAME} -- auto-fixed isPrimaryInLocation=true on ${fixed} device(s): ${deviceNames}`,
+      );
+    }
+
+    const elapsed = ((Date.now() - jobStart) / 1000).toFixed(1);
+    logText(`${JOB_NAME} -- scan complete in ${elapsed}s`);
+
+    // Alert for multi-device sites with no primary
+    if (multiDeviceNoPrimary.length > 0) {
+      logger.warn(buildNoPrimaryMultiDeviceMessage(multiDeviceNoPrimary, new Date()));
+    }
+
+    // Alert for sites with multiple primaries
+    if (multiPrimarySites.length > 0) {
+      logger.warn(buildMultiplePrimaryMessage(multiPrimarySites, new Date()));
+    }
+
+    if (noPrimarySites.length === 0 && multiPrimarySites.length === 0) {
+      logText(`${JOB_NAME} -- all sites have exactly one primary device, no issues found`);
+    }
+  } catch (error) {
+    logger.error(`${JOB_NAME} -- unhandled error: ${error.message}`);
+  } finally {
+    await releaseJobLock();
+  }
+}
+
+// ── Schedule ──────────────────────────────────────────────────────────────────
+
+cron.schedule(
+  JOB_SCHEDULE,
+  () => {
+    runCheckPrimaryDeviceJob().catch((err) => {
+      logger.error(`${JOB_NAME} -- scheduler error: ${err.message}`);
+    });
+  },
+  { timezone: "UTC" },
+);
+
+logText(`${JOB_NAME} -- scheduled (${JOB_SCHEDULE})`);
+
+module.exports = { runCheckPrimaryDeviceJob };

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -168,6 +168,7 @@ require("@bin/jobs/check-network-status-job");
 require("@bin/jobs/check-unassigned-devices-job");
 require("@bin/jobs/check-active-statuses");
 require("@bin/jobs/check-unassigned-sites-job");
+require("@bin/jobs/check-primary-device-job");
 require("@bin/jobs/check-duplicate-site-fields-job");
 require("@bin/jobs/update-duplicate-site-fields-job");
 require("@bin/jobs/backfill-site-metadata-job");

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -168,7 +168,13 @@ require("@bin/jobs/check-network-status-job");
 require("@bin/jobs/check-unassigned-devices-job");
 require("@bin/jobs/check-active-statuses");
 require("@bin/jobs/check-unassigned-sites-job");
-require("@bin/jobs/check-primary-device-job");
+try {
+  require("@bin/jobs/check-primary-device-job");
+} catch (err) {
+  global.dedupLogger.error(
+    `check-primary-device-job failed to start: ${err.message}`,
+  );
+}
 require("@bin/jobs/check-duplicate-site-fields-job");
 require("@bin/jobs/update-duplicate-site-fields-job");
 require("@bin/jobs/backfill-site-metadata-job");

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -838,7 +838,30 @@ const createActivity = {
           deviceBody.body.height = height;
           deviceBody.body.mountType = mountType;
           deviceBody.body.powerType = powerType;
-          deviceBody.body.isPrimaryInLocation = isPrimaryInLocation;
+
+          // Auto-assign primary: if no deployed device at this site already holds
+          // isPrimaryInLocation=true, make this device the primary regardless of
+          // what the caller passed. This ensures every site always has exactly one
+          // primary device to drive rawOnlineStatus propagation.
+          let effectiveIsPrimary = isPrimaryInLocation;
+          if (!isPrimaryInLocation) {
+            try {
+              const existingPrimary = await DeviceModel(tenant)
+                .findOne({ site_id, isPrimaryInLocation: true, status: "deployed" })
+                .lean();
+              if (!existingPrimary) {
+                effectiveIsPrimary = true;
+                logger.info(
+                  `Auto-assigning isPrimaryInLocation=true to ${deviceName} — no primary device at site ${site_id}`,
+                );
+              }
+            } catch (primaryCheckErr) {
+              logger.error(
+                `Failed to check existing primary for site ${site_id}: ${primaryCheckErr.message}`,
+              );
+            }
+          }
+          deviceBody.body.isPrimaryInLocation = effectiveIsPrimary;
           deviceBody.body.deployment_type = "static";
           deviceBody.body.mobility = false;
           deviceBody.body.nextMaintenance = getNextMaintenanceDate(date, 3);
@@ -1899,6 +1922,34 @@ const createActivity = {
         gridMap.set(grid._id.toString(), grid);
       });
 
+      // Pre-fetch which site_ids already have a primary device so the Phase 4
+      // loop can auto-assign without an N+1 query per device.
+      const allStaticSiteIds = [];
+      for (const [, deployment] of deviceNameToDeployment) {
+        if (deployment.actualDeploymentType === "static") {
+          const coordsKey = `${Number(deployment.latitude)},${Number(deployment.longitude)}`;
+          const sid = siteMap.get(coordsKey);
+          if (sid) allStaticSiteIds.push(sid);
+        }
+      }
+      const sitesWithPrimary = new Set();
+      if (allStaticSiteIds.length > 0) {
+        try {
+          const primaries = await DeviceModel(tenant)
+            .find(
+              { site_id: { $in: allStaticSiteIds }, isPrimaryInLocation: true, status: "deployed" },
+              { site_id: 1 },
+            )
+            .lean();
+          primaries.forEach((d) => sitesWithPrimary.add(d.site_id.toString()));
+        } catch (err) {
+          logger.error(`Failed to pre-fetch primary devices for bulk deploy: ${err.message}`);
+        }
+      }
+      // Tracks which sites have been assigned a primary within this batch so
+      // only the first device per site gets the auto-assigned flag.
+      const batchPrimaryAssigned = new Set();
+
       // PHASE 4: Prepare bulk operations
       for (const [deviceName, deployment] of deviceNameToDeployment) {
         const {
@@ -1986,6 +2037,19 @@ const createActivity = {
               nextMaintenance: getNextMaintenanceDate(date, 3),
             });
 
+            // Auto-assign primary: if this site has no existing primary and no
+            // earlier device in this batch was already assigned as primary, make
+            // this device primary regardless of the caller-supplied value.
+            const siteIdStr = site_id.toString();
+            let effectiveBulkIsPrimary = isPrimaryInLocation;
+            if (!isPrimaryInLocation && !sitesWithPrimary.has(siteIdStr) && !batchPrimaryAssigned.has(siteIdStr)) {
+              effectiveBulkIsPrimary = true;
+              batchPrimaryAssigned.add(siteIdStr);
+              logger.info(
+                `Auto-assigning isPrimaryInLocation=true to ${deviceName} (bulk) — no primary at site ${siteIdStr}`,
+              );
+            }
+
             // Device bulk update
             deviceBulkOps.push({
               updateOne: {
@@ -1995,7 +2059,7 @@ const createActivity = {
                     height,
                     mountType,
                     powerType,
-                    isPrimaryInLocation,
+                    isPrimaryInLocation: effectiveBulkIsPrimary,
                     deployment_type: "static",
                     mobility: false,
                     nextMaintenance: getNextMaintenanceDate(date, 3),

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -839,10 +839,11 @@ const createActivity = {
           deviceBody.body.mountType = mountType;
           deviceBody.body.powerType = powerType;
 
-          // Auto-assign primary: if no deployed device at this site already holds
+          // Best-effort auto-assign primary: if no deployed device at this site already holds
           // isPrimaryInLocation=true, make this device the primary regardless of
-          // what the caller passed. This ensures every site always has exactly one
-          // primary device to drive rawOnlineStatus propagation.
+          // what the caller passed. This helps ensure each site has a primary device
+          // to drive rawOnlineStatus propagation, but cannot guarantee uniqueness
+          // under concurrent deployments or DB errors.
           let effectiveIsPrimary = isPrimaryInLocation;
           if (!isPrimaryInLocation) {
             try {
@@ -1925,11 +1926,18 @@ const createActivity = {
       // Pre-fetch which site_ids already have a primary device so the Phase 4
       // loop can auto-assign without an N+1 query per device.
       const allStaticSiteIds = [];
+      const _seenSiteIds = new Set();
       for (const [, deployment] of deviceNameToDeployment) {
         if (deployment.actualDeploymentType === "static") {
           const coordsKey = `${Number(deployment.latitude)},${Number(deployment.longitude)}`;
           const sid = siteMap.get(coordsKey);
-          if (sid) allStaticSiteIds.push(sid);
+          if (sid) {
+            const sidStr = sid.toString();
+            if (!_seenSiteIds.has(sidStr)) {
+              _seenSiteIds.add(sidStr);
+              allStaticSiteIds.push(sid);
+            }
+          }
         }
       }
       const sitesWithPrimary = new Set();

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -2049,6 +2049,11 @@ const createActivity = {
             // earlier device in this batch was already assigned as primary, make
             // this device primary regardless of the caller-supplied value.
             const siteIdStr = site_id.toString();
+            // Record caller-selected primaries first so later items in the same
+            // batch for the same site are not also auto-promoted.
+            if (isPrimaryInLocation) {
+              batchPrimaryAssigned.add(siteIdStr);
+            }
             let effectiveBulkIsPrimary = isPrimaryInLocation;
             if (!isPrimaryInLocation && !sitesWithPrimary.has(siteIdStr) && !batchPrimaryAssigned.has(siteIdStr)) {
               effectiveBulkIsPrimary = true;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Introduces automatic assignment of `isPrimaryInLocation: true` during device deployment when no primary device already exists at the target site. Adds a new daily job (`check-primary-device-job`) that scans all sites for primary-device anomalies, auto-fixes single-device sites where the device is not primary, and sends Slack alerts for multi-device sites with no primary and for sites with more than one primary device.

### Why is this change needed?
`update-raw-online-status-job` propagates `rawOnlineStatus` from device to site only for devices with `isPrimaryInLocation: true`. Devices deployed without this flag set leave their site permanently stuck at `rawOnlineStatus: false` / `lastRawData: null`, causing the site to display as **"Data Available"** instead of **"Operational"** even when the device is fully live. The system had no write-time guard and no automated mechanism to detect or correct this condition. This PR removes the need for manual `isPrimaryInLocation` metadata updates for both new and existing deployments.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `utils/activity.util.js` (`_deployStatic`, `bulkDeploymentFunction`)
- `device-registry` — `bin/jobs/check-primary-device-job.js` (new)
- `device-registry` — `bin/server.js` (job registration)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Confirmed against device `ag_74569` (site `6a05a5791ff6660013b69b3b`) which had `isPrimaryInLocation: false` as the sole deployed device, causing `rawOnlineStatus: false` and `lastRawData: null` on the site despite the device being live. The auto-assign logic in `_deployStatic` was verified against the deployment code path; the daily job's auto-fix covers existing devices in this state without requiring a re-deployment.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The auto-assign logic only activates when `isPrimaryInLocation` is falsy and no existing primary is found at the site. If a primary already exists, the caller-supplied value is used unchanged, preserving all existing behaviour.

---

## :memo: Additional Notes

- **No write-time guard against multiple primaries exists** in the current schema — `isPrimaryInLocation` is a plain boolean with no uniqueness constraint. The new job detects this condition and sends a Slack alert but does not auto-resolve it, since the correct choice of primary requires human judgement when multiple devices are deployed.
- The bulk deployment path (`bulkDeploymentFunction`) pre-fetches all site primaries in a single query before the Phase 4 loop to avoid N+1 queries; a per-batch tracker ensures only one device per site is auto-promoted within the same batch.
- The daily job runs at **02:00 UTC** with a Redis distributed lock so it is safe across multi-pod deployments.
- These changes complement the previously merged `fix-raw-site` PR (which fixed `rawOnlineStatus` propagation paths in `update-raw-online-status-job`). Both PRs are required for complete resolution.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated daily monitoring to ensure every site has exactly one primary device.
  * Auto-assigns primary device status when deploying to sites without one.

* **Bug Fixes**
  * Single-device sites missing primary status are now auto-corrected.
  * Alerts generated for sites with multiple or missing primary devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->