### PR TITLE
Enforce backend authorization on system admin panel API routes

### DIFF
--- a/src/auth-service/routes/v2/clients.routes.js
+++ b/src/auth-service/routes/v2/clients.routes.js
@@ -5,14 +5,18 @@ const createClientController = require("@controllers/client.controller");
 const clientValidations = require("@validators/clients.validators");
 const { enhancedJWTAuth } = require("@middleware/passport");
 const { validate, headers, pagination } = require("@validators/common");
+const { requireSystemAdmin } = require("@middleware/adminAccess");
 
 router.use(headers); // Keep headers global
+
+const requireAirQoSuperAdmin = requireSystemAdmin();
 
 router.get(
   "/",
   clientValidations.list,
   enhancedJWTAuth,
-  pagination(), // Apply pagination here
+  requireAirQoSuperAdmin,
+  pagination(),
   createClientController.list
 );
 
@@ -20,6 +24,7 @@ router.post(
   "/",
   clientValidations.create,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createClientController.create
 );
 
@@ -27,6 +32,7 @@ router.patch(
   "/:client_id/secret",
   clientValidations.updateClientSecret,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createClientController.updateClientSecret
 );
 
@@ -34,6 +40,7 @@ router.put(
   "/:client_id",
   clientValidations.update,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createClientController.update
 );
 
@@ -41,6 +48,7 @@ router.post(
   "/activate/:client_id",
   clientValidations.activateClient,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createClientController.activateClient
 );
 
@@ -48,6 +56,7 @@ router.get(
   "/activate-request/:client_id",
   clientValidations.activateClientRequest,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createClientController.activateClientRequest
 );
 
@@ -55,6 +64,7 @@ router.delete(
   "/:client_id",
   clientValidations.deleteClient,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createClientController.delete
 );
 
@@ -62,6 +72,7 @@ router.get(
   "/:client_id",
   clientValidations.getClientById,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createClientController.getById
 );
 

--- a/src/auth-service/routes/v2/roles.routes.js
+++ b/src/auth-service/routes/v2/roles.routes.js
@@ -5,6 +5,9 @@ const roleController = require("@controllers/role.controller");
 const roleValidations = require("@validators/roles.validators");
 const { enhancedJWTAuth } = require("@middleware/passport");
 const { validate, headers, pagination } = require("@validators/common");
