### PR TITLE
Updates the PM2.5 unit from ug/m3 to µg/m³

### DIFF
--- a/src/predict/api/helpers.py
+++ b/src/predict/api/helpers.py
@@ -447,7 +447,7 @@ def get_site_hourly_forecasts(
 
 
 SITE_FORECAST_UNITS = {
-    "pm2_5": "ug/m3",
+    "pm2_5": "µg/m³",
     "air_temperature": "degC",
     "relative_humidity": "%",
     "air_pressure_at_sea_level": "hPa",


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
<!-- Brief summary of the changes -->
Use the correct scientific notation for PM2.5 concentration units in API responses

### Why is this change needed?
<!-- Explain the motivation/problem this solves -->
Updates the PM2.5 unit from ug/m3 to µg/m³. This is a display-only change and does not affect forecast calculations or values.
---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated PM2.5 air quality unit display to use proper Unicode characters (µg/m³) instead of ASCII notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->