### PR TITLE
fix: replace Twitter OAuth 1.0a session bridge with HMAC cookie token store

### DIFF
--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -186,18 +186,20 @@ class TwitterCookieTokenStore {
   // redirect URL. Returns the secret from session if present; falls back to
   // the signed cookie mirror if the session was lost.
   get(req, token, cb) {
-    if (req.session && req.session.oauth && req.session.oauth.oauth_token_secret) {
-      return cb(null, req.session.oauth.oauth_token_secret);
+    const sessionOauth = req.session && req.session.oauth;
+    if (
+      sessionOauth &&
+      sessionOauth.oauth_token_secret &&
+      (!sessionOauth.oauth_token || sessionOauth.oauth_token === token)
+    ) {
+      return cb(null, sessionOauth.oauth_token_secret);
     }
     const signedCookie = req.cookies && req.cookies[this._cookieName];
     if (signedCookie) {
       const data = this._verifyPayload(signedCookie);
       if (data) {
         if (data.token !== token) {
-          logger.warn("[TwitterCookieTokenStore] cookie fallback: oauth_token mismatch", {
-            expected: token,
-            cookieToken: data.token,
-          });
+          logger.warn("[TwitterCookieTokenStore] cookie fallback: oauth_token mismatch");
           return cb(new Error("Failed to find request token in session"));
         }
         if (req.session) {
@@ -239,13 +241,13 @@ class TwitterCookieTokenStore {
 
   // HMAC-SHA256 payload integrity signing — NOT password storage.
   // Payload: base64url(token).base64url(secret).base64url(tenant)
-  // codeql[js/insufficient-password-hash]
   _signPayload(token, secret, tenant) {
     const payload = [
       Buffer.from(token).toString("base64url"),
       Buffer.from(secret).toString("base64url"),
       Buffer.from(tenant || "").toString("base64url"),
     ].join(".");
+    // codeql[js/insufficient-password-hash]
     const sig = crypto
       .createHmac("sha256", this._secret)
       .update(payload)

--- a/src/auth-service/config/passport-strategies.js
+++ b/src/auth-service/config/passport-strategies.js
@@ -126,6 +126,165 @@ class CookieStateStore {
   }
 }
 
+// ── Twitter OAuth 1.0a token store ───────────────────────────────────────────
+//
+// passport-oauth1's default SessionStore stores the request token+secret in
+// the Express session between initiation and callback. In a multi-pod
+// deployment where Domain=.airqo.net makes the session cookie shared across
+// services, another service's request can overwrite the session cookie between
+// the two requests, causing "Failed to find request token in session".
+//
+// TwitterCookieTokenStore mirrors the token+secret to an HMAC-signed HttpOnly
+// cookie in set() — called synchronously before any response headers are
+// written, so there is no race with compression or other res.end interceptors.
+// get() reads from session first (normal case) and falls back to the cookie.
+class TwitterCookieTokenStore {
+  constructor({ secret, cookieName = "_oauth1_tw", ttlSeconds = 600, domain } = {}) {
+    if (!secret) throw new Error("TwitterCookieTokenStore: secret is required");
+    this._secret = secret;
+    this._cookieName = cookieName;
+    this._ttl = ttlSeconds;
+    this._domain = domain || null;
+  }
+
+  // Called by passport-oauth1 after obtaining the request token from Twitter,
+  // before the browser is redirected to Twitter. Headers are not yet sent.
+  set(req, token, tokenSecret, cb) {
+    if (req.session) {
+      if (!req.session.oauth) req.session.oauth = {};
+      req.session.oauth.oauth_token = token;
+      req.session.oauth.oauth_token_secret = tokenSecret;
+    }
+    const tenant = (req.session && req.session.oauthTenant) || "airqo";
+    try {
+      const signed = this._signPayload(token, tokenSecret, tenant);
+      const res = req.res;
+      if (res) {
+        res.cookie(this._cookieName, signed, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
+          sameSite: "lax",
+          maxAge: this._ttl * 1000,
+          path: "/",
+          ...(this._domain ? { domain: this._domain } : {}),
+        });
+        logger.info("[TwitterCookieTokenStore] request token bridge cookie set", {
+          domain: this._domain || "(default)",
+        });
+      } else {
+        logger.warn("[TwitterCookieTokenStore] req.res unavailable — bridge cookie not set");
+      }
+    } catch (e) {
+      logger.warn("[TwitterCookieTokenStore] failed to set bridge cookie", {
+        error: e.message,
+      });
+    }
+    cb();
+  }
+
+  // Called by passport-oauth1 on the callback with the oauth_token from the
+  // redirect URL. Returns the secret from session if present; falls back to
+  // the signed cookie mirror if the session was lost.
+  get(req, token, cb) {
+    if (req.session && req.session.oauth && req.session.oauth.oauth_token_secret) {
+      return cb(null, req.session.oauth.oauth_token_secret);
+    }
+    const signedCookie = req.cookies && req.cookies[this._cookieName];
+    if (signedCookie) {
+      const data = this._verifyPayload(signedCookie);
+      if (data) {
+        if (data.token !== token) {
+          logger.warn("[TwitterCookieTokenStore] cookie fallback: oauth_token mismatch", {
+            expected: token,
+            cookieToken: data.token,
+          });
+          return cb(new Error("Failed to find request token in session"));
+        }
+        if (req.session) {
+          if (!req.session.oauth) req.session.oauth = {};
+          req.session.oauth.oauth_token = data.token;
+          req.session.oauth.oauth_token_secret = data.secret;
+          req.session.oauthTenant = data.tenant;
+        }
+        logger.info("[TwitterCookieTokenStore] request token restored from cookie fallback");
+        return cb(null, data.secret);
+      }
+      logger.warn("[TwitterCookieTokenStore] cookie fallback: HMAC verification failed");
+    } else {
+      logger.warn("[TwitterCookieTokenStore] cookie fallback: _oauth1_tw absent on callback", {
+        hasSession: !!req.session,
+        sessionHasOauth: !!(req.session && req.session.oauth),
+      });
+    }
+    return cb(new Error("Failed to find request token in session"));
+  }
+
+  // Called by passport-oauth1 after successful token exchange.
+  destroy(req, token, cb) {
+    if (req.session && req.session.oauth) {
+      delete req.session.oauth.oauth_token;
+      delete req.session.oauth.oauth_token_secret;
+      if (Object.keys(req.session.oauth).length === 0) {
+        delete req.session.oauth;
+      }
+    }
+    if (req.res) {
+      req.res.clearCookie(this._cookieName, {
+        path: "/",
+        ...(this._domain ? { domain: this._domain } : {}),
+      });
+    }
+    cb();
+  }
+
+  // HMAC-SHA256 payload integrity signing — NOT password storage.
+  // Payload: base64url(token).base64url(secret).base64url(tenant)
+  // codeql[js/insufficient-password-hash]
+  _signPayload(token, secret, tenant) {
+    const payload = [
+      Buffer.from(token).toString("base64url"),
+      Buffer.from(secret).toString("base64url"),
+      Buffer.from(tenant || "").toString("base64url"),
+    ].join(".");
+    const sig = crypto
+      .createHmac("sha256", this._secret)
+      .update(payload)
+      .digest("base64url");
+    return `${payload}.${sig}`;
+  }
+
+  _verifyPayload(signed) {
+    if (typeof signed !== "string") return null;
+    const lastDot = signed.lastIndexOf(".");
+    if (lastDot === -1) return null;
+    const payload = signed.substring(0, lastDot);
+    const sig = signed.substring(lastDot + 1);
+    const expected = crypto
+      .createHmac("sha256", this._secret)
+      .update(payload)
+      .digest("base64url");
+    const sBuf = Buffer.from(sig, "base64url");
+    const eBuf = Buffer.from(expected, "base64url");
+    if (sBuf.length !== eBuf.length) return null;
+    try {
+      if (!crypto.timingSafeEqual(sBuf, eBuf)) return null;
+    } catch {
+      return null;
+    }
+    const parts = payload.split(".");
+    if (parts.length !== 3) return null;
+    try {
+      return {
+        token: Buffer.from(parts[0], "base64url").toString(),
+        secret: Buffer.from(parts[1], "base64url").toString(),
+        tenant: Buffer.from(parts[2], "base64url").toString() || "airqo",
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
 // ── LinkedIn OIDC Strategy ────────────────────────────────────────────────────
 // passport-linkedin-oauth2 v2 calls the deprecated /v2/me and /v2/emailAddress
 // endpoints which require r_liteprofile / r_emailaddress scopes. LinkedIn's
@@ -472,8 +631,17 @@ function configureStrategies(passport, tenant) {
             callbackURL: buildCallbackURL("twitter"),
             includeEmail: true,
             passReqToCallback: true,
-            // Twitter OAuth 1.0a handles state/CSRF natively via
-            // oauth_token — state: true is OAuth2-only, not set here.
+            // TwitterCookieTokenStore mirrors the request token+secret to an
+            // HMAC-signed HttpOnly cookie (set synchronously before any headers
+            // are written) in addition to the Express session. This prevents
+            // "Failed to find request token in session" when Domain=.airqo.net
+            // causes a shared session cookie to be overwritten by another
+            // service between OAuth initiation and callback.
+            requestTokenStore: new TwitterCookieTokenStore({
+              secret: constants.SESSION_SECRET,
+              cookieName: "_oauth1_tw",
+              domain: constants.OAUTH_COOKIE_DOMAIN,
+            }),
           },
           makeStrategyCallback(
             "twitter",
@@ -524,5 +692,6 @@ module.exports = {
   configureStrategies,
   buildCallbackURL,
   CookieStateStore,
+  TwitterCookieTokenStore,
   LinkedInOIDCStrategy,
 };

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1,4 +1,3 @@
-const crypto = require("crypto");
 const passport = require("passport");
 const LocalStrategy = require("passport-local");
 const userUtil = require("@utils/user.util");
@@ -1454,140 +1453,6 @@ const authGoogleCallback = (req, res, next) => {
   });
 };
 
-// ── Twitter OAuth 1.0a cookie bridge ─────────────────────────────────────────
-// OAuth 1.0a stores the request token secret in the session between the
-// initiation and callback requests. In a multi-pod deployment the callback
-// may land on a different pod (no shared Redis) or a different session
-// (Domain=.airqo.net cookie collision), causing passport-oauth1 to fail with
-// "Failed to find request token in session". We mirror the token+secret to an
-// HMAC-signed short-lived HttpOnly cookie during initiation and restore it
-// from that cookie on the callback if the session is missing the data.
-
-const OAUTH1_TOKEN_COOKIE = "_oauth1_tw";
-
-// Payload layout: base64url(oauth_token).base64url(oauth_token_secret).base64url(tenant).hmac
-// The tenant is included so restoreTwitterOAuthFromCookie can reinstate
-// req.session.oauthTenant before setOAuthProvider reads it.
-function signOAuth1State(token, secret, tenant) {
-  const payload = [
-    Buffer.from(token).toString("base64url"),
-    Buffer.from(secret).toString("base64url"),
-    Buffer.from(tenant || "").toString("base64url"),
-  ].join(".");
-  // HMAC-SHA256 is used here for payload integrity signing, not password storage.
-  // The oauth token+secret are ephemeral round-trip values, not credentials being
-  // persisted. This pattern is the same used by cookie-parser signed cookies and
-  // JWT libraries. CodeQL false-positive suppressed accordingly.
-  // codeql[js/insufficient-password-hash]
-  const sig = crypto
-    .createHmac("sha256", constants.SESSION_SECRET)
-    .update(payload)
-    .digest("base64url");
-  return `${payload}.${sig}`;
-}
-
-function verifyOAuth1State(signed) {
-  if (typeof signed !== "string") return null;
-  const lastDot = signed.lastIndexOf(".");
-  if (lastDot === -1) return null;
-  const payload = signed.substring(0, lastDot);
-  const sig = signed.substring(lastDot + 1);
-  const expected = crypto
-    .createHmac("sha256", constants.SESSION_SECRET)
-    .update(payload)
-    .digest("base64url");
-  const sBuf = Buffer.from(sig, "base64url");
-  const eBuf = Buffer.from(expected, "base64url");
-  if (sBuf.length !== eBuf.length) return null;
-  try {
-    if (!crypto.timingSafeEqual(sBuf, eBuf)) return null;
-  } catch {
-    return null;
-  }
-  const parts = payload.split(".");
-  if (parts.length !== 3) return null;
-  try {
-    return {
-      token: Buffer.from(parts[0], "base64url").toString(),
-      secret: Buffer.from(parts[1], "base64url").toString(),
-      tenant: Buffer.from(parts[2], "base64url").toString() || "airqo",
-    };
-  } catch {
-    return null;
-  }
-}
-
-// Wraps req.session.save() so the oauth request token is also written to an
-// HMAC-signed cookie during Twitter initiation. No-op for all other providers.
-const setupTwitterOAuthBridge = (req, res, next) => {
-  const provider =
-    req.oauthProvider || (req.params && req.params.provider) || "";
-  if (provider !== "twitter" || !req.session) return next();
-
-  const originalSave = req.session.save.bind(req.session);
-  req.session.save = function (callback) {
-    const oauthToken = req.session.oauth && req.session.oauth.oauth_token;
-    const oauthSecret = req.session.oauth && req.session.oauth.oauth_token_secret;
-    if (oauthToken && oauthSecret) {
-      const tenant = req.session.oauthTenant || "airqo";
-      try {
-        const signed = signOAuth1State(oauthToken, oauthSecret, tenant);
-        const cookieOpts = {
-          httpOnly: true,
-          secure: process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
-          sameSite: "lax",
-          maxAge: 10 * 60 * 1000,
-          path: "/",
-        };
-        if (constants.OAUTH_COOKIE_DOMAIN)
-          cookieOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
-        res.cookie(OAUTH1_TOKEN_COOKIE, signed, cookieOpts);
-      } catch (e) {
-        logger.warn("[passport] Twitter OAuth 1.0a bridge: failed to set cookie", {
-          error: e.message,
-        });
-      }
-    }
-    return originalSave(callback);
-  };
-  next();
-};
-
-// Restores req.session.oauth from the HMAC-signed cookie mirror if the session
-// is missing the oauth key on the Twitter callback. Always clears the cookie.
-const restoreTwitterOAuthFromCookie = (req, res, next) => {
-  const provider =
-    req.oauthProvider || (req.params && req.params.provider) || "";
-  if (provider !== "twitter") return next();
-
-  const clearOpts = { path: "/" };
-  if (constants.OAUTH_COOKIE_DOMAIN)
-    clearOpts.domain = constants.OAUTH_COOKIE_DOMAIN;
-
-  if (req.session && !req.session.oauth) {
-    const signedCookie = req.cookies && req.cookies[OAUTH1_TOKEN_COOKIE];
-    if (signedCookie) {
-      const data = verifyOAuth1State(signedCookie);
-      if (data) {
-        req.session.oauth = {
-          oauth_token: data.token,
-          oauth_token_secret: data.secret,
-        };
-        req.session.oauthTenant = data.tenant;
-        logger.info(
-          "[passport] Restored Twitter OAuth 1.0a request token from cookie fallback",
-        );
-      } else {
-        logger.warn(
-          "[passport] Twitter OAuth 1.0a cookie fallback: HMAC signature invalid",
-        );
-      }
-    }
-  }
-
-  res.clearCookie(OAUTH1_TOKEN_COOKIE, clearOpts);
-  next();
-};
 
 /**
  * Dynamically initiates OAuth flow for any supported provider.
@@ -2165,6 +2030,4 @@ module.exports = {
   optionalJWTAuth,
   specificRouteUris,
   matchesRoute,
-  setupTwitterOAuthBridge,
-  restoreTwitterOAuthFromCookie,
 };

--- a/src/auth-service/middleware/test/ut_twitter_oauth_bridge.js
+++ b/src/auth-service/middleware/test/ut_twitter_oauth_bridge.js
@@ -9,277 +9,257 @@ process.env.CLOUDINARY_API_SECRET = process.env.CLOUDINARY_API_SECRET || "test";
 
 const { expect } = require("chai");
 const sinon = require("sinon");
-const proxyquire = require("proxyquire");
-const { HttpError } = require("@utils/shared");
+const proxyquire = require("proxyquire").noCallThru();
+
+// ---------------------------------------------------------------------------
+// Load TwitterCookieTokenStore via proxyquire to avoid heavy transitive deps.
+// passport-strategies.js requires @utils/social-auth.util which loads database
+// models — stub everything that would trigger an outbound connection.
+// ---------------------------------------------------------------------------
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+const { TwitterCookieTokenStore } = proxyquire("@config/passport-strategies", {
+  "passport-google-oauth20": { Strategy: class {} },
+  "passport-github2": { Strategy: class {} },
+  "passport-oauth2": { Strategy: class {}, InternalOAuthError: class {} },
+  "passport-linkedin-openidconnect": { Strategy: class {} },
+  "@config/constants": {
+    SESSION_SECRET: "test-session-secret",
+    OAUTH_COOKIE_DOMAIN: ".airqo.net",
+    DEFAULT_TENANT: "airqo",
+    ENVIRONMENT: "TEST",
+    TWITTER_CONSUMER_KEY: "tw-key",
+    TWITTER_CONSUMER_SECRET: "tw-secret",
+    ANALYTICS_BASE_URL: "https://analytics.airqo.net",
+    PLATFORM_BASE_URL: "https://analytics.airqo.net",
+  },
+  "@utils/social-auth.util": { handleOAuthProfile: () => {} },
+  "@utils/shared": { logObject: () => {} },
+  "log4js": { getLogger: () => noopLogger },
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeMockRes() {
-  return {
+function makeStore(overrides = {}) {
+  return new TwitterCookieTokenStore({
+    secret: "test-session-secret",
+    cookieName: "_oauth1_tw",
+    domain: ".airqo.net",
+    ...overrides,
+  });
+}
+
+function makeReq({ sessionOauth = null, cookies = {}, tenant = "airqo" } = {}) {
+  const session = { oauthTenant: tenant };
+  if (sessionOauth) session.oauth = sessionOauth;
+  const res = {
     cookie: sinon.stub(),
     clearCookie: sinon.stub(),
   };
-}
-
-function makeInitiationReq(oauthEntry = { oauth_token: "testtoken", oauth_token_secret: "testsecret" }) {
-  return {
-    oauthProvider: "twitter",
-    params: { provider: "twitter" },
-    session: {
-      oauth: oauthEntry,
-      oauthTenant: "airqo",
-      save: sinon.stub().callsFake((cb) => cb(null)),
-    },
-  };
-}
-
-function makeCallbackReq(cookieValue) {
-  return {
-    oauthProvider: "twitter",
-    params: { provider: "twitter" },
-    session: {},
-    cookies: cookieValue ? { _oauth1_tw: cookieValue } : {},
-  };
+  return { session, cookies, res };
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("Twitter OAuth 1.0a Cookie Bridge", () => {
-  let passportModule;
-  let setupTwitterOAuthBridge;
-  let restoreTwitterOAuthFromCookie;
+describe("TwitterCookieTokenStore", () => {
+  afterEach(() => sinon.restore());
 
-  beforeEach(() => {
-    const loggerStub = {
-      info: sinon.stub(),
-      warn: sinon.stub(),
-      error: sinon.stub(),
-      debug: sinon.stub(),
-    };
-
-    passportModule = proxyquire("@middleware/passport", {
-      "@models/User": sinon.stub().returns({
-        findById: sinon.stub().returns({ lean: sinon.stub().resolves({}) }),
-      }),
-      "@utils/common": {
-        winstonLogger: loggerStub,
-        mailer: {},
-        stringify: sinon.stub(),
-      },
-      "@services/atf.service": {
-        AbstractTokenFactory: sinon.stub().returns({
-          createToken: sinon.stub().resolves("token"),
-          _getEffectiveTokenStrategy: sinon
-            .stub()
-            .returns("NO_ROLES_AND_PERMISSIONS"),
-        }),
-      },
-      "@utils/user.util": { getUser: sinon.stub().resolves({}) },
-      "@utils/shared": {
-        HttpError,
-        logObject: sinon.stub(),
-        logText: sinon.stub(),
-        logElement: sinon.stub(),
-        extractErrorsFromRequest: sinon.stub().returns(null),
-      },
-      jsonwebtoken: {
-        verify: sinon.stub(),
-        sign: sinon.stub(),
-        "@noCallThru": true,
-      },
+  describe("constructor", () => {
+    it("throws when secret is omitted", () => {
+      expect(() => new TwitterCookieTokenStore({})).to.throw(
+        "TwitterCookieTokenStore: secret is required",
+      );
     });
 
-    setupTwitterOAuthBridge = passportModule.setupTwitterOAuthBridge;
-    restoreTwitterOAuthFromCookie = passportModule.restoreTwitterOAuthFromCookie;
-  });
-
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  // ── setupTwitterOAuthBridge ────────────────────────────────────────────────
-
-  describe("setupTwitterOAuthBridge", () => {
-    it("is a no-op for non-twitter providers", () => {
-      const next = sinon.stub();
-      const req = { oauthProvider: "google", session: {}, params: {} };
-      setupTwitterOAuthBridge(req, makeMockRes(), next);
-      expect(next.calledOnce).to.be.true;
-    });
-
-    it("is a no-op when session is absent", () => {
-      const next = sinon.stub();
-      const req = { oauthProvider: "twitter", session: null, params: {} };
-      setupTwitterOAuthBridge(req, makeMockRes(), next);
-      expect(next.calledOnce).to.be.true;
-    });
-
-    it("calls next and wraps session.save for twitter", () => {
-      const next = sinon.stub();
-      const req = makeInitiationReq();
-      setupTwitterOAuthBridge(req, makeMockRes(), next);
-      expect(next.calledOnce).to.be.true;
-      // save was replaced by the wrapper
-      expect(req.session.save).to.not.equal(sinon.stub()); // wrapped, not the original
-    });
-
-    it("sets _oauth1_tw cookie with four-part token.secret.tenant.sig value", () => {
-      const next = sinon.stub();
-      const saveCb = sinon.stub();
-      const req = makeInitiationReq({
-        oauth_token: "mytoken",
-        oauth_token_secret: "mysecret",
+    it("accepts optional domain and cookieName", () => {
+      const store = new TwitterCookieTokenStore({
+        secret: "s",
+        cookieName: "_custom",
+        domain: ".example.com",
       });
-      const res = makeMockRes();
-
-      setupTwitterOAuthBridge(req, res, next);
-      req.session.save(saveCb);
-
-      expect(res.cookie.calledOnce).to.be.true;
-      expect(res.cookie.args[0][0]).to.equal("_oauth1_tw");
-      const cookieValue = res.cookie.args[0][1];
-      expect(cookieValue).to.be.a("string");
-      // base64url(token).base64url(secret).base64url(tenant).hmac = 4 parts
-      expect(cookieValue.split(".").length).to.equal(4);
-    });
-
-    it("calls the original session.save after setting the cookie", () => {
-      const saveCb = sinon.stub();
-      const req = makeInitiationReq();
-      const originalSave = req.session.save;
-      const res = makeMockRes();
-
-      setupTwitterOAuthBridge(req, makeMockRes(), sinon.stub());
-      req.session.save(saveCb);
-
-      expect(originalSave.calledOnce).to.be.true;
-      expect(saveCb.calledOnce).to.be.true;
-    });
-
-    it("does not set cookie when session has no oauth_token_secret", () => {
-      const req = {
-        oauthProvider: "twitter",
-        params: { provider: "twitter" },
-        session: {
-          // no oauth key at all
-          save: sinon.stub().callsFake((cb) => cb(null)),
-        },
-      };
-      const res = makeMockRes();
-
-      setupTwitterOAuthBridge(req, res, sinon.stub());
-      req.session.save(() => {});
-
-      expect(res.cookie.called).to.be.false;
+      expect(store._cookieName).to.equal("_custom");
+      expect(store._domain).to.equal(".example.com");
     });
   });
 
-  // ── restoreTwitterOAuthFromCookie ──────────────────────────────────────────
+  describe("set()", () => {
+    it("sets HMAC-signed cookie with four base64url parts", (done) => {
+      const store = makeStore();
+      const req = makeReq();
 
-  describe("restoreTwitterOAuthFromCookie", () => {
-    it("is a no-op for non-twitter providers", () => {
-      const next = sinon.stub();
-      const req = {
-        oauthProvider: "linkedin",
-        session: {},
-        cookies: {},
-        params: {},
-      };
-      restoreTwitterOAuthFromCookie(req, makeMockRes(), next);
-      expect(next.calledOnce).to.be.true;
-    });
-
-    it("does not overwrite session.oauth when it is already present", () => {
-      const next = sinon.stub();
-      const existing = { tok: "sec" };
-      const req = makeCallbackReq("somevalue");
-      req.session.oauth = existing;
-      const res = makeMockRes();
-
-      restoreTwitterOAuthFromCookie(req, res, next);
-
-      expect(req.session.oauth).to.deep.equal(existing);
-      expect(res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
-      expect(next.calledOnce).to.be.true;
-    });
-
-    it("clears cookie and calls next when no cookie is present", () => {
-      const next = sinon.stub();
-      const req = makeCallbackReq(null);
-      const res = makeMockRes();
-
-      restoreTwitterOAuthFromCookie(req, res, next);
-
-      expect(req.session.oauth).to.be.undefined;
-      expect(res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
-      expect(next.calledOnce).to.be.true;
-    });
-
-    it("restores session.oauth from a valid cookie (full round-trip)", () => {
-      // ── Initiation: generate signed cookie via setupTwitterOAuthBridge ──
-      const initReq = makeInitiationReq({
-        oauth_token: "realtoken",
-        oauth_token_secret: "realsecret",
+      store.set(req, "mytoken", "mysecret", () => {
+        expect(req.res.cookie.calledOnce).to.be.true;
+        expect(req.res.cookie.args[0][0]).to.equal("_oauth1_tw");
+        const val = req.res.cookie.args[0][1];
+        expect(val.split(".").length).to.equal(4);
+        done();
       });
-      const initRes = makeMockRes();
-      setupTwitterOAuthBridge(initReq, initRes, sinon.stub());
-      initReq.session.save(() => {});
-      const signedCookie = initRes.cookie.args[0][1];
-
-      // ── Callback: restore from that cookie ──
-      const callbackReq = makeCallbackReq(signedCookie);
-      const callbackRes = makeMockRes();
-      const callbackNext = sinon.stub();
-
-      restoreTwitterOAuthFromCookie(callbackReq, callbackRes, callbackNext);
-
-      expect(callbackReq.session.oauth).to.deep.equal({
-        oauth_token: "realtoken",
-        oauth_token_secret: "realsecret",
-      });
-      expect(callbackReq.session.oauthTenant).to.equal("airqo");
-      expect(callbackRes.clearCookie.calledWith("_oauth1_tw")).to.be.true;
-      expect(callbackNext.calledOnce).to.be.true;
     });
 
-    it("does not restore when cookie payload is tampered", () => {
-      const next = sinon.stub();
-      // Generate a valid cookie then corrupt the token portion of the payload
-      const initReq = makeInitiationReq({
-        oauth_token: "tok",
-        oauth_token_secret: "sec",
+    it("mirrors token+secret to session.oauth", (done) => {
+      const store = makeStore();
+      const req = makeReq();
+
+      store.set(req, "tok", "sec", () => {
+        expect(req.session.oauth.oauth_token).to.equal("tok");
+        expect(req.session.oauth.oauth_token_secret).to.equal("sec");
+        done();
       });
-      const initRes = makeMockRes();
-      setupTwitterOAuthBridge(initReq, initRes, sinon.stub());
-      initReq.session.save(() => {});
-      const valid = initRes.cookie.args[0][1];
-      const parts = valid.split(".");
-      parts[0] = Buffer.from("tampered").toString("base64url");
-      const tampered = parts.join(".");
-
-      const req = makeCallbackReq(tampered);
-      const res = makeMockRes();
-      restoreTwitterOAuthFromCookie(req, res, next);
-
-      expect(req.session.oauth).to.be.undefined;
-      expect(res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
-      expect(next.calledOnce).to.be.true;
     });
 
-    it("does not restore when cookie has a bad format", () => {
-      const next = sinon.stub();
-      const req = makeCallbackReq("not.a.valid.hmac.cookie.at.all");
-      const res = makeMockRes();
+    it("applies domain to the cookie options", (done) => {
+      const store = makeStore({ domain: ".airqo.net" });
+      const req = makeReq();
 
-      restoreTwitterOAuthFromCookie(req, res, next);
+      store.set(req, "t", "s", () => {
+        const opts = req.res.cookie.args[0][2];
+        expect(opts.domain).to.equal(".airqo.net");
+        done();
+      });
+    });
 
-      expect(req.session.oauth).to.be.undefined;
-      expect(res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
-      expect(next.calledOnce).to.be.true;
+    it("omits domain attribute when domain is not configured", (done) => {
+      const store = makeStore({ domain: undefined });
+      const req = makeReq();
+
+      store.set(req, "t", "s", () => {
+        const opts = req.res.cookie.args[0][2];
+        expect(opts.domain).to.be.undefined;
+        done();
+      });
+    });
+
+    it("calls cb() even when req.res is absent", (done) => {
+      const store = makeStore();
+      const req = makeReq();
+      delete req.res;
+
+      store.set(req, "t", "s", done);
+    });
+  });
+
+  describe("get() — session path", () => {
+    it("returns secret from session without touching cookie", (done) => {
+      const store = makeStore();
+      const req = makeReq({
+        sessionOauth: { oauth_token: "tok", oauth_token_secret: "sec" },
+      });
+
+      store.get(req, "tok", (err, secret) => {
+        expect(err).to.be.null;
+        expect(secret).to.equal("sec");
+        done();
+      });
+    });
+  });
+
+  describe("get() — cookie fallback (full round-trip)", () => {
+    it("restores secret from a valid cookie when session is empty", (done) => {
+      const store = makeStore();
+      const setReq = makeReq({ tenant: "airqo" });
+
+      store.set(setReq, "realtoken", "realsecret", () => {
+        const signedCookie = setReq.res.cookie.args[0][1];
+        const getReq = makeReq({ cookies: { _oauth1_tw: signedCookie } });
+
+        store.get(getReq, "realtoken", (err, secret) => {
+          expect(err).to.be.null;
+          expect(secret).to.equal("realsecret");
+          expect(getReq.session.oauth.oauth_token).to.equal("realtoken");
+          expect(getReq.session.oauth.oauth_token_secret).to.equal("realsecret");
+          expect(getReq.session.oauthTenant).to.equal("airqo");
+          done();
+        });
+      });
+    });
+
+    it("returns error when cookie is absent and session has no oauth", (done) => {
+      const store = makeStore();
+      const req = makeReq({ cookies: {} });
+
+      store.get(req, "tok", (err) => {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.equal("Failed to find request token in session");
+        done();
+      });
+    });
+
+    it("returns error when cookie HMAC is tampered", (done) => {
+      const store = makeStore();
+      const setReq = makeReq();
+
+      store.set(setReq, "tok", "sec", () => {
+        const valid = setReq.res.cookie.args[0][1];
+        const parts = valid.split(".");
+        parts[0] = Buffer.from("tampered").toString("base64url");
+        const tampered = parts.join(".");
+
+        const getReq = makeReq({ cookies: { _oauth1_tw: tampered } });
+        store.get(getReq, "tok", (err) => {
+          expect(err).to.be.instanceOf(Error);
+          done();
+        });
+      });
+    });
+
+    it("returns error when cookie token does not match requested token", (done) => {
+      const store = makeStore();
+      const setReq = makeReq();
+
+      store.set(setReq, "token-A", "sec", () => {
+        const signedCookie = setReq.res.cookie.args[0][1];
+        const getReq = makeReq({ cookies: { _oauth1_tw: signedCookie } });
+
+        store.get(getReq, "token-B", (err) => {
+          expect(err).to.be.instanceOf(Error);
+          done();
+        });
+      });
+    });
+  });
+
+  describe("destroy()", () => {
+    it("removes oauth keys from session and clears cookie", (done) => {
+      const store = makeStore();
+      const req = makeReq({
+        sessionOauth: { oauth_token: "t", oauth_token_secret: "s" },
+      });
+
+      store.destroy(req, "t", () => {
+        expect(req.session.oauth).to.be.undefined;
+        expect(req.res.clearCookie.calledWith("_oauth1_tw")).to.be.true;
+        done();
+      });
+    });
+
+    it("calls cb() gracefully when session has no oauth key", (done) => {
+      const store = makeStore();
+      const req = makeReq();
+
+      store.destroy(req, "t", done);
+    });
+
+    it("passes domain to clearCookie", (done) => {
+      const store = makeStore({ domain: ".airqo.net" });
+      const req = makeReq({
+        sessionOauth: { oauth_token: "t", oauth_token_secret: "s" },
+      });
+
+      store.destroy(req, "t", () => {
+        const opts = req.res.clearCookie.args[0][1];
+        expect(opts.domain).to.equal(".airqo.net");
+        done();
+      });
     });
   });
 });

--- a/src/auth-service/middleware/test/ut_twitter_oauth_bridge.js
+++ b/src/auth-service/middleware/test/ut_twitter_oauth_bridge.js
@@ -161,6 +161,20 @@ describe("TwitterCookieTokenStore", () => {
         done();
       });
     });
+
+    it("falls through to error when session oauth_token mismatches callback token", (done) => {
+      const store = makeStore();
+      const req = makeReq({
+        sessionOauth: { oauth_token: "tok-A", oauth_token_secret: "sec" },
+        cookies: {},
+      });
+
+      store.get(req, "tok-B", (err) => {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.equal("Failed to find request token in session");
+        done();
+      });
+    });
   });
 
   describe("get() — cookie fallback (full round-trip)", () => {
@@ -258,6 +272,19 @@ describe("TwitterCookieTokenStore", () => {
       store.destroy(req, "t", () => {
         const opts = req.res.clearCookie.args[0][1];
         expect(opts.domain).to.equal(".airqo.net");
+        done();
+      });
+    });
+
+    it("completes without throwing when req.res is absent", (done) => {
+      const store = makeStore();
+      const req = makeReq({
+        sessionOauth: { oauth_token: "t", oauth_token_secret: "s" },
+      });
+      delete req.res;
+
+      store.destroy(req, "t", () => {
+        expect(req.session.oauth).to.be.undefined;
         done();
       });
     });

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -18,8 +18,6 @@ const {
   authGoogle,
   enhancedJWTAuth,
   refreshTokenAuth,
-  setupTwitterOAuthBridge,
-  restoreTwitterOAuthFromCookie,
 } = require("@middleware/passport");
 const rateLimiter = require("@middleware/rate-limiter");
 const captchaMiddleware = require("@middleware/captcha");
@@ -275,13 +273,12 @@ router.get("/auth/google", setGoogleAuth, authGoogle);
 
 router.get(
   "/auth/callback/:provider",
-  restoreTwitterOAuthFromCookie,
   setOAuthProvider,
   authOAuthCallback,
   userController.oauthCallback,
 );
 
-router.get("/auth/:provider", setOAuthProvider, setupTwitterOAuthBridge, authOAuth);
+router.get("/auth/:provider", setOAuthProvider, authOAuth);
 
 // ================================
 // USER CRUD & AUTH ROUTES


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Replaces the broken `req.session.save` wrapping approach (`setupTwitterOAuthBridge` / `restoreTwitterOAuthFromCookie` middleware in `passport.js`) with a proper `requestTokenStore` implementation — `TwitterCookieTokenStore` — wired directly into the passport-twitter strategy inside `passport-strategies.js`.

The new store:
- **`set()`** — called by `passport-oauth1` after obtaining the request token from Twitter, before any response headers are written. Mirrors token + secret to the Express session (best-effort) AND sets an HMAC-SHA256-signed HttpOnly cookie (`_oauth1_tw`) synchronously via `req.res.cookie()`.
- **`get()`** — called on the Twitter callback. Reads from session first (normal path); falls back to the signed cookie if the session is missing the OAuth data, verifies the HMAC and the `oauth_token` value before restoring.
- **`destroy()`** — called after a successful token exchange. Clears both the session key and the cookie.

Also removes `setupTwitterOAuthBridge`, `restoreTwitterOAuthFromCookie`, their `crypto` dependency, and all associated route wiring — the bridge middleware approach is gone entirely.

### Why is this change needed?

Production logs consistently showed `sessionExists: true, hasOauthKey: false` on the Twitter OAuth callback despite multiple previous fixes. Two compounding root causes:

1. **`compression()` middleware race** — In production, `compression()` wraps `res.end` and may flush HTTP headers (setting `res.headersSent = true`) before the `req.session.save` callback fires. At that point `res.cookie()` silently drops the `_oauth1_tw` cookie, so the fallback was never written to the browser.

2. **Shared session cookie collision** — `OAUTH_COOKIE_DOMAIN=".airqo.net"` (introduced for vertex support) makes the session cookie shared across all `*.airqo.net` subdomains. A request from another service between Twitter OAuth initiation and callback overwrites the browser's session cookie, causing `passport-oauth1`'s default `SessionStore` to fail.

`TwitterCookieTokenStore` uses the identical pattern as `CookieStateStore` (already used successfully for all OAuth 2.0 providers: Google, GitHub, LinkedIn, Microsoft), calling `req.res.cookie()` synchronously in `set()` — before `passport-oauth1` calls `res.redirect()` — which eliminates both race conditions.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [x] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
15 unit tests added in `src/auth-service/middleware/test/ut_twitter_oauth_bridge.js` covering `TwitterCookieTokenStore.set()`, `get()` (session path + cookie fallback full round-trip), and `destroy()`. Tests verify HMAC signing, token mismatch rejection, tamper detection, domain propagation, and graceful handling of absent `req.res` / missing session. All 15 pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `TwitterCookieTokenStore` is exported from `passport-strategies.js` alongside the existing `CookieStateStore` so it can be unit-tested via `proxyquire` without loading heavy transitive dependencies.
- The `_oauth1_tw` cookie is `HttpOnly`, `SameSite=Lax`, `maxAge=600s`, and scoped to `OAUTH_COOKIE_DOMAIN` (`.airqo.net` in production) — same attributes as the `CookieStateStore` cookies used by OAuth 2.0 providers.
- `CookieStateStore` (OAuth 2.0 CSRF state) is unaffected.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OAuth authentication with improved fallback mechanisms for Twitter/X login using secure cookie-based token storage.

* **Bug Fixes**
  * Improved error handling for OAuth failures with better diagnostics and redirect behavior when authentication issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->