### PR TITLE
fix: guard undefined response in create-cohort-util on duplicate name

### DIFF
--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -68,6 +68,10 @@ const createCohort = {
 
       logObject("responseFromRegisterCohort", responseFromRegisterCohort);
 
+      if (!responseFromRegisterCohort) {
+        return;
+      }
+
       if (responseFromRegisterCohort.success === true) {
         try {
           const kafkaProducer = kafka.producer();


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Guards against an `undefined` response in `create-cohort-util` after `CohortModel.register` calls `next(error)` on a validation failure (e.g. duplicate cohort name), preventing a secondary crash when accessing `.success` on the undefined return value.

### Why is this change needed?
When a duplicate cohort name is submitted, `CohortModel.register` correctly forwards the error via `next(error)` but returns `undefined` implicitly. The calling code in `cohort.util.js` then tried to read `.success` off that `undefined`, causing a secondary `Internal Server Error: Cannot read properties of undefined (reading 'success')` — masking the real validation error in logs and producing a confusing error response.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `utils/cohort.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Reproduced the duplicate-name request on staging; confirmed the primary validation error is now surfaced cleanly with no secondary `Cannot read properties of undefined` crash in logs.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The fix is a one-line early return in `cohort.util.js` (`create` function). When `register` returns `undefined` (because `next` was already called with the error), the util simply returns without further processing — the error is already in Express's error pipeline.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during cohort registration to prevent processing failures when registration responses are invalid or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->