### PR TITLE
fix: add per-pod jitter to sync-networks cron to prevent thundering herd

### DIFF
--- a/src/device-registry/bin/jobs/sync-networks-job.js
+++ b/src/device-registry/bin/jobs/sync-networks-job.js
@@ -12,6 +12,7 @@ const { getSchedule } = require("@utils/common");
 // Job configuration
 const JOB_NAME = "sync-networks-job";
 const JOB_SCHEDULE = getSchedule("0 */1 * * *", constants.ENVIRONMENT); // Every hour
+const MAX_INITIAL_JITTER_MS = 60000; // Up to 60s — spreads pod starts across the minute
 
 // Global state management
 let isJobRunning = false;
@@ -330,6 +331,9 @@ const start = () => {
   const cronJob = cron.schedule(
     JOB_SCHEDULE,
     async () => {
+      // Stagger pod starts to prevent thundering herd on auth-service at the hour boundary
+      const jitterMs = Math.floor(Math.random() * MAX_INITIAL_JITTER_MS);
+      await new Promise((res) => setTimeout(res, jitterMs));
       await performNetworkSync();
     },
     {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a random 0–60 second jitter delay to the `sync-networks-job` cron callback in device-registry, applied per-pod before each hourly execution.

### Why is this change needed?
All device-registry pods share the same cron schedule (`0 * * * *`). At every hour boundary, every running pod simultaneously fires `GET /api/v2/users/networks` against the auth-service, creating a thundering herd that overwhelms its connection pool/ingress and produces `502 Bad Gateway` responses. Retry logic already had jitter, but the first attempt from every pod was entirely synchronised. Spreading pod starts randomly across a 60-second window eliminates the burst.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `bin/jobs/sync-networks-job.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that the cron callback now waits a random delay (0–60 s) before invoking `performNetworkSync`. The startup `setTimeout` run is unaffected. Retry backoff jitter (already present on lines 149–155) is also unaffected.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

Each pod independently samples `Math.random()`, so no coordination between pods is needed. The maximum sync completion time per pod shifts by at most 60 seconds relative to the hour boundary, which is well within the hourly cadence. The `MAX_INITIAL_JITTER_MS = 60000` constant is defined alongside the other job-level configuration for easy tuning.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
