### PR TITLE
fix: cookie fallback for Twitter OAuth 1.0a request token loss

### DIFF
--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const passport = require("passport");
 const LocalStrategy = require("passport-local");
 const userUtil = require("@utils/user.util");
@@ -1453,6 +1454,124 @@ const authGoogleCallback = (req, res, next) => {
   });
 };
 
+// ── Twitter OAuth 1.0a cookie bridge ─────────────────────────────────────────
+// OAuth 1.0a stores the request token secret in the session between the
+// initiation and callback requests. In a multi-pod deployment the callback
+// may land on a different pod (no shared Redis) or a different session
+// (Domain=.airqo.net cookie collision), causing passport-oauth1 to fail with
+// "Failed to find request token in session". We mirror the token+secret to an
+// HMAC-signed short-lived HttpOnly cookie during initiation and restore it
+// from that cookie on the callback if the session is missing the data.
+
+const OAUTH1_TOKEN_COOKIE = "_oauth1_tw";
+
+function signOAuth1State(token, secret) {
+  const payload = `${Buffer.from(token).toString("base64url")}.${Buffer.from(secret).toString("base64url")}`;
+  const sig = crypto
+    .createHmac("sha256", constants.SESSION_SECRET)
+    .update(payload)
+    .digest("base64url");
+  return `${payload}.${sig}`;
+}
+
+function verifyOAuth1State(signed) {
+  if (typeof signed !== "string") return null;
+  const lastDot = signed.lastIndexOf(".");
+  if (lastDot === -1) return null;
+  const payload = signed.substring(0, lastDot);
+  const sig = signed.substring(lastDot + 1);
+  const expected = crypto
+    .createHmac("sha256", constants.SESSION_SECRET)
+    .update(payload)
+    .digest("base64url");
+  let valid = false;
+  try {
+    valid = crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
+  } catch {
+    return null;
+  }
+  if (!valid) return null;
+  const parts = payload.split(".");
+  if (parts.length !== 2) return null;
+  try {
+    return {
+      token: Buffer.from(parts[0], "base64url").toString(),
+      secret: Buffer.from(parts[1], "base64url").toString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Wraps req.session.save() so the oauth request token is also written to an
+// HMAC-signed cookie during Twitter initiation. No-op for all other providers.
+const setupTwitterOAuthBridge = (req, res, next) => {
+  const provider =
+    req.oauthProvider || (req.params && req.params.provider) || "";
+  if (provider !== "twitter" || !req.session) return next();
+
+  const originalSave = req.session.save.bind(req.session);
+  req.session.save = function (callback) {
+    if (req.session.oauth && typeof req.session.oauth === "object") {
+      const entries = Object.entries(req.session.oauth);
+      if (entries.length > 0) {
+        const [oauthToken, oauthSecret] = entries[0];
+        try {
+          const signed = signOAuth1State(oauthToken, oauthSecret);
+          const cookieOpts = {
+            httpOnly: true,
+            secure: process.env.NODE_ENV !== "development",
+            sameSite: "lax",
+            maxAge: 10 * 60 * 1000,
+            path: "/",
+          };
+          if (constants.OAUTH_COOKIE_DOMAIN)
+            cookieOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
+          res.cookie(OAUTH1_TOKEN_COOKIE, signed, cookieOpts);
+        } catch (e) {
+          logger.warn("[passport] Twitter OAuth 1.0a bridge: failed to set cookie", {
+            error: e.message,
+          });
+        }
+      }
+    }
+    return originalSave(callback);
+  };
+  next();
+};
+
+// Restores req.session.oauth from the HMAC-signed cookie mirror if the session
+// is missing the oauth key on the Twitter callback. Always clears the cookie.
+const restoreTwitterOAuthFromCookie = (req, res, next) => {
+  const provider =
+    req.oauthProvider || (req.params && req.params.provider) || "";
+  if (provider !== "twitter") return next();
+
+  const clearOpts = { path: "/" };
+  if (constants.OAUTH_COOKIE_DOMAIN)
+    clearOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
+
+  if (req.session && !req.session.oauth) {
+    const signedCookie = req.cookies && req.cookies[OAUTH1_TOKEN_COOKIE];
+    if (signedCookie) {
+      const data = verifyOAuth1State(signedCookie);
+      if (data) {
+        req.session.oauth = { [data.token]: data.secret };
+        logger.info(
+          "[passport] Restored Twitter OAuth 1.0a request token from cookie fallback",
+        );
+      } else {
+        logger.warn(
+          "[passport] Twitter OAuth 1.0a cookie fallback: HMAC signature invalid",
+        );
+      }
+    }
+  }
+
+  res.clearCookie(OAUTH1_TOKEN_COOKIE, clearOpts);
+  next();
+};
+
 /**
  * Dynamically initiates OAuth flow for any supported provider.
  * Used by the generic GET /auth/:provider route.
@@ -2029,4 +2148,6 @@ module.exports = {
   optionalJWTAuth,
   specificRouteUris,
   matchesRoute,
+  setupTwitterOAuthBridge,
+  restoreTwitterOAuthFromCookie,
 };

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1465,8 +1465,15 @@ const authGoogleCallback = (req, res, next) => {
 
 const OAUTH1_TOKEN_COOKIE = "_oauth1_tw";
 
-function signOAuth1State(token, secret) {
-  const payload = `${Buffer.from(token).toString("base64url")}.${Buffer.from(secret).toString("base64url")}`;
+// Payload layout: base64url(oauth_token).base64url(oauth_token_secret).base64url(tenant).hmac
+// The tenant is included so restoreTwitterOAuthFromCookie can reinstate
+// req.session.oauthTenant before setOAuthProvider reads it.
+function signOAuth1State(token, secret, tenant) {
+  const payload = [
+    Buffer.from(token).toString("base64url"),
+    Buffer.from(secret).toString("base64url"),
+    Buffer.from(tenant || "").toString("base64url"),
+  ].join(".");
   // HMAC-SHA256 is used here for payload integrity signing, not password storage.
   // The oauth token+secret are ephemeral round-trip values, not credentials being
   // persisted. This pattern is the same used by cookie-parser signed cookies and
@@ -1498,11 +1505,12 @@ function verifyOAuth1State(signed) {
     return null;
   }
   const parts = payload.split(".");
-  if (parts.length !== 2) return null;
+  if (parts.length !== 3) return null;
   try {
     return {
       token: Buffer.from(parts[0], "base64url").toString(),
       secret: Buffer.from(parts[1], "base64url").toString(),
+      tenant: Buffer.from(parts[2], "base64url").toString() || "airqo",
     };
   } catch {
     return null;
@@ -1518,27 +1526,26 @@ const setupTwitterOAuthBridge = (req, res, next) => {
 
   const originalSave = req.session.save.bind(req.session);
   req.session.save = function (callback) {
-    if (req.session.oauth && typeof req.session.oauth === "object") {
-      const entries = Object.entries(req.session.oauth);
-      if (entries.length > 0) {
-        const [oauthToken, oauthSecret] = entries[0];
-        try {
-          const signed = signOAuth1State(oauthToken, oauthSecret);
-          const cookieOpts = {
-            httpOnly: true,
-            secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
-            sameSite: "lax",
-            maxAge: 10 * 60 * 1000,
-            path: "/",
-          };
-          if (constants.OAUTH_COOKIE_DOMAIN)
-            cookieOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
-          res.cookie(OAUTH1_TOKEN_COOKIE, signed, cookieOpts);
-        } catch (e) {
-          logger.warn("[passport] Twitter OAuth 1.0a bridge: failed to set cookie", {
-            error: e.message,
-          });
-        }
+    const oauthToken = req.session.oauth && req.session.oauth.oauth_token;
+    const oauthSecret = req.session.oauth && req.session.oauth.oauth_token_secret;
+    if (oauthToken && oauthSecret) {
+      const tenant = req.session.oauthTenant || "airqo";
+      try {
+        const signed = signOAuth1State(oauthToken, oauthSecret, tenant);
+        const cookieOpts = {
+          httpOnly: true,
+          secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
+          sameSite: "lax",
+          maxAge: 10 * 60 * 1000,
+          path: "/",
+        };
+        if (constants.OAUTH_COOKIE_DOMAIN)
+          cookieOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
+        res.cookie(OAUTH1_TOKEN_COOKIE, signed, cookieOpts);
+      } catch (e) {
+        logger.warn("[passport] Twitter OAuth 1.0a bridge: failed to set cookie", {
+          error: e.message,
+        });
       }
     }
     return originalSave(callback);
@@ -1562,7 +1569,11 @@ const restoreTwitterOAuthFromCookie = (req, res, next) => {
     if (signedCookie) {
       const data = verifyOAuth1State(signedCookie);
       if (data) {
-        req.session.oauth = { [data.token]: data.secret };
+        req.session.oauth = {
+          oauth_token: data.token,
+          oauth_token_secret: data.secret,
+        };
+        req.session.oauthTenant = data.tenant;
         logger.info(
           "[passport] Restored Twitter OAuth 1.0a request token from cookie fallback",
         );

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1489,13 +1489,14 @@ function verifyOAuth1State(signed) {
     .createHmac("sha256", constants.SESSION_SECRET)
     .update(payload)
     .digest("base64url");
-  let valid = false;
+  const sBuf = Buffer.from(sig, "base64url");
+  const eBuf = Buffer.from(expected, "base64url");
+  if (sBuf.length !== eBuf.length) return null;
   try {
-    valid = crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
+    if (!crypto.timingSafeEqual(sBuf, eBuf)) return null;
   } catch {
     return null;
   }
-  if (!valid) return null;
   const parts = payload.split(".");
   if (parts.length !== 2) return null;
   try {
@@ -1525,7 +1526,7 @@ const setupTwitterOAuthBridge = (req, res, next) => {
           const signed = signOAuth1State(oauthToken, oauthSecret);
           const cookieOpts = {
             httpOnly: true,
-            secure: process.env.NODE_ENV !== "development",
+            secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
             sameSite: "lax",
             maxAge: 10 * 60 * 1000,
             path: "/",

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1467,6 +1467,11 @@ const OAUTH1_TOKEN_COOKIE = "_oauth1_tw";
 
 function signOAuth1State(token, secret) {
   const payload = `${Buffer.from(token).toString("base64url")}.${Buffer.from(secret).toString("base64url")}`;
+  // HMAC-SHA256 is used here for payload integrity signing, not password storage.
+  // The oauth token+secret are ephemeral round-trip values, not credentials being
+  // persisted. This pattern is the same used by cookie-parser signed cookies and
+  // JWT libraries. CodeQL false-positive suppressed accordingly.
+  // codeql[js/insufficient-password-hash]
   const sig = crypto
     .createHmac("sha256", constants.SESSION_SECRET)
     .update(payload)

--- a/src/auth-service/middleware/test/ut_twitter_oauth_bridge.js
+++ b/src/auth-service/middleware/test/ut_twitter_oauth_bridge.js
@@ -1,0 +1,271 @@
+require("module-alias/register");
+
+// Guard env vars that throw at require-time (cloudinary, session HMAC, log4js).
+process.env.NODE_ENV = process.env.NODE_ENV || "test";
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || "test-session-secret";
+process.env.CLOUD_NAME = process.env.CLOUD_NAME || "test";
+process.env.CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY || "test";
+process.env.CLOUDINARY_API_SECRET = process.env.CLOUDINARY_API_SECRET || "test";
+
+const { expect } = require("chai");
+const sinon = require("sinon");
+const proxyquire = require("proxyquire");
+const { HttpError } = require("@utils/shared");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockRes() {
+  return {
+    cookie: sinon.stub(),
+    clearCookie: sinon.stub(),
+  };
+}
+
+function makeInitiationReq(oauthEntry = { testtoken: "testsecret" }) {
+  return {
+    oauthProvider: "twitter",
+    params: { provider: "twitter" },
+    session: {
+      oauth: oauthEntry,
+      save: sinon.stub().callsFake((cb) => cb(null)),
+    },
+  };
+}
+
+function makeCallbackReq(cookieValue) {
+  return {
+    oauthProvider: "twitter",
+    params: { provider: "twitter" },
+    session: {},
+    cookies: cookieValue ? { _oauth1_tw: cookieValue } : {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Twitter OAuth 1.0a Cookie Bridge", () => {
+  let passportModule;
+  let setupTwitterOAuthBridge;
+  let restoreTwitterOAuthFromCookie;
+
+  beforeEach(() => {
+    const loggerStub = {
+      info: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+    };
+
+    passportModule = proxyquire("@middleware/passport", {
+      "@models/User": sinon.stub().returns({
+        findById: sinon.stub().returns({ lean: sinon.stub().resolves({}) }),
+      }),
+      "@utils/common": {
+        winstonLogger: loggerStub,
+        mailer: {},
+        stringify: sinon.stub(),
+      },
+      "@services/atf.service": {
+        AbstractTokenFactory: sinon.stub().returns({
+          createToken: sinon.stub().resolves("token"),
+          _getEffectiveTokenStrategy: sinon
+            .stub()
+            .returns("NO_ROLES_AND_PERMISSIONS"),
+        }),
+      },
+      "@utils/user.util": { getUser: sinon.stub().resolves({}) },
+      "@utils/shared": {
+        HttpError,
+        logObject: sinon.stub(),
+        logText: sinon.stub(),
+        logElement: sinon.stub(),
+        extractErrorsFromRequest: sinon.stub().returns(null),
+      },
+      jsonwebtoken: {
+        verify: sinon.stub(),
+        sign: sinon.stub(),
+        "@noCallThru": true,
+      },
+    });
+
+    setupTwitterOAuthBridge = passportModule.setupTwitterOAuthBridge;
+    restoreTwitterOAuthFromCookie = passportModule.restoreTwitterOAuthFromCookie;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // ── setupTwitterOAuthBridge ────────────────────────────────────────────────
+
+  describe("setupTwitterOAuthBridge", () => {
+    it("is a no-op for non-twitter providers", () => {
+      const next = sinon.stub();
+      const req = { oauthProvider: "google", session: {}, params: {} };
+      setupTwitterOAuthBridge(req, makeMockRes(), next);
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("is a no-op when session is absent", () => {
+      const next = sinon.stub();
+      const req = { oauthProvider: "twitter", session: null, params: {} };
+      setupTwitterOAuthBridge(req, makeMockRes(), next);
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("calls next and wraps session.save for twitter", () => {
+      const next = sinon.stub();
+      const req = makeInitiationReq();
+      setupTwitterOAuthBridge(req, makeMockRes(), next);
+      expect(next.calledOnce).to.be.true;
+      // save was replaced by the wrapper
+      expect(req.session.save).to.not.equal(sinon.stub()); // wrapped, not the original
+    });
+
+    it("sets _oauth1_tw cookie with three-part base64url.base64url.sig value", () => {
+      const next = sinon.stub();
+      const saveCb = sinon.stub();
+      const req = makeInitiationReq({ mytoken: "mysecret" });
+      const res = makeMockRes();
+
+      setupTwitterOAuthBridge(req, res, next);
+      req.session.save(saveCb);
+
+      expect(res.cookie.calledOnce).to.be.true;
+      expect(res.cookie.args[0][0]).to.equal("_oauth1_tw");
+      const cookieValue = res.cookie.args[0][1];
+      expect(cookieValue).to.be.a("string");
+      expect(cookieValue.split(".").length).to.equal(3);
+    });
+
+    it("calls the original session.save after setting the cookie", () => {
+      const saveCb = sinon.stub();
+      const req = makeInitiationReq();
+      const originalSave = req.session.save;
+      const res = makeMockRes();
+
+      setupTwitterOAuthBridge(req, makeMockRes(), sinon.stub());
+      req.session.save(saveCb);
+
+      expect(originalSave.calledOnce).to.be.true;
+      expect(saveCb.calledOnce).to.be.true;
+    });
+
+    it("does not set cookie when session has no oauth key", () => {
+      const req = {
+        oauthProvider: "twitter",
+        params: { provider: "twitter" },
+        session: {
+          save: sinon.stub().callsFake((cb) => cb(null)),
+        },
+      };
+      const res = makeMockRes();
+
+      setupTwitterOAuthBridge(req, res, sinon.stub());
+      req.session.save(() => {});
+
+      expect(res.cookie.called).to.be.false;
+    });
+  });
+
+  // ── restoreTwitterOAuthFromCookie ──────────────────────────────────────────
+
+  describe("restoreTwitterOAuthFromCookie", () => {
+    it("is a no-op for non-twitter providers", () => {
+      const next = sinon.stub();
+      const req = {
+        oauthProvider: "linkedin",
+        session: {},
+        cookies: {},
+        params: {},
+      };
+      restoreTwitterOAuthFromCookie(req, makeMockRes(), next);
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("does not overwrite session.oauth when it is already present", () => {
+      const next = sinon.stub();
+      const existing = { tok: "sec" };
+      const req = makeCallbackReq("somevalue");
+      req.session.oauth = existing;
+      const res = makeMockRes();
+
+      restoreTwitterOAuthFromCookie(req, res, next);
+
+      expect(req.session.oauth).to.deep.equal(existing);
+      expect(res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("clears cookie and calls next when no cookie is present", () => {
+      const next = sinon.stub();
+      const req = makeCallbackReq(null);
+      const res = makeMockRes();
+
+      restoreTwitterOAuthFromCookie(req, res, next);
+
+      expect(req.session.oauth).to.be.undefined;
+      expect(res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("restores session.oauth from a valid cookie (full round-trip)", () => {
+      // ── Initiation: generate signed cookie via setupTwitterOAuthBridge ──
+      const initReq = makeInitiationReq({ realtoken: "realsecret" });
+      const initRes = makeMockRes();
+      setupTwitterOAuthBridge(initReq, initRes, sinon.stub());
+      initReq.session.save(() => {});
+      const signedCookie = initRes.cookie.args[0][1];
+
+      // ── Callback: restore from that cookie ──
+      const callbackReq = makeCallbackReq(signedCookie);
+      const callbackRes = makeMockRes();
+      const callbackNext = sinon.stub();
+
+      restoreTwitterOAuthFromCookie(callbackReq, callbackRes, callbackNext);
+
+      expect(callbackReq.session.oauth).to.deep.equal({
+        realtoken: "realsecret",
+      });
+      expect(callbackRes.clearCookie.calledWith("_oauth1_tw")).to.be.true;
+      expect(callbackNext.calledOnce).to.be.true;
+    });
+
+    it("does not restore when cookie payload is tampered", () => {
+      const next = sinon.stub();
+      // Generate a valid cookie then corrupt the payload portion
+      const initReq = makeInitiationReq({ tok: "sec" });
+      const initRes = makeMockRes();
+      setupTwitterOAuthBridge(initReq, initRes, sinon.stub());
+      initReq.session.save(() => {});
+      const valid = initRes.cookie.args[0][1];
+      const parts = valid.split(".");
+      parts[0] = Buffer.from("tampered").toString("base64url");
+      const tampered = parts.join(".");
+
+      const req = makeCallbackReq(tampered);
+      const res = makeMockRes();
+      restoreTwitterOAuthFromCookie(req, res, next);
+
+      expect(req.session.oauth).to.be.undefined;
+      expect(res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("does not restore when cookie has a bad format", () => {
+      const next = sinon.stub();
+      const req = makeCallbackReq("not.a.valid.hmac.cookie.at.all");
+      const res = makeMockRes();
+
+      restoreTwitterOAuthFromCookie(req, res, next);
+
+      expect(req.session.oauth).to.be.undefined;
+      expect(res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/auth-service/middleware/test/ut_twitter_oauth_bridge.js
+++ b/src/auth-service/middleware/test/ut_twitter_oauth_bridge.js
@@ -23,12 +23,13 @@ function makeMockRes() {
   };
 }
 
-function makeInitiationReq(oauthEntry = { testtoken: "testsecret" }) {
+function makeInitiationReq(oauthEntry = { oauth_token: "testtoken", oauth_token_secret: "testsecret" }) {
   return {
     oauthProvider: "twitter",
     params: { provider: "twitter" },
     session: {
       oauth: oauthEntry,
+      oauthTenant: "airqo",
       save: sinon.stub().callsFake((cb) => cb(null)),
     },
   };
@@ -126,10 +127,13 @@ describe("Twitter OAuth 1.0a Cookie Bridge", () => {
       expect(req.session.save).to.not.equal(sinon.stub()); // wrapped, not the original
     });
 
-    it("sets _oauth1_tw cookie with three-part base64url.base64url.sig value", () => {
+    it("sets _oauth1_tw cookie with four-part token.secret.tenant.sig value", () => {
       const next = sinon.stub();
       const saveCb = sinon.stub();
-      const req = makeInitiationReq({ mytoken: "mysecret" });
+      const req = makeInitiationReq({
+        oauth_token: "mytoken",
+        oauth_token_secret: "mysecret",
+      });
       const res = makeMockRes();
 
       setupTwitterOAuthBridge(req, res, next);
@@ -139,7 +143,8 @@ describe("Twitter OAuth 1.0a Cookie Bridge", () => {
       expect(res.cookie.args[0][0]).to.equal("_oauth1_tw");
       const cookieValue = res.cookie.args[0][1];
       expect(cookieValue).to.be.a("string");
-      expect(cookieValue.split(".").length).to.equal(3);
+      // base64url(token).base64url(secret).base64url(tenant).hmac = 4 parts
+      expect(cookieValue.split(".").length).to.equal(4);
     });
 
     it("calls the original session.save after setting the cookie", () => {
@@ -155,11 +160,12 @@ describe("Twitter OAuth 1.0a Cookie Bridge", () => {
       expect(saveCb.calledOnce).to.be.true;
     });
 
-    it("does not set cookie when session has no oauth key", () => {
+    it("does not set cookie when session has no oauth_token_secret", () => {
       const req = {
         oauthProvider: "twitter",
         params: { provider: "twitter" },
         session: {
+          // no oauth key at all
           save: sinon.stub().callsFake((cb) => cb(null)),
         },
       };
@@ -215,7 +221,10 @@ describe("Twitter OAuth 1.0a Cookie Bridge", () => {
 
     it("restores session.oauth from a valid cookie (full round-trip)", () => {
       // ── Initiation: generate signed cookie via setupTwitterOAuthBridge ──
-      const initReq = makeInitiationReq({ realtoken: "realsecret" });
+      const initReq = makeInitiationReq({
+        oauth_token: "realtoken",
+        oauth_token_secret: "realsecret",
+      });
       const initRes = makeMockRes();
       setupTwitterOAuthBridge(initReq, initRes, sinon.stub());
       initReq.session.save(() => {});
@@ -229,16 +238,21 @@ describe("Twitter OAuth 1.0a Cookie Bridge", () => {
       restoreTwitterOAuthFromCookie(callbackReq, callbackRes, callbackNext);
 
       expect(callbackReq.session.oauth).to.deep.equal({
-        realtoken: "realsecret",
+        oauth_token: "realtoken",
+        oauth_token_secret: "realsecret",
       });
+      expect(callbackReq.session.oauthTenant).to.equal("airqo");
       expect(callbackRes.clearCookie.calledWith("_oauth1_tw")).to.be.true;
       expect(callbackNext.calledOnce).to.be.true;
     });
 
     it("does not restore when cookie payload is tampered", () => {
       const next = sinon.stub();
-      // Generate a valid cookie then corrupt the payload portion
-      const initReq = makeInitiationReq({ tok: "sec" });
+      // Generate a valid cookie then corrupt the token portion of the payload
+      const initReq = makeInitiationReq({
+        oauth_token: "tok",
+        oauth_token_secret: "sec",
+      });
       const initRes = makeMockRes();
       setupTwitterOAuthBridge(initReq, initRes, sinon.stub());
       initReq.session.save(() => {});

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -275,8 +275,8 @@ router.get("/auth/google", setGoogleAuth, authGoogle);
 
 router.get(
   "/auth/callback/:provider",
-  setOAuthProvider,
   restoreTwitterOAuthFromCookie,
+  setOAuthProvider,
   authOAuthCallback,
   userController.oauthCallback,
 );

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -18,6 +18,8 @@ const {
   authGoogle,
   enhancedJWTAuth,
   refreshTokenAuth,
+  setupTwitterOAuthBridge,
+  restoreTwitterOAuthFromCookie,
 } = require("@middleware/passport");
 const rateLimiter = require("@middleware/rate-limiter");
 const captchaMiddleware = require("@middleware/captcha");
@@ -274,11 +276,12 @@ router.get("/auth/google", setGoogleAuth, authGoogle);
 router.get(
   "/auth/callback/:provider",
   setOAuthProvider,
+  restoreTwitterOAuthFromCookie,
   authOAuthCallback,
   userController.oauthCallback,
 );
 
-router.get("/auth/:provider", setOAuthProvider, authOAuth);
+router.get("/auth/:provider", setOAuthProvider, setupTwitterOAuthBridge, authOAuth);
 
 // ================================
 // USER CRUD & AUTH ROUTES


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds an HMAC-signed HttpOnly cookie bridge (`_oauth1_tw`) for Twitter OAuth 1.0a to eliminate the session dependency between initiation and callback.

Two new Express middlewares are introduced in `passport.js` and wired into `routes/v2/users.routes.js`:

- **`setupTwitterOAuthBridge`** — inserted before `authOAuth` on the initiation route. It wraps `req.session.save()` so that when passport-oauth1 stores the request token secret in the session and calls `save()`, the middleware also writes an HMAC-SHA256-signed copy of the token+secret to a short-lived (10 min) HttpOnly cookie `_oauth1_tw`. No-op for all non-Twitter providers.
- **`restoreTwitterOAuthFromCookie`** — inserted before `authOAuthCallback` on the callback route. If `req.session.oauth` is absent when the callback arrives, it reads the `_oauth1_tw` cookie, verifies the HMAC signature (constant-time comparison), and restores `req.session.oauth = { [token]: secret }` so passport-oauth1 can complete token exchange. The cookie is always cleared after this step regardless of whether restoration was needed. No-op for all non-Twitter providers.

### Why is this change needed?

Setting `OAUTH_COOKIE_DOMAIN=".airqo.net"` for vertex support made the `express-session` cookie shared across all `*.airqo.net` subdomains. Any request from the vertex frontend to the auth service between Twitter's initiation redirect and the provider callback overwrites the `airqo_auth.sid` session cookie in the browser, causing a different session to be loaded on the callback.

Twitter OAuth 1.0a is the only provider affected because it is the only one that stores round-trip state in the session. Google, GitHub, LinkedIn, and Microsoft all use a stateless `CookieStateStore` (HMAC-signed, no session dependency) and were unaffected.

Production logs confirmed the pattern on every Twitter callback attempt:

```
[ERROR] [passport] OAuth 1.0a session token missing for twitter {
  provider: 'twitter',
  errorType: 'Error',
  message: 'Failed to find request token in session',
  sessionExists: true,
  hasOauthKey: false
}
```

`sessionExists: true` with `hasOauthKey: false` means the session was loaded but was not the session that stored the Twitter request token — consistent with the session cookie being overwritten between the two requests.

A previous fix that renamed the session cookie to `airqo_auth.sid` did not resolve the issue because the collision is between two different requests to the same auth service (not between Next.js and the auth service), both writing the same `airqo_auth.sid` cookie on `Domain=.airqo.net`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service` — `middleware/passport.js`, `routes/v2/users.routes.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

Twitter OAuth 1.0a tested end-to-end on analytics (`analytics.airqo.net`). Verified that the `_oauth1_tw` cookie is set during initiation and cleared on callback. Confirmed `restoreTwitterOAuthFromCookie` fires and restores the oauth key when the session is missing it, allowing passport-oauth1 to complete token exchange and redirect to the dashboard successfully.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The two new middlewares are no-ops for all non-Twitter providers. The `_oauth1_tw` cookie is short-lived (10 min), HttpOnly, and cleared on every Twitter callback regardless of outcome. No existing behaviour is altered for Google, GitHub, LinkedIn, or Microsoft OAuth flows.

---

## :memo: Additional Notes

- The HMAC key is `SESSION_SECRET` (already in production env). No new environment variables are required.
- The cookie uses `sameSite: "lax"` so it is correctly included on the top-level GET navigation that Twitter uses for its callback redirect.
- If `OAUTH_COOKIE_DOMAIN` is set, the `_oauth1_tw` cookie inherits the same domain so it is sent to the auth service callback endpoint regardless of which subdomain initiated the flow.
- This fix is additive: if the session does survive intact (e.g. in a single-pod local dev environment), `restoreTwitterOAuthFromCookie` detects `req.session.oauth` is already present and is a complete no-op; it still clears the cookie.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Twitter OAuth reliability in multi-pod deployments and session-missing scenarios, ensuring OAuth callbacks complete successfully even when session state is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->