### PR TITLE
fix: return site, createdAt, and groups in getMyDevices response

### DIFF
--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -3332,14 +3332,12 @@ const deviceUtil = {
           .lean(),
       ]);
 
-      const siteIds = [
-        ...new Set(
-          (rawDevices || [])
-            .map((d) => d.site_id)
-            .filter(Boolean)
-            .map((id) => id.toString()),
-        ),
-      ];
+      const siteIdByKey = new Map();
+      (rawDevices || [])
+        .map((d) => d.site_id)
+        .filter(Boolean)
+        .forEach((id) => siteIdByKey.set(id.toString(), id));
+      const siteIds = [...siteIdByKey.values()];
 
       const siteMap = new Map();
       if (siteIds.length > 0) {

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -3,6 +3,7 @@ const DeviceModel = require("@models/Device");
 const ActivityModel = require("@models/Activity");
 const CohortModel = require("@models/Cohort");
 const ShippingBatchModel = require("@models/ShippingBatch");
+const SiteModel = require("@models/Site");
 const mongoose = require("mongoose");
 const { isValidObjectId } = require("mongoose");
 const axios = require("axios");
@@ -3318,12 +3319,12 @@ const deviceUtil = {
         filter.$or.push({ cohorts: { $in: allCohortIds } });
       }
 
-      const [total, devices] = await Promise.all([
+      const [total, rawDevices] = await Promise.all([
         DeviceModel(tenant).countDocuments(filter),
         DeviceModel(tenant)
           .find(filter)
           .select(
-            "name long_name status isActive deployment_date latitude longitude claim_status owner_id claimed_at",
+            "name long_name status isActive deployment_date latitude longitude claim_status owner_id claimed_at createdAt groups site_id",
           )
           .sort({ claimed_at: -1 })
           .skip(skip)
@@ -3331,10 +3332,33 @@ const deviceUtil = {
           .lean(),
       ]);
 
+      const siteIds = [
+        ...new Set(
+          (rawDevices || [])
+            .map((d) => d.site_id)
+            .filter(Boolean)
+            .map((id) => id.toString()),
+        ),
+      ];
+
+      const siteMap = new Map();
+      if (siteIds.length > 0) {
+        const sites = await SiteModel(tenant)
+          .find({ _id: { $in: siteIds } })
+          .select("_id name location_name")
+          .lean();
+        sites.forEach((s) => siteMap.set(s._id.toString(), s));
+      }
+
+      const devices = (rawDevices || []).map(({ site_id, ...dev }) => ({
+        ...dev,
+        site: site_id ? siteMap.get(site_id.toString()) || null : null,
+      }));
+
       return {
         success: true,
         message: "Devices retrieved successfully",
-        data: devices || [],
+        data: devices,
         status: httpStatus.OK,
         meta: {
           total,

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -8,6 +8,7 @@ const axios = require("axios");
 const deviceUtil = require("@utils/device.util");
 const DeviceModel = require("@models/Device");
 const CohortModel = require("@models/Cohort");
+const SiteModel = require("@models/Site");
 const generateFilter = require("@utils/common/generate-filter");
 const ActivityModel = require("@models/Activity");
 const { getModelByTenant } = require("@config/database");
@@ -2855,6 +2856,219 @@ describe("Device Util", () => {
       await proxiedDeviceUtil.createOnPlatform(request, nextStub);
 
       expect(getNetworkAdapterStub.called).to.be.false;
+    });
+  });
+
+  describe("getMyDevices", () => {
+    const VALID_USER_ID = "507f1f77bcf86cd799439011";
+    const VALID_SITE_ID = "507f1f77bcf86cd799439022";
+
+    let deviceCountStub;
+    let deviceLeanStub;
+    let siteFindStub;
+    let siteLeanStub;
+
+    beforeEach(() => {
+      const deviceModelMock = {
+        countDocuments: sinon.stub(),
+        find: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        lean: sinon.stub(),
+      };
+      const cohortModelMock = {
+        find: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub(),
+      };
+      const siteModelMock = {
+        find: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub(),
+      };
+
+      sinon.stub(DeviceModel, "default").returns(deviceModelMock);
+      sinon.stub(CohortModel, "default").returns(cohortModelMock);
+      sinon.stub(SiteModel, "default").returns(siteModelMock);
+
+      deviceCountStub = deviceModelMock.countDocuments;
+      deviceLeanStub = deviceModelMock.lean;
+      siteFindStub = siteModelMock.find;
+      siteLeanStub = siteModelMock.lean;
+
+      deviceCountStub.resolves(0);
+      deviceLeanStub.resolves([]);
+      siteLeanStub.resolves([]);
+      cohortModelMock.lean.resolves([]);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should return BAD_REQUEST when user_id is missing", async () => {
+      const request = { query: { tenant: "airqo" } };
+      const result = await deviceUtil.getMyDevices(request, () => {});
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+    });
+
+    it("should return BAD_REQUEST for an invalid user_id format", async () => {
+      const request = {
+        query: { tenant: "airqo", user_id: "not-an-objectid" },
+      };
+      const result = await deviceUtil.getMyDevices(request, () => {});
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+    });
+
+    it("should attach site details when devices have a site_id", async () => {
+      const siteObjectId = new mongoose.Types.ObjectId(VALID_SITE_ID);
+      const mockDevices = [
+        {
+          _id: "dev1",
+          long_name: "Test Device",
+          site_id: siteObjectId,
+          createdAt: "2024-01-15T10:00:00.000Z",
+          groups: ["airqo"],
+        },
+      ];
+      const mockSites = [
+        {
+          _id: siteObjectId,
+          name: "Kampala Site",
+          location_name: "Kampala",
+        },
+      ];
+
+      deviceCountStub.resolves(1);
+      deviceLeanStub.resolves(mockDevices);
+      siteLeanStub.resolves(mockSites);
+
+      const request = {
+        query: { tenant: "airqo", user_id: VALID_USER_ID },
+      };
+      const result = await deviceUtil.getMyDevices(request, () => {});
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.lengthOf(1);
+      expect(result.data[0].site).to.deep.equal(mockSites[0]);
+      expect(result.data[0]).to.not.have.property("site_id");
+      expect(result.data[0].createdAt).to.equal("2024-01-15T10:00:00.000Z");
+      expect(result.data[0].groups).to.deep.equal(["airqo"]);
+    });
+
+    it("should return site: null for devices without a site_id", async () => {
+      const mockDevices = [
+        {
+          _id: "dev1",
+          long_name: "Undeployed Device",
+          site_id: null,
+          createdAt: "2024-01-15T10:00:00.000Z",
+          groups: [],
+        },
+      ];
+
+      deviceCountStub.resolves(1);
+      deviceLeanStub.resolves(mockDevices);
+
+      const request = {
+        query: { tenant: "airqo", user_id: VALID_USER_ID },
+      };
+      const result = await deviceUtil.getMyDevices(request, () => {});
+
+      expect(result.success).to.be.true;
+      expect(result.data[0].site).to.be.null;
+      expect(siteFindStub.called).to.be.false;
+    });
+
+    it("should return site: null when the site document is not found in the database", async () => {
+      const siteObjectId = new mongoose.Types.ObjectId(VALID_SITE_ID);
+      const mockDevices = [
+        {
+          _id: "dev1",
+          long_name: "Orphan Device",
+          site_id: siteObjectId,
+          createdAt: "2024-01-15T10:00:00.000Z",
+          groups: [],
+        },
+      ];
+
+      deviceCountStub.resolves(1);
+      deviceLeanStub.resolves(mockDevices);
+      siteLeanStub.resolves([]);
+
+      const request = {
+        query: { tenant: "airqo", user_id: VALID_USER_ID },
+      };
+      const result = await deviceUtil.getMyDevices(request, () => {});
+
+      expect(result.success).to.be.true;
+      expect(result.data[0].site).to.be.null;
+    });
+
+    it("should deduplicate site_ids and issue a single site query for the whole page", async () => {
+      const siteObjectId = new mongoose.Types.ObjectId(VALID_SITE_ID);
+      const mockDevices = [
+        {
+          _id: "dev1",
+          site_id: siteObjectId,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          groups: [],
+        },
+        {
+          _id: "dev2",
+          site_id: siteObjectId,
+          createdAt: "2024-01-02T00:00:00.000Z",
+          groups: [],
+        },
+        {
+          _id: "dev3",
+          site_id: siteObjectId,
+          createdAt: "2024-01-03T00:00:00.000Z",
+          groups: [],
+        },
+      ];
+      const mockSites = [
+        {
+          _id: siteObjectId,
+          name: "Shared Site",
+          location_name: "Shared Location",
+        },
+      ];
+
+      deviceCountStub.resolves(3);
+      deviceLeanStub.resolves(mockDevices);
+      siteLeanStub.resolves(mockSites);
+
+      const request = {
+        query: { tenant: "airqo", user_id: VALID_USER_ID },
+      };
+      const result = await deviceUtil.getMyDevices(request, () => {});
+
+      expect(result.success).to.be.true;
+      expect(siteFindStub.calledOnce).to.be.true;
+      expect(siteFindStub.firstCall.args[0]._id.$in).to.have.lengthOf(1);
+      result.data.forEach((d) => {
+        expect(d.site).to.deep.equal(mockSites[0]);
+      });
+    });
+
+    it("should skip the SiteModel query entirely when no devices are returned", async () => {
+      deviceCountStub.resolves(0);
+      deviceLeanStub.resolves([]);
+
+      const request = {
+        query: { tenant: "airqo", user_id: VALID_USER_ID },
+      };
+      const result = await deviceUtil.getMyDevices(request, () => {});
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.lengthOf(0);
+      expect(siteFindStub.called).to.be.false;
+      expect(result.meta.total).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the `/api/v2/devices/my-devices` endpoint to include `site`, `createdAt`, and `groups` fields in every device object returned. The `site` field is resolved via a manual batched lookup against the sites collection — collecting all `site_id` values from the device page, fetching them in a single `$in` query, then attaching the result to each device under the `site` key the frontend consumes.

### Why is this change needed?
The vertex web app's **My Devices** page (`/api/v2/devices/my-devices`) displayed empty columns for **Site**, **Created On**, and **Organization** because the `getMyDevices` query selected only a minimal set of fields and performed no site lookup. This patch extends the field projection and adds a batched site lookup so the three missing columns are filled from the database.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/device-registry` — `utils/device.util.js` (`getMyDevices`)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually verified that `GET /api/v2/devices/my-devices?user_id=<id>&group_ids=<ids>` now returns `site` (with `_id`, `name`, `location_name`), `createdAt`, and `groups` on each device object. Devices with no assigned site return `site: null`.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The response shape is additive — existing fields are untouched and three new fields are added.

---

## :memo: Additional Notes

- The `site` field mirrors the shape used by the `list()` aggregation pipeline (object with `_id`, `name`, `location_name`) so no frontend changes are required.
- `groups` is already filtered client-side by the frontend and only rendered for AirQo admin users.
- Site resolution uses a batched `$in` query on the indexed `_id` field — at most one additional query per page, regardless of page size. Devices with no `site_id` return `site: null` and skip the lookup entirely.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device information now includes associated site details for improved context and device visibility.
  * Device queries return expanded attributes including coordinates, claim fields, and group associations for more comprehensive device insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->