### PR TITLE
Reduce Slack noise by scoping ops-alerts WARN routing to network uptime only

### DIFF
--- a/src/device-registry/bin/jobs/check-network-status-job.js
+++ b/src/device-registry/bin/jobs/check-network-status-job.js
@@ -128,8 +128,6 @@ const checkNetworkStatus = async () => {
     logText(message);
     if (status === "CRITICAL") {
       logger.error(message);
-    } else if (status === "WARNING") {
-      logger.warn(message);
     } else {
       logger.info(message);
     }

--- a/src/device-registry/bin/jobs/check-unassigned-sites-job.js
+++ b/src/device-registry/bin/jobs/check-unassigned-sites-job.js
@@ -70,7 +70,7 @@ const checkUnassignedSites = async () => {
         ", ",
       )})`;
       logText(message);
-      logger.warn(message);
+      logger.info(message);
     }
   } catch (error) {
     logText(`🐛🐛 Error checking unassigned sites: ${error.message}`);

--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -298,7 +298,7 @@ async function fetchAndStoreReadings() {
     const filter = generateFilter.fetch(request);
 
     const jobStartMs = Date.now();
-    logger.warn(
+    logger.info(
       `⏰ store-readings-job STARTED at ${new Date().toISOString()}`,
     );
 
@@ -342,7 +342,7 @@ async function fetchAndStoreReadings() {
 
     const data = viewEventsResponse.data[0].data;
     const fetchDuration = Date.now() - jobStartMs;
-    logger.warn(
+    logger.info(
       `📦 store-readings-job: EventModel.fetch() returned ${
         data.length
       } events in ${fetchDuration}ms`,
@@ -398,7 +398,7 @@ async function fetchAndStoreReadings() {
     // Always surface the final result to Slack so we can confirm the job is healthy
     const totalDuration = Date.now() - jobStartMs;
     if (report.summary.successRate >= 95) {
-      logger.warn(
+      logger.info(
         `✅ store-readings-job DONE — ${report.summary.readingsProcessed}/${
           report.summary.totalDocuments
         } readings stored (${
@@ -435,7 +435,7 @@ let currentJobPromise = null;
 
 const jobWrapper = async () => {
   if (isJobRunning) {
-    logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    logger.info(`${JOB_NAME} is already running, skipping this execution`);
     return;
   }
 

--- a/src/device-registry/config/log4js.js
+++ b/src/device-registry/config/log4js.js
@@ -81,24 +81,9 @@ if (isDevelopment()) {
   // full category name explicitly. Always include the "app" appender so
   // INFO/WARN messages reach the log file regardless of environment;
   // slackWarn is added later only for production.
-  const OPS_ALERTS_JOB_NAMES = [
-    "network-status-check-job",
-    "daily-activity-summary-job",
-    "check-unassigned-sites-job",
-    "backfill-site-metadata-job",
-    "/bin/jobs/check-unassigned-devices-job",
-    "/bin/jobs/check-active-statuses-job",
-    "/bin/jobs/check-duplicate-site-fields-job",
-    "/bin/jobs/private-cohort-alert-job",
-    "/bin/jobs/events-health-check-job",
-    "/bin/jobs/health-tip-checker-job",
-    "/bin/jobs/store-readings-job",
-    "/bin/jobs/network-uptime-analysis-job",
-    "/bin/jobs/device-status-check-job",
-    "/bin/jobs/device-status-hourly-check-job",
-    "/bin/jobs/check-primary-device-job",
-    "/bin/jobs/device-uptime-job",
-  ];
+  // Only the network status job gets WARN→Slack routing in production.
+  // All other jobs rely on the default category (ERROR only → Slack).
+  const OPS_ALERTS_JOB_NAMES = ["network-status-check-job"];
   const env = constants.ENVIRONMENT;
   OPS_ALERTS_JOB_NAMES.forEach((jobName) => {
     config.categories[`${env} -- ${jobName} -- ops-alerts`] = {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Reduces non-actionable Slack noise across device-registry jobs by narrowing
ops-alerts WARN→Slack routing exclusively to the network status job, downgrading
informational and persistent-state messages to `logger.info`, and applying
code-review feedback fixes on threshold boundary, log levels, timezone-aware date
windows, and legacy-document aggregation.

### Why is this change needed?
The Slack ops-alerts channel was flooding with informational messages every 30
minutes and every 2 hours — job start/stop notices, fetch counts, successful
completion lines, and a persistent "8.70% sites unassigned" warning that has been
stable for years. None of these are actionable. The network is also consistently
in the 41% not-transmitting range, so WARNING-level threshold alerts from the
2-hourly check are expected background state, not incidents. Only the once-daily
11 AM EAT network uptime summary and CRITICAL-level (ERROR) alerts warrant Slack
visibility.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :wrench: Enhancement/improvement
- [ ] :sparkles: New feature
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified against live Slack output — confirmed CRITICAL alerts and the daily
11 AM EAT network uptime summary are the only messages that now reach the channel.
Informational messages continue to appear in the `app.log` file at INFO level.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Files changed and why:**

- `src/device-registry/config/log4js.js` — `OPS_ALERTS_JOB_NAMES` trimmed from
  16 entries to `["network-status-check-job"]` only. All other jobs fall back to
  the `default` category (ERROR → Slack in all environments). Non-production
  ops-alerts categories now correctly receive `slackErrors` instead of nothing,
  restoring ERROR-level Slack parity with the pre-change `default` fallback.

- `src/device-registry/bin/jobs/store-readings-job.js` — Downgraded four
  `logger.warn` calls to `logger.info`: job STARTED notice, `EventModel.fetch()`
  event count, DONE ≥ 95% success completion, and "already running, skipping"
  dedup notice. Actionable cases (0 events returned, invalid fetch response, DONE
  WITH ISSUES < 95%) remain at `warn`.

- `src/device-registry/bin/jobs/check-unassigned-sites-job.js` — Downgraded the
  "X% of active sites not assigned to grid" message from `warn` to `info`. This
  is a persistent background data-quality state that requires manual data work,
  not an incident requiring immediate attention every 2 hours.

- `src/device-registry/bin/jobs/check-network-status-job.js` — WARNING status
  (35–50% not transmitting) downgraded from `warn` to `info` on the 2-hourly
  check; only CRITICAL fires `logger.error` to Slack. The once-daily 11 AM EAT
  summary retains `logger.warn` so it still reaches Slack. Also applied
  code-review feedback: `>` → `>=` on `UPTIME_THRESHOLD` boundary for
  consistency; timezone-aware yesterday/today window via `moment.tz(TIMEZONE)`.

- `src/device-registry/models/NetworkStatusAlert.js` — `$avg` on the three new
  status-count fields wrapped in `$ifNull(..., 0)` so legacy documents without
  those fields contribute zero rather than being excluded from aggregation averages.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging levels across job status messages for improved diagnostic accuracy
  * Refined production alert routing configuration to optimize alert delivery for critical operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->