### PR TITLE
Fix site registration crash on duplicate lat_long validation error

### DIFF
--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -722,7 +722,7 @@ siteSchema.statics = {
           status: httpStatus.CREATED,
         };
       } else if (isEmpty(createdSite)) {
-        next(
+        return next(
           new HttpError(
             "Internal Server Error",
             httpStatus.INTERNAL_SERVER_ERROR,
@@ -739,13 +739,13 @@ siteSchema.statics = {
       let response = {};
       let message = "validation errors for some of the provided fields";
       let status = httpStatus.CONFLICT;
-      Object.entries(error.errors).forEach(([key, value]) => {
-        response.message = value.message;
-        response[key] = value.message;
-        return response;
-      });
-
-      next(new HttpError(message, status, response));
+      if (error.errors) {
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response.message = value.message;
+          response[key] = value.message;
+        });
+      }
+      return next(new HttpError(message, status, response));
     }
   },
   async list({ skip = 0, limit = 1000, filter = {} } = {}, next) {

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -737,13 +737,19 @@ siteSchema.statics = {
       const stingifiedMessage = JSON.stringify(error ? error : "");
       logger.error(`🐛🐛 Internal Server Error -- ${stingifiedMessage}`);
       let response = {};
-      let message = "validation errors for some of the provided fields";
-      let status = httpStatus.CONFLICT;
+      let message;
+      let status;
       if (error.errors) {
+        message = "validation errors for some of the provided fields";
+        status = httpStatus.CONFLICT;
         Object.entries(error.errors).forEach(([key, value]) => {
           response.message = value.message;
           response[key] = value.message;
         });
+      } else {
+        message = error.message || "internal server error";
+        status = error.status || httpStatus.INTERNAL_SERVER_ERROR;
+        response.error = error.message;
       }
       return next(new HttpError(message, status, response));
     }

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -683,6 +683,7 @@ const createSite = {
 
       logObject("responseFromCreateSite in the util", responseFromCreateSite);
 
+      if (!responseFromCreateSite) return;
       if (responseFromCreateSite.success === true) {
         const createdSite = responseFromCreateSite.data;
         try {

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -683,7 +683,14 @@ const createSite = {
 
       logObject("responseFromCreateSite in the util", responseFromCreateSite);
 
-      if (!responseFromCreateSite) return;
+      if (!responseFromCreateSite) {
+        logger.warn(`🐛🐛 createSite: model returned falsy response for tenant: ${tenant}`);
+        return {
+          success: false,
+          message: "Model returned no response",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
       if (responseFromCreateSite.success === true) {
         const createdSite = responseFromCreateSite.data;
         try {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes two chained bugs in the site creation flow within the device-registry service:
1. Adds `return` before both `next()` calls in `SiteModel.register()` so the async function no longer resolves to `undefined` after invoking the error handler.
2. Adds an `if (error.errors)` guard in the catch block to prevent a secondary crash when a non-Mongoose error (without an `.errors` property) is caught.
3. Adds a null guard in `site.util.js` (`if (!responseFromCreateSite) return;`) as a defensive safety net before accessing `.success` on the model response.

### Why is this change needed?
When a site creation request was submitted with coordinates (`lat_long`) or a `description` that already existed in the database, Mongoose threw a `ValidationError`. The `register()` catch block called `next(new HttpError(...))` but did **not** `return`, so the async function resolved to `undefined`. Back in `site.util.js`, the code tried to read `.success` on that `undefined` value, throwing `TypeError: Cannot read properties of undefined (reading 'success')` — causing a full Internal Server Error instead of a clean 409 Conflict response.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `models/Site.js`, `utils/site.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Reproduced the error by attempting to create a site with a duplicate `lat_long` value. Before the fix, the request returned a 500 Internal Server Error with `Cannot read properties of undefined (reading 'success')`. After the fix, the request correctly returns a 409 Conflict with the validation error details.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The staging logs that surfaced this bug showed repeated retry attempts against the same duplicate coordinates (`70.5685245_56.5643536`), which means the broken error response was likely causing the caller to retry instead of handling the conflict. The fix ensures the 409 is propagated cleanly so callers can act on it correctly.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling robustness in site operations to ensure proper error propagation and prevent potential failures when processing responses with missing or incomplete error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->