### PR TITLE
fix: restore correct OAuth failure redirect path and Twitter session logging

### DIFF
--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -45,6 +45,16 @@ const handleError = (error, next) => {
   );
 };
 
+const ANALYTICS_ORIGIN = (() => {
+  try {
+    return constants.ANALYTICS_BASE_URL
+      ? new URL(constants.ANALYTICS_BASE_URL).origin
+      : null;
+  } catch {
+    return null;
+  }
+})();
+
 function validateRedirectUrl(raw) {
   if (!raw || typeof raw !== "string") return null;
   try {
@@ -84,9 +94,14 @@ function resolveOAuthRedirectContext(req, res) {
   if (req.session) delete req.session.oauthRedirectAfter;
   let redirectOrigin = null;
   if (validatedUrl) { try { redirectOrigin = new URL(validatedUrl).origin; } catch {} }
-  const failureRedirectUrl = redirectOrigin
-    ? `${redirectOrigin}/login?error=oauth_failed`
-    : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
+  let failureRedirectUrl;
+  if (redirectOrigin && redirectOrigin !== ANALYTICS_ORIGIN) {
+    failureRedirectUrl = `${redirectOrigin}/login?error=oauth_failed`;
+  } else {
+    const base = constants.GMAIL_VERIFICATION_FAILURE_REDIRECT || `${redirectOrigin || ""}/user/login`;
+    const sep = base.includes("?") ? "&" : "?";
+    failureRedirectUrl = `${base}${sep}error=oauth_failed`;
+  }
   return { validatedUrl, redirectOrigin, failureRedirectUrl };
 }
 

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -98,9 +98,12 @@ function resolveOAuthRedirectContext(req, res) {
   if (redirectOrigin && redirectOrigin !== ANALYTICS_ORIGIN) {
     failureRedirectUrl = `${redirectOrigin}/login?error=oauth_failed`;
   } else {
-    const base = constants.GMAIL_VERIFICATION_FAILURE_REDIRECT || `${redirectOrigin || ""}/user/login`;
+    const base =
+      constants.GMAIL_VERIFICATION_FAILURE_REDIRECT ||
+      (redirectOrigin ? `${redirectOrigin}/user/login` : "/");
+    const hasErrorParam = /[?&]error=/.test(base);
     const sep = base.includes("?") ? "&" : "?";
-    failureRedirectUrl = `${base}${sep}error=oauth_failed`;
+    failureRedirectUrl = hasErrorParam ? base : `${base}${sep}error=oauth_failed`;
   }
   return { validatedUrl, redirectOrigin, failureRedirectUrl };
 }

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1158,6 +1158,18 @@ function resolveAllowedRedirectOrigins() {
 // Computed once at module load — inputs are fixed env vars.
 const ALLOWED_ORIGINS = resolveAllowedRedirectOrigins();
 
+// Origin of the analytics frontend. Used to select the correct failure-redirect
+// path: analytics uses /user/login, vertex and others use /login.
+const ANALYTICS_ORIGIN = (() => {
+  try {
+    return constants.ANALYTICS_BASE_URL
+      ? new URL(constants.ANALYTICS_BASE_URL).origin
+      : null;
+  } catch {
+    return null;
+  }
+})();
+
 function isAllowedRedirect(url, allowedOrigins) {
   if (!url || typeof url !== "string") return false;
   try {
@@ -1428,7 +1440,7 @@ const authGoogleCallback = (req, res, next) => {
   if (rawRedirect && isAllowedRedirect(rawRedirect, ALLOWED_ORIGINS)) {
     try { validatedOrigin = new URL(rawRedirect).origin; } catch {}
   }
-  const failureBase = validatedOrigin
+  const failureBase = validatedOrigin && validatedOrigin !== ANALYTICS_ORIGIN
     ? `${validatedOrigin}/login`
     : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
   passport.authenticate("google", {
@@ -1499,7 +1511,7 @@ const authOAuthCallback = (req, res, next) => {
   if (rawRedirect && isAllowedRedirect(rawRedirect, ALLOWED_ORIGINS)) {
     try { validatedOrigin = new URL(rawRedirect).origin; } catch {}
   }
-  const failureBase = validatedOrigin
+  const failureBase = validatedOrigin && validatedOrigin !== ANALYTICS_ORIGIN
     ? `${validatedOrigin}/login`
     : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
   const failureRedirectUrl = buildOAuthFailureRedirect(failureBase);
@@ -1537,13 +1549,16 @@ const authOAuthCallback = (req, res, next) => {
       err.message &&
       err.message.includes("Failed to find request token in session")
     ) {
-      // OAuth 1.0a session expiry — not actionable; occurs when the session
-      // expires between request-token and callback (pod restart, sticky-session
-      // miss, or browser back-button replay).
-      logger.warn(`[passport] OAuth session expired for ${safeProvider}`, {
+      // OAuth 1.0a request token missing from session. Common causes:
+      // (1) session cookie overwritten by another service sharing Domain=.airqo.net,
+      // (2) Redis session store unavailable — pod fell back to in-memory MongoStore,
+      // (3) browser back-button replay after the token was already consumed.
+      // Logged at ERROR so it surfaces in ArgoCD / alerting pipelines.
+      logger.error(`[passport] Twitter OAuth session token missing for ${safeProvider}`, {
         provider: safeProvider,
         errorType: err.name || "Error",
-        message: err.message,
+        sessionExists: !!req.session,
+        hasOauthKey: !!(req.session && req.session.oauth),
       });
     } else if (err.name === "TokenError" && err.code === "invalid_grant") {
       // Authorization code expired or already used — user-triggered (slow

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1442,7 +1442,8 @@ const authGoogleCallback = (req, res, next) => {
   }
   const failureBase = validatedOrigin && validatedOrigin !== ANALYTICS_ORIGIN
     ? `${validatedOrigin}/login`
-    : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
+    : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT
+      || (validatedOrigin ? `${validatedOrigin}/user/login` : "/");
   passport.authenticate("google", {
     failureRedirect: buildOAuthFailureRedirect(failureBase),
     session: false,
@@ -1513,7 +1514,8 @@ const authOAuthCallback = (req, res, next) => {
   }
   const failureBase = validatedOrigin && validatedOrigin !== ANALYTICS_ORIGIN
     ? `${validatedOrigin}/login`
-    : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT;
+    : constants.GMAIL_VERIFICATION_FAILURE_REDIRECT
+      || (validatedOrigin ? `${validatedOrigin}/user/login` : "/");
   const failureRedirectUrl = buildOAuthFailureRedirect(failureBase);
   passport.authenticate(provider, {
     session: false,
@@ -1551,12 +1553,13 @@ const authOAuthCallback = (req, res, next) => {
     ) {
       // OAuth 1.0a request token missing from session. Common causes:
       // (1) session cookie overwritten by another service sharing Domain=.airqo.net,
-      // (2) Redis session store unavailable — pod fell back to in-memory MongoStore,
+      // (2) Redis session store unavailable — the app fell back to MongoStore (MongoDB-backed),
       // (3) browser back-button replay after the token was already consumed.
       // Logged at ERROR so it surfaces in ArgoCD / alerting pipelines.
-      logger.error(`[passport] Twitter OAuth session token missing for ${safeProvider}`, {
+      logger.error(`[passport] OAuth 1.0a session token missing for ${safeProvider}`, {
         provider: safeProvider,
         errorType: err.name || "Error",
+        message: err.message,
         sessionExists: !!req.session,
         hasOauthKey: !!(req.session && req.session.oauth),
       });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes two regressions introduced when adding vertex OAuth support:

1. **Wrong failure redirect path for analytics** — all three OAuth failure-redirect builders (`authGoogleCallback`, `authOAuthCallback`, `resolveOAuthRedirectContext`) were constructing failure URLs as `${validatedOrigin}/login`. Analytics uses `/user/login`, not `/login`. A new `ANALYTICS_ORIGIN` constant (derived from `ANALYTICS_BASE_URL`) gates the path choice: analytics gets `GMAIL_VERIFICATION_FAILURE_REDIRECT`, all other origins (vertex, beacon, etc.) continue to use `${origin}/login`.

2. **Twitter session error invisible in ArgoCD** — the "Failed to find request token in session" error from passport-oauth1 was logged at `warn` level, below most ArgoCD alert thresholds. Upgraded to `error` with two diagnostic fields: `sessionExists` (was the session loaded at all?) and `hasOauthKey` (was the `oauth` namespace present in the session?). These distinguish between a missing session cookie (domain/cookie collision) and a Redis write failure.

### Why is this change needed?

Twitter was consistently failing on analytics with a double-redirect to `analytics.airqo.net/user/login?callbackUrl=%2Flogin%3Ferror%3Doauth_failed`. LinkedIn appeared to succeed but landed on `analytics.airqo.net/login?error=oauth_failed&success=linkedin` — a page that doesn't exist. Google and GitHub were unaffected.

Root cause of the cascading LinkedIn issue: Twitter failure redirected to the non-existent `/login` path. The analytics frontend, sitting on that broken page, then passed `redirect_after=https://analytics.airqo.net/login?error=oauth_failed` for the LinkedIn retry. LinkedIn succeeded, `buildSuccessRedirectUrl` appended `&success=linkedin`, producing the mixed error+success URL. Clicking "Home" worked because the `#token=JWT` hash was still present and picked up client-side.

The Twitter root cause (session token missing) is now surfaced as an ERROR with diagnostic fields. The most likely infrastructure trigger is the shared `Domain=.airqo.net` session cookie: if vertex runs its own Express session, `connect.sid` from vertex can overwrite analytics's session cookie in the browser, causing the Twitter callback to load vertex's session (no `oauth` key) rather than analytics's.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service`
  - `middleware/passport.js` — `ANALYTICS_ORIGIN` constant; fixed `authGoogleCallback` and `authOAuthCallback` failure base; Twitter session error promoted to `error` with diagnostic fields
  - `controllers/user.controller.js` — `ANALYTICS_ORIGIN` constant; fixed `resolveOAuthRedirectContext` failure path

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Manually verified on analytics staging:
- Twitter failure now redirects to `analytics.airqo.net/user/login?error=oauth_failed` (no more double-redirect)
- LinkedIn success now redirects to the correct `redirect_after` URL with `success=linkedin`
- Google and GitHub OAuth unaffected
- ArgoCD now shows the Twitter session error at ERROR level with `sessionExists`/`hasOauthKey` fields

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Twitter root cause — next steps:**

The code fix restores the correct failure path so users are no longer stuck in a redirect loop. The underlying Twitter session issue (likely `connect.sid` cookie collision between analytics and vertex sharing `Domain=.airqo.net`) will now surface as an ERROR in ArgoCD. Check for:

```
[passport] Twitter OAuth session token missing for twitter
  sessionExists: true   → session loaded, but oauth key absent (Redis write failure or cross-service session overwrite)
  sessionExists: false  → session cookie missing entirely (cookie domain conflict)
```

If `sessionExists: true, hasOauthKey: false` is consistent, the fix is to use distinct session cookie names per deployment (`SESSION_COOKIE_NAME` env var) so vertex and analytics session cookies do not collide under `Domain=.airqo.net`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined OAuth failure redirect behavior so users are sent to the appropriate login/verification page depending on the redirect origin.
  * Improved OAuth error handling and logging for session/token failures to provide clearer diagnostics and aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->