### PR TITLE
Fix misleading bulk shipping failure message and add shipping API guide

### DIFF
--- a/src/device-registry/docs/DEVICE_SHIPPING_API_GUIDE.md
+++ b/src/device-registry/docs/DEVICE_SHIPPING_API_GUIDE.md
@@ -7,8 +7,8 @@ This guide walks through the full device shipping workflow — from preparing de
 ## Overview: Correct Order of Operations
 
 ```
-1. Prepare devices  →  POST /devices/prepare-bulk-for-shipping
-2. Generate labels  →  POST /devices/generate-shipping-labels
+1. Prepare devices  →  POST /api/v2/devices/prepare-bulk-for-shipping
+2. Generate labels  →  POST /api/v2/devices/generate-shipping-labels
 ```
 
 Step 2 **will fail** if Step 1 has not been completed successfully first. Labels can only be generated for devices that have been prepared.
@@ -17,7 +17,7 @@ Step 2 **will fail** if Step 1 has not been completed successfully first. Labels
 
 ## Step 1 — Prepare Devices for Shipping
 
-**Endpoint:** `POST /devices/prepare-bulk-for-shipping`
+**Endpoint:** `POST /api/v2/devices/prepare-bulk-for-shipping`
 
 Sets a claim token on each device and marks it as ready for shipping. Optionally groups prepared devices into a named shipping batch.
 
@@ -59,7 +59,9 @@ Sets a claim token on each device and marks it as ready for shipping. Optionally
         "device_name": "aq_device_001",
         "claim_token": "abc123...",
         "token_type": "hex",
+        "qr_code_data": { "..." : "..." },
         "qr_code_image": "data:image/png;base64,...",
+        "label_data": { "..." : "..." },
         "shipping_prepared_at": "2026-06-11T10:00:00.000Z"
       }
     ],
@@ -75,14 +77,14 @@ Sets a claim token on each device and marks it as ready for shipping. Optionally
 
 ### Partial Failure Response (`200 OK`)
 
-The endpoint always returns `200`. Check `failed_preparations` for individual device errors.
+For valid requests, the endpoint returns `200` even when one or more devices fail. Check `failed_preparations` for individual device errors. Invalid requests (e.g. missing `device_names`) return `400`.
 
 ```json
 {
   "success": true,
   "message": "Bulk preparation completed: 1 successful, 1 failed. Shipping batch 'shipment-june-2026' was created.",
   "bulk_preparation_results": {
-    "successful_preparations": [...],
+    "successful_preparations": ["..."],
     "failed_preparations": [
       {
         "device_name": "aq_device_002",
@@ -116,7 +118,7 @@ The endpoint always returns `200`. Check `failed_preparations` for individual de
 
 ## Step 2 — Generate Shipping Labels
 
-**Endpoint:** `POST /devices/generate-shipping-labels`
+**Endpoint:** `POST /api/v2/devices/generate-shipping-labels`
 
 Generates printable QR code labels for devices that have already been prepared via Step 1.
 
@@ -153,8 +155,9 @@ Generates printable QR code labels for devices that have already been prepared v
         "device_name": "aq_device_001",
         "device_long_name": "AirQo Device 001",
         "claim_token": "abc123...",
+        "qr_code_data": { "..." : "..." },
         "qr_code_image": "data:image/png;base64,...",
-        "qr_code_data": { ... }
+        "label_data": { "..." : "..." }
       }
     ],
     "total_labels": 1
@@ -185,7 +188,7 @@ This error means either:
 ### 1. Prepare devices
 
 ```bash
-curl -X POST https://<host>/devices/prepare-bulk-for-shipping \
+curl -X POST https://<host>/api/v2/devices/prepare-bulk-for-shipping \
   -H "Authorization: JWT <token>" \
   -H "Content-Type: application/json" \
   -d '{
