### PR TITLE
Add server-side network filter and available networks to coverage API

### DIFF
--- a/src/device-registry/utils/network-coverage.util.js
+++ b/src/device-registry/utils/network-coverage.util.js
@@ -251,9 +251,10 @@ function buildAirQoMonitorItem(siteDoc, registryDoc, deviceCategory) {
   const reg = registryDoc || {};
   const country = siteDoc.country || "";
 
-  // Derive type directly from the device's own category — the canonical,
-  // validated source of truth in DeviceModel. No manual curation needed.
-  const type = DEVICE_CATEGORY_TO_TYPE[deviceCategory] || "LCS";
+  // Registry type wins when explicitly set — allows curators to correct
+  // misclassifications without touching device metadata. Falls back to the
+  // canonical device category mapping when no registry override exists.
+  const type = reg.type || DEVICE_CATEGORY_TO_TYPE[deviceCategory] || "LCS";
 
   return {
     id: String(siteDoc._id),
@@ -366,9 +367,9 @@ function groupByCountry(monitors) {
 }
 
 /**
- * Applies search / activeOnly / types filters to a flat monitor list.
+ * Applies search / activeOnly / types / network filters to a flat monitor list.
  */
-function applyFilters(monitors, { search, activeOnly, types } = {}) {
+function applyFilters(monitors, { search, activeOnly, types, network } = {}) {
   let result = monitors;
 
   if (activeOnly === true || activeOnly === "true") {
@@ -382,6 +383,18 @@ function applyFilters(monitors, { search, activeOnly, types } = {}) {
       .filter(Boolean);
     if (allowedTypes.length > 0) {
       result = result.filter((m) => allowedTypes.includes(m.type));
+    }
+  }
+
+  if (network) {
+    const allowedNetworks = network
+      .split(",")
+      .map((n) => n.trim().toLowerCase())
+      .filter(Boolean);
+    if (allowedNetworks.length > 0) {
+      result = result.filter((m) =>
+        allowedNetworks.includes((m.network || "").trim().toLowerCase())
+      );
     }
   }
 
@@ -528,7 +541,7 @@ const networkCoverageUtil = {
    */
   list: async (request) => {
     try {
-      const { tenant, search, activeOnly, types } = request.query;
+      const { tenant, search, activeOnly, types, network } = request.query;
 
       const { airqoSites, standaloneEntries, registryBySiteId, categoryBySiteId } =
         await fetchAllSources(tenant);
@@ -543,10 +556,25 @@ const networkCoverageUtil = {
       );
       const externalMonitors = standaloneEntries.map(buildStandaloneMonitorItem);
 
-      const filtered = applyFilters([...airqoMonitors, ...externalMonitors], {
+      const allMonitors = [...airqoMonitors, ...externalMonitors];
+
+      // Collect distinct network values before applying network filter so the
+      // caller always receives the full networks list regardless of the active
+      // filter — this lets the frontend populate the source dropdown in a single
+      // request without needing a separate endpoint.
+      const availableNetworks = [
+        ...new Set(
+          allMonitors
+            .map((m) => (m.network || "").trim())
+            .filter(Boolean)
+        ),
+      ].sort();
+
+      const filtered = applyFilters(allMonitors, {
         search,
         activeOnly,
         types,
+        network,
       });
 
       const countries = groupByCountry(filtered);
@@ -560,6 +588,7 @@ const networkCoverageUtil = {
             totalCountries: countries.length,
             monitoredCountries: countries.filter((c) => c.monitors.length > 0)
               .length,
+            availableNetworks,
             generatedAt: new Date().toISOString(),
           },
         },
@@ -681,7 +710,7 @@ const networkCoverageUtil = {
    */
   getCountryMonitors: async (request) => {
     try {
-      const { tenant, activeOnly, types } = request.query;
+      const { tenant, activeOnly, types, network } = request.query;
       const { countryId } = request.params;
 
       const { airqoSites, standaloneEntries, registryBySiteId, categoryBySiteId } =
@@ -703,7 +732,7 @@ const networkCoverageUtil = {
 
       const allMonitors = applyFilters(
         [...airqoMonitors, ...externalMonitors],
-        { activeOnly, types }
+        { activeOnly, types, network }
       );
 
       if (allMonitors.length === 0) {
@@ -749,7 +778,7 @@ const networkCoverageUtil = {
    */
   exportCsv: async (request) => {
     try {
-      const { tenant, search, activeOnly, types, countryId } = request.query;
+      const { tenant, search, activeOnly, types, network, countryId } = request.query;
 
       const { airqoSites, standaloneEntries, registryBySiteId, categoryBySiteId } =
         await fetchAllSources(tenant);
@@ -767,6 +796,7 @@ const networkCoverageUtil = {
         search,
         activeOnly,
         types,
+        network,
       });
 
       if (countryId) {

--- a/src/device-registry/utils/network-coverage.util.js
+++ b/src/device-registry/utils/network-coverage.util.js
@@ -244,17 +244,26 @@ function buildRegistryBySiteId(registryRecords) {
  * extended metadata is layered from the registry entry when present.
  *
  * deviceCategory — the dominant category of active devices at this site
- * (bam | lowcost | gas). This is the authoritative source for `type`;
- * the registry entry never overrides it for AirQo pipeline monitors.
+ * (bam | lowcost | gas). Used to derive `type` via DEVICE_CATEGORY_TO_TYPE
+ * unless the registry entry carries an explicit, valid type override.
+ *
+ * Type precedence:
+ *   1. reg.type — when set and a recognised MONITOR_TYPES value (curator override)
+ *   2. DEVICE_CATEGORY_TO_TYPE[deviceCategory] — canonical device-category mapping
+ *   3. "LCS" — safe default
  */
 function buildAirQoMonitorItem(siteDoc, registryDoc, deviceCategory) {
   const reg = registryDoc || {};
   const country = siteDoc.country || "";
 
-  // Registry type wins when explicitly set — allows curators to correct
-  // misclassifications without touching device metadata. Falls back to the
-  // canonical device category mapping when no registry override exists.
-  const type = reg.type || DEVICE_CATEGORY_TO_TYPE[deviceCategory] || "LCS";
+  // Registry type wins when explicitly set to a valid enum value — allows curators
+  // to correct misclassifications without touching device metadata. Invalid or
+  // blank registry values fall through to the canonical device category mapping.
+  const validTypes = NetworkCoverageRegistryModel.MONITOR_TYPES;
+  const type =
+    (reg.type && validTypes.includes(reg.type) ? reg.type : null) ||
+    DEVICE_CATEGORY_TO_TYPE[deviceCategory] ||
+    "LCS";
 
   return {
     id: String(siteDoc._id),
@@ -565,7 +574,7 @@ const networkCoverageUtil = {
       const availableNetworks = [
         ...new Set(
           allMonitors
-            .map((m) => (m.network || "").trim())
+            .map((m) => (m.network || "").trim().toLowerCase())
             .filter(Boolean)
         ),
       ].sort();
@@ -778,7 +787,8 @@ const networkCoverageUtil = {
    */
   exportCsv: async (request) => {
     try {
-      const { tenant, search, activeOnly, types, network, countryId } = request.query;
+      const { tenant, search, activeOnly, types, network, countryId } =
+        request.query;
 
       const { airqoSites, standaloneEntries, registryBySiteId, categoryBySiteId } =
         await fetchAllSources(tenant);

--- a/src/device-registry/validators/network-coverage.validators.js
+++ b/src/device-registry/validators/network-coverage.validators.js
@@ -48,6 +48,13 @@ const activeOnlyFilter = query("activeOnly")
   .isIn(["true", "false"])
   .withMessage("activeOnly must be 'true' or 'false'");
 
+// Comma-separated list of network slugs, e.g. "airqo" or "airqo,metone"
+const networkFilter = query("network")
+  .optional()
+  .isString()
+  .withMessage("network must be a comma-separated string")
+  .trim();
+
 const networkCoverageValidations = {
   /**
    * GET /network-coverage
@@ -57,6 +64,7 @@ const networkCoverageValidations = {
     query("search").optional().isString().trim(),
     activeOnlyFilter,
     typesFilter,
+    networkFilter,
   ],
 
   /**
@@ -77,6 +85,7 @@ const networkCoverageValidations = {
       .trim(),
     activeOnlyFilter,
     typesFilter,
+    networkFilter,
   ],
 
   /**
@@ -87,6 +96,7 @@ const networkCoverageValidations = {
     query("countryId").optional().isString().trim(),
     activeOnlyFilter,
     typesFilter,
+    networkFilter,
     query("search").optional().isString().trim(),
   ],
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds a `?network=` query parameter to all network coverage GET endpoints (`/network-coverage`, `/network-coverage/countries/:countryId/monitors`, `/network-coverage/export.csv`) so source/network filtering is done server-side instead of client-side
- Surfaces `availableNetworks[]` in the summary response `meta` block, computed before the network filter is applied so the full source list is always returned regardless of the active filter
- Allows a `NetworkCoverageRegistry` enrichment entry to override the `type` field (Reference / LCS / Inactive) for an AirQo pipeline site without touching device metadata
- Adds frontend integration notes (`network-coverage-frontend-notes.md`) for the frontend team

### Why is this change needed?
Source/network filtering on the network coverage map was entirely client-side — the API returned all monitors regardless of network and the frontend filtered locally. This meant selecting "AirQo" as a source in the UI still fetched every monitor from every network over the wire. Moving the filter server-side reduces payload size, makes map and sidebar results consistent by construction, and allows the source dropdown to be populated from `meta.availableNetworks` without a second API call.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified via API calls:
- `GET /network-coverage?network=airqo` returns only `network: "airqo"` monitors
- `GET /network-coverage?network=airqo,metone` returns monitors for both networks
- `GET /network-coverage` (no filter) returns all monitors unchanged — backwards compatible
- `meta.availableNetworks` is present and contains all distinct network values regardless of active filter
- `GET /network-coverage/countries/ethiopia/monitors?network=airqo` correctly excludes MetOne/Embassy monitors

---

## :boom: Breaking Changes

- [x] **No breaking changes**

The `network` query parameter is optional. Existing calls without it continue to return all monitors. The `availableNetworks` field in `meta` is additive.

---

## :memo: Additional Notes

**Frontend changes required (non-blocking):** The frontend team needs to wire `network` into `summaryParams` and `countryMonitorsQuery`, read the source dropdown from `meta.availableNetworks`, and remove the now-redundant `mapCountries` / `matchesNetworkFilter` client-side filter logic. Full notes shared in `src/device-registry/network-coverage-frontend-notes.md`.

**Context:** This investigation was triggered by US Embassy / MetOne BAM monitors (discontinued ~Jan 2025 when the US State Department air quality program ended) appearing on the network coverage map when no source filter was active. Those monitors are correctly attributed as `network: "metone"` — they are not AirQo monitors — and will be excluded from the "AirQo" filtered view with this change. The Embassy devices themselves will be recalled separately via Vertex as a data pipeline hygiene action.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **network** filter to device lists, country-specific monitors, and **CSV exports**
  * Exposed **available networks** as dropdown options based on current results
* **Bug Fixes**
  * Improved monitor **type** resolution by honoring an explicit registry value when available (with a fallback when it’s not)
* **Validation**
  * Network query parameter is now validated for the affected endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->