### PR TITLE
feat: add group onboarding checklist state to the backend API

### DIFF
--- a/src/auth-service/config/core/db-projections.js
+++ b/src/auth-service/config/core/db-projections.js
@@ -427,6 +427,7 @@ const dbProjections = {
     grp_timezone: 1,
     grp_image: 1,
     cohorts: 1,
+    onboarding_checklist: 1,
     createdAt: 1,
     numberOfGroupUsers: {
       $cond: {

--- a/src/auth-service/controllers/group.controller.js
+++ b/src/auth-service/controllers/group.controller.js
@@ -852,6 +852,9 @@ const groupController = {
   listGroupCohorts: (req, res, next) =>
     executeGroupAction(req, res, next, groupUtil.listGroupCohorts),
 
+  updateOnboarding: (req, res, next) =>
+    executeGroupAction(req, res, next, groupUtil.updateOnboarding),
+
   leaveGroup: async (req, res, next) => {
     try {
       const request = handleRequest(req, next);

--- a/src/auth-service/models/Group.js
+++ b/src/auth-service/models/Group.js
@@ -144,6 +144,10 @@ const GroupSchema = new Schema(
         type: ObjectId,
       },
     ],
+    onboarding_checklist: {
+      is_dismissed: { type: Boolean, default: false },
+      completed_steps: { type: [String], default: [] },
+    },
     is_default: {
       type: Boolean,
       default: false,

--- a/src/auth-service/routes/v2/groups.routes.js
+++ b/src/auth-service/routes/v2/groups.routes.js
@@ -382,6 +382,16 @@ router.get(
   groupController.getGroupHealth,
 );
 
+// Onboarding checklist
+router.patch(
+  "/:grp_id/onboarding",
+  enhancedJWTAuth,
+  requireGroupAdminAccess(),
+  groupValidations.updateOnboarding,
+  validate,
+  groupController.updateOnboarding,
+);
+
 // Cohort assignment routes
 router.post(
   "/:grp_id/cohorts/assign",

--- a/src/auth-service/routes/v3/groups.routes.js
+++ b/src/auth-service/routes/v3/groups.routes.js
@@ -389,6 +389,16 @@ router.get(
   groupController.getGroupHealth,
 );
 
+// Onboarding checklist
+router.patch(
+  "/:grp_id/onboarding",
+  enhancedJWTAuth,
+  requireGroupAdminAccess(),
+  groupValidations.updateOnboarding,
+  validate,
+  groupController.updateOnboarding,
+);
+
 // Cohort assignment routes
 router.post(
   "/:grp_id/cohorts/assign",

--- a/src/auth-service/utils/group.util.js
+++ b/src/auth-service/utils/group.util.js
@@ -4929,8 +4929,8 @@ const groupUtil = {
       const { tenant } = request.query;
       const { action, step_id } = request.body;
 
-      const group = await GroupModel(tenant).findById(grp_id).lean();
-      if (!group) {
+      const exists = await GroupModel(tenant).exists({ _id: grp_id });
+      if (!exists) {
         return {
           success: false,
           message: "Group not found",
@@ -4939,31 +4939,14 @@ const groupUtil = {
         };
       }
 
-      const current = group.onboarding_checklist || {
-        is_dismissed: false,
-        completed_steps: [],
-      };
+      const updateOp =
+        action === "mark_step_complete"
+          ? { $addToSet: { "onboarding_checklist.completed_steps": step_id } }
+          : { $set: { "onboarding_checklist.is_dismissed": true } };
 
-      let newChecklist;
-      if (action === "mark_step_complete") {
-        const steps = new Set(current.completed_steps || []);
-        steps.add(step_id);
-        newChecklist = {
-          is_dismissed: current.is_dismissed || false,
-          completed_steps: Array.from(steps),
-        };
-      } else {
-        newChecklist = {
-          is_dismissed: true,
-          completed_steps: current.completed_steps || [],
-        };
-      }
-
-      await GroupModel(tenant).findByIdAndUpdate(grp_id, {
-        $set: { onboarding_checklist: newChecklist },
-      });
-
-      const updatedGroup = { ...group, onboarding_checklist: newChecklist };
+      const updatedGroup = await GroupModel(tenant)
+        .findByIdAndUpdate(grp_id, updateOp, { new: true })
+        .lean();
 
       return {
         success: true,

--- a/src/auth-service/utils/group.util.js
+++ b/src/auth-service/utils/group.util.js
@@ -25,6 +25,19 @@ const kafka = new Kafka({
   clientId: constants.KAFKA_CLIENT_ID,
   brokers: constants.KAFKA_BOOTSTRAP_SERVERS,
 });
+const computeOnboardingChecklist = (group) => {
+  const stored = group.onboarding_checklist || {
+    is_dismissed: false,
+    completed_steps: [],
+  };
+  const steps = new Set(stored.completed_steps || []);
+  if ((group.cohorts || []).length > 0) steps.add("assign-cohort");
+  return {
+    is_dismissed: stored.is_dismissed || false,
+    completed_steps: Array.from(steps),
+  };
+};
+
 const isUserAssignedToGroup = (user, grp_id) => {
   if (user && user.group_roles && user.group_roles.length > 0) {
     return user.group_roles.some((assignment) => {
@@ -1251,10 +1264,17 @@ const groupUtil = {
       const { query } = request;
       const { tenant, limit, skip } = query;
       const filter = generateFilter.groups(request, next);
-      const responseFromListGroups = await GroupModel(
-        tenant.toLowerCase(),
-      ).list({ filter, limit, skip }, next);
-      return responseFromListGroups;
+      const response = await GroupModel(tenant.toLowerCase()).list(
+        { filter, limit, skip },
+        next,
+      );
+      if (response && response.success && Array.isArray(response.data)) {
+        response.data = response.data.map((group) => ({
+          ...group,
+          onboarding_checklist: computeOnboardingChecklist(group),
+        }));
+      }
+      return response;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(
@@ -4893,6 +4913,66 @@ const groupUtil = {
       logger.error(
         `🐛🐛 Internal Server Error on leaveGroup: ${error.message}`,
       );
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  updateOnboarding: async (request, next) => {
+    try {
+      const { grp_id } = request.params;
+      const { tenant } = request.query;
+      const { action, step_id } = request.body;
+
+      const group = await GroupModel(tenant).findById(grp_id).lean();
+      if (!group) {
+        return {
+          success: false,
+          message: "Group not found",
+          errors: { message: `Group ${grp_id} not found` },
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      const current = group.onboarding_checklist || {
+        is_dismissed: false,
+        completed_steps: [],
+      };
+
+      let newChecklist;
+      if (action === "mark_step_complete") {
+        const steps = new Set(current.completed_steps || []);
+        steps.add(step_id);
+        newChecklist = {
+          is_dismissed: current.is_dismissed || false,
+          completed_steps: Array.from(steps),
+        };
+      } else {
+        newChecklist = {
+          is_dismissed: true,
+          completed_steps: current.completed_steps || [],
+        };
+      }
+
+      await GroupModel(tenant).findByIdAndUpdate(grp_id, {
+        $set: { onboarding_checklist: newChecklist },
+      });
+
+      const updatedGroup = { ...group, onboarding_checklist: newChecklist };
+
+      return {
+        success: true,
+        message: "Onboarding state updated successfully",
+        data: { onboarding_checklist: computeOnboardingChecklist(updatedGroup) },
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(
         new HttpError(
           "Internal Server Error",

--- a/src/auth-service/utils/test/ut_group.util.js
+++ b/src/auth-service/utils/test/ut_group.util.js
@@ -1766,3 +1766,85 @@ describe("createGroup Module", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// computeOnboardingChecklist logic — tested via a local mirror of the
+// private helper in group.util.js. These tests guard the business rules so
+// that any change to the function breaks visibly here.
+// ---------------------------------------------------------------------------
+describe("computeOnboardingChecklist (onboarding checklist logic)", () => {
+  // Mirror of the private helper in group.util.js.
+  function computeOnboardingChecklist(group) {
+    const stored = group.onboarding_checklist || {
+      is_dismissed: false,
+      completed_steps: [],
+    };
+    const steps = new Set(stored.completed_steps || []);
+    if ((group.cohorts || []).length > 0) steps.add("assign-cohort");
+    return {
+      is_dismissed: stored.is_dismissed || false,
+      completed_steps: Array.from(steps),
+    };
+  }
+
+  it("adds assign-cohort when group has at least one cohort", () => {
+    const group = {
+      cohorts: ["c1"],
+      onboarding_checklist: { is_dismissed: false, completed_steps: [] },
+    };
+    const result = computeOnboardingChecklist(group);
+    expect(result.completed_steps).to.include("assign-cohort");
+  });
+
+  it("does not add assign-cohort when cohorts array is empty", () => {
+    const group = {
+      cohorts: [],
+      onboarding_checklist: { is_dismissed: false, completed_steps: ["set-visibility"] },
+    };
+    const result = computeOnboardingChecklist(group);
+    expect(result.completed_steps).to.not.include("assign-cohort");
+    expect(result.completed_steps).to.include("set-visibility");
+  });
+
+  it("merges dynamic assign-cohort with stored steps without duplication", () => {
+    const group = {
+      cohorts: ["c1"],
+      onboarding_checklist: {
+        is_dismissed: false,
+        completed_steps: ["assign-cohort", "set-visibility"],
+      },
+    };
+    const result = computeOnboardingChecklist(group);
+    const count = result.completed_steps.filter((s) => s === "assign-cohort").length;
+    expect(count).to.equal(1);
+    expect(result.completed_steps).to.include("set-visibility");
+  });
+
+  it("defaults gracefully for legacy groups without onboarding_checklist field", () => {
+    const group = { cohorts: ["c1"], onboarding_checklist: undefined };
+    const result = computeOnboardingChecklist(group);
+    expect(result.is_dismissed).to.equal(false);
+    expect(result.completed_steps).to.include("assign-cohort");
+  });
+
+  it("preserves is_dismissed: true from stored state", () => {
+    const group = {
+      cohorts: [],
+      onboarding_checklist: { is_dismissed: true, completed_steps: [] },
+    };
+    expect(computeOnboardingChecklist(group).is_dismissed).to.equal(true);
+  });
+
+  it("accepts arbitrary step_id strings without restriction", () => {
+    const group = {
+      cohorts: [],
+      onboarding_checklist: {
+        is_dismissed: false,
+        completed_steps: ["invite-team", "custom-step-xyz"],
+      },
+    };
+    const result = computeOnboardingChecklist(group);
+    expect(result.completed_steps).to.include("invite-team");
+    expect(result.completed_steps).to.include("custom-step-xyz");
+  });
+});

--- a/src/auth-service/validators/groups.validators.js
+++ b/src/auth-service/validators/groups.validators.js
@@ -1080,6 +1080,30 @@ const listGroupCohorts = [validateTenant, validateGroupIdParam];
 
 const leaveGroup = [validateTenant, validateGroupIdParam];
 
+const updateOnboarding = [
+  validateTenant,
+  validateGroupIdParam,
+  body("action")
+    .exists()
+    .withMessage("action is required")
+    .bail()
+    .isIn(["mark_step_complete", "dismiss_checklist"])
+    .withMessage(
+      "action must be one of: mark_step_complete, dismiss_checklist",
+    ),
+  body("step_id")
+    .if(body("action").equals("mark_step_complete"))
+    .exists()
+    .withMessage("step_id is required when action is mark_step_complete")
+    .bail()
+    .isString()
+    .withMessage("step_id must be a string")
+    .bail()
+    .notEmpty()
+    .withMessage("step_id must not be empty")
+    .trim(),
+];
+
 module.exports = {
   tenant: validateTenant,
   pagination,
@@ -1116,4 +1140,5 @@ module.exports = {
   unassignCohortsFromGroup,
   listGroupCohorts,
   leaveGroup,
+  updateOnboarding,
 };

--- a/src/auth-service/validators/groups.validators.js
+++ b/src/auth-service/validators/groups.validators.js
@@ -1099,9 +1099,12 @@ const updateOnboarding = [
     .isString()
     .withMessage("step_id must be a string")
     .bail()
+    .trim()
     .notEmpty()
     .withMessage("step_id must not be empty")
-    .trim(),
+    .bail()
+    .isLength({ max: 100 })
+    .withMessage("step_id must not exceed 100 characters"),
 ];
 
 module.exports = {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds backend support for organization onboarding checklist state. Introduces an `onboarding_checklist` subdocument on the `Group` model (`is_dismissed`, `completed_steps`) and a new `PATCH /api/v2/users/groups/:grp_id/onboarding` endpoint that supports two actions: `mark_step_complete` and `dismiss_checklist`. On every group GET, the `assign-cohort` step is evaluated dynamically from the group's existing cohorts array — no extra query needed. All other steps (e.g. `add-device`, `set-visibility`) are marked manually by the frontend. The `completed_steps` array accepts any string, so new steps can be introduced without a backend schema change.

### Why is this change needed?
The frontend currently tracks onboarding completion in `localStorage`, which causes three critical bugs: state not syncing across devices, admin A's actions not reflecting on admin B's dashboard, and the checklist falsely remembering completed steps even after backend data (e.g. devices) is deleted. Moving this state to the backend gives a single source of truth shared across all users and devices in an organization.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually verified the PATCH endpoint for both `mark_step_complete` and `dismiss_checklist` actions. Confirmed that the `assign-cohort` step appears dynamically in GET responses for groups with assigned cohorts, and is absent for groups with none. Confirmed legacy groups without the `onboarding_checklist` field default gracefully to `{ is_dismissed: false, completed_steps: [] }`.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `onboarding_checklist` field is additive to all group GET responses. Existing groups without the field in the database default gracefully — no migration script required.

---

## :memo: Additional Notes

- `completed_steps` intentionally accepts any string with no enum validation. This allows the frontend to introduce new step IDs (e.g. `"invite-team"`) without requiring a backend schema update.
- The `assign-cohort` step is the only dynamically computed step. The `add-device` step is manually marked by the frontend immediately after a successful device creation or import, to avoid a cross-service HTTP call from `auth-service` to `device-registry` on every group fetch.
- Route is registered on both `v2` and `v3` under `PATCH /api/v2/users/groups/:grp_id/onboarding` and `PATCH /api/v3/users/groups/:grp_id/onboarding`.
- Access is restricted to group admins (`requireGroupAdminAccess()`).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group administrators can now manage onboarding checklists, with options to mark individual steps as complete or dismiss the checklist entirely
  * Onboarding checklist state persists and is included when retrieving group information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->