### PR TITLE
fix: share session cookie domain to enable Twitter OAuth across subdomains

### DIFF
--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -31,6 +31,7 @@ const {
 } = require("@utils/shared");
 const isDev = process.env.NODE_ENV === "development";
 const isProd = process.env.NODE_ENV === "production";
+const isSecureEnv = !isDev && process.env.NODE_ENV !== "test";
 const rateLimit = require("express-rate-limit");
 
 // ── Session store ─────────────────────────────────────────────────────────
@@ -177,7 +178,7 @@ const sessionMiddleware = session({
   resave: false,
   saveUninitialized: false,
   cookie: {
-    secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
+    secure: isSecureEnv,
     httpOnly: true,
     sameSite: "lax",
     // Share the session cookie across all *.airqo.net subdomains so that

--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -177,9 +177,13 @@ const sessionMiddleware = session({
   resave: false,
   saveUninitialized: false,
   cookie: {
-    secure: isProd,
+    secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
     httpOnly: true,
     sameSite: "lax",
+    // Share the session cookie across all *.airqo.net subdomains so that
+    // Twitter OAuth 1.0a request tokens written by one server (e.g. vertex)
+    // are readable by the analytics callback server that handles the redirect.
+    ...(constants.OAUTH_COOKIE_DOMAIN ? { domain: constants.OAUTH_COOKIE_DOMAIN } : {}),
   },
 });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Sets a shared parent-domain (`Domain=.airqo.net`) on the Express session cookie
and aligns its `Secure` flag with the rest of the auth cookies. This is a
one-line config change in `bin/server.js` — no new dependencies, no new env
vars, no new infrastructure.

### Why is this change needed?

Twitter OAuth 1.0a stores a short-lived request token (`oauth_token`) in
`req.session` during login initiation. The registered Twitter callback URL
always points to `analytics.airqo.net`. When a user starts Twitter login from
Vertex, the session cookie (`connect.sid`) is scoped to
`staging-vertex.airqo.net` — so when Twitter redirects back to
`staging-analytics.airqo.net/callback`, the browser does not send the cookie,
analytics cannot locate the session, and passport-twitter throws
`"Failed to find request token in session"`, causing login to fail.

The Redis session store (`connect-redis`) was already fully implemented and
enabled (`USE_REDIS_SESSIONS=true`) in staging and production — session data was
already shared across pods. The only missing piece was the session cookie domain.
Setting `Domain=.airqo.net` (reusing the existing `OAUTH_COOKIE_DOMAIN` env var)
makes the browser send `connect.sid` to all `*.airqo.net` subdomains, completing
the fix.

The `Secure` flag is also corrected from `isProd` (false on staging) to
`NODE_ENV !== "development" && NODE_ENV !== "test"`, consistent with the same
fix applied to other auth cookies in the `oauth-redirect` PR.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified Twitter/X OAuth login initiated from Vertex completes successfully and
redirects back to Vertex. Confirmed Google, GitHub, LinkedIn, and Microsoft
flows on both Analytics and Vertex are unaffected. Same-server Analytics Twitter
login also confirmed working. Dev behaviour unchanged (`OAUTH_COOKIE_DOMAIN` is
empty in development, so no domain is set on the session cookie).

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Expanding the session cookie domain is fully backward-compatible. All sessions
that worked before continue to work. The change only allows additional subdomains
to read the cookie — it does not invalidate existing sessions.

---

## :memo: Additional Notes

- `OAUTH_COOKIE_DOMAIN` (already `.airqo.net` in staging and production env
  files) is reused for the session cookie domain. No new env var is required.
- In development `OAUTH_COOKIE_DOMAIN` is intentionally empty, so no domain is
  applied to the session cookie — local dev behaviour is unchanged.
- `isProd` is removed from the cookie config entirely; the `Secure` flag now
  uses `NODE_ENV !== "development" && NODE_ENV !== "test"` so staging also sends
  cookies over HTTPS only.
- The Redis session store was already in place — this PR does not add
  `connect-redis` or any new package.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced session cookie security configuration based on deployment environment
  * Improved OAuth authentication handling across subdomains with configurable cookie domain support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->