### PR TITLE
Exclude recalled device readings from map via ReadingModel.recent

### DIFF
--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -653,6 +653,17 @@ ReadingsSchema.index(
   },
 );
 
+// Compound index to support the recent() $match on time + deviceDetails.isActive.
+// Without this, MongoDB filters deviceDetails.isActive in memory after the time
+// range scan. background: true avoids blocking reads during the index build.
+ReadingsSchema.index(
+  { time: -1, "deviceDetails.isActive": 1 },
+  {
+    name: "time_device_active_idx",
+    background: true,
+  },
+);
+
 // Sparse index for non-null coordinates (mobile devices)
 ReadingsSchema.index(
   { "location.latitude.value": 1, "location.longitude.value": 1, time: -1 },

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -1002,6 +1002,7 @@ ReadingsSchema.statics.recent = async function(
         time: {
           $gte: lookbackStart,
         },
+        "deviceDetails.isActive": { $ne: false },
       })
       .sort({ time: -1 })
       .group({

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -991,14 +991,32 @@ ReadingsSchema.statics.recent = async function(
     let lookbackStart = new Date();
     lookbackStart.setDate(lookbackStart.getDate() - DIAGNOSTIC_WINDOW_DAYS);
 
+    // Guard against non-object filter values. The createEventUtil.read()
+    // caller passes next (a function) as the filter argument when invoked
+    // with only two arguments — spreading a function silently yields {}.
+    // Normalising here makes the drop visible rather than silent.
+    const safeFilter =
+      filter !== null &&
+      typeof filter === "object" &&
+      !Array.isArray(filter)
+        ? filter
+        : {};
+
+    if (safeFilter !== filter) {
+      logger.warn(
+        `ReadingModel.recent: received non-object filter (${typeof filter}) — ` +
+          `falling back to empty filter. Likely cause: caller passed next as filter.`
+      );
+    }
+
     let groupBy = "$site_id";
-    if (filter.device || filter.device_id) {
+    if (safeFilter.device || safeFilter.device_id) {
       groupBy = "$device_id";
     }
 
     const pipeline = this.aggregate()
       .match({
-        ...filter,
+        ...safeFilter,
         time: {
           $gte: lookbackStart,
         },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds `"deviceDetails.isActive": { $ne: false }` to the `$match` stage inside `ReadingModel.recent()` in `src/device-registry/models/Reading.js`.

### Why is this change needed?
The analytics map (`GET /devices/readings/map`) routes through `readingsForMap` controller → `createEventUtil.read()` → `ReadingModel.recent()`. This is a different code path from `ReadingModel.listForMap()`, which is only reachable via the `/map/test` route and was the target of an earlier fix.

The `readingsForMap` controller calls `createEventUtil.read(request, next)`, passing the Express `next` middleware function as the second argument. The `read()` function signature is `(request, filter, next)`, so `filter` receives the `next` function. When `ReadingModel.recent()` spreads this into its `$match`, spreading a function in JavaScript yields an empty object — meaning the production map query ran with only a time-window constraint and no filter on device activity status.

As a result, readings from recalled devices — already correctly marked `deviceDetails.isActive: false` by the recall flow — were not being excluded. A site recalled on June 2 was still appearing on the map on June 7 because its reading (timestamped June 2, within the 7-day window) passed through unchecked.

Adding the `deviceDetails.isActive: { $ne: false }` filter to `recent()` excludes all recalled-device readings at query time, immediately removing recalled sites from the map on the next request after deployment.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Confirmed via the production `GET /devices/readings/map` response before and after deployment. Before: old site (`Lion Pride 1 - Serengeti`, site_772, recalled June 2) appeared in the map response with `deviceDetails.isActive: false`. After: the reading is excluded by the new filter and the site no longer appears. The new site (`Lion Pride 1 - Serengeti 782`, site_782) with the active redeployed device continues to appear correctly.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Readings where `deviceDetails.isActive` is `false` are excluded. These are readings that were explicitly marked inactive by the recall flow at recall time. Readings where the field is `true`, `undefined`, or absent are unaffected — `{ $ne: false }` passes all of these through.

---

## :memo: Additional Notes

- A secondary architectural issue was identified during this investigation: `readingsForMap` passes `next` as the `filter` argument to `createEventUtil.read()`, which means the production map query has never carried a proper filter (no time window from `generateFilter.readingsMap()`, no site constraints). The intended 24-hour time window is therefore not enforced in production — the effective window is `DIAGNOSTIC_WINDOW_DAYS` (7 days). A follow-up PR is needed to fix the `readingsForMap` → `read()` call chain to pass the correct filter from `generateFilter.readingsMap()`.
- The earlier fix in `ReadingModel.listForMap()` (`"deviceDetails.isActive": { $ne: false }`) remains correct for the `/map/test` route but had no effect on the production map. Both fixes are now in place.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recent readings now exclude data from inactive devices, ensuring only active device information appears in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->