### PR TITLE
fix: OAuth redirects now respect exact paths from redirect_after parameter

### DIFF
--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -70,6 +70,39 @@ function validateRedirectUrl(raw) {
   }
 }
 
+function resolveOAuthRedirectContext(req, res) {
+  const rawRedirectUrl =
+    (req.cookies && req.cookies["_oauth_redirect_after"]) ||
+    (req.session && req.session.oauthRedirectAfter) ||
+    null;
+  const validatedUrl = validateRedirectUrl(rawRedirectUrl);
+  if (req.cookies && req.cookies["_oauth_redirect_after"]) {
+    const clearOpts = { path: "/" };
+    if (constants.OAUTH_COOKIE_DOMAIN) clearOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
+    res.clearCookie("_oauth_redirect_after", clearOpts);
+  }
+  if (req.session) delete req.session.oauthRedirectAfter;
+  let redirectOrigin = null;
+  if (validatedUrl) { try { redirectOrigin = new URL(validatedUrl).origin; } catch {} }
+  const failureRedirectUrl = redirectOrigin
+    ? `${redirectOrigin}/login?error=oauth_failed`
+    : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
+  return { validatedUrl, redirectOrigin, failureRedirectUrl };
+}
+
+function buildSuccessRedirectUrl(base, successParam, token) {
+  try {
+    const url = new URL(base);
+    url.searchParams.set("success", successParam);
+    url.hash = `token=${encodeURIComponent(token)}`;
+    return url.toString();
+  } catch {
+    // Fallback for relative paths (e.g. when GMAIL_VERIFICATION_SUCCESS_REDIRECT is unset)
+    const sep = base.includes("?") ? "&" : "?";
+    return `${base}${sep}success=${encodeURIComponent(successParam)}#token=${encodeURIComponent(token)}`;
+  }
+}
+
 const sendResponse = (res, result, dataKey = "data") => {
   if (isEmpty(result) || res.headersSent) {
     return;
@@ -182,24 +215,7 @@ const userController = {
       const request = handleRequest(req, next);
       if (!request) return;
 
-      // Resolve and validate the full redirect URL early so every branch —
-      // failure and success — routes back to the originating app and path.
-      const rawRedirectUrl =
-        (req.cookies && req.cookies["_oauth_redirect_after"]) ||
-        (req.session && req.session.oauthRedirectAfter) ||
-        null;
-      const validatedUrl = validateRedirectUrl(rawRedirectUrl);
-      if (req.cookies && req.cookies["_oauth_redirect_after"]) {
-        const clearOpts = { path: "/" };
-        if (constants.OAUTH_COOKIE_DOMAIN) clearOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
-        res.clearCookie("_oauth_redirect_after", clearOpts);
-      }
-      if (req.session) delete req.session.oauthRedirectAfter;
-      let redirectOrigin = null;
-      if (validatedUrl) { try { redirectOrigin = new URL(validatedUrl).origin; } catch {} }
-      const failureRedirectUrl = redirectOrigin
-        ? `${redirectOrigin}/login?error=oauth_failed`
-        : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
+      const { validatedUrl, failureRedirectUrl } = resolveOAuthRedirectContext(req, res);
 
       // Guard: req.user must be set by Passport before this controller runs.
       // If it is missing, Passport failed silently or the middleware chain
@@ -265,14 +281,10 @@ const userController = {
         }
       })();
 
-      // Use the exact path from redirect_after for custom origins; fall back
-      // to the default analytics success path when no redirect_after was given.
       const baseRedirect = validatedUrl
         ? validatedUrl.replace(/\/$/, "")
         : (constants.GMAIL_VERIFICATION_SUCCESS_REDIRECT || "").replace(/\/$/, "") + "/user/home";
-      res.redirect(
-        `${baseRedirect}?success=google#token=${encodeURIComponent(token)}`,
-      );
+      res.redirect(buildSuccessRedirectUrl(baseRedirect, "google", token));
     } catch (error) {
       handleError(error, next);
     }
