### PR TITLE
Revert admin guard on shared client routes to restore user profile access

### DIFF
--- a/src/auth-service/routes/v2/clients.routes.js
+++ b/src/auth-service/routes/v2/clients.routes.js
@@ -5,17 +5,13 @@ const createClientController = require("@controllers/client.controller");
 const clientValidations = require("@validators/clients.validators");
 const { enhancedJWTAuth } = require("@middleware/passport");
 const { validate, headers, pagination } = require("@validators/common");
-const { requireSystemAdmin } = require("@middleware/adminAccess");
 
 router.use(headers); // Keep headers global
-
-const requireAirQoSuperAdmin = requireSystemAdmin();
 
 router.get(
   "/",
   clientValidations.list,
   enhancedJWTAuth,
-  requireAirQoSuperAdmin,
   pagination(),
   createClientController.list
 );
@@ -24,7 +20,6 @@ router.post(
   "/",
   clientValidations.create,
   enhancedJWTAuth,
-  requireAirQoSuperAdmin,
   createClientController.create
 );
 
@@ -32,7 +27,6 @@ router.patch(
   "/:client_id/secret",
   clientValidations.updateClientSecret,
   enhancedJWTAuth,
-  requireAirQoSuperAdmin,
   createClientController.updateClientSecret
 );
 
@@ -40,7 +34,6 @@ router.put(
   "/:client_id",
   clientValidations.update,
   enhancedJWTAuth,
-  requireAirQoSuperAdmin,
   createClientController.update
 );
 
@@ -48,7 +41,6 @@ router.post(
   "/activate/:client_id",
   clientValidations.activateClient,
   enhancedJWTAuth,
-  requireAirQoSuperAdmin,
   createClientController.activateClient
 );
 
@@ -56,7 +48,6 @@ router.get(
   "/activate-request/:client_id",
   clientValidations.activateClientRequest,
   enhancedJWTAuth,
-  requireAirQoSuperAdmin,
   createClientController.activateClientRequest
 );
 
@@ -64,7 +55,6 @@ router.delete(
   "/:client_id",
   clientValidations.deleteClient,
   enhancedJWTAuth,
-  requireAirQoSuperAdmin,
   createClientController.delete
 );
 
@@ -72,7 +62,6 @@ router.get(
   "/:client_id",
   clientValidations.getClientById,
   enhancedJWTAuth,
-  requireAirQoSuperAdmin,
   createClientController.getById
 );
 

--- a/src/auth-service/routes/v2/clients.routes.js
+++ b/src/auth-service/routes/v2/clients.routes.js
@@ -5,13 +5,77 @@ const createClientController = require("@controllers/client.controller");
 const clientValidations = require("@validators/clients.validators");
 const { enhancedJWTAuth } = require("@middleware/passport");
 const { validate, headers, pagination } = require("@validators/common");
+const { HttpError } = require("@utils/shared");
+const ClientModel = require("@models/Client");
+const RBACService = require("@services/rbac.service");
+const constants = require("@config/constants");
+const httpStatus = require("http-status");
+const mongoose = require("mongoose");
 
-router.use(headers); // Keep headers global
+router.use(headers);
+
+// Non-admins may only list their own clients.
+// Admins (isSystemSuperAdmin) may list across all users via ?user_id=.
+const scopeListToUser = async (req, res, next) => {
+  try {
+    const tenant = req.query.tenant || constants.DEFAULT_TENANT;
+    const isAdmin = await RBACService.getInstance(tenant).isSystemSuperAdmin(req.user._id);
+    if (!isAdmin) req.query.user_id = req.user._id.toString();
+    next();
+  } catch (error) {
+    next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+  }
+};
+
+// Non-admins may only create clients for themselves.
+// Silently overrides any body.user_id supplied by a non-admin.
+const scopeCreateToUser = async (req, res, next) => {
+  try {
+    const tenant = req.query.tenant || constants.DEFAULT_TENANT;
+    const isAdmin = await RBACService.getInstance(tenant).isSystemSuperAdmin(req.user._id);
+    if (!isAdmin) req.body.user_id = req.user._id.toString();
+    next();
+  } catch (error) {
+    next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+  }
+};
+
+// Non-admins may only operate on clients they own.
+// Must run after enhancedJWTAuth (needs req.user) and after validation (needs req.params.client_id).
+const requireClientOwnership = async (req, res, next) => {
+  try {
+    const { user } = req;
+    const tenant = req.query.tenant || constants.DEFAULT_TENANT;
+    const { client_id } = req.params;
+
+    const isAdmin = await RBACService.getInstance(tenant).isSystemSuperAdmin(user._id);
+    if (isAdmin) return next();
+
+    if (!mongoose.isValidObjectId(client_id)) {
+      return next(new HttpError("Bad Request", httpStatus.BAD_REQUEST, { message: "Invalid client_id" }));
+    }
+
+    const client = await ClientModel(tenant.toLowerCase()).findById(client_id).lean();
+
+    if (!client) {
+      return next(new HttpError("Not Found", httpStatus.NOT_FOUND, { message: "Client not found" }));
+    }
+
+    if (!client.user_id || client.user_id.toString() !== user._id.toString()) {
+      return next(new HttpError("Forbidden", httpStatus.FORBIDDEN, { message: "You do not have access to this client" }));
+    }
+
+    next();
+  } catch (error) {
+    next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+  }
+};
 
 router.get(
   "/",
   clientValidations.list,
   enhancedJWTAuth,
+  scopeListToUser,
   pagination(),
   createClientController.list
 );
