### PR TITLE
Fix log levels for cohort duplicates and AirGradient feed timeouts

### DIFF
--- a/src/device-registry/models/Cohort.js
+++ b/src/device-registry/models/Cohort.js
@@ -215,7 +215,7 @@ cohortSchema.statics.register = async function(args, next) {
       response.errors = { message: error.message };
     }
 
-    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    logger.warn(`⚠️ cohort-model -- validation conflict: ${error.message}`);
     next(new HttpError(response.message, response.status, response.errors));
   }
 };

--- a/src/device-registry/models/Cohort.js
+++ b/src/device-registry/models/Cohort.js
@@ -215,7 +215,13 @@ cohortSchema.statics.register = async function(args, next) {
       response.errors = { message: error.message };
     }
 
-    logger.warn(`⚠️ cohort-model -- validation conflict: ${error.message}`);
+    const isValidationConflict =
+      error.name === "ValidationError" || error.code === 11000;
+    if (isValidationConflict) {
+      logger.warn(`⚠️ cohort-model -- validation conflict: ${error.message}`);
+    } else {
+      logger.error(`🐛🐛 cohort-model -- unexpected error: ${error.message}`);
+    }
     next(new HttpError(response.message, response.status, response.errors));
   }
 };

--- a/src/device-registry/utils/feed.util.js
+++ b/src/device-registry/utils/feed.util.js
@@ -670,10 +670,13 @@ const createFeed = {
       // Non-actionable vendor errors (404 device not found, 422 transient,
       // 5xx vendor outage) are outside our control and map to "device offline"
       // — log at warn to avoid flooding Slack.
-      // Network-level failures (no HTTP response: ECONNREFUSED, ETIMEDOUT,
-      // DNS) may indicate problems on our side and stay at error.
+      // Network-level failures split by cause:
+      //   ECONNABORTED — Axios client timeout; vendor API was slow, not our fault → warn
+      //   ECONNREFUSED / DNS / other no-response errors → may be our side → error
       const ACTIONABLE_STATUSES = [401, 403, 429];
-      if (!error.response) {
+      if (!error.response && error.code === "ECONNABORTED") {
+        logger.warn(logMsg);
+      } else if (!error.response) {
         logger.error(logMsg);
       } else if (ACTIONABLE_STATUSES.includes(error.response.status)) {
         logger.error(logMsg);


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Downgrades `logger.error` to `logger.warn` in `Cohort.register()` when a duplicate name validation error (409 Conflict) is caught — the error is already handled gracefully and returned to the caller as a conflict response.
- Splits the no-response error branch in `fetchExternalDeviceData` (feed.util.js) to demote Axios client timeouts (`ECONNABORTED`) to `logger.warn`, while keeping genuine network failures (`ECONNREFUSED`, DNS) at `logger.error`.

### Why is this change needed?
Both cases were producing `[ERROR]` Slack alerts for conditions that are either user-input validation errors or vendor-side slowness — neither requires operator intervention. Keeping them at `error` level creates alert fatigue and obscures truly actionable errors. Downgrading to `warn` preserves observability without noise.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified by log inspection — duplicate cohort creation returns a 409 with no `[ERROR]` emitted; AirGradient timeout path confirmed to hit `ECONNABORTED` branch and emit `[WARN]` instead of `[ERROR]`.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `ECONNREFUSED`, DNS errors, and other no-response failures in `fetchExternalDeviceData` intentionally remain at `logger.error` — those may indicate misconfiguration or infrastructure issues on our side.
- If AirGradient timeouts cluster across many devices in a short window, the pattern is still visible in `warn` logs for trend analysis.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during device registration to properly classify validation conflicts separately from server errors.
  * Enhanced network failure detection to accurately distinguish timeout errors from other connection failures, enabling more precise error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->