@@ -292,24 +304,7 @@ const userController = {
       const request = handleRequest(req, next);
       if (!request) return;
 
-      // Resolve and validate the full redirect URL early so every branch —
-      // failure and success — routes back to the originating app and path.
-      const rawRedirectUrl =
-        (req.cookies && req.cookies["_oauth_redirect_after"]) ||
-        (req.session && req.session.oauthRedirectAfter) ||
-        null;
-      const validatedUrl = validateRedirectUrl(rawRedirectUrl);
-      if (req.cookies && req.cookies["_oauth_redirect_after"]) {
-        const clearOpts = { path: "/" };
-        if (constants.OAUTH_COOKIE_DOMAIN) clearOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
-        res.clearCookie("_oauth_redirect_after", clearOpts);
-      }
-      if (req.session) delete req.session.oauthRedirectAfter;
-      let redirectOrigin = null;
-      if (validatedUrl) { try { redirectOrigin = new URL(validatedUrl).origin; } catch {} }
-      const failureRedirectUrl = redirectOrigin
-        ? `${redirectOrigin}/login?error=oauth_failed`
-        : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
+      const { validatedUrl, failureRedirectUrl } = resolveOAuthRedirectContext(req, res);
 
       if (!req.user) {
         logger.error("oauthCallback: req.user is not set after passport auth");
@@ -382,14 +377,10 @@ const userController = {
         }
       })();
 
-      // Use the exact path from redirect_after for custom origins; fall back
-      // to the default analytics success path when no redirect_after was given.
       const baseRedirect = validatedUrl
         ? validatedUrl.replace(/\/$/, "")
         : (constants.GMAIL_VERIFICATION_SUCCESS_REDIRECT || "").replace(/\/$/, "") + "/user/home";
-      return res.redirect(
-        `${baseRedirect}?success=${encodeURIComponent(providerForLog)}#token=${encodeURIComponent(token)}`,
-      );
+      return res.redirect(buildSuccessRedirectUrl(baseRedirect, providerForLog, token));
     } catch (error) {
       handleError(error, next);
     }

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -45,7 +45,7 @@ const handleError = (error, next) => {
   );
 };
 
