### PR TITLE
Fix site.created Kafka payload: missing siteId and invalid groupId

### DIFF
--- a/src/auth-service/bin/jobs/kafka-consumer.js
+++ b/src/auth-service/bin/jobs/kafka-consumer.js
@@ -566,27 +566,22 @@ const operationForSiteCreated = async (messageData) => {
     const event = JSON.parse(messageData);
     logObject("site.created event", event);
 
-    if (event.groupId) {
-      const { siteId, groupId, tenant } = event;
-      // Validate that IDs are proper ObjectIds before proceeding
-      if (!ObjectId.isValid(siteId) || !ObjectId.isValid(groupId)) {
-        logger.error(
-          `🛑 Invalid ObjectId format - siteId: ${siteId}, groupId: ${groupId}`
-        );
+    if (event.grp_title) {
+      const { siteId, grp_title, tenant } = event;
+      if (!ObjectId.isValid(siteId)) {
+        logger.error(`🛑 Invalid ObjectId format - siteId: ${siteId}`);
         return;
       }
 
-      // Check if the group exists before attempting to update
-      const groupExists = await GroupModel(tenant).findOne({ _id: groupId });
+      const groupExists = await GroupModel(tenant).findOne({ grp_title });
       if (!groupExists) {
         logger.error(
-          `🛑 Group with ID ${groupId} not found for tenant ${tenant}`
+          `🛑 Group "${grp_title}" not found for tenant ${tenant}`
         );
         return;
       }
-      const filter = { _id: groupId };
+      const filter = { _id: groupExists._id };
       const update = { $addToSet: { grp_sites: siteId } };
-      const options = { new: true };
       const responseFromModifyGroup = await GroupModel(tenant).modify(
         { filter, update },
         (error) => {

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -731,7 +731,8 @@ const createSite = {
                 action: "create",
                 value: JSON.stringify({
                   ...createdSite,
-                  groupId: group,
+                  siteId: createdSite._id,
+                  grp_title: group,
                   tenant: request.query.tenant,
                 }),
               },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the `site.created` Kafka event payload published by `device-registry` and the corresponding consumer in `auth-service`. The producer now sends `siteId` (mapped from `createdSite._id`) and `grp_title` (the group name string) instead of the previous `groupId` field. The consumer is updated to guard on `grp_title`, validate only `siteId` as a MongoDB ObjectId, and look up the group via `findOne({ grp_title })` before updating `grp_sites`.

### Why is this change needed?
Two bugs caused `grp_sites` association to silently fail on every site creation:
1. The producer spread `createdSite` (which has `_id`) but the consumer expected an explicit `siteId` field — so `siteId` was always `undefined`.
2. The producer sent `groupId: group` where `group` is a string slug like `"airqo"`, not a MongoDB ObjectId. The consumer tried `ObjectId.isValid(groupId)` and `findOne({ _id: groupId })` — both always failed. This means no site has ever been successfully added to a group's `grp_sites` via this Kafka flow.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `src/device-registry/utils/site.util.js`
- `auth-service` — `src/auth-service/bin/jobs/kafka-consumer.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified via staging logs that the `🛑 Invalid ObjectId format` error was caused by `siteId: undefined` and `groupId: airqo` in the consumed event. Fix confirmed by tracing producer payload construction and consumer field expectations end-to-end.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The Kafka message shape changes (`groupId` → `grp_title`, adds `siteId`), but this topic (`sites-topic`) is only consumed by `auth-service`, which is updated in the same PR.

---

## :memo: Additional Notes

The `grp_sites` group-site association has never been populated via this Kafka flow due to these bugs. After this fix, newly created sites will correctly appear in their group's `grp_sites` array going forward. Existing groups are unaffected (no backfill).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