@@ -199,7 +202,7 @@ Confirm `successful_count > 0` before proceeding.
 ### 2. Generate labels
 
 ```bash
-curl -X POST https://<host>/devices/generate-shipping-labels \
+curl -X POST https://<host>/api/v2/devices/generate-shipping-labels \
   -H "Authorization: JWT <token>" \
   -H "Content-Type: application/json" \
   -d '{

--- a/src/device-registry/docs/DEVICE_SHIPPING_API_GUIDE.md
+++ b/src/device-registry/docs/DEVICE_SHIPPING_API_GUIDE.md
@@ -1,0 +1,208 @@
+# Device Shipping API Guide
+
+This guide walks through the full device shipping workflow — from preparing devices for shipping to generating printable labels.
+
+---
+
+## Overview: Correct Order of Operations
+
+```
+1. Prepare devices  →  POST /devices/prepare-bulk-for-shipping
+2. Generate labels  →  POST /devices/generate-shipping-labels
+```
+
+Step 2 **will fail** if Step 1 has not been completed successfully first. Labels can only be generated for devices that have been prepared.
+
+---
+
+## Step 1 — Prepare Devices for Shipping
+
+**Endpoint:** `POST /devices/prepare-bulk-for-shipping`
+
+Sets a claim token on each device and marks it as ready for shipping. Optionally groups prepared devices into a named shipping batch.
+
+### Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `JWT <token>` |
+| `Content-Type` | `application/json` |
+
+### Request Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `device_names` | `string[]` | Yes | Array of 1–50 device names to prepare. Names must match exactly as stored (case-sensitive). |
+| `batch_name` | `string` | No | If provided, groups all successfully prepared devices into a named shipping batch. |
+| `token_type` | `string` | No | Token format: `"hex"` (default) or `"readable"`. |
+
+### Example Request
+
+```json
+{
+  "device_names": ["aq_device_001", "aq_device_002"],
+  "batch_name": "shipment-june-2026",
+  "token_type": "hex"
+}
+```
+
+### Success Response (`200 OK`)
+
+```json
+{
+  "success": true,
+  "message": "Bulk preparation completed: 2 successful, 0 failed. Shipping batch 'shipment-june-2026' was created.",
+  "bulk_preparation_results": {
+    "successful_preparations": [
+      {
+        "device_id": "<mongo_id>",
+        "device_name": "aq_device_001",
+        "claim_token": "abc123...",
+        "token_type": "hex",
+        "qr_code_image": "data:image/png;base64,...",
+        "shipping_prepared_at": "2026-06-11T10:00:00.000Z"
+      }
+    ],
+    "failed_preparations": [],
+    "summary": {
+      "total_requested": 2,
+      "successful_count": 2,
+      "failed_count": 0
+    }
+  }
+}
+```
+
+### Partial Failure Response (`200 OK`)
+
+The endpoint always returns `200`. Check `failed_preparations` for individual device errors.
+
+```json
+{
+  "success": true,
+  "message": "Bulk preparation completed: 1 successful, 1 failed. Shipping batch 'shipment-june-2026' was created.",
+  "bulk_preparation_results": {
+    "successful_preparations": [...],
+    "failed_preparations": [
+      {
+        "device_name": "aq_device_002",
+        "error": "Device not found"
+      }
+    ],
+    "summary": {
+      "total_requested": 2,
+      "successful_count": 1,
+      "failed_count": 1
+    }
+  }
+}
+```
+
+### Common Failure Reasons (per device)
+
+| `error` value | Cause | Fix |
+|---|---|---|
+| `"Device not found"` | Name doesn't match any device in the system | Verify the exact device name (case-sensitive) |
+| `"Device is currently deployed and cannot be prepared for shipping"` | Device has `status: deployed` | Recall the device before preparing it for shipping |
+
+### Important Notes
+
+- `batch_name` is **optional**. Omitting it still prepares the devices; it just skips batch grouping.
+- A batch is only created if `batch_name` is provided **and** at least one device was prepared successfully.
+- If all devices fail, the message will read: `"No shipping batch was created as no devices were prepared successfully."` — even if `batch_name` was provided.
+- Device names are **case-sensitive**.
+
+---
+
+## Step 2 — Generate Shipping Labels
+
+**Endpoint:** `POST /devices/generate-shipping-labels`
+
+Generates printable QR code labels for devices that have already been prepared via Step 1.
+
+### Request Headers
+
+| Header | Value |
+|---|---|
+| `Authorization` | `JWT <token>` |
+| `Content-Type` | `application/json` |
+
+### Request Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `device_names` | `string[]` | Yes | Array of 1–20 device names. Each device must have been prepared for shipping first. |
+
+### Example Request
+
+```json
+{
+  "device_names": ["aq_device_001", "aq_device_002"]
+}
+```
+
+### Success Response (`200 OK`)
+
+```json
+{
+  "success": true,
+  "message": "Shipping labels generated successfully",
+  "shipping_labels": {
+    "labels": [
+      {
+        "device_name": "aq_device_001",
+        "device_long_name": "AirQo Device 001",
+        "claim_token": "abc123...",
+        "qr_code_image": "data:image/png;base64,...",
+        "qr_code_data": { ... }
+      }
+    ],
+    "total_labels": 1
+  }
+}
+```
+
+### Failure Response (`404 Not Found`)
+
+```json
+{
+  "success": false,
+  "message": "No prepared devices found",
+  "errors": {
+    "message": "Devices not found or not prepared for shipping"
+  }
+}
+```
+
+This error means either:
+- The device names don't exist in the system, **or**
+- The devices exist but Step 1 (prepare for shipping) has not been completed for them yet
+
+---
+
+## End-to-End Example
+
+### 1. Prepare devices
+
+```bash
+curl -X POST https://<host>/devices/prepare-bulk-for-shipping \
+  -H "Authorization: JWT <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "device_names": ["aq_device_001"],
+    "batch_name": "shipment-june-2026"
+  }'
+```
+
+Confirm `successful_count > 0` before proceeding.
+
+### 2. Generate labels
+
+```bash
+curl -X POST https://<host>/devices/generate-shipping-labels \
+  -H "Authorization: JWT <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "device_names": ["aq_device_001"]
+  }'
+```

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -3835,8 +3835,10 @@ const deviceUtil = {
         `Bulk preparation completed: ${successful.length} successful, ${failed.length} failed.` +
         (batchCreated
           ? ` Shipping batch '${batch_name}' was created.`
-          : batch_name
+          : successful.length === 0 && batch_name
           ? " No shipping batch was created as no devices were prepared successfully."
+          : batch_name
+          ? " Shipping batch was not created due to a batch creation error."
           : " No shipping batch was created as 'batch_name' was not provided.");
       return {
         success: true,

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -3835,6 +3835,8 @@ const deviceUtil = {
         `Bulk preparation completed: ${successful.length} successful, ${failed.length} failed.` +
         (batchCreated
           ? ` Shipping batch '${batch_name}' was created.`
+          : batch_name
+          ? " No shipping batch was created as no devices were prepared successfully."
           : " No shipping batch was created as 'batch_name' was not provided.");
       return {
         success: true,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

- Fixes a misleading response message in `prepareBulkDevicesForShipping` (`device.util.js`) where the fallback text always read _"No shipping batch was created as 'batch_name' was not provided"_ — even when `batch_name` **was** provided but no devices were prepared successfully. The message now correctly distinguishes between the two failure cases.
- Adds `DEVICE_SHIPPING_API_GUIDE.md` to the device-registry docs covering the full shipping workflow, request/response examples, per-device failure reasons, and end-to-end curl examples.

### Why is this change needed?

The incorrect message was misleading API consumers into thinking they had omitted the `batch_name` field when the real issue was that device preparation itself had failed (e.g. device not found, or device still deployed). The new guide addresses a documentation gap around the sequential dependency between `prepare-bulk-for-shipping` and `generate-shipping-labels`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually tested `POST /devices/prepare-bulk-for-shipping` with three scenarios:
1. `batch_name` provided, all devices fail → message now reads _"no devices were prepared successfully"_
2. `batch_name` omitted, all devices fail → message still reads _"batch_name was not provided"_ (unchanged)
3. `batch_name` provided, at least one device succeeds → batch is created and message confirms it (unchanged)

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The `generate-shipping-labels` endpoint requires `prepare-bulk-for-shipping` to have completed successfully first. This sequential dependency is now documented in `DEVICE_SHIPPING_API_GUIDE.md`. No logic change was made to `generate-shipping-labels` itself.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for the device shipping API workflow, documenting the complete two-step process for preparing devices and generating QR shipping labels, with detailed request/response formats, comprehensive error handling documentation, and practical end-to-end examples.

* **Bug Fixes**
  * Enhanced error messaging for bulk device preparation operations with improved contextual messages based on operation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->