### PR TITLE
Clear stale rawOnlineStatus on device-less sites each job run

### DIFF
--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -993,6 +993,39 @@ const updateRawOnlineStatus = async () => {
       }
     }
 
+    // Cleanup pass: find sites that have rawOnlineStatus: true but no active
+    // device currently assigned. These are sites recalled before the recall
+    // flow was fixed to clear rawOnlineStatus at recall time.
+    if (!processor.shouldStopExecution()) {
+      try {
+        const activeSiteIds = await DeviceModel("airqo").distinct("site_id", {
+          isActive: true,
+          site_id: { $ne: null },
+        });
+
+        const staleResult = await SiteModel("airqo").updateMany(
+          {
+            rawOnlineStatus: true,
+            _id: { $nin: activeSiteIds },
+          },
+          {
+            $set: { rawOnlineStatus: false, isOnline: false },
+          }
+        );
+
+        if (staleResult.modifiedCount > 0) {
+          logger.info(
+            `Stale-site cleanup: cleared rawOnlineStatus on ${staleResult.modifiedCount} site(s) with no active device.`
+          );
+        }
+      } catch (cleanupError) {
+        logger.error(
+          `Stale-site cleanup failed: ${cleanupError.message}`,
+          { stack: cleanupError.stack }
+        );
+      }
+    }
+
     const duration = (Date.now() - startTime) / 1000;
     logText(
       `Raw online status check complete in ${duration}s. Processed ${totalProcessed} devices.`,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a cleanup pass at the end of each `update-raw-online-status-job` run in `src/device-registry/bin/jobs/update-raw-online-status-job.js`.

After all device batches are fully processed, the cleanup:
1. Fetches all `site_id` values that currently have at least one `isActive: true` device (`DeviceModel.distinct`)
2. Finds every site with `rawOnlineStatus: true` whose `_id` is **not** in that set
3. Sets `rawOnlineStatus: false` and `isOnline: false` on all matching sites in a single `updateMany`
4. Logs the number of sites corrected (info) or the full error with stack (error) so the result is always visible in monitoring

The cleanup is skipped if the job's stop signal has been raised, and its failure is non-fatal so it cannot mask the main job's result.

### Why is this change needed?
The `update-raw-online-status-job` derives each site's `rawOnlineStatus` as a side effect of processing its active device. A site that has lost all its devices becomes **invisible to the job** — no device points to it, so nothing ever updates it. Whatever value `rawOnlineStatus` held at the time the last device left is frozen there indefinitely.

This produces the "Transmitting" UI status (`isOnline: false` + `rawOnlineStatus: true`) on sites that have had all devices recalled, with no mechanism to recover without a manual database write.

The companion fix in `activity.util.js` (clearing `rawOnlineStatus` at recall time) only covers **future recalls**. This cleanup pass retroactively corrects all sites already in the stale state — including `Lion Pride 1 - Serengeti` (site_772), recalled June 2 2026, which was still showing as "Transmitting" on June 4 — and keeps the collection clean on an ongoing basis.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified against the real-world case of `Lion Pride 1 - Serengeti` (site_772, ID: `6a05bff80c37890013723df1`) which had `rawOnlineStatus: true` and `devices: []` 48 hours after device recall. The cleanup query correctly identifies such sites via `_id: { $nin: activeSiteIds }` and clears both flags in a single write. Confirmed that sites with at least one active device are excluded from the update.

Note: this fix covers **sites only**. Devices are not affected by the stale data problem because the raw online status job processes all devices — including recalled ones — on every run via `DeviceModel("airqo").find({})`, so device `rawOnlineStatus` is always current.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The cleanup only writes `rawOnlineStatus: false` and `isOnline: false` to sites that have no active device. Sites with at least one active device are never touched. The first run after deployment will silently correct any backlog of stale sites.

---

## :memo: Additional Notes

- The cleanup runs **after** all device batches complete, ensuring that any device updated during the current job cycle is reflected in the `distinct` query before the cleanup filter is applied.
- The cleanup is guarded by `processor.shouldStopExecution()` so a graceful job stop skips it rather than leaving a partial write mid-batch.
- Device `rawOnlineStatus` does not have this problem and requires no equivalent cleanup — the job iterates every device on every run with no filter.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