-function validateRedirectOrigin(raw) {
+function validateRedirectUrl(raw) {
   if (!raw || typeof raw !== "string") return null;
   try {
     const origin = new URL(raw).origin;
@@ -64,7 +64,7 @@ function validateRedirectOrigin(raw) {
       allowed.add("http://localhost:3000");
       allowed.add("http://localhost:5000");
     }
-    return allowed.has(origin) ? origin : null;
+    return allowed.has(origin) ? raw : null;
   } catch {
     return null;
   }
@@ -182,22 +182,24 @@ const userController = {
       const request = handleRequest(req, next);
       if (!request) return;
 
-      // Resolve and validate redirect origin early so every branch —
-      // failure and success — routes back to the originating app.
-      const rawRedirectOrigin =
+      // Resolve and validate the full redirect URL early so every branch —
+      // failure and success — routes back to the originating app and path.
+      const rawRedirectUrl =
         (req.cookies && req.cookies["_oauth_redirect_after"]) ||
         (req.session && req.session.oauthRedirectAfter) ||
         null;
-      const validatedOrigin = validateRedirectOrigin(rawRedirectOrigin);
+      const validatedUrl = validateRedirectUrl(rawRedirectUrl);
       if (req.cookies && req.cookies["_oauth_redirect_after"]) {
         const clearOpts = { path: "/" };
         if (constants.OAUTH_COOKIE_DOMAIN) clearOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
         res.clearCookie("_oauth_redirect_after", clearOpts);
       }
       if (req.session) delete req.session.oauthRedirectAfter;
-      const failureRedirectUrl = validatedOrigin
-        ? `${validatedOrigin}/user/login?error=oauth_failed`
-        : `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}`;
+      let redirectOrigin = null;
+      if (validatedUrl) { try { redirectOrigin = new URL(validatedUrl).origin; } catch {} }
+      const failureRedirectUrl = redirectOrigin
+        ? `${redirectOrigin}/login?error=oauth_failed`
+        : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
 
       // Guard: req.user must be set by Passport before this controller runs.
       // If it is missing, Passport failed silently or the middleware chain
@@ -263,11 +265,13 @@ const userController = {
         }
       })();
 
-      const baseRedirect = (
-        validatedOrigin || constants.GMAIL_VERIFICATION_SUCCESS_REDIRECT || ""
-      ).replace(/\/$/, "");
+      // Use the exact path from redirect_after for custom origins; fall back
+      // to the default analytics success path when no redirect_after was given.
+      const baseRedirect = validatedUrl
+        ? validatedUrl.replace(/\/$/, "")
+        : (constants.GMAIL_VERIFICATION_SUCCESS_REDIRECT || "").replace(/\/$/, "") + "/user/home";
       res.redirect(
-        `${baseRedirect}/user/home?success=google#token=${encodeURIComponent(token)}`,
+        `${baseRedirect}?success=google#token=${encodeURIComponent(token)}`,
       );
     } catch (error) {
       handleError(error, next);
@@ -288,22 +292,24 @@ const userController = {
       const request = handleRequest(req, next);
       if (!request) return;
 
-      // Resolve and validate redirect origin early so every branch —
-      // failure and success — routes back to the originating app.
-      const rawRedirectOrigin =
+      // Resolve and validate the full redirect URL early so every branch —
+      // failure and success — routes back to the originating app and path.
+      const rawRedirectUrl =
         (req.cookies && req.cookies["_oauth_redirect_after"]) ||
         (req.session && req.session.oauthRedirectAfter) ||
         null;
-      const validatedOrigin = validateRedirectOrigin(rawRedirectOrigin);
+      const validatedUrl = validateRedirectUrl(rawRedirectUrl);
       if (req.cookies && req.cookies["_oauth_redirect_after"]) {
         const clearOpts = { path: "/" };
         if (constants.OAUTH_COOKIE_DOMAIN) clearOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
         res.clearCookie("_oauth_redirect_after", clearOpts);
       }
       if (req.session) delete req.session.oauthRedirectAfter;
-      const failureRedirectUrl = validatedOrigin
-        ? `${validatedOrigin}/user/login?error=oauth_failed`
-        : `${constants.GMAIL_VERIFICATION_FAILURE_REDIRECT}`;
+      let redirectOrigin = null;
+      if (validatedUrl) { try { redirectOrigin = new URL(validatedUrl).origin; } catch {} }
+      const failureRedirectUrl = redirectOrigin
+        ? `${redirectOrigin}/login?error=oauth_failed`
+        : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
 
       if (!req.user) {
         logger.error("oauthCallback: req.user is not set after passport auth");
@@ -376,11 +382,13 @@ const userController = {
         }
       })();
 
-      const baseRedirect = (
-        validatedOrigin || constants.GMAIL_VERIFICATION_SUCCESS_REDIRECT || ""
-      ).replace(/\/$/, "");
+      // Use the exact path from redirect_after for custom origins; fall back
+      // to the default analytics success path when no redirect_after was given.
+      const baseRedirect = validatedUrl
+        ? validatedUrl.replace(/\/$/, "")
+        : (constants.GMAIL_VERIFICATION_SUCCESS_REDIRECT || "").replace(/\/$/, "") + "/user/home";
       return res.redirect(
-        `${baseRedirect}/user/home?success=${encodeURIComponent(providerForLog)}#token=${encodeURIComponent(token)}`,
+        `${baseRedirect}?success=${encodeURIComponent(providerForLog)}#token=${encodeURIComponent(token)}`,
       );
     } catch (error) {
       handleError(error, next);

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1201,7 +1201,6 @@ function setGoogleAuth(req, res, next) {
     const redirectAfter = req.query.redirect_after;
     if (redirectAfter) {
       if (isAllowedRedirect(redirectAfter, ALLOWED_ORIGINS)) {
-        const redirectOrigin = new URL(redirectAfter).origin;
         const cookieOpts = {
           httpOnly: true,
           secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
@@ -1210,8 +1209,8 @@ function setGoogleAuth(req, res, next) {
           path: "/",
         };
         if (cookieDomain) cookieOpts.domain = cookieDomain;
-        res.cookie("_oauth_redirect_after", redirectOrigin, cookieOpts);
-        if (req.session) req.session.oauthRedirectAfter = redirectOrigin;
+        res.cookie("_oauth_redirect_after", redirectAfter, cookieOpts);
+        if (req.session) req.session.oauthRedirectAfter = redirectAfter;
       } else {
         let rejectedOrigin;
         try { rejectedOrigin = new URL(redirectAfter).origin; } catch (_) { rejectedOrigin = "invalid"; }
@@ -1276,7 +1275,6 @@ function setOAuthProvider(req, res, next) {
     const redirectAfter = req.query.redirect_after;
     if (redirectAfter) {
       if (isAllowedRedirect(redirectAfter, ALLOWED_ORIGINS)) {
-        const redirectOrigin = new URL(redirectAfter).origin;
         const cookieOpts = {
           httpOnly: true,
           secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
@@ -1285,8 +1283,8 @@ function setOAuthProvider(req, res, next) {
           path: "/",
         };
         if (cookieDomain) cookieOpts.domain = cookieDomain;
-        res.cookie("_oauth_redirect_after", redirectOrigin, cookieOpts);
-        if (req.session) req.session.oauthRedirectAfter = redirectOrigin;
+        res.cookie("_oauth_redirect_after", redirectAfter, cookieOpts);
+        if (req.session) req.session.oauthRedirectAfter = redirectAfter;
       } else {
         let rejectedOrigin;
         try { rejectedOrigin = new URL(redirectAfter).origin; } catch (_) { rejectedOrigin = "invalid"; }
@@ -1425,10 +1423,13 @@ function handleOAuthCallbackError(err, provider, res, next) {
  * failure URL instead of surfacing as an unhandled 500.
  */
 const authGoogleCallback = (req, res, next) => {
-  const rawOrigin = req.cookies && req.cookies["_oauth_redirect_after"];
-  const validatedOrigin = rawOrigin && isAllowedRedirect(rawOrigin, ALLOWED_ORIGINS) ? rawOrigin : null;
+  const rawRedirect = req.cookies && req.cookies["_oauth_redirect_after"];
+  let validatedOrigin = null;
+  if (rawRedirect && isAllowedRedirect(rawRedirect, ALLOWED_ORIGINS)) {
+    try { validatedOrigin = new URL(rawRedirect).origin; } catch {}
+  }
   const failureBase = validatedOrigin
-    ? `${validatedOrigin}/user/login`
+    ? `${validatedOrigin}/login`
     : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
   passport.authenticate("google", {
     failureRedirect: buildOAuthFailureRedirect(failureBase),
@@ -1493,10 +1494,13 @@ const authOAuth = (req, res, next) => {
  */
 const authOAuthCallback = (req, res, next) => {
   const provider = req.oauthProvider || (req.params.provider || "").toLowerCase() || "google";
-  const rawOrigin = req.cookies && req.cookies["_oauth_redirect_after"];
-  const validatedOrigin = rawOrigin && isAllowedRedirect(rawOrigin, ALLOWED_ORIGINS) ? rawOrigin : null;
+  const rawRedirect = req.cookies && req.cookies["_oauth_redirect_after"];
+  let validatedOrigin = null;
+  if (rawRedirect && isAllowedRedirect(rawRedirect, ALLOWED_ORIGINS)) {
+    try { validatedOrigin = new URL(rawRedirect).origin; } catch {}
+  }
   const failureBase = validatedOrigin
-    ? `${validatedOrigin}/user/login`
+    ? `${validatedOrigin}/login`
     : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
   const failureRedirectUrl = buildOAuthFailureRedirect(failureBase);
   passport.authenticate(provider, {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes two OAuth redirect path bugs reported by the Vertex frontend team, and hardens the redirect cookie security following a code review.

- **Success redirect**: the backend was extracting only the origin from `redirect_after` and hardcoding `/user/home` as the landing path (e.g. `https://vertex.airqo.net/user/home`). The full URL passed in `redirect_after` is now used as-is, so apps that use a different path (e.g. `/home`) land correctly.
- **Failure redirect**: the backend was appending `/user/login` to the origin on OAuth failure. Changed to `/login` to match apps that do not use the `/user` prefix. The analytics fallback (`GMAIL_VERIFICATION_FAILURE_REDIRECT`) is unchanged and still points to the correct path.
- **Open-redirect hardening**: re-validates the `_oauth_redirect_after` cookie value against the origin allowlist inside the controller before using it to build any redirect URL. Renames the internal helper from `validateRedirectOrigin` to `validateRedirectUrl` to reflect that it now returns the full URL rather than just the origin.
- **Cookie `Secure` flag**: corrects the flag from `NODE_ENV === "production"` to `NODE_ENV !== "development" && NODE_ENV !== "test"` so staging deployments also set `Secure=true` on the CSRF state cookies and the `_oauth_redirect_after` cookie.

### Why is this change needed?

Vertex uses `/home` and `/login` as its route paths, not `/user/home` and `/user/login`. With the previous hardcoded paths, successful OAuth login redirected users to an unrecognised route (`/user/home`) which was intercepted by Vertex's Next.js security middleware and immediately bounced back to the login screen — causing an unwanted flash. Failures similarly landed on the wrong page. The `Secure` flag fix ensures cookies are protected in transit on staging, which mirrors the production security posture.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified end-to-end Google OAuth flow from Vertex with `redirect_after=https://staging-vertex.airqo.net/home`. Confirmed the browser lands on `/home?success=google#token=…` on success and `/login?error=oauth_failed` on failure. Analytics flows (no `redirect_after`) verified to be unchanged — still land on `/user/home` and `/user/login` via `GMAIL_VERIFICATION_SUCCESS_REDIRECT` / `GMAIL_VERIFICATION_FAILURE_REDIRECT`.

---

## :boom: Breaking Changes

- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

Apps that previously relied on the backend always redirecting to `{origin}/user/home` after OAuth success will now need to pass the exact desired landing path via `redirect_after` (e.g. `redirect_after=https://yourapp.com/user/home`). The default analytics flow is unaffected. This is a corrective change — the old behaviour was a bug, not a contract.

---

## :memo: Additional Notes

- **Twitter/X**: Twitter OAuth 1.0a is not fixed by this PR. The consent screen correctly shows `analytics.airqo.net` (the registered OAuth app) — this is expected behaviour. The underlying cross-server session issue (request token stored in Vertex session, callback handled by Analytics) requires a shared Redis session store and is tracked as separate work.
- The `_oauth_redirect_after` cookie now stores the full `redirect_after` URL instead of just the origin. Any code that reads this cookie expecting an origin-only value should be updated.
- `GMAIL_VERIFICATION_FAILURE_REDIRECT` in staging/production env must contain the full path (e.g. `https://analytics.airqo.net/user/login`) — it is used verbatim as the analytics failure fallback and is no longer augmented with `/user/login`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened OAuth redirect validation and resolution for more secure, reliable authentication across providers.
  * Standardized failure redirect to a /login path and ensured consistent handling on callback errors.
  * Fixed redirect target handling so users land on the intended page after successful or failed sign-in.

* **New Features**
  * Success redirects now include the provider as a query param and place the auth token in the URL fragment for client consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->