### PR TITLE
fix/update-site-daily-aggregated-forecasting-sql select data looking at NULL

### DIFF
--- a/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
+++ b/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
@@ -41,8 +41,8 @@ SELECT
     DATE(t1.timestamp) AS day,
     t1.site_id,
         COALESCE(
-            NULLIF(TRIM(t2.display_name), NULL),
-            NULLIF(TRIM(t2.name), NULL)
+            NULLIF(TRIM(t2.display_name), ''),
+            NULLIF(TRIM(t2.name), '')
         )AS site_name,
     COALESCE(
         ANY_VALUE(t2.latitude),

--- a/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
+++ b/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
@@ -40,10 +40,12 @@ ORDER BY day, site_id;
 SELECT
     DATE(t1.timestamp) AS day,
     t1.site_id,
+    ANY_VALUE(
         COALESCE(
             NULLIF(TRIM(t2.display_name), ''),
             NULLIF(TRIM(t2.name), '')
-        )AS site_name,
+        )
+    )AS site_name,
     COALESCE(
         ANY_VALUE(t2.latitude),
         ANY_VALUE(t2.approximate_latitude)

--- a/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
+++ b/src/workflows/airqo_etl_utils/sql/forecasting/2026022002site_daily_aggregated.sql
@@ -43,9 +43,10 @@ SELECT
     ANY_VALUE(
         COALESCE(
             NULLIF(TRIM(t2.display_name), ''),
-            NULLIF(TRIM(t2.name), '')
+            NULLIF(TRIM(t2.name), ''),
+            t1.site_id
         )
-    )AS site_name,
+    ) AS site_name,
     COALESCE(
         ANY_VALUE(t2.latitude),
         ANY_VALUE(t2.approximate_latitude)


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
<!-- Brief summary of the changes -->

Improved data handling in forecasting operations by treating blank and whitespace-containing field values as missing data, ensuring proper fallback between alternative site identifiers for more accurate site information in forecast results.

### Why is this change needed?
<!-- Explain the motivation/problem this solves -->
Yesterday changes broke the daily forecast at the data fetch task. I have redone the change
---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forecasting now treats blank or whitespace-only site name fields as missing, improving fallback selection between alternative site identifiers and producing more consistent, accurate site names in aggregated forecast outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->