### PR TITLE
Fix map persistence and stale site status after device recall

### DIFF
--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -1967,6 +1967,7 @@ ReadingsSchema.statics.listForMap = async function(
           ...safeFilterForMatch,
           time: timeConstraint,
           "pm2_5.value": { $gt: 0 },
+          "deviceDetails.isActive": { $ne: false },
         },
       },
 

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -2626,9 +2626,20 @@ const createActivity = {
                 ? sortedNetworks[0]
                 : constants.DEFAULT_NETWORK || "airqo";
 
+            const siteFields = { network: networkToSet };
+
+            // When no devices remain, clear the online status flags immediately.
+            // The raw-online-status job only iterates active devices, so a site
+            // with no device would otherwise keep rawOnlineStatus: true
+            // indefinitely, causing the UI to display it as "Transmitting".
+            if (sortedNetworks.length === 0) {
+              siteFields.rawOnlineStatus = false;
+              siteFields.isOnline = false;
+            }
+
             const updateResult = await SiteModel(tenant).findByIdAndUpdate(
               device.site_id,
-              { $set: { network: networkToSet } },
+              { $set: siteFields },
               { new: false },
             );
 

--- a/src/device-registry/utils/activity.util.js
+++ b/src/device-registry/utils/activity.util.js
@@ -2539,15 +2539,22 @@ const createActivity = {
       // Mark readings for this device as inactive so map/recent-readings
       // endpoints stop surfacing it immediately. Readings are preserved for
       // historical access — only the embedded isActive flag is updated.
-      // Non-fatal: a failure here does not roll back the recall.
+      // Non-fatal: a failure here does not roll back the recall, but it is
+      // logged as an error so it is actionable and visible in monitoring.
       try {
-        await ReadingModel(tenant).updateMany(
+        const readingUpdateResult = await ReadingModel(tenant).updateMany(
           { device_id: updatedDevice._id.toString() },
           { $set: { "deviceDetails.isActive": false } }
         );
+        logger.info(
+          `Recall: marked ${readingUpdateResult.modifiedCount ?? "unknown"} readings inactive for device ${deviceName} (${updatedDevice._id})`
+        );
       } catch (readingUpdateError) {
-        logger.warn(
-          `⚠️ Recall: device ${deviceName} recalled but readings could not be marked inactive: ${readingUpdateError.message}`
+        logger.error(
+          `🚨 Recall: failed to mark readings inactive for device ${deviceName} (${updatedDevice._id}). ` +
+            `Query: { device_id: "${updatedDevice._id}" }. ` +
+            `Error: ${readingUpdateError.message}`,
+          { stack: readingUpdateError.stack }
         );
       }
 

--- a/src/device-registry/utils/test/ut_activity.util.js
+++ b/src/device-registry/utils/test/ut_activity.util.js
@@ -1022,6 +1022,80 @@ describe("createActivity", () => {
       // ... Implement the test for the case when an internal server error occurs
     });
 
+    describe("post-recall site online-status clearing", () => {
+      let siteUpdateStub;
+      let distinctStub;
+      let sandbox;
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        siteUpdateStub = sandbox.stub().resolves({ _id: "site_id_123" });
+        distinctStub = sandbox.stub();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it("clears rawOnlineStatus and isOnline when no active devices remain after recall", async () => {
+        // No active devices remain at the site
+        distinctStub.resolves([]);
+
+        // Simulate the post-recall site-update logic in isolation
+        const sortedNetworks = [];
+        const siteFields = {
+          network: sortedNetworks.length > 0 ? sortedNetworks[0] : "airqo",
+        };
+
+        if (sortedNetworks.length === 0) {
+          siteFields.rawOnlineStatus = false;
+          siteFields.isOnline = false;
+        }
+
+        await siteUpdateStub("site_id_123", { $set: siteFields });
+
+        const callArgs = siteUpdateStub.firstCall.args[1].$set;
+        expect(callArgs.rawOnlineStatus).to.equal(false);
+        expect(callArgs.isOnline).to.equal(false);
+        expect(callArgs.network).to.equal("airqo");
+      });
+
+      it("does NOT clear rawOnlineStatus when active devices still remain after recall", async () => {
+        // One active device remains
+        distinctStub.resolves(["airgradient"]);
+
+        const sortedNetworks = ["airgradient"];
+        const siteFields = {
+          network: sortedNetworks[0],
+        };
+
+        if (sortedNetworks.length === 0) {
+          siteFields.rawOnlineStatus = false;
+          siteFields.isOnline = false;
+        }
+
+        await siteUpdateStub("site_id_123", { $set: siteFields });
+
+        const callArgs = siteUpdateStub.firstCall.args[1].$set;
+        expect(callArgs).to.not.have.property("rawOnlineStatus");
+        expect(callArgs).to.not.have.property("isOnline");
+        expect(callArgs.network).to.equal("airgradient");
+      });
+
+      it("uses the first sorted network when multiple active devices remain", async () => {
+        distinctStub.resolves(["airqo", "airgradient"]);
+
+        const sortedNetworks = ["airgradient", "airqo"].sort();
+        const siteFields = { network: sortedNetworks[0] };
+
+        await siteUpdateStub("site_id_123", { $set: siteFields });
+
+        expect(siteUpdateStub.firstCall.args[1].$set.network).to.equal(
+          "airgradient"
+        );
+      });
+    });
+
     // Add more test cases as needed to cover different scenarios
   });
   describe("maintain", () => {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Two targeted fixes to the device recall flow and map readings query in the `device-registry` service:

1. **`activity.util.js`** — When the last active device is recalled from a site, immediately set `rawOnlineStatus: false` and `isOnline: false` on the site document in the same write that updates `site.network`.

2. **`models/Reading.js`** — Added `"deviceDetails.isActive": { $ne: false }` to the `$match` stage of the `listForMap` aggregation pipeline. The recall flow already marks all of a recalled device's readings with `deviceDetails.isActive: false` via `updateMany` at recall time; the map query was simply not using that signal.

### Why is this change needed?
After a device is recalled from a site and redeployed elsewhere, two problems persisted:

- **Stale "Transmitting" UI status**: The `update-raw-online-status-job` only iterates active devices and updates their *current* site. A site that has lost its last device is never visited by the job, so `rawOnlineStatus: true` remained indefinitely — causing the site registry UI to display the empty site as "Transmitting" (defined as `isOnline: false` + `rawOnlineStatus: true`).

- **Site lingering on the map**: The map endpoint (`GET /devices/readings/map`) uses a 24-hour rolling window over the readings collection. The recall flow marks existing readings with `deviceDetails.isActive: false`, but the map `$match` did not filter on this field, so those readings remained visible on the map until they aged out naturally — or indefinitely if any new readings were still being routed to the old site by the pipeline.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified against a real recall event (device `ag_176072`, recalled June 2 2026) where the old site (`Lion Pride 1 - Serengeti`, site_772) remained "Transmitting" and visible on the map 48 hours after recall. Confirmed that:
- After the `activity.util.js` fix, a site with no remaining active devices will have `rawOnlineStatus: false` and `isOnline: false` set atomically at recall time.
- After the `Reading.js` fix, readings marked `deviceDetails.isActive: false` by the recall flow are excluded from the next map load, removing the old site immediately rather than waiting for the 24-hour window to expire.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `$match` addition is purely additive — readings without `deviceDetails.isActive` set (existing historical data or unaffected devices) pass through since `undefined !== false`. The site document update only fires when `remainingActiveDevices === 0`, so sites with multiple devices are unaffected.

---

## :memo: Additional Notes

- The `ReadingModel.updateMany()` call in the recall flow that marks readings inactive is non-fatal (a failure does not roll back the recall). If that write silently fails, the map filter provides no protection for that run. A follow-up to make this write observable (log the result count, alert on failure) may be worth considering.
- An anomaly was observed where `onlineStatusAccuracy.lastSuccessfulUpdate` on the recalled site was updated today (June 4) within 695ms of the new site's update, despite no active device pointing to the old site. The source of this cross-site write was not identified in this PR and warrants a separate investigation.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Map readings now show only readings from active devices.
  * Sites no longer remain marked as transmitting after all devices are inactive or recalled; site online status is cleared appropriately.
* **Refactor**
  * Device recall flow made more robust and non-fatal, with improved logging around reading updates.
* **Tests**
  * Added tests to verify post-recall site online-status clearing and network selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->