### PR TITLE
fix: add service account anomaly detection bypass to prevent false positives

### DIFF
--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -89,6 +89,11 @@ const AccessTokenSchema = new mongoose.Schema(
     // When enforce_origin is true on the parent Client, requests must carry
     // an Origin or Referer header matching one of these values.
     allowed_origins: [{ type: String }],
+    // Service-account flag. When true, behavioural anomaly scoring is skipped
+    // entirely so high-volume internal services (spatial, predict, mobile) are
+    // never auto-suspended by rate-spike or UA-change heuristics.
+    // Honeypot traps, IP blocks, and manual suspension still apply.
+    bypass_anomaly_detection: { type: Boolean, default: false },
   },
   { timestamps: true }
 );
@@ -466,6 +471,7 @@ AccessTokenSchema.methods = {
       last_user_agent: this.last_user_agent,
       request_pattern: this.request_pattern,
       allowed_origins: this.allowed_origins,
+      bypass_anomaly_detection: this.bypass_anomaly_detection,
     };
   },
 };

--- a/src/auth-service/routes/v2/tokens.routes.js
+++ b/src/auth-service/routes/v2/tokens.routes.js
@@ -88,12 +88,14 @@ router.put(
 );
 
 // Update token (legacy path — kept for backwards compatibility)
+// enhancedJWTAuth runs before validateTokenUpdate so req.user is available
+// for the bypass_anomaly_detection admin-only custom validator.
 router.put(
   "/:token/update",
   validateTenant,
   validateTokenParam,
-  validateTokenUpdate,
   enhancedJWTAuth,
+  validateTokenUpdate,
   createTokenController.update,
 );
 
@@ -102,8 +104,8 @@ router.patch(
   "/:token",
   validateTenant,
   validateTokenParam,
-  validateTokenUpdate,
   enhancedJWTAuth,
+  validateTokenUpdate,
   createTokenController.update,
 );
 

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -907,6 +907,11 @@ const isIPBlacklisted = (...args) =>
  * Never throws — all errors are logged and swallowed.
  */
 const _trackBehaviouralAnomaly = async ({ accessToken, token: rawToken, ip, userAgent }) => {
+  // Service-account tokens opt out of behavioural scoring entirely.
+  // Honeypot traps, IP blocks, and manual suspension still apply.
+  if (accessToken.bypass_anomaly_detection) {
+    return;
+  }
   const ANOMALY_SUSPEND_THRESHOLD = constants.ANOMALY_SUSPEND_THRESHOLD || 10;
   try {
     const tokenId = accessToken._id || accessToken.client_id;
@@ -1312,7 +1317,8 @@ const token = {
         .findOne({ token })
         .select(
           "client_id token name tier scopes allowed_grids allowed_cohorts " +
-          "access_schedule last_user_agent request_pattern allowed_origins"
+          "access_schedule last_user_agent request_pattern allowed_origins " +
+          "bypass_anomaly_detection"
         );
 
       if (isEmpty(accessToken)) {

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1212,6 +1212,16 @@ const token = {
         if (update._id) {
           delete update._id;
         }
+        // bypass_anomaly_detection is admin-only — non-super-admins cannot set it
+        // via the public PATCH endpoint even if the validator accepts the field.
+        if (update.bypass_anomaly_detection !== undefined) {
+          const userEmail = ((request.user && request.user.email) || "").toLowerCase();
+          const isAdmin = (constants.SUPER_ADMIN_EMAIL_ALLOWLIST || [])
+            .some(e => e.toLowerCase() === userEmail);
+          if (!isAdmin) {
+            delete update.bypass_anomaly_detection;
+          }
+        }
         const updatedToken = await AccessTokenModel(tenant)
           .findByIdAndUpdate(tokenId, update, { new: true })
           .lean();

--- a/src/auth-service/validators/test/ut_token.validators.js
+++ b/src/auth-service/validators/test/ut_token.validators.js
@@ -146,6 +146,23 @@ describe("Validation Functions", () => {
         .to.have.property("msg")
         .that.equals("the date should not be before the current date");
     });
+
+    it("should accept bypass_anomaly_detection true", () => {
+      const result = validateTokenUpdate([{ bypass_anomaly_detection: true }]);
+      expect(result).to.be.undefined;
+    });
+
+    it("should accept bypass_anomaly_detection false", () => {
+      const result = validateTokenUpdate([{ bypass_anomaly_detection: false }]);
+      expect(result).to.be.undefined;
+    });
+
+    it("should reject non-boolean bypass_anomaly_detection", () => {
+      const result = validateTokenUpdate([{ bypass_anomaly_detection: "yes" }]);
+      expect(result)
+        .to.have.property("msg")
+        .that.equals("bypass_anomaly_detection must be a boolean");
+    });
   });
 
   describe("validateSingleIp", () => {

--- a/src/auth-service/validators/token.validators.js
+++ b/src/auth-service/validators/token.validators.js
@@ -164,7 +164,20 @@ const validateTokenUpdate = [
   body("bypass_anomaly_detection")
     .optional()
     .isBoolean()
-    .withMessage("bypass_anomaly_detection must be a boolean"),
+    .withMessage("bypass_anomaly_detection must be a boolean")
+    .custom((value, { req }) => {
+      // req.user is set by enhancedJWTAuth, which runs before validateTokenUpdate
+      // on the PATCH/PUT-update routes.  On any other route (e.g. regenerate)
+      // req.user is not yet available — pass through and rely on the util guard.
+      if (!req.user) return true;
+      const userEmail = (req.user.email || "").toLowerCase();
+      const isAdmin = (constants.SUPER_ADMIN_EMAIL_ALLOWLIST || [])
+        .some((e) => e.toLowerCase() === userEmail);
+      if (!isAdmin) {
+        throw new Error("bypass_anomaly_detection can only be set by administrators");
+      }
+      return true;
+    }),
   validate,
 ];
 

--- a/src/auth-service/validators/token.validators.js
+++ b/src/auth-service/validators/token.validators.js
@@ -158,6 +158,13 @@ const validateTokenUpdate = [
     .withMessage("request_pattern.auto_suspended must be a boolean"),
   // anomaly_score is intentionally excluded — allowing callers to reset their
   // own score would let them bypass the anomaly detector indefinitely.
+  // bypass_anomaly_detection is admin-controlled: set true for known
+  // high-volume service accounts (spatial, mobile) to prevent false-positive
+  // auto-suspension from rate-spike / UA-change heuristics.
+  body("bypass_anomaly_detection")
+    .optional()
+    .isBoolean()
+    .withMessage("bypass_anomaly_detection must be a boolean"),
   validate,
 ];
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a `bypass_anomaly_detection` boolean field to the `AccessToken` model. When set to `true` on a token, behavioural anomaly scoring (UA-change detection and hourly rate-spike detection) is skipped entirely for that token, preventing automatic suspension. Honeypot traps, IP blocks, manual suspension, and rate limiting still apply.

Three files changed in `src/auth-service`:
- **`models/AccessToken.js`** — new `bypass_anomaly_detection: Boolean, default: false` schema field, exposed in `toJSON()`
- **`utils/token.util.js`** — early return in `_trackBehaviouralAnomaly` when flag is set; field added to `.select()` projection in `verifyToken`
- **`validators/token.validators.js`** — `bypass_anomaly_detection` accepted in `validateTokenUpdate` (PATCH endpoint)

### Why is this change needed?
Several legitimate high-volume service account tokens (`ai.airqo.net` Vercel app, spatial service, mobile app) were repeatedly auto-suspended by the behavioural anomaly detector due to pagination-driven API call bursts and UA changes across service contexts — not actual abuse. The anomaly detector is calibrated for unknown attackers probing with stolen tokens; known internal service accounts with predictable high-volume patterns are false positives by design. Raising `ANOMALY_SUSPEND_THRESHOLD` is a blunt instrument that weakens detection for everyone. This flag gives admins a surgical per-token opt-out.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/auth-service` — model, util, validator

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that tokens with `bypass_anomaly_detection: false` (the default) continue to accumulate anomaly scores and auto-suspend exactly as before. Verified that setting the flag to `true` via `PATCH /api/v2/users/tokens/:token` and then sending requests with rapid rate spikes and changing User-Agent strings does not increment the anomaly score or trigger suspension. Existing verify flow, IP blocking, and honeypot traps are unaffected.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`bypass_anomaly_detection` defaults to `false`, so all existing tokens behave identically to before deployment with no migration required.

---

## :memo: Additional Notes

**Tokens that should be marked `bypass_anomaly_detection: true` after deployment** (via admin PATCH):
- `ai.airqo.net` Vercel app service token
- Spatial service `AIRQO_API_TOKEN` (production and staging)
- Mobile app shared API token (if a single token is used across all app users)

Any token belonging to a backend service that makes paginated bulk API calls is a candidate.

**Reinstating currently suspended tokens** (before or alongside deployment):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new administrative control flag for access tokens that allows bypassing behavioral anomaly detection scoring when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->