### PR TITLE
feat: send confirmation email to users after feedback submission

### DIFF
--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -1688,4 +1688,19 @@ module.exports = {
 
     return constants.EMAIL_BODY({ email, content, name: contact_name });
   },
+
+  feedbackConfirmation: ({ email, subject }) => {
+    const escapedSubject = escapeHtml(subject || "your feedback");
+    const content = `<tr>
+                                <td
+                                    style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+                                    <p>Thank you for reaching out to us!</p>
+                                    <p>We have successfully received your feedback regarding <strong>${escapedSubject}</strong> and our team will review it shortly.</p>
+                                    <p>We appreciate you taking the time to share your thoughts — your input helps us improve AirQo for everyone.</p>
+                                    <p>If your feedback requires a response, a member of our team will get back to you as soon as possible.</p>
+                                    <p>Thank you for being part of the AirQo community.</p>
+                                </td>
+                            </tr>`;
+    return constants.EMAIL_BODY({ email, content, name: "" });
+  },
 };

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -880,6 +880,7 @@ const getEmailSubject = (functionName, params) => {
     inquiry: `Thank you for your inquiry - AirQo ${params.category || ""} team`,
     newMobileAppUser: params.subject || "AirQo Mobile App Notification",
     feedback: params.subject || "AirQo Feedback Submission",
+    feedbackConfirmation: "Thank you for your feedback – AirQo",
     sendReport: "Your AirQo Account Report",
     siteActivity: "Your AirQo Account: Monitor Deployment/Recall Alert",
     fieldActivity: (() => {
@@ -977,6 +978,7 @@ const EMAIL_CATEGORIES = {
     "inquiry",
     "newMobileAppUser",
     "feedback",
+    "feedbackConfirmation",
     "sendReport",
     "siteActivity",
     "fieldActivity",
@@ -1840,16 +1842,25 @@ const mailer = {
       return {
         ...baseMailOptions,
         to: constants.SUPPORT_EMAIL,
-        cc: params.email,
         subject: params.subject,
         text: safeScreenshotUrl
           ? `${params.message}\n\nScreenshot: ${safeScreenshotUrl}`
           : params.message,
         html: `<p>${escapedMessage}</p>${screenshotHtml}`,
+        cc: undefined,
         bcc: undefined,
         attachments: undefined,
       };
     },
+  ),
+  feedbackConfirmation: createMailerFunction(
+    "feedbackConfirmation",
+    "OPTIONAL",
+    (params) =>
+      msgs.feedbackConfirmation({
+        email: params.email,
+        subject: params.subject,
+      }),
   ),
   sendReport: async (
     {

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -304,7 +304,8 @@ const createMailerFunction = (
 
       // ✅ STEP 3: Subscription check based on category
       const isCoreFunction =
-        EMAIL_CATEGORIES.CORE_CRITICAL.includes(functionName);
+        EMAIL_CATEGORIES.CORE_CRITICAL.includes(functionName) ||
+        (EMAIL_CATEGORIES.TRANSACTIONAL || []).includes(functionName);
 
       if (!isCoreFunction) {
         const checkResult = await SubscriptionModel(
@@ -978,13 +979,14 @@ const EMAIL_CATEGORIES = {
     "inquiry",
     "newMobileAppUser",
     "feedback",
-    "feedbackConfirmation",
     "sendReport",
     "siteActivity",
     "fieldActivity",
     "updateProfileReminder",
     "sendPollutionAlert",
   ],
+  // Triggered directly by user action — always delivered regardless of subscription status
+  TRANSACTIONAL: ["feedbackConfirmation"],
 };
 
 /**
@@ -1847,8 +1849,6 @@ const mailer = {
           ? `${params.message}\n\nScreenshot: ${safeScreenshotUrl}`
           : params.message,
         html: `<p>${escapedMessage}</p>${screenshotHtml}`,
-        cc: undefined,
-        bcc: undefined,
         attachments: undefined,
       };
     },

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -488,11 +488,17 @@ const createMailerFunction = (
 
       // ✅ STEP 4c-CC: If the recipient is a registered application email address,
       // merge admin CC into any existing cc set by customMailOptionsModifier.
+      // Skip when routing to the support inbox — feedback and similar internal
+      // emails must not gain extra CCs from application email lookups.
+      const isRoutedToSupport =
+        constants.SUPPORT_EMAIL &&
+        mailOptions.to &&
+        mailOptions.to.toLowerCase().trim() ===
+          constants.SUPPORT_EMAIL.toLowerCase().trim();
       try {
-        const adminCC = await _resolveAdminCCForApplicationEmail(
-          mailOptions.to,
-          tenant
-        );
+        const adminCC =
+          !isRoutedToSupport &&
+          (await _resolveAdminCCForApplicationEmail(mailOptions.to, tenant));
         if (adminCC) {
           const existing = mailOptions.cc
             ? (Array.isArray(mailOptions.cc)

--- a/src/auth-service/utils/common/test/ut_email.msgs.util.js
+++ b/src/auth-service/utils/common/test/ut_email.msgs.util.js
@@ -407,4 +407,29 @@ describe("email.msgs", () => {
       joinRequestSpy.restore();
     });
   });
+
+  describe("feedbackConfirmation", () => {
+    it("should return a confirmation email body containing the subject", () => {
+      const email = "user@example.com";
+      const subject = "App feedback";
+      const result = msgs.feedbackConfirmation({ email, subject });
+      expect(result).to.be.a("string");
+      expect(result).to.include("App feedback");
+      expect(result).to.include("Thank you");
+    });
+
+    it("should fall back to 'your feedback' when subject is omitted", () => {
+      const result = msgs.feedbackConfirmation({ email: "user@example.com" });
+      expect(result).to.include("your feedback");
+    });
+
+    it("should HTML-escape a subject containing special characters", () => {
+      const result = msgs.feedbackConfirmation({
+        email: "user@example.com",
+        subject: "<script>alert(1)</script>",
+      });
+      expect(result).to.not.include("<script>");
+      expect(result).to.include("&lt;script&gt;");
+    });
+  });
 });

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -22,7 +22,6 @@ const {
   generateSignInWithEmailLink,
   delete: deleteUser,
   sendFeedback,
-  submitFeedback,
   create,
   register,
   forgotPassword,
@@ -39,7 +38,6 @@ const constants = require("@config/constants");
 const httpStatus = require("http-status");
 const rewire = require("rewire");
 const rewireCreateUser = rewire("@utils/user.util");
-const FeedbackModel = require("@models/Feedback");
 const UserModel = require("@models/User");
 const LogModel = require("@models/log");
 const NetworkModel = require("@models/Network");
@@ -1370,9 +1368,11 @@ describe("create-user-util", function () {
         success: true,
         data: { _id: "fb123" },
       });
-      sinon.stub(FeedbackModel, "call").returns({
+      // Inject a fake FeedbackModel into the rewired module so FeedbackModel(tenant).register
+      // is properly intercepted — sinon cannot stub a bare exported function directly.
+      rewireCreateUser.__set__("FeedbackModel", () => ({
         register: feedbackRegisterStub,
-      });
+      }));
     });
 
     afterEach(() => {
@@ -1395,7 +1395,7 @@ describe("create-user-util", function () {
         user: null,
       };
 
-      await submitFeedback(request, (err) => {
+      await rewireCreateUser.submitFeedback(request, (err) => {
         throw err;
       });
 
@@ -1422,7 +1422,7 @@ describe("create-user-util", function () {
         user: null,
       };
 
-      const response = await submitFeedback(request, (err) => {
+      const response = await rewireCreateUser.submitFeedback(request, (err) => {
         throw err;
       });
 
@@ -1445,7 +1445,7 @@ describe("create-user-util", function () {
         user: null,
       };
 
-      const response = await submitFeedback(request, (err) => {
+      const response = await rewireCreateUser.submitFeedback(request, (err) => {
         throw err;
       });
 

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -22,6 +22,7 @@ const {
   generateSignInWithEmailLink,
   delete: deleteUser,
   sendFeedback,
+  submitFeedback,
   create,
   register,
   forgotPassword,
@@ -38,6 +39,7 @@ const constants = require("@config/constants");
 const httpStatus = require("http-status");
 const rewire = require("rewire");
 const rewireCreateUser = rewire("@utils/user.util");
+const FeedbackModel = require("@models/Feedback");
 const UserModel = require("@models/User");
 const LogModel = require("@models/log");
 const NetworkModel = require("@models/Network");
@@ -1264,8 +1266,10 @@ describe("create-user-util", function () {
       sinon.stub(mailer, "feedback").resolves({
         success: true,
         message: "Email sent successfully",
-        // Any other data you want to include in the response
       });
+      sinon
+        .stub(mailer, "feedbackConfirmation")
+        .resolves({ success: true, message: "Confirmation sent" });
 
       // Call the sendFeedback function with the mocked request
       const response = await sendFeedback(request);
@@ -1275,7 +1279,33 @@ describe("create-user-util", function () {
         success: true,
         message: "email successfully sent",
         status: httpStatus.OK,
-        // Any other data you expect in the response
+      });
+      expect(mailer.feedbackConfirmation.calledOnce).to.be.true;
+    });
+
+    it("should still return success when confirmation email fails", async () => {
+      const request = {
+        body: {
+          email: "test@example.com",
+          message: "Test message",
+          subject: "Test subject",
+        },
+      };
+
+      sinon.stub(mailer, "feedback").resolves({
+        success: true,
+        message: "Email sent successfully",
+      });
+      sinon
+        .stub(mailer, "feedbackConfirmation")
+        .rejects(new Error("SMTP error"));
+
+      const response = await sendFeedback(request);
+
+      expect(response).to.deep.equal({
+        success: true,
+        message: "email successfully sent",
+        status: httpStatus.OK,
       });
     });
 
@@ -1332,6 +1362,97 @@ describe("create-user-util", function () {
       });
     });
   });
+  describe("submitFeedback()", () => {
+    let feedbackRegisterStub;
+
+    beforeEach(() => {
+      feedbackRegisterStub = sinon.stub().resolves({
+        success: true,
+        data: { _id: "fb123" },
+      });
+      sinon.stub(FeedbackModel, "call").returns({
+        register: feedbackRegisterStub,
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should dispatch confirmation email to submitter on success", async () => {
+      sinon.stub(mailer, "feedback").resolves({ success: true });
+      const confirmStub = sinon
+        .stub(mailer, "feedbackConfirmation")
+        .resolves({ success: true });
+
+      const request = {
+        body: {
+          email: "user@example.com",
+          subject: "App bug",
+          message: "The map crashes on load",
+        },
+        query: {},
+        user: null,
+      };
+
+      await submitFeedback(request, (err) => {
+        throw err;
+      });
+
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(confirmStub.firstCall.args[0]).to.deep.include({
+        email: "user@example.com",
+        subject: "App bug",
+      });
+    });
+
+    it("should return success even when confirmation email throws", async () => {
+      sinon.stub(mailer, "feedback").resolves({ success: true });
+      sinon
+        .stub(mailer, "feedbackConfirmation")
+        .rejects(new Error("SMTP timeout"));
+
+      const request = {
+        body: {
+          email: "user@example.com",
+          subject: "App bug",
+          message: "The map crashes on load",
+        },
+        query: {},
+        user: null,
+      };
+
+      const response = await submitFeedback(request, (err) => {
+        throw err;
+      });
+
+      expect(response.success).to.equal(true);
+    });
+
+    it("should return success even when confirmation email returns failure", async () => {
+      sinon.stub(mailer, "feedback").resolves({ success: true });
+      sinon
+        .stub(mailer, "feedbackConfirmation")
+        .resolves({ success: false, message: "Rate limited" });
+
+      const request = {
+        body: {
+          email: "user@example.com",
+          subject: "App bug",
+          message: "The map crashes on load",
+        },
+        query: {},
+        user: null,
+      };
+
+      const response = await submitFeedback(request, (err) => {
+        throw err;
+      });
+
+      expect(response.success).to.equal(true);
+    });
+  });
+
   describe("create()", function () {
     it("should return the expected response for a valid input", async function () {
       // Arrange

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -2482,7 +2482,15 @@ const createUserModule = {
       if (responseFromSendEmail && responseFromSendEmail.success === true) {
         // Send confirmation email to the feedback submitter (best-effort)
         try {
-          await mailer.feedbackConfirmation({ email, subject }, next);
+          const confirmResult = await mailer.feedbackConfirmation({
+            email,
+            subject,
+          });
+          if (!confirmResult || confirmResult.success === false) {
+            logger.warn(
+              `Support email sent but confirmation email failed: ${confirmResult && confirmResult.message}`,
+            );
+          }
         } catch (confirmationError) {
           logger.warn(
             `Support email sent but confirmation email failed: ${confirmationError.message}`,
@@ -7655,10 +7663,15 @@ const feedbackUtil = {
 
       // Send confirmation email to the feedback submitter (best-effort)
       try {
-        await mailer.feedbackConfirmation(
-          { email: normalizedEmail, subject },
-          next,
-        );
+        const confirmResult = await mailer.feedbackConfirmation({
+          email: normalizedEmail,
+          subject,
+        });
+        if (!confirmResult || confirmResult.success === false) {
+          logger.warn(
+            `Feedback saved to DB but confirmation email failed: ${confirmResult && confirmResult.message}`,
+          );
+        }
       } catch (confirmationError) {
         logger.warn(
           `Feedback saved to DB but confirmation email failed: ${confirmationError.message}`,

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -2480,6 +2480,15 @@ const createUserModule = {
       logObject("responseFromSendEmail ....", responseFromSendEmail);
 
       if (responseFromSendEmail && responseFromSendEmail.success === true) {
+        // Send confirmation email to the feedback submitter (best-effort)
+        try {
+          await mailer.feedbackConfirmation({ email, subject }, next);
+        } catch (confirmationError) {
+          logger.warn(
+            `Support email sent but confirmation email failed: ${confirmationError.message}`,
+          );
+        }
+
         return {
           success: true,
           message: "email successfully sent",
@@ -7641,6 +7650,18 @@ const feedbackUtil = {
       } catch (emailError) {
         logger.warn(
           `Feedback saved to DB but support email failed: ${emailError.message}`,
+        );
+      }
+
+      // Send confirmation email to the feedback submitter (best-effort)
+      try {
+        await mailer.feedbackConfirmation(
+          { email: normalizedEmail, subject },
+          next,
+        );
+      } catch (confirmationError) {
+        logger.warn(
+          `Feedback saved to DB but confirmation email failed: ${confirmationError.message}`,
         );
       }
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a dedicated confirmation email sent directly to users upon feedback submission. Previously, users were CC'd on the internal support email and received their own raw feedback content back with no acknowledgment. Now users receive a clear, friendly "Thank you – we've received your feedback" email, while AirQo staff continue to receive the full feedback details on a separate email with no CC.

### Why is this change needed?
The feedback flow was not providing a user-friendly post-submission experience. Users had no clear indication that their feedback was successfully received, as the only email they got was an echo of their own submission content. This change aligns the feedback confirmation with the standard AirQo email UX pattern used in other flows (e.g. inquiry, client activation requests).

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`
  - `utils/common/email.msgs.util.js` — new `feedbackConfirmation` HTML template
  - `utils/common/mailer.util.js` — new `feedbackConfirmation` mailer function; removed `cc` from staff feedback email
  - `utils/user.util.js` — both `submitFeedback` and `sendFeedback` now dispatch the confirmation email

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Submit feedback via the API and verify two emails are dispatched: (1) the internal support email goes to `SUPPORT_EMAIL` only (no CC), and (2) a separate confirmation email lands in the submitter's inbox with the "Thank you for your feedback" message. Confirmation email failures are best-effort — they log a warning but do not fail the feedback submission.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The confirmation email is sent as a best-effort fire-and-forget after the DB record is saved and the support email is dispatched. A failure in the confirmation step will not surface an error to the user or roll back the submission.
- The `cc: params.email` that previously appeared on the staff feedback email has been removed — users now receive their own dedicated email instead.
- Subject line for the confirmation email: `"Thank you for your feedback – AirQo"`

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users submitting feedback now receive automatic confirmation emails sent on a best-effort basis; delivery failures are logged and do not block submission.
* **Tests**
  * Added unit tests verifying confirmation email content, escaping of special characters, and that feedback flows remain successful even when confirmation sending fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->