+const { requireSystemAdmin } = require("@middleware/adminAccess");
+
+const requireAirQoSuperAdmin = requireSystemAdmin();
 
 const injectCurrentUserId = (req, res, next) => {
   req.params.user_id = req.user._id;
@@ -27,6 +30,7 @@ router.get(
   roleValidations.listSummary,
   validate,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   pagination(),
   roleController.listSummary,
 );
@@ -94,6 +98,7 @@ router.put(
   roleValidations.assignUserToRolePut,
   validate,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   roleController.assignUserToRole,
 );
 

--- a/src/auth-service/routes/v2/surveys.routes.js
+++ b/src/auth-service/routes/v2/surveys.routes.js
@@ -6,6 +6,9 @@ const createSurveyController = require("@controllers/survey.controller");
 const surveyValidations = require("@validators/surveys.validators");
 const { enhancedJWTAuth } = require("@middleware/passport");
 const { validate, headers, pagination } = require("@validators/common");
+const { requireSystemAdmin } = require("@middleware/adminAccess");
+
+const requireAirQoSuperAdmin = requireSystemAdmin();
 
 router.use(headers);
 
@@ -50,6 +53,7 @@ router.get(
   "/responses",
   surveyValidations.listResponses,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   pagination(),
   createSurveyController.listResponses,
 );
@@ -59,6 +63,7 @@ router.get(
   "/stats/:survey_id",
   surveyValidations.getSurveyStats,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createSurveyController.getStats,
 );
 
@@ -81,6 +86,7 @@ router.post(
   "/",
   surveyValidations.create,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createSurveyController.create,
 );
 
@@ -89,6 +95,7 @@ router.put(
   "/:survey_id",
   surveyValidations.update,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createSurveyController.update,
 );
 
@@ -97,6 +104,7 @@ router.delete(
   "/:survey_id",
   surveyValidations.deleteSurvey,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createSurveyController.delete,
 );
 

--- a/src/auth-service/routes/v2/tokens.routes.js
+++ b/src/auth-service/routes/v2/tokens.routes.js
@@ -34,6 +34,9 @@ const { tokenVerifyIpRateLimiter, tokenVerifyRateLimiter } = require("@middlewar
 
 const domainBlockingMiddleware = require("@middleware/domain-blocking.middleware");
 const honeypotHandler = require("@middleware/honeypot.middleware");
+const { requireSystemAdmin } = require("@middleware/adminAccess");
+
+const requireAirQoSuperAdmin = requireSystemAdmin();
 // Apply common middleware
 router.use(headers); // Keep headers global
 
@@ -335,6 +338,7 @@ router.post(
   validateAirqoTenantOnly,
   createBlockedASN,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createTokenController.createBlockedASN,
 );
 
@@ -344,6 +348,7 @@ router.get(
   listBlockedASNs,
   pagination(),
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createTokenController.listBlockedASNs,
 );
 
@@ -352,6 +357,7 @@ router.delete(
   validateAirqoTenantOnly,
   deleteBlockedASN,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createTokenController.deleteBlockedASN,
 );
 
@@ -362,6 +368,7 @@ router.get(
   listFlaggedTokens,
   pagination(),
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createTokenController.listFlaggedTokens,
 );
 
@@ -370,6 +377,7 @@ router.put(
   validateAirqoTenantOnly,
   resolveFlaggedToken,
   enhancedJWTAuth,
+  requireAirQoSuperAdmin,
   createTokenController.resolveFlaggedToken,
 );
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds `requireSystemAdmin()` middleware to backend routes that back the system admin panel (`/system/*` pages), ensuring only AirQo super-admins can reach them.

Four route files in `auth-service` are updated:

| File | Endpoints secured |
|------|------------------|
| `routes/v2/clients.routes.js` | All 8 client management endpoints (list, create, update, delete, activate, refresh secret, get by ID, activate-request) |
| `routes/v2/tokens.routes.js` | Blocked ASNs (GET/POST/DELETE) and flagged tokens (GET/PUT resolve) — 5 endpoints |
| `routes/v2/surveys.routes.js` | Create, update, delete, list responses, get stats — 5 endpoints (public survey read endpoints intentionally left open) |
| `routes/v2/roles.routes.js` | `GET /summary` and `PUT /:role_id/user/:user_id` — 2 endpoints used by the user-statistics admin page |

### Why is this change needed?

The frontend system admin panel (`/system/*`) guards pages with `PermissionGuard` / `AdminPageGuard` checks, but those checks only protect the UI. Without matching backend enforcement, any authenticated user with a valid JWT could call these endpoints directly and perform privileged operations (manage API clients, block ASNs, manage surveys, assign roles, etc.).

The existing `requireSystemAdmin()` middleware — already used by `organization-requests.routes.js` — calls `rbacService.isSystemSuperAdmin(user._id)` to verify the caller holds the AirQo super-admin role. This PR consistently applies that same guard to the remaining unprotected admin routes.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service` — route-level authorization middleware added to four route files

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Verify that:
1. An AirQo super-admin JWT receives a `200` on all affected endpoints (no regression).
2. A regular authenticated user JWT receives a `403 Forbidden` on all affected endpoints.
3. An unauthenticated request receives a `401 Unauthorized`.
4. Public survey endpoints (`GET /users/surveys` and `GET /users/surveys/:id`) remain accessible without auth.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Previously unauthenticated or non-admin users could call these endpoints with a valid JWT. That access is now blocked with a `403`. Any client that was relying on under-protected access to these admin endpoints will be rejected — but that is the intended security fix, not a regression.

---

## :memo: Additional Notes

- `requireSystemAdmin()` is instantiated once per file as `const requireAirQoSuperAdmin = requireSystemAdmin()` and reused across routes in that file, consistent with the pattern already used in `application-email-configs.routes.js`.
- The following route files were **already correctly secured** and required no changes:
  - `application-email-configs.routes.js` — `requirePermissions([SUPER_ADMIN])`
  - `organization-requests.routes.js` — `requireSystemAdmin()`
  - `users.routes.js` (`/stats`, `/feedback/submissions`) — `requirePermissions([SYSTEM_ADMIN])`
- Public survey read endpoints (`GET /` and `GET /:survey_id`) are deliberately kept open — they serve unauthenticated mobile app users browsing available surveys.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