@@ -20,6 +84,7 @@ router.post(
   "/",
   clientValidations.create,
   enhancedJWTAuth,
+  scopeCreateToUser,
   createClientController.create
 );
 
@@ -27,6 +92,7 @@ router.patch(
   "/:client_id/secret",
   clientValidations.updateClientSecret,
   enhancedJWTAuth,
+  requireClientOwnership,
   createClientController.updateClientSecret
 );
 
@@ -34,6 +100,7 @@ router.put(
   "/:client_id",
   clientValidations.update,
   enhancedJWTAuth,
+  requireClientOwnership,
   createClientController.update
 );
 
@@ -41,6 +108,7 @@ router.post(
   "/activate/:client_id",
   clientValidations.activateClient,
   enhancedJWTAuth,
+  requireClientOwnership,
   createClientController.activateClient
 );
 
@@ -48,6 +116,7 @@ router.get(
   "/activate-request/:client_id",
   clientValidations.activateClientRequest,
   enhancedJWTAuth,
+  requireClientOwnership,
   createClientController.activateClientRequest
 );
 
@@ -55,6 +124,7 @@ router.delete(
   "/:client_id",
   clientValidations.deleteClient,
   enhancedJWTAuth,
+  requireClientOwnership,
   createClientController.delete
 );
 
@@ -62,6 +132,7 @@ router.get(
   "/:client_id",
   clientValidations.getClientById,
   enhancedJWTAuth,
+  requireClientOwnership,
   createClientController.getById
 );
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Reverts `requireSystemAdmin()` from all routes in `routes/v2/clients.routes.js`, restoring JWT-auth-only protection on all `/users/clients` endpoints.

### Why is this change needed?

A prior security hardening PR (`add-admin-auth`) added `requireSystemAdmin()` to every client endpoint to protect the system admin panel (`/system/clients`). This inadvertently locked out regular authenticated users from managing their own API clients on the user profile page (`/user/profile?tab=api`), breaking:

- Viewing their list of API clients (`GET /users/clients`)
- Creating new clients (`POST /users/clients`)
- Updating, deleting, refreshing secrets, activating their own clients
- Effectively blocking token generation too, since a `client_id` is required

**Why JWT-only is the right guard here:**
The `/users/clients` endpoints are shared between the system admin panel and the user profile API tab — both call the exact same routes. The controller already handles data scoping: regular users receive only their own clients; admins receive all clients. Applying `requireSystemAdmin()` at the route level was over-broad for a shared endpoint. The admin panel's security is maintained by the frontend `PermissionGuard` and the fact that only super-admins are issued tokens with those roles.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service` — `routes/v2/clients.routes.js` only

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Verify that:
1. A regular authenticated user can `GET /users/clients` and sees only their own clients (profile page restored).
2. A regular authenticated user can `POST /users/clients` to create a new client.
3. A regular authenticated user can update, delete, refresh secret, and activate their own client.
4. An AirQo super-admin using the system admin panel (`/system/clients`) continues to work as expected — no regression.
5. An unauthenticated request still receives `401 Unauthorized`.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

This restores the original behaviour of `clients.routes.js` before the `add-admin-auth` PR. No new behaviour is introduced.

---

## :memo: Additional Notes

- All other security guards introduced in `add-admin-auth` remain in place and are unaffected:
  - `tokens.routes.js` — `requireSystemAdmin()` on blocked-ASN and flagged-token endpoints ✓
  - `surveys.routes.js` — `requireSystemAdmin()` on create, update, delete, responses list, stats ✓
  - `roles.routes.js` — `requireSystemAdmin()` on `GET /summary` and `PUT /:role_id/user/:user_id` ✓
- Frontend investigation confirmed that `GET /users/surveys/responses`, `GET /users/surveys/stats/:id`, blocked-ASN endpoints, flagged-token endpoints, and role assignment endpoints are **exclusively** called from admin-guarded pages (`/system/*`) — no regular user pages use them.
- The proper long-term fix for the admin panel listing **all** clients (vs. only the admin's own) is a controller-level role check, not a route-level guard, since the endpoint is shared.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated client access controls to enforce user-scoped authorization. Non-admin users can now only view and manage their own clients, while administrators retain full access across all clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->