### PR TITLE
feat: add personal user onboarding checklist state to the backend API

### DIFF
--- a/src/auth-service/config/core/db-projections.js
+++ b/src/auth-service/config/core/db-projections.js
@@ -218,6 +218,7 @@ const dbProjections = {
     updatedAt: 1,
     my_groups: "$my_groups",
     firebase_uid: 1,
+    onboarding_checklist: 1,
   },
   USERS_EXCLUSION_PROJECTION: function (category) {
     const initialProjection = {

--- a/src/auth-service/config/core/db-projections.js
+++ b/src/auth-service/config/core/db-projections.js
@@ -161,6 +161,7 @@ const dbProjections = {
     phoneNumber: 1,
     timezone: 1,
     cohorts: 1,
+    devices: 1,
     clients: "$clients",
     groups: {
       $cond: {

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -1869,6 +1869,17 @@ const userController = {
       handleError(error, next);
     }
   },
+
+  updateOnboarding: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+      const result = await userUtil.updateOnboarding(request, next);
+      sendResponse(res, result, "onboarding_checklist");
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
 };
 
 module.exports = userController;

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -465,6 +465,10 @@ const UserSchema = new Schema(
         ref: "device",
       },
     ],
+    onboarding_checklist: {
+      is_dismissed: { type: Boolean, default: false },
+      completed_steps: { type: [String], default: [] },
+    },
     sites: [
       {
         type: ObjectId,

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -670,6 +670,15 @@ router.get(
   userController.listCohorts,
 );
 
+// Onboarding checklist
+router.patch(
+  "/onboarding",
+  enhancedJWTAuth,
+  userValidations.updateOnboarding,
+  validate,
+  userController.updateOnboarding,
+);
+
 // ================================
 // ERROR HANDLING
 // ================================

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -3257,3 +3257,102 @@ describe("buildAuthMethods()", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// computeUserOnboardingChecklist logic
+// ---------------------------------------------------------------------------
+describe("computeUserOnboardingChecklist (personal onboarding checklist logic)", () => {
+  function computeUserOnboardingChecklist(user) {
+    const stored = user.onboarding_checklist || {
+      is_dismissed: false,
+      completed_steps: [],
+    };
+    const steps = new Set(stored.completed_steps || []);
+    if ((user.devices || []).length > 0) steps.add("add-device");
+    if ((user.cohorts || []).length > 0) steps.add("assign-cohort");
+    return {
+      is_dismissed: stored.is_dismissed || false,
+      completed_steps: Array.from(steps),
+    };
+  }
+
+  const { expect } = require("chai");
+
+  it("adds add-device when user has at least one device", () => {
+    const user = {
+      devices: ["d1"],
+      cohorts: [],
+      onboarding_checklist: { is_dismissed: false, completed_steps: [] },
+    };
+    const result = computeUserOnboardingChecklist(user);
+    expect(result.completed_steps).to.include("add-device");
+    expect(result.completed_steps).to.not.include("assign-cohort");
+  });
+
+  it("adds assign-cohort when user has at least one cohort", () => {
+    const user = {
+      devices: [],
+      cohorts: ["c1"],
+      onboarding_checklist: { is_dismissed: false, completed_steps: [] },
+    };
+    const result = computeUserOnboardingChecklist(user);
+    expect(result.completed_steps).to.include("assign-cohort");
+    expect(result.completed_steps).to.not.include("add-device");
+  });
+
+  it("adds both dynamic steps when user has devices and cohorts", () => {
+    const user = {
+      devices: ["d1"],
+      cohorts: ["c1"],
+      onboarding_checklist: { is_dismissed: false, completed_steps: ["set-visibility"] },
+    };
+    const result = computeUserOnboardingChecklist(user);
+    expect(result.completed_steps).to.include("add-device");
+    expect(result.completed_steps).to.include("assign-cohort");
+    expect(result.completed_steps).to.include("set-visibility");
+  });
+
+  it("deduplicates dynamic steps already present in stored completed_steps", () => {
+    const user = {
+      devices: ["d1"],
+      cohorts: ["c1"],
+      onboarding_checklist: {
+        is_dismissed: false,
+        completed_steps: ["add-device", "assign-cohort"],
+      },
+    };
+    const result = computeUserOnboardingChecklist(user);
+    expect(result.completed_steps.filter((s) => s === "add-device")).to.have.length(1);
+    expect(result.completed_steps.filter((s) => s === "assign-cohort")).to.have.length(1);
+  });
+
+  it("defaults gracefully for legacy users without onboarding_checklist field", () => {
+    const user = { devices: ["d1"], cohorts: [], onboarding_checklist: undefined };
+    const result = computeUserOnboardingChecklist(user);
+    expect(result.is_dismissed).to.equal(false);
+    expect(result.completed_steps).to.include("add-device");
+  });
+
+  it("preserves is_dismissed: true from stored state", () => {
+    const user = {
+      devices: [],
+      cohorts: [],
+      onboarding_checklist: { is_dismissed: true, completed_steps: [] },
+    };
+    expect(computeUserOnboardingChecklist(user).is_dismissed).to.equal(true);
+  });
+
+  it("accepts arbitrary step_id strings without restriction", () => {
+    const user = {
+      devices: [],
+      cohorts: [],
+      onboarding_checklist: {
+        is_dismissed: false,
+        completed_steps: ["download-desktop-app", "invite-team"],
+      },
+    };
+    const result = computeUserOnboardingChecklist(user);
+    expect(result.completed_steps).to.include("download-desktop-app");
+    expect(result.completed_steps).to.include("invite-team");
+  });
+});

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -3262,19 +3262,9 @@ describe("buildAuthMethods()", () => {
 // computeUserOnboardingChecklist logic
 // ---------------------------------------------------------------------------
 describe("computeUserOnboardingChecklist (personal onboarding checklist logic)", () => {
-  function computeUserOnboardingChecklist(user) {
-    const stored = user.onboarding_checklist || {
-      is_dismissed: false,
-      completed_steps: [],
-    };
-    const steps = new Set(stored.completed_steps || []);
-    if ((user.devices || []).length > 0) steps.add("add-device");
-    if ((user.cohorts || []).length > 0) steps.add("assign-cohort");
-    return {
-      is_dismissed: stored.is_dismissed || false,
-      completed_steps: Array.from(steps),
-    };
-  }
+  const computeUserOnboardingChecklist = rewireCreateUser.__get__(
+    "computeUserOnboardingChecklist",
+  );
 
   const { expect } = require("chai");
 

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -7863,6 +7863,65 @@ const feedbackUtil = {
       );
     }
   },
+
+  updateOnboarding: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { _id: user_id } = request.user;
+      const { action, step_id } = request.body;
+
+      const exists = await UserModel(tenant).exists({ _id: user_id });
+      if (!exists) {
+        return {
+          success: false,
+          message: "User not found",
+          errors: { message: `User ${user_id} not found` },
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      const updateOp =
+        action === "mark_step_complete"
+          ? { $addToSet: { "onboarding_checklist.completed_steps": step_id } }
+          : { $set: { "onboarding_checklist.is_dismissed": true } };
+
+      const updatedUser = await UserModel(tenant)
+        .findByIdAndUpdate(user_id, updateOp, { new: true })
+        .lean();
+
+      return {
+        success: true,
+        message: "Onboarding state updated successfully",
+        data: {
+          onboarding_checklist: computeUserOnboardingChecklist(updatedUser),
+        },
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+};
+
+const computeUserOnboardingChecklist = (user) => {
+  const stored = user.onboarding_checklist || {
+    is_dismissed: false,
+    completed_steps: [],
+  };
+  const steps = new Set(stored.completed_steps || []);
+  if ((user.devices || []).length > 0) steps.add("add-device");
+  if ((user.cohorts || []).length > 0) steps.add("assign-cohort");
+  return {
+    is_dismissed: stored.is_dismissed || false,
+    completed_steps: Array.from(steps),
+  };
 };
 
 module.exports = {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -907,16 +907,19 @@ const createUserModule = {
       const { tenant, limit, skip } = query;
 
       const filter = generateFilter.users(request, next);
-      const responseFromListUser = await UserModel(tenant).list(
-        {
-          filter,
-          limit,
-          skip,
-        },
+      const response = await UserModel(tenant).list(
+        { filter, limit, skip },
         next,
       );
 
-      return responseFromListUser;
+      if (response && response.success && Array.isArray(response.data)) {
+        response.data = response.data.map((user) => ({
+          ...user,
+          onboarding_checklist: computeUserOnboardingChecklist(user),
+        }));
+      }
+
+      return response;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(
@@ -7870,8 +7873,27 @@ const feedbackUtil = {
       const { _id: user_id } = request.user;
       const { action, step_id } = request.body;
 
-      const exists = await UserModel(tenant).exists({ _id: user_id });
-      if (!exists) {
+      let updateOp;
+      if (action === "mark_step_complete") {
+        updateOp = {
+          $addToSet: { "onboarding_checklist.completed_steps": step_id },
+        };
+      } else if (action === "dismiss_checklist") {
+        updateOp = { $set: { "onboarding_checklist.is_dismissed": true } };
+      } else {
+        return {
+          success: false,
+          message: "Bad Request Error",
+          errors: { message: `Unsupported action: ${action}` },
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      const updatedUser = await UserModel(tenant)
+        .findByIdAndUpdate(user_id, updateOp, { new: true })
+        .lean();
+
+      if (!updatedUser) {
         return {
           success: false,
           message: "User not found",
@@ -7880,21 +7902,10 @@ const feedbackUtil = {
         };
       }
 
-      const updateOp =
-        action === "mark_step_complete"
-          ? { $addToSet: { "onboarding_checklist.completed_steps": step_id } }
-          : { $set: { "onboarding_checklist.is_dismissed": true } };
-
-      const updatedUser = await UserModel(tenant)
-        .findByIdAndUpdate(user_id, updateOp, { new: true })
-        .lean();
-
       return {
         success: true,
         message: "Onboarding state updated successfully",
-        data: {
-          onboarding_checklist: computeUserOnboardingChecklist(updatedUser),
-        },
+        data: computeUserOnboardingChecklist(updatedUser),
         status: httpStatus.OK,
       };
     } catch (error) {

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1594,6 +1594,32 @@ const updateFeedbackStatus = [
     .withMessage(`status must be one of: ${FEEDBACK_STATUSES.join(", ")}`),
 ];
 
+const updateOnboarding = [
+  validateTenant,
+  body("action")
+    .exists()
+    .withMessage("action is required")
+    .bail()
+    .isIn(["mark_step_complete", "dismiss_checklist"])
+    .withMessage(
+      "action must be one of: mark_step_complete, dismiss_checklist",
+    ),
+  body("step_id")
+    .if(body("action").equals("mark_step_complete"))
+    .exists()
+    .withMessage("step_id is required when action is mark_step_complete")
+    .bail()
+    .isString()
+    .withMessage("step_id must be a string")
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage("step_id must not be empty")
+    .bail()
+    .isLength({ max: 100 })
+    .withMessage("step_id must not exceed 100 characters"),
+];
+
 module.exports = {
   tenant: validateTenant,
   AirqoTenantOnly: validateAirqoTenantOnly,
@@ -1654,4 +1680,5 @@ module.exports = {
   listFeedbackSubmissions,
   getFeedbackById,
   updateFeedbackStatus,
+  updateOnboarding,
 };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds backend support for personal user onboarding checklist state. Introduces an
`onboarding_checklist` subdocument on the `User` model (`is_dismissed`,
`completed_steps`) and a new `PATCH /api/v2/users/onboarding` endpoint that
supports two actions: `mark_step_complete` and `dismiss_checklist`. The user is
always derived from the JWT token — no user ID in the path. Both `add-device`
and `assign-cohort` are evaluated dynamically from the `devices` and `cohorts`
arrays already present on the User document, requiring zero extra queries. The
`completed_steps` array accepts any string, so new step IDs can be introduced
by the frontend without any backend schema change.

### Why is this change needed?
The frontend currently tracks personal onboarding completion in `localStorage`,
which causes the checklist widget to reappear when a user switches devices or
browsers, and to fall out of sync when backend data (e.g. devices) is deleted.
Moving this state to the backend gives a single source of truth that follows the
user across all devices and sessions. This complements the existing
org-level onboarding checklist (on the `Group` model) and is kept entirely
separate — the two checklists serve different workspace contexts and are never
merged.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually verified the PATCH endpoint for both `mark_step_complete` and
`dismiss_checklist` actions. Confirmed that `add-device` and `assign-cohort`
appear dynamically in the user GET response when the user has devices and
cohorts respectively, and are absent when the arrays are empty. Confirmed
legacy users without the `onboarding_checklist` field default gracefully to
`{ is_dismissed: false, completed_steps: [] }`.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `onboarding_checklist` field is additive to all user GET responses.
Existing users without the field in the database default gracefully — no
migration script required.

---

## :memo: Additional Notes

- The `PATCH /api/v2/users/onboarding` endpoint derives the user identity
  from the JWT token (`req.user._id`). There is no `:userId` in the path,
  which prevents one user from modifying another user's checklist.
- Both `add-device` and `assign-cohort` are computed dynamically from
  `user.devices.length` and `user.cohorts.length` — both arrays already exist
  on the User document, so no cross-service calls are needed.
- `completed_steps` accepts any string with no enum validation. New step IDs
  (e.g. `"download-desktop-app"`) can be introduced by the frontend at any
  point without a backend schema update.
- This is intentionally a separate checklist from the org-level one on the
  `Group` model. The two are isolated by workspace context on the frontend and
  are never merged on the backend.
- Access requires only `enhancedJWTAuth` — no group-admin middleware, since
  users own their own personal checklist.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding checklist added so users can track and persist setup steps.
  * Users can mark steps complete or dismiss the checklist via a new authenticated update endpoint.
  * Checklist state in user lists is now derived from stored checklist plus device and cohort membership (auto-marking relevant steps).

* **Tests**
  * New test suite covers checklist normalization, dynamic step generation, deduplication, and legacy defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->