### PR TITLE
Fix daily network uptime summary Slack alerts and device status alignment

### DIFF
--- a/src/device-registry/bin/jobs/check-network-status-job.js
+++ b/src/device-registry/bin/jobs/check-network-status-job.js
@@ -116,7 +116,7 @@ const checkNetworkStatus = async () => {
       status = "CRITICAL";
       message = `🚨🆘 CRITICAL: ${notTransmittingPercentage.toFixed(2)}% of deployed devices are not transmitting (${notTransmittingDevicesCount}/${totalDeployedDevices}) | operational: ${operational}, transmitting: ${transmitting}, data_available: ${data_available}`;
       thresholdExceeded = true;
-    } else if (notTransmittingPercentage > UPTIME_THRESHOLD) {
+    } else if (notTransmittingPercentage >= UPTIME_THRESHOLD) {
       status = "WARNING";
       message = `⚠️💔😥 More than ${UPTIME_THRESHOLD}% of deployed devices are not transmitting: ${notTransmittingPercentage.toFixed(2)}% (${notTransmittingDevicesCount}/${totalDeployedDevices}) | operational: ${operational}, transmitting: ${transmitting}, data_available: ${data_available}`;
       thresholdExceeded = true;
@@ -128,8 +128,10 @@ const checkNetworkStatus = async () => {
     logText(message);
     if (status === "CRITICAL") {
       logger.error(message);
-    } else {
+    } else if (status === "WARNING") {
       logger.warn(message);
+    } else {
+      logger.info(message);
     }
 
     // Create alert record in database
@@ -204,12 +206,8 @@ const dailyNetworkStatusSummary = async () => {
       return;
     }
 
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    yesterday.setHours(0, 0, 0, 0);
-
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    const yesterday = moment.tz(TIMEZONE).subtract(1, "day").startOf("day").toDate();
+    const today = moment.tz(TIMEZONE).startOf("day").toDate();
 
     const filter = {
       checked_at: {

--- a/src/device-registry/bin/jobs/check-network-status-job.js
+++ b/src/device-registry/bin/jobs/check-network-status-job.js
@@ -63,7 +63,13 @@ const checkNetworkStatus = async () => {
 
     const deviceSummary = responseFromGetDeviceCountSummary.data;
 
-    const { total_monitors, operational, not_transmitting } = deviceSummary;
+    const {
+      total_monitors,
+      operational,
+      transmitting,
+      data_available,
+      not_transmitting,
+    } = deviceSummary;
 
     const totalDeployedDevices = total_monitors;
     const notTransmittingDevicesCount = not_transmitting;
@@ -75,8 +81,11 @@ const checkNetworkStatus = async () => {
       const alertData = {
         checked_at: new Date(),
         total_deployed_devices: 0,
-        not_transmitting_devices_count: 0, // Updated field
-        not_transmitting_percentage: 0, // Updated field
+        operational_count: 0,
+        transmitting_count: 0,
+        data_available_count: 0,
+        not_transmitting_devices_count: 0,
+        not_transmitting_percentage: 0,
         status: "OK",
         message: "No deployed devices found",
         threshold_exceeded: false,
@@ -87,7 +96,7 @@ const checkNetworkStatus = async () => {
       return;
     }
 
-    const notTransmittingPercentage = // Renamed for clarity
+    const notTransmittingPercentage =
       totalDeployedDevices > 0
         ? (notTransmittingDevicesCount / totalDeployedDevices) * 100
         : 0;
@@ -98,38 +107,27 @@ const checkNetworkStatus = async () => {
       return;
     }
 
-    // Determine status based on offline percentage
+    // Determine status based on not-transmitting percentage
     let status = "OK";
     let message = "";
     let thresholdExceeded = false;
 
     if (notTransmittingPercentage >= CRITICAL_THRESHOLD) {
-      // Logic based on notTransmittingPercentage
       status = "CRITICAL";
-      message = `🚨🆘 CRITICAL: ${notTransmittingPercentage.toFixed(
-        2,
-      )}% of deployed devices are not transmitting (${notTransmittingDevicesCount}/${totalDeployedDevices})`;
+      message = `🚨🆘 CRITICAL: ${notTransmittingPercentage.toFixed(2)}% of deployed devices are not transmitting (${notTransmittingDevicesCount}/${totalDeployedDevices}) | operational: ${operational}, transmitting: ${transmitting}, data_available: ${data_available}`;
       thresholdExceeded = true;
     } else if (notTransmittingPercentage > UPTIME_THRESHOLD) {
-      // Logic based on notTransmittingPercentage
       status = "WARNING";
-      message = `⚠️💔😥 More than ${UPTIME_THRESHOLD}% of deployed devices are not transmitting: ${notTransmittingPercentage.toFixed(
-        2,
-      )}% (${notTransmittingDevicesCount}/${totalDeployedDevices})`;
+      message = `⚠️💔😥 More than ${UPTIME_THRESHOLD}% of deployed devices are not transmitting: ${notTransmittingPercentage.toFixed(2)}% (${notTransmittingDevicesCount}/${totalDeployedDevices}) | operational: ${operational}, transmitting: ${transmitting}, data_available: ${data_available}`;
       thresholdExceeded = true;
     } else {
       status = "OK";
-      message = `✅ Network status is acceptable. ${operational} devices are operational, while ${notTransmittingPercentage.toFixed(
-        // Updated OK message
-        2,
-      )}% are not transmitting (${notTransmittingDevicesCount}/${totalDeployedDevices})`;
+      message = `✅ Network status OK. Operational: ${operational}, Transmitting: ${transmitting}, Data Available: ${data_available}, Not Transmitting: ${notTransmittingDevicesCount}/${totalDeployedDevices} (${notTransmittingPercentage.toFixed(2)}%)`;
     }
 
     logText(message);
     if (status === "CRITICAL") {
       logger.error(message);
-    } else if (status === "WARNING") {
-      logger.warn(message);
     } else {
       logger.warn(message);
     }
@@ -138,14 +136,16 @@ const checkNetworkStatus = async () => {
     const alertData = {
       checked_at: new Date(),
       total_deployed_devices: totalDeployedDevices,
-      not_transmitting_devices_count: notTransmittingDevicesCount, // Updated field
+      operational_count: operational,
+      transmitting_count: transmitting,
+      data_available_count: data_available,
+      not_transmitting_devices_count: notTransmittingDevicesCount,
       not_transmitting_percentage: parseFloat(
-        // Updated field
         notTransmittingPercentage.toFixed(2),
       ),
       status,
       message,
-      threshold_exceeded: notTransmittingPercentage >= UPTIME_THRESHOLD, // Logic based on notTransmittingPercentage
+      threshold_exceeded: notTransmittingPercentage >= UPTIME_THRESHOLD,
       threshold_value: UPTIME_THRESHOLD,
     };
 
@@ -172,8 +172,8 @@ const checkNetworkStatus = async () => {
       const errorAlertData = {
         checked_at: new Date(),
         total_deployed_devices: 0,
-        not_transmitting_devices_count: 0, // Updated field
-        not_transmitting_percentage: 0, // Updated field
+        not_transmitting_devices_count: 0,
+        not_transmitting_percentage: 0,
         status: "CRITICAL",
         message: `Error checking network status: ${error.message}`,
         threshold_exceeded: true,
@@ -224,14 +224,17 @@ const dailyNetworkStatusSummary = async () => {
 
     if (statistics.success && statistics.data.length > 0) {
       const stats = statistics.data[0];
+      const avgOp = Math.round(stats.avg_operational_count || 0);
+      const avgTx = Math.round(stats.avg_transmitting_count || 0);
+      const avgDa = Math.round(stats.avg_data_available_count || 0);
       const summaryMessage = `
 📊 Daily Network Status Summary (${moment(yesterday).format("YYYY-MM-DD")})
-Total Alerts: ${stats.totalAlerts}
-Average Not Transmitting %: ${stats.avg_not_transmitting_percentage.toFixed(2)}%
+Total Checks: ${stats.totalAlerts}
+Avg Operational: ${avgOp} | Avg Transmitting: ${avgTx} | Avg Data Available: ${avgDa}
+Avg Not Transmitting %: ${stats.avg_not_transmitting_percentage.toFixed(2)}%
 Max Not Transmitting %: ${stats.max_not_transmitting_percentage.toFixed(2)}%
 Min Not Transmitting %: ${stats.min_not_transmitting_percentage.toFixed(2)}%
-Warning Alerts: ${stats.warningCount}
-Critical Alerts: ${stats.criticalCount}
+Warning Checks: ${stats.warningCount} | Critical Checks: ${stats.criticalCount}
       `;
 
       logText(summaryMessage);

--- a/src/device-registry/config/log4js.js
+++ b/src/device-registry/config/log4js.js
@@ -74,6 +74,39 @@ if (isDevelopment()) {
     },
   };
 
+  // log4js uses exact or dot-hierarchical category matching — it does NOT
+  // do suffix matching. Job files use the naming pattern:
+  //   `${ENVIRONMENT} -- <job-name> -- ops-alerts`
+  // which never resolves to the "ops-alerts" category above. Register each
+  // full category name explicitly. Always include the "app" appender so
+  // INFO/WARN messages reach the log file regardless of environment;
+  // slackWarn is added later only for production.
+  const OPS_ALERTS_JOB_NAMES = [
+    "network-status-check-job",
+    "daily-activity-summary-job",
+    "check-unassigned-sites-job",
+    "backfill-site-metadata-job",
+    "/bin/jobs/check-unassigned-devices-job",
+    "/bin/jobs/check-active-statuses-job",
+    "/bin/jobs/check-duplicate-site-fields-job",
+    "/bin/jobs/private-cohort-alert-job",
+    "/bin/jobs/events-health-check-job",
+    "/bin/jobs/health-tip-checker-job",
+    "/bin/jobs/store-readings-job",
+    "/bin/jobs/network-uptime-analysis-job",
+    "/bin/jobs/device-status-check-job",
+    "/bin/jobs/device-status-hourly-check-job",
+    "/bin/jobs/check-primary-device-job",
+    "/bin/jobs/device-uptime-job",
+  ];
+  const env = constants.ENVIRONMENT;
+  OPS_ALERTS_JOB_NAMES.forEach((jobName) => {
+    config.categories[`${env} -- ${jobName} -- ops-alerts`] = {
+      appenders: ["app"],
+      level: "info",
+    };
+  });
+
   if (hasSlackConfig) {
     try {
       config.appenders.slack = {
@@ -102,7 +135,17 @@ if (isDevelopment()) {
 
       config.categories.default.appenders.push("slackErrors");
       config.categories.error.appenders.push("slackErrors");
-      config.categories["ops-alerts"].appenders.push("slackWarn");
+
+      // ops-alerts WARN → Slack only in production; in staging/other envs
+      // ops-alerts jobs still log to file but not to Slack at WARN level.
+      if (env === "PRODUCTION ENVIRONMENT") {
+        config.categories["ops-alerts"].appenders.push("slackWarn");
+        OPS_ALERTS_JOB_NAMES.forEach((jobName) => {
+          config.categories[`${env} -- ${jobName} -- ops-alerts`].appenders.push(
+            "slackWarn",
+          );
+        });
+      }
 
       console.log(
         "✅ Slack appender configured successfully (ERROR and above only, WARN and above for ops-alerts)",

--- a/src/device-registry/config/log4js.js
+++ b/src/device-registry/config/log4js.js
@@ -136,16 +136,17 @@ if (isDevelopment()) {
       config.categories.default.appenders.push("slackErrors");
       config.categories.error.appenders.push("slackErrors");
 
-      // ops-alerts WARN → Slack only in production; in staging/other envs
-      // ops-alerts jobs still log to file but not to Slack at WARN level.
-      if (env === "PRODUCTION ENVIRONMENT") {
-        config.categories["ops-alerts"].appenders.push("slackWarn");
-        OPS_ALERTS_JOB_NAMES.forEach((jobName) => {
-          config.categories[`${env} -- ${jobName} -- ops-alerts`].appenders.push(
-            "slackWarn",
-          );
-        });
-      }
+      // Production: WARN and above → Slack for ops-alerts jobs.
+      // Non-production: only ERROR → Slack (same as default), WARN is silent.
+      // In both cases ops-alerts categories already have "app" for file logging.
+      const opsAlertsSlackAppender =
+        env === "PRODUCTION ENVIRONMENT" ? "slackWarn" : "slackErrors";
+      config.categories["ops-alerts"].appenders.push(opsAlertsSlackAppender);
+      OPS_ALERTS_JOB_NAMES.forEach((jobName) => {
+        config.categories[
+          `${env} -- ${jobName} -- ops-alerts`
+        ].appenders.push(opsAlertsSlackAppender);
+      });
 
       console.log(
         "✅ Slack appender configured successfully (ERROR and above only, WARN and above for ops-alerts)",

--- a/src/device-registry/models/NetworkStatusAlert.js
+++ b/src/device-registry/models/NetworkStatusAlert.js
@@ -22,6 +22,21 @@ const networkStatusAlertSchema = new Schema(
       required: true,
       min: 0,
     },
+    operational_count: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    transmitting_count: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    data_available_count: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
     not_transmitting_devices_count: {
       type: Number,
       required: true,
@@ -109,6 +124,9 @@ networkStatusAlertSchema.methods = {
       _id: this._id,
       checked_at: this.checked_at,
       total_deployed_devices: this.total_deployed_devices,
+      operational_count: this.operational_count,
+      transmitting_count: this.transmitting_count,
+      data_available_count: this.data_available_count,
       not_transmitting_devices_count: this.not_transmitting_devices_count,
       not_transmitting_percentage: this.not_transmitting_percentage,
       status: this.status,
@@ -251,6 +269,9 @@ networkStatusAlertSchema.statics = {
           $group: {
             _id: null,
             totalAlerts: { $sum: 1 },
+            avg_operational_count: { $avg: "$operational_count" },
+            avg_transmitting_count: { $avg: "$transmitting_count" },
+            avg_data_available_count: { $avg: "$data_available_count" },
             avg_not_transmitting_percentage: {
               $avg: "$not_transmitting_percentage",
             },

--- a/src/device-registry/models/NetworkStatusAlert.js
+++ b/src/device-registry/models/NetworkStatusAlert.js
@@ -269,9 +269,9 @@ networkStatusAlertSchema.statics = {
           $group: {
             _id: null,
             totalAlerts: { $sum: 1 },
-            avg_operational_count: { $avg: "$operational_count" },
-            avg_transmitting_count: { $avg: "$transmitting_count" },
-            avg_data_available_count: { $avg: "$data_available_count" },
+            avg_operational_count: { $avg: { $ifNull: ["$operational_count", 0] } },
+            avg_transmitting_count: { $avg: { $ifNull: ["$transmitting_count", 0] } },
+            avg_data_available_count: { $avg: { $ifNull: ["$data_available_count", 0] } },
             avg_not_transmitting_percentage: {
               $avg: "$not_transmitting_percentage",
             },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the daily network uptime summary Slack notification that was silently not sending,
aligns the network status job and schema with all four current device statuses
(`operational`, `transmitting`, `data_available`, `not_transmitting`), and restricts
ops-alerts WARN-level Slack messages to production only.

### Why is this change needed?
The daily 11 AM EAT network status summary (`dailyNetworkStatusSummary`) was never
reaching Slack despite `logger.warn()` being in place. Root cause: log4js uses exact or
dot-hierarchical category matching — it does **not** do suffix matching. Every ops-alerts
job creates its logger as `` `${ENVIRONMENT} -- <job-name> -- ops-alerts` ``, which
never resolves to the configured `"ops-alerts"` category, so all WARN-level messages fell
through to `default` (ERROR-only Slack). ERROR-level alerts were unaffected and continued
to work.

Additionally, `checkNetworkStatus` and the `NetworkStatusAlert` schema only tracked
`not_transmitting` devices, silently discarding the `transmitting` and `data_available`
counts that `getDeviceCountSummary` already returns.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that `constants.ENVIRONMENT` resolves to `"PRODUCTION ENVIRONMENT"` on the
production server (UTC timezone, `moment.tz.guess()` = `"UTC"`), confirming the
production guard in log4js will correctly activate `slackWarn` for ops-alerts categories.
Schema changes are additive (new fields have defaults, no `required: true`), so existing
alert documents are unaffected.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Files changed:**

- `src/device-registry/config/log4js.js` — Registers all 16 ops-alerts job category
  names explicitly (e.g. `"PRODUCTION ENVIRONMENT -- network-status-check-job -- ops-alerts"`)
  so log4js routes WARN-level messages correctly. `slackWarn` appender is only added when
  `env === "PRODUCTION ENVIRONMENT"`, keeping staging environments clean.

- `src/device-registry/models/NetworkStatusAlert.js` — Added optional fields
  `operational_count`, `transmitting_count`, `data_available_count` to the schema and
  `toJSON`. Updated `getStatistics()` aggregation pipeline to average all three new fields.

- `src/device-registry/bin/jobs/check-network-status-job.js` — Destructures all four
  status counts from `getDeviceCountSummary`; saves them on every alert record; includes
  the full breakdown in real-time alert messages and in the 11 AM EAT daily summary.

**Schedule note:** The `"0 8 * * *"` cron schedule is correct and unchanged — on the UTC
production server it fires at 8 AM UTC = 11 AM EAT.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Alerts now include detailed device status metrics: operational count, transmitting count, data available count, and not-transmitting percentage.
  * Daily summaries enriched with average operational and transmitting device metrics.

* **Improvements**
  * Critical status determination refined with new threshold criteria.
  * Alert routing optimized for production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->