### PR TITLE
fix: suppress ERR_ERL_KEY_GEN_IPV6 on HAProxy-keyed rate limiters

### DIFF
--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -294,7 +294,7 @@ const transactionLimiter = rateLimit({
     req.headers["x-client-ip"] ||
     req.headers["x-client-original-ip"] ||
     req.ip,
-  validate: { trustProxy: false },
+  validate: { trustProxy: false, keyGeneratorIpFallback: false },
 });
 app.use("/api/v2/users/transactions", transactionLimiter);
 

--- a/src/auth-service/middleware/rate-limiter.js
+++ b/src/auth-service/middleware/rate-limiter.js
@@ -73,8 +73,9 @@ const createLimiterConfig = (options, useRedis = false) => {
     legacyHeaders: false,
     skipFailedRequests: false,
     skipSuccessfulRequests: false,
-    // Suppress trust-proxy validation — keyGenerator reads HAProxy-set headers
-    // (x-client-ip / x-client-original-ip) that clients cannot spoof.
+    // Suppress both trust-proxy and IPv6-fallback validations — keyGenerator reads
+    // HAProxy-set headers (x-client-ip / x-client-original-ip) that clients cannot
+    // spoof, so req.ip trustworthiness and IPv6 normalisation are not concerns here.
     validate: { trustProxy: false, keyGeneratorIpFallback: false },
 
     // Key by the HAProxy-set header. x-forwarded-for is intentionally avoided

--- a/src/auth-service/middleware/rate-limiter.js
+++ b/src/auth-service/middleware/rate-limiter.js
@@ -75,7 +75,7 @@ const createLimiterConfig = (options, useRedis = false) => {
     skipSuccessfulRequests: false,
     // Suppress trust-proxy validation — keyGenerator reads HAProxy-set headers
     // (x-client-ip / x-client-original-ip) that clients cannot spoof.
-    validate: { trustProxy: false },
+    validate: { trustProxy: false, keyGeneratorIpFallback: false },
 
     // Key by the HAProxy-set header. x-forwarded-for is intentionally avoided
     // because clients can inject arbitrary values into it.


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds `keyGeneratorIpFallback: false` to the `validate` option on two rate limiters — the inline `transactionLimiter` in `bin/server.js` and `createLimiterConfig` in `middleware/rate-limiter.js` — suppressing the `ERR_ERL_KEY_GEN_IPV6` startup error thrown by `express-rate-limit` v7+.

### Why is this change needed?
A previous fix added custom `keyGenerator` functions to both limiters to read HAProxy-set headers (`x-client-ip`, `x-client-original-ip`) instead of the spoofable `req.ip`. `express-rate-limit` v7+ detects any custom `keyGenerator` that falls back to `req.ip` and throws `ERR_ERL_KEY_GEN_IPV6` at startup, warning that IPv6-mapped IPv4 addresses (e.g. `::ffff:192.168.1.1` vs `192.168.1.1`) could be treated as different clients. Since HAProxy normalises IP addresses before setting these headers, and `req.ip` is only a last-resort fallback for local development, the concern does not apply here and the validation can be safely suppressed.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
The error was thrown at process startup before any requests were served. After adding `keyGeneratorIpFallback: false`, the service starts cleanly without the `ERR_ERL_KEY_GEN_IPV6` validation error. No rate-limiting logic or key-generation behaviour is altered.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

This is the third in a series of `express-rate-limit` v7+ validation fixes on this branch:

1. `ERR_ERL_PERMISSIVE_TRUST_PROXY` — suppressed via `trustProxy: false` on limiters that were missing it.
2. `ERR_ERL_KEY_GEN_IPV6` (this PR) — suppressed via `keyGeneratorIpFallback: false` on the same two limiters after custom `keyGenerator` functions were added.

`middleware/rate-limit.middleware.js` is unaffected — its `createSafeRateLimiter` factory does not fall back to `req.ip` in the keyGenerator.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rate limiting configuration for improved request identification accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->