### PR TITLE
fix: prevent duplicate BlockedASN entries on repeated POST requests

### DIFF
--- a/src/auth-service/models/BlockedASN.js
+++ b/src/auth-service/models/BlockedASN.js
@@ -61,6 +61,10 @@ const BlockedASNSchema = new mongoose.Schema(
 
 BlockedASNSchema.index({ asn: 1 });
 BlockedASNSchema.index({ active: 1 });
+// Unique on provider so repeated POST requests upsert rather than duplicate.
+// Pre-deploy requirement: if the collection already has duplicate provider
+// values from an earlier deploy, run a one-time deduplication query before
+// this index is applied, otherwise the index build will fail on startup.
 BlockedASNSchema.index({ provider: 1 }, { unique: true });
 
 // Require at least one of asn or a non-empty cidr_ranges so every document
@@ -84,9 +88,17 @@ BlockedASNSchema.pre("findOneAndUpdate", function (next) {
   // passed validation when it was first created.
   if (!this.getOptions().upsert) return next();
 
-  const setData = (this.getUpdate() && this.getUpdate().$set) || {};
+  const update = this.getUpdate() || {};
+  const setData = update.$set || {};
+  // cidr_ranges is written via $addToSet.$each in register() so check both
+  // operators when deciding whether the constraint is satisfied.
+  const addToSetCidrs =
+    update.$addToSet &&
+    update.$addToSet.cidr_ranges &&
+    update.$addToSet.cidr_ranges.$each;
+
   const asn = setData.asn;
-  const cidrRanges = setData.cidr_ranges;
+  const cidrRanges = setData.cidr_ranges || addToSetCidrs;
 
   if (!asn && (!cidrRanges || cidrRanges.length === 0)) {
     return next(
@@ -99,18 +111,72 @@ BlockedASNSchema.pre("findOneAndUpdate", function (next) {
 BlockedASNSchema.statics = {
   async register(args, next) {
     try {
-      const { provider, ...rest } = args;
-      const result = await this.findOneAndUpdate(
+      const { provider, cidr_ranges, ...scalars } = args;
+
+      // Split operators:
+      //   $set     — scalar fields (asn, reason, active, blockedAt)
+      //   $addToSet — cidr_ranges array, so repeated POSTs merge new ranges
+      //               instead of overwriting existing ones.
+      const updateOp = {
+        $set: { provider, ...scalars },
+        ...(cidr_ranges && cidr_ranges.length > 0 && {
+          $addToSet: { cidr_ranges: { $each: cidr_ranges } },
+        }),
+      };
+
+      const rawResult = await this.findOneAndUpdate(
         { provider },
-        { $set: { provider, ...rest } },
-        { upsert: true, new: true, runValidators: true, setDefaultsOnInsert: true }
+        updateOp,
+        {
+          upsert: true,
+          new: true,
+          runValidators: true,
+          setDefaultsOnInsert: true,
+          rawResult: true,
+        }
       );
-      const wasInserted = result && result.createdAt &&
-        (Date.now() - result.createdAt.getTime()) < 2000;
-      return createSuccessResponse("create", result.toObject(), "blocked ASN", {
-        message: wasInserted ? "ASN block created" : "ASN block updated",
-      });
+
+      const doc = rawResult && rawResult.value;
+      // lastErrorObject.updatedExisting is false for inserts, true for updates.
+      const wasInserted = !(
+        rawResult &&
+        rawResult.lastErrorObject &&
+        rawResult.lastErrorObject.updatedExisting
+      );
+
+      if (!isEmpty(doc)) {
+        return createSuccessResponse("create", doc.toObject(), "blocked ASN", {
+          message: wasInserted ? "ASN block created" : "ASN block updated",
+        });
+      }
+      return createEmptySuccessResponse(
+        "blocked ASN",
+        "operation successful but ASN block NOT created"
+      );
     } catch (err) {
+      // E11000: concurrent upsert race — another request won the insert.
+      // The document now exists; treat as success (same pattern as BlacklistedIPPrefix).
+      if (err.code === 11000) {
+        logger.warn(
+          `⚠️ BlockedASN upsert race — provider already exists. Treating as success.`
+        );
+        try {
+          const existing = await this.findOne({ provider: args.provider });
+          return createSuccessResponse("create", existing.toObject(), "blocked ASN", {
+            message: "ASN block already exists",
+          });
+        } catch (fetchErr) {
+          logger.error(
+            `🐛🐛 Could not fetch existing BlockedASN after duplicate key: ${fetchErr.message}`
+          );
+          return {
+            success: true,
+            message: "ASN block already exists (confirmed via duplicate key)",
+            status: httpStatus.OK,
+            data: { provider: args.provider },
+          };
+        }
+      }
       logObject("the error", err);
       logger.error(`🐛🐛 Internal Server Error ${err.message}`);
       return createErrorResponse(err, "create", logger, "blocked ASN");

--- a/src/auth-service/models/BlockedASN.js
+++ b/src/auth-service/models/BlockedASN.js
@@ -61,6 +61,7 @@ const BlockedASNSchema = new mongoose.Schema(
 
 BlockedASNSchema.index({ asn: 1 });
 BlockedASNSchema.index({ active: 1 });
+BlockedASNSchema.index({ provider: 1 }, { unique: true });
 
 // Require at least one of asn or a non-empty cidr_ranges so every document
 // carries meaningful blocking information.
@@ -76,16 +77,17 @@ BlockedASNSchema.pre("validate", function (next) {
 BlockedASNSchema.statics = {
   async register(args, next) {
     try {
-      const data = await this.create({ ...args });
-      if (!isEmpty(data)) {
-        return createSuccessResponse("create", data, "blocked ASN", {
-          message: "ASN block created",
-        });
-      }
-      return createEmptySuccessResponse(
-        "blocked ASN",
-        "operation successful but ASN block NOT created"
+      const { provider, ...rest } = args;
+      const result = await this.findOneAndUpdate(
+        { provider },
+        { $set: { provider, ...rest } },
+        { upsert: true, new: true, runValidators: true, setDefaultsOnInsert: true }
       );
+      const wasInserted = result && result.createdAt &&
+        (Date.now() - result.createdAt.getTime()) < 2000;
+      return createSuccessResponse("create", result.toObject(), "blocked ASN", {
+        message: wasInserted ? "ASN block created" : "ASN block updated",
+      });
     } catch (err) {
       logObject("the error", err);
       logger.error(`🐛🐛 Internal Server Error ${err.message}`);

--- a/src/auth-service/models/BlockedASN.js
+++ b/src/auth-service/models/BlockedASN.js
@@ -65,8 +65,30 @@ BlockedASNSchema.index({ provider: 1 }, { unique: true });
 
 // Require at least one of asn or a non-empty cidr_ranges so every document
 // carries meaningful blocking information.
+// pre('validate') covers save() paths; pre('findOneAndUpdate') covers the
+// upsert path used by register() — runValidators:true does not invoke
+// document middleware, so both hooks are needed.
 BlockedASNSchema.pre("validate", function (next) {
   if (!this.asn && (!this.cidr_ranges || this.cidr_ranges.length === 0)) {
+    return next(
+      new Error("BlockedASN must have at least one of: asn or cidr_ranges")
+    );
+  }
+  return next();
+});
+
+BlockedASNSchema.pre("findOneAndUpdate", function (next) {
+  // Only enforce on upserts (new document creation). Partial updates on
+  // existing documents (e.g. toggling active or changing reason) are allowed
+  // without re-validating cross-field constraints — the document already
+  // passed validation when it was first created.
+  if (!this.getOptions().upsert) return next();
+
+  const setData = (this.getUpdate() && this.getUpdate().$set) || {};
+  const asn = setData.asn;
+  const cidrRanges = setData.cidr_ranges;
+
+  if (!asn && (!cidrRanges || cidrRanges.length === 0)) {
     return next(
       new Error("BlockedASN must have at least one of: asn or cidr_ranges")
     );


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a unique index on `BlockedASN.provider` and switches `BlockedASN.register` from a plain `create()` to a `findOneAndUpdate` upsert. Sending the same provider body twice now merges into the existing document instead of creating a duplicate.

### Why is this change needed?
The original `register` method used `this.create()` with no duplicate guard. Repeating the same `POST /api/v2/tokens/blocked-asns` request (e.g. re-running the migration script for the legacy first-octet CIDR ranges) silently created duplicate documents, making the blocked-ASN list confusing and causing `DELETE` on one entry to leave a silent duplicate still active.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service` — `BlockedASN` model only

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that posting the same provider body twice returns the existing document on the second call rather than creating a duplicate. Verified that posting the same provider with updated `cidr_ranges` merges the new ranges in-place. Syntax check passes.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

`provider` is the upsert key — it is already required on the schema and is the natural deduplication identifier for a blocked ASN entry. `FlaggedToken.logHit` intentionally retains plain `create()` since each honeypot hit is a distinct audit event, not a logical entity that should be deduplicated.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced BlockedASN record management to enforce provider-level uniqueness and enable automatic updates to existing records. The system now provides clearer differentiation between newly created and updated blocked ASN entries, improving data consistency and operational transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->