### PR TITLE
Add network coverage impact stats, city population endpoints and breakdowns

### DIFF
--- a/src/device-registry/controllers/network-coverage.controller.js
+++ b/src/device-registry/controllers/network-coverage.controller.js
@@ -220,6 +220,70 @@ const networkCoverageController = {
       handleError(error, next);
     }
   },
+
+  /**
+   * GET /network-coverage/cities
+   * List crowd-sourced city population records.
+   */
+  listCities: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await networkCoverageUtil.listCities(request);
+      sendResponse(res, result, "cities");
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
+
+  /**
+   * POST /network-coverage/cities
+   * Submit or update a city population record.
+   */
+  upsertCity: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await networkCoverageUtil.upsertCity(request);
+      sendResponse(res, result, "city");
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
+
+  /**
+   * DELETE /network-coverage/cities/:cityId
+   * Remove a city population record.
+   */
+  deleteCity: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await networkCoverageUtil.deleteCity(request);
+      sendResponse(res, result, "city");
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
+
+  /**
+   * GET /network-coverage/impact
+   * Aggregate impact metrics – no monitor payload.
+   */
+  impact: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await networkCoverageUtil.impact(request);
+      sendResponse(res, result, "impact");
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
 };
 
 module.exports = networkCoverageController;

--- a/src/device-registry/models/CityPopulationRegistry.js
+++ b/src/device-registry/models/CityPopulationRegistry.js
@@ -1,0 +1,181 @@
+// CityPopulationRegistry.js
+// Crowd-sourced city population data for the Network Coverage page.
+//
+// Distinct from SdgCity (which requires a Grid document and is populated
+// from authoritative SDG pipelines). Records here are user-submitted
+// estimates — useful until SdgCity is seeded for a given city. When both
+// sources have data for the same city, SdgCity takes priority.
+//
+// Lookup key: city + country, both stored lowercase for case-insensitive
+// matching. The unique index prevents duplicate submissions for the same
+// city-country pair — POST is always an upsert.
+
+const { Schema } = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const httpStatus = require("http-status");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- city-population-registry-model`
+);
+
+const cityPopulationRegistrySchema = new Schema(
+  {
+    // Stored lowercase so lookups are case-insensitive without collations.
+    city: { type: String, trim: true, lowercase: true, required: true },
+    country: { type: String, trim: true, lowercase: true, required: true },
+
+    // Optional display name preserving original casing (e.g. "Addis Ababa")
+    displayCity: { type: String, trim: true, default: "" },
+    displayCountry: { type: String, trim: true, default: "" },
+
+    iso2: { type: String, trim: true, uppercase: true, default: "" },
+    population: { type: Number, required: true, min: 1 },
+
+    // Year the estimate applies to — useful when data is updated over time.
+    year: {
+      type: Number,
+      default: () => new Date().getFullYear(),
+    },
+
+    // Free-text attribution: "WorldPop 2023", "UN 2022", "Wikipedia", etc.
+    source: { type: String, trim: true, default: "" },
+    notes: { type: String, trim: true, default: "" },
+  },
+  { timestamps: true }
+);
+
+// One record per city-country combination.
+cityPopulationRegistrySchema.index({ city: 1, country: 1 }, { unique: true });
+
+// ---------------------------------------------------------------------------
+// Statics
+// ---------------------------------------------------------------------------
+
+cityPopulationRegistrySchema.statics.list = async function (filter = {}) {
+  try {
+    const records = await this.find(filter)
+      .sort({ country: 1, city: 1 })
+      .lean();
+    return {
+      success: true,
+      data: records,
+      message: "City population records retrieved successfully",
+      status: httpStatus.OK,
+    };
+  } catch (error) {
+    logger.error(`Error listing city population records: ${error.message}`);
+    return {
+      success: false,
+      message: "Internal Server Error",
+      errors: { message: error.message },
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+    };
+  }
+};
+
+/**
+ * Upsert by city + country. displayCity and displayCountry capture the
+ * original casing from the submission for rendering purposes.
+ */
+cityPopulationRegistrySchema.statics.register = async function (data) {
+  try {
+    const city = (data.city || "").trim().toLowerCase();
+    const country = (data.country || "").trim().toLowerCase();
+    const payload = {
+      ...data,
+      city,
+      country,
+      displayCity: data.city ? data.city.trim() : "",
+      displayCountry: data.country ? data.country.trim() : "",
+    };
+
+    const raw = await this.findOneAndUpdate(
+      { city, country },
+      { $set: payload },
+      { new: true, upsert: true, runValidators: true, rawResult: true }
+    );
+    const isNew = !raw.lastErrorObject.updatedExisting;
+
+    return {
+      success: true,
+      data: raw.value,
+      message: isNew
+        ? "City population record created"
+        : "City population record updated",
+      status: isNew ? httpStatus.CREATED : httpStatus.OK,
+    };
+  } catch (error) {
+    logger.error(`Error saving city population record: ${error.message}`);
+
+    if (error.code === 11000) {
+      return {
+        success: false,
+        message: "A population record for this city already exists",
+        errors: { message: error.message },
+        status: httpStatus.CONFLICT,
+      };
+    }
+    if (error.name === "ValidationError" || error.name === "CastError") {
+      return {
+        success: false,
+        message: "Invalid city population data",
+        errors: { message: error.message },
+        status: httpStatus.BAD_REQUEST,
+      };
+    }
+    return {
+      success: false,
+      message: "Internal Server Error",
+      errors: { message: error.message },
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+    };
+  }
+};
+
+cityPopulationRegistrySchema.statics.removeById = async function (cityId) {
+  try {
+    const deleted = await this.findByIdAndDelete(cityId);
+    if (!deleted) {
+      return {
+        success: false,
+        message: "City population record not found",
+        errors: { message: `No record with id ${cityId}` },
+        status: httpStatus.NOT_FOUND,
+      };
+    }
+    return {
+      success: true,
+      message: "City population record deleted",
+      status: httpStatus.OK,
+    };
+  } catch (error) {
+    logger.error(
+      `Error deleting city population record: ${error.message}`
+    );
+    return {
+      success: false,
+      message: "Internal Server Error",
+      errors: { message: error.message },
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+    };
+  }
+};
+
+const CityPopulationRegistryModel = (tenant) => {
+  try {
+    return getModelByTenant(
+      tenant,
+      "city_population_registry",
+      cityPopulationRegistrySchema
+    );
+  } catch (error) {
+    logger.error(
+      `Error getting CityPopulationRegistry model for tenant ` +
+        `${tenant}: ${error.message}`
+    );
+    throw error;
+  }
+};
+
+module.exports = CityPopulationRegistryModel;

--- a/src/device-registry/models/CityPopulationRegistry.js
+++ b/src/device-registry/models/CityPopulationRegistry.js
@@ -83,11 +83,15 @@ cityPopulationRegistrySchema.statics.register = async function (data) {
     const city = (data.city || "").trim().toLowerCase();
     const country = (data.country || "").trim().toLowerCase();
     const payload = {
-      ...data,
       city,
       country,
       displayCity: data.city ? data.city.trim() : "",
       displayCountry: data.country ? data.country.trim() : "",
+      population: data.population,
+      ...(data.iso2 != null ? { iso2: data.iso2 } : {}),
+      ...(data.year != null ? { year: data.year } : {}),
+      ...(data.source != null ? { source: data.source } : {}),
+      ...(data.notes != null ? { notes: data.notes } : {}),
     };
 
     const raw = await this.findOneAndUpdate(

--- a/src/device-registry/routes/v2/network-coverage.routes.js
+++ b/src/device-registry/routes/v2/network-coverage.routes.js
@@ -56,6 +56,55 @@ router.get(
 );
 
 // ---------------------------------------------------------------------------
+// Impact stats – aggregate metrics only, no monitors payload
+// GET /network-coverage/impact
+// ---------------------------------------------------------------------------
+router.get(
+  "/impact",
+  networkCoverageValidations.impact,
+  validate,
+  networkCoverageController.impact
+);
+
+// ---------------------------------------------------------------------------
+// City population data — crowd-sourced, public submission
+// GET    /network-coverage/cities            – list known city populations
+// POST   /network-coverage/cities            – submit / update a city
+// DELETE /network-coverage/cities/:cityId    – remove a city record
+//
+// THREAT MODEL (same pattern as /registry):
+//   - GET is fully public (read-only, no sensitive data).
+//   - POST and DELETE are unauthenticated to allow public contributions.
+//   - Worst-case outcome is inaccurate population figures — no device or
+//     site data is touched.
+//   - IP rate limiting (registryLimiter) and CAPTCHA guard writes.
+// ---------------------------------------------------------------------------
+router.get(
+  "/cities",
+  networkCoverageValidations.listCities,
+  validate,
+  networkCoverageController.listCities
+);
+
+router.post(
+  "/cities",
+  registryLimiter,
+  verifyCaptcha,
+  networkCoverageValidations.upsertCity,
+  validate,
+  networkCoverageController.upsertCity
+);
+
+router.delete(
+  "/cities/:cityId",
+  registryLimiter,
+  verifyCaptcha,
+  networkCoverageValidations.deleteCity,
+  validate,
+  networkCoverageController.deleteCity
+);
+
+// ---------------------------------------------------------------------------
 // Single monitor detail
 // GET /network-coverage/monitors/:monitorId
 // ---------------------------------------------------------------------------

--- a/src/device-registry/utils/network-coverage.util.js
+++ b/src/device-registry/utils/network-coverage.util.js
@@ -360,20 +360,21 @@ function buildStandaloneMonitorItem(registryDoc) {
  * Used by the impact util for both the overall aggregate and each per-
  * manufacturer slice so every entry exposes identical metrics.
  *
- * populationByCity is a unified, lowercase-keyed Map built by fetchAllSources
+ * populationByCity is a unified, composite-keyed Map built by fetchAllSources
  * from two sources (CityPopulationRegistry crowd data + SdgCity, in that
  * priority order). Cities absent from both sources return population: null.
  *
  * @param {object[]} monitors        - Flat MonitorListItem array
- * @param {Map}      populationByCity - From fetchAllSources; key: lowercase
- *                                      city name, value: population number
+ * @param {Map}      populationByCity - From fetchAllSources; keys are either
+ *                                      "city|country" (full lowercase name,
+ *                                      CityPopulationRegistry) or "city|iso2"
+ *                                      (lowercase ISO2, SdgCity). Lookups try
+ *                                      both formats.
  */
 function computeMonitorStats(monitors, populationByCity) {
 
   const byType = { Reference: 0, LCS: 0, Inactive: 0 };
   const byStatus = { active: 0, inactive: 0 };
-  const cityNamesSeen = new Set();
-  const countriesSeen = new Set();
   const byCountryMap = new Map();
   // Composite key = "city|country" to disambiguate same-named cities across
   // different countries (e.g. "Lagos, Nigeria" vs "Lagos, Portugal").
@@ -382,8 +383,6 @@ function computeMonitorStats(monitors, populationByCity) {
   for (const monitor of monitors) {
     if (byType[monitor.type] !== undefined) byType[monitor.type]++;
     if (byStatus[monitor.status] !== undefined) byStatus[monitor.status]++;
-    if (monitor.city) cityNamesSeen.add(monitor.city.trim());
-    if (monitor.country) countriesSeen.add(monitor.country);
 
     const countryKey = monitor.country || "Unknown";
     if (!byCountryMap.has(countryKey)) {
@@ -407,8 +406,13 @@ function computeMonitorStats(monitors, populationByCity) {
     if (monitor.city) {
       const cityKey = `${monitor.city.trim()}|${countryKey}`;
       if (!byCityMap.has(cityKey)) {
+        const cityLower = monitor.city.trim().toLowerCase();
+        const countryLower = (monitor.country || "").toLowerCase();
+        const iso2Lower = (monitor.iso2 || "").toLowerCase();
         const cityPop =
-          populationByCity.get(monitor.city.trim().toLowerCase()) ?? null;
+          populationByCity.get(`${cityLower}|${countryLower}`) ??
+          populationByCity.get(`${cityLower}|${iso2Lower}`) ??
+          null;
         byCityMap.set(cityKey, {
           city: monitor.city.trim(),
           country: countryKey,
@@ -437,8 +441,8 @@ function computeMonitorStats(monitors, populationByCity) {
     }
   }
 
-  // Sum city populations for the total. null means no SdgCity data yet —
-  // never substitute estimates or default to 0.
+  // Sum city populations for the total. null means no population data yet
+  // from either source — never substitute estimates or default to 0.
   let totalPopulationReached = null;
   let citiesWithPopulationData = 0;
   for (const cityEntry of byCityMap.values()) {
@@ -452,8 +456,8 @@ function computeMonitorStats(monitors, populationByCity) {
   return {
     byType,
     byStatus,
-    totalCities: cityNamesSeen.size,
-    totalCountries: countriesSeen.size,
+    totalCities: byCityMap.size,
+    totalCountries: byCountryMap.size,
     totalPopulationReached,
     citiesWithPopulationData,
     byCountry: Array.from(byCountryMap.values()).sort((a, b) =>
@@ -721,6 +725,7 @@ async function fetchAllSources(tenant) {
                 _id: "$grid_id",
                 population: { $first: "$population" },
                 name: { $first: "$name" },
+                country: { $first: "$country" },
               },
             },
           ]);
@@ -728,6 +733,7 @@ async function fetchAllSources(tenant) {
             sdgByGridId.set(doc._id.toString(), {
               population: doc.population,
               name: doc.name,
+              country: doc.country,
             });
           }
         } catch (err) {
@@ -743,18 +749,21 @@ async function fetchAllSources(tenant) {
     }
   }
 
-  // 6. Build unified city population map (lowercase city name → population).
-  //    Priority: CityPopulationRegistry (crowd-sourced) as base; SdgCity
-  //    values override when both exist for the same name — SdgCity is the
-  //    authoritative SDG source. Both fetches are non-fatal.
+  // 6. Build unified city population map (composite key → population).
+  //    Key format: "city|country" (both lowercase) for CityPopulationRegistry
+  //    entries (country is full name, e.g. "kampala|uganda") and "city|iso2"
+  //    (lowercase ISO2) for SdgCity entries (e.g. "kampala|ug").
+  //    Priority: CityPopulationRegistry as base; SdgCity overrides when both
+  //    exist for the same city — SdgCity is the authoritative SDG source.
+  //    Both fetches are non-fatal.
   const populationByCity = new Map();
   try {
     const cityPopDocs = await CityPopulationRegistryModel(tenant)
-      .find({}, { city: 1, population: 1 })
+      .find({}, { city: 1, country: 1, population: 1 })
       .lean();
     for (const doc of cityPopDocs) {
-      if (doc.city && doc.population != null) {
-        populationByCity.set(doc.city, doc.population);
+      if (doc.city && doc.country && doc.population != null) {
+        populationByCity.set(`${doc.city}|${doc.country}`, doc.population);
       }
     }
   } catch (err) {
@@ -764,10 +773,9 @@ async function fetchAllSources(tenant) {
   }
   for (const sdgEntry of sdgByGridId.values()) {
     if (sdgEntry.name && sdgEntry.population != null) {
-      populationByCity.set(
-        sdgEntry.name.trim().toLowerCase(),
-        sdgEntry.population
-      );
+      const cityLower = sdgEntry.name.trim().toLowerCase();
+      const iso2Lower = (sdgEntry.country || "").toLowerCase();
+      populationByCity.set(`${cityLower}|${iso2Lower}`, sdgEntry.population);
     }
   }
 
@@ -838,23 +846,40 @@ const networkCoverageUtil = {
       // ── Impact stats (computed from the filtered set) ──────────────────────
       const byType = { Reference: 0, LCS: 0, Inactive: 0 };
       const byStatus = { active: 0, inactive: 0 };
-      const cityNamesSeen = new Set();
+      // Track city+country pairs to avoid double-counting same-named cities
+      // in different countries (e.g. "Lagos, Nigeria" vs "Lagos, Portugal").
+      const cityPairsMap = new Map();
 
       for (const monitor of filtered) {
         if (byType[monitor.type] !== undefined) byType[monitor.type]++;
         if (byStatus[monitor.status] !== undefined) byStatus[monitor.status]++;
-        if (monitor.city) cityNamesSeen.add(monitor.city.trim());
+        if (monitor.city) {
+          const cityKey = `${monitor.city.trim()}|${monitor.country || ""}`;
+          if (!cityPairsMap.has(cityKey)) {
+            cityPairsMap.set(cityKey, {
+              city: monitor.city.trim(),
+              country: monitor.country || "",
+              iso2: monitor.iso2 || "",
+            });
+          }
+        }
       }
 
-      // Population: sum by city name from the unified populationByCity map
-      // (CityPopulationRegistry + SdgCity merged in fetchAllSources).
-      // null when no population data exists for any monitored city.
+      // Population: sum by city+country composite key from the unified
+      // populationByCity map (CityPopulationRegistry + SdgCity merged in
+      // fetchAllSources). null when no population data exists for any city.
       let totalPopulationReached = null;
       let citiesWithPopulationData = 0;
       if (populationByCity.size > 0) {
         let popSum = 0;
-        for (const cityName of cityNamesSeen) {
-          const pop = populationByCity.get(cityName.toLowerCase());
+        for (const { city, country, iso2 } of cityPairsMap.values()) {
+          const cityLower = city.toLowerCase();
+          const countryLower = country.toLowerCase();
+          const iso2Lower = iso2.toLowerCase();
+          const pop =
+            populationByCity.get(`${cityLower}|${countryLower}`) ??
+            populationByCity.get(`${cityLower}|${iso2Lower}`) ??
+            null;
           if (pop != null) {
             popSum += pop;
             citiesWithPopulationData++;
@@ -872,7 +897,7 @@ const networkCoverageUtil = {
             totalMonitors: filtered.length,
             byType,
             byStatus,
-            totalCities: cityNamesSeen.size,
+            totalCities: cityPairsMap.size,
             totalCountries: countries.length,
             monitoredCountries: countries.filter((c) => c.monitors.length > 0)
               .length,
@@ -1314,14 +1339,16 @@ const networkCoverageUtil = {
    *
    * Response shape:
    *   top-level fields  — overall stats for the filtered set
-   *   byCountry[]       — per-country breakdown (total, type, status)
-   *   byNetwork[]       — per-network breakdown with the full stats suite
-   *                       (byType, byStatus, totalCities, totalCountries,
-   *                        totalPopulationReached, citiesWithPopulationData,
-   *                        byCountry) so any source / manufacturer slice
-   *                       exposes identical metrics to the overall view.
+   *   byCountry[]             — per-country breakdown (total, type, status)
+   *   bySensorManufacturer[]  — per-manufacturer breakdown with the full stats
+   *                             suite (byType, byStatus, totalCities,
+   *                             totalCountries, totalPopulationReached,
+   *                             citiesWithPopulationData, byCountry, byCity)
+   *                             so any manufacturer slice exposes identical
+   *                             metrics to the overall view.
    *
-   * totalPopulationReached is null (not 0) when SDG data does not yet exist.
+   * totalPopulationReached is null (not 0) when no population data exists
+   * for any monitored city.
    */
   impact: async (request) => {
     try {

--- a/src/device-registry/utils/network-coverage.util.js
+++ b/src/device-registry/utils/network-coverage.util.js
@@ -16,6 +16,9 @@
 const DeviceModel = require("@models/Device");
 const SiteModel = require("@models/Site");
 const NetworkCoverageRegistryModel = require("@models/NetworkCoverageRegistry");
+const GridModel = require("@models/Grid");
+const SdgCityModel = require("@models/SdgCity");
+const CityPopulationRegistryModel = require("@models/CityPopulationRegistry");
 const httpStatus = require("http-status");
 const constants = require("@config/constants");
 const log4js = require("log4js");
@@ -353,6 +356,117 @@ function buildStandaloneMonitorItem(registryDoc) {
 }
 
 /**
+ * Computes the full impact stats suite for any flat list of monitors.
+ * Used by the impact util for both the overall aggregate and each per-
+ * manufacturer slice so every entry exposes identical metrics.
+ *
+ * populationByCity is a unified, lowercase-keyed Map built by fetchAllSources
+ * from two sources (CityPopulationRegistry crowd data + SdgCity, in that
+ * priority order). Cities absent from both sources return population: null.
+ *
+ * @param {object[]} monitors        - Flat MonitorListItem array
+ * @param {Map}      populationByCity - From fetchAllSources; key: lowercase
+ *                                      city name, value: population number
+ */
+function computeMonitorStats(monitors, populationByCity) {
+
+  const byType = { Reference: 0, LCS: 0, Inactive: 0 };
+  const byStatus = { active: 0, inactive: 0 };
+  const cityNamesSeen = new Set();
+  const countriesSeen = new Set();
+  const byCountryMap = new Map();
+  // Composite key = "city|country" to disambiguate same-named cities across
+  // different countries (e.g. "Lagos, Nigeria" vs "Lagos, Portugal").
+  const byCityMap = new Map();
+
+  for (const monitor of monitors) {
+    if (byType[monitor.type] !== undefined) byType[monitor.type]++;
+    if (byStatus[monitor.status] !== undefined) byStatus[monitor.status]++;
+    if (monitor.city) cityNamesSeen.add(monitor.city.trim());
+    if (monitor.country) countriesSeen.add(monitor.country);
+
+    const countryKey = monitor.country || "Unknown";
+    if (!byCountryMap.has(countryKey)) {
+      byCountryMap.set(countryKey, {
+        country: countryKey,
+        iso2: monitor.iso2 || "",
+        population: null,
+        total: 0,
+        Reference: 0,
+        LCS: 0,
+        Inactive: 0,
+        active: 0,
+        inactive: 0,
+      });
+    }
+    const cs = byCountryMap.get(countryKey);
+    cs.total++;
+    if (cs[monitor.type] !== undefined) cs[monitor.type]++;
+    if (cs[monitor.status] !== undefined) cs[monitor.status]++;
+
+    if (monitor.city) {
+      const cityKey = `${monitor.city.trim()}|${countryKey}`;
+      if (!byCityMap.has(cityKey)) {
+        const cityPop =
+          populationByCity.get(monitor.city.trim().toLowerCase()) ?? null;
+        byCityMap.set(cityKey, {
+          city: monitor.city.trim(),
+          country: countryKey,
+          iso2: monitor.iso2 || "",
+          population: cityPop,
+          total: 0,
+          Reference: 0,
+          LCS: 0,
+          Inactive: 0,
+          active: 0,
+          inactive: 0,
+        });
+      }
+      const cty = byCityMap.get(cityKey);
+      cty.total++;
+      if (cty[monitor.type] !== undefined) cty[monitor.type]++;
+      if (cty[monitor.status] !== undefined) cty[monitor.status]++;
+    }
+  }
+
+  // Roll up city populations to their parent country entries.
+  for (const cityEntry of byCityMap.values()) {
+    if (cityEntry.population !== null) {
+      const ce = byCountryMap.get(cityEntry.country);
+      if (ce) ce.population = (ce.population ?? 0) + cityEntry.population;
+    }
+  }
+
+  // Sum city populations for the total. null means no SdgCity data yet —
+  // never substitute estimates or default to 0.
+  let totalPopulationReached = null;
+  let citiesWithPopulationData = 0;
+  for (const cityEntry of byCityMap.values()) {
+    if (cityEntry.population !== null) {
+      totalPopulationReached = (totalPopulationReached ?? 0) +
+        cityEntry.population;
+      citiesWithPopulationData++;
+    }
+  }
+
+  return {
+    byType,
+    byStatus,
+    totalCities: cityNamesSeen.size,
+    totalCountries: countriesSeen.size,
+    totalPopulationReached,
+    citiesWithPopulationData,
+    byCountry: Array.from(byCountryMap.values()).sort((a, b) =>
+      a.country.localeCompare(b.country)
+    ),
+    byCity: Array.from(byCityMap.values()).sort((a, b) => {
+      const cc = a.country.localeCompare(b.country);
+      return cc !== 0 ? cc : a.city.localeCompare(b.city);
+    }),
+  };
+}
+
+/**
  * Groups a flat list of MonitorListItems by country → CountryCoverage[].
  * Sorted alphabetically by country name.
  */
@@ -365,10 +479,24 @@ function groupByCountry(monitors) {
         id: slugify(key),
         country: key,
         iso2: monitor.iso2,
+        stats: {
+          total: 0,
+          Reference: 0,
+          LCS: 0,
+          Inactive: 0,
+          active: 0,
+          inactive: 0,
+        },
         monitors: [],
       });
     }
-    countryMap.get(key).monitors.push(monitor);
+    const entry = countryMap.get(key);
+    entry.monitors.push(monitor);
+    entry.stats.total++;
+    if (entry.stats[monitor.type] !== undefined)
+      entry.stats[monitor.type]++;
+    if (entry.stats[monitor.status] !== undefined)
+      entry.stats[monitor.status]++;
   }
   return Array.from(countryMap.values()).sort((a, b) =>
     a.country.localeCompare(b.country)
@@ -443,18 +571,26 @@ const SITE_PROJECTION = {
   description: 1,
   land_use: 1,
   site_category: 1,
+  grids: 1,
 };
+
+// Minimal Grid projection — shape, centers, geoHash, shape_update_history are
+// heavy spatial fields not needed for city aggregation.
+const GRID_PROJECTION = { _id: 1, name: 1, long_name: 1, admin_level: 1 };
 
 /**
  * Core data fetch used by list, getCountryMonitors, and exportCsv.
  *
- * Returns { airqoSites, standaloneEntries, registryBySiteId, categoryBySiteId }
- * so callers can build monitor items in whatever way they need.
- *
- * categoryBySiteId — Map<String(site_id), category> where category is the
- * dominant equipment category of active devices at that site.
- * Priority: bam (2) > gas (1) > lowcost (0). This ensures a site hosting
- * both a reference monitor and a low-cost sensor is classified as "Reference".
+ * Returns:
+ *   airqoSites          — Site docs for all sites with at least one active device
+ *   standaloneEntries   — standalone NetworkCoverageRegistry docs (no site_id)
+ *   registryBySiteId    — Map<String(site_id), registryDoc> for enrichment
+ *   categoryBySiteId    — Map<String(site_id), category> dominant device category
+ *   cityGridsBySiteId   — Map<String(site_id), Grid[]> sub-country grids per site
+ *                         (empty map when Grid lookup fails — non-fatal)
+ *   sdgByGridId         — Map<String(grid_id), { population, name }> latest SDG
+ *                         population per city grid. Empty when no SDG data exists
+ *                         yet — callers must treat population as optional.
  */
 async function fetchAllSources(tenant) {
   // 1. Aggregate active devices to get both the site_id list AND the dominant
@@ -535,7 +671,115 @@ async function fetchAllSources(tenant) {
   // 4. Build enrichment map
   const registryBySiteId = buildRegistryBySiteId(enrichmentDocs);
 
-  return { airqoSites, standaloneEntries, registryBySiteId, categoryBySiteId };
+  // 5. Resolve sub-country grids for each active site so callers can derive
+  //    city names and population without fetching heavy spatial Grid documents.
+  //    Both the Grid lookup and the SdgCity join are non-fatal — callers receive
+  //    empty maps and degrade gracefully when data is unavailable.
+  const cityGridsBySiteId = new Map();
+  const sdgByGridId = new Map();
+
+  const allGridIds = [
+    ...new Set(
+      airqoSites.flatMap((s) => (s.grids || []).map((id) => id.toString()))
+    ),
+  ];
+
+  if (allGridIds.length > 0) {
+    try {
+      // Only sub-country grids are relevant for city-level aggregation.
+      const cityGridDocs = await GridModel(tenant)
+        .find(
+          { _id: { $in: allGridIds }, admin_level: { $ne: "country" } },
+          GRID_PROJECTION
+        )
+        .lean();
+
+      const gridById = new Map(
+        cityGridDocs.map((g) => [g._id.toString(), g])
+      );
+
+      for (const site of airqoSites) {
+        const siteGrids = (site.grids || [])
+          .map((id) => gridById.get(id.toString()))
+          .filter(Boolean);
+        if (siteGrids.length > 0) {
+          cityGridsBySiteId.set(site._id.toString(), siteGrids);
+        }
+      }
+
+      // Population join via SdgCity — new use case, data may not exist yet.
+      // Use aggregate to pick the most recent year when multiple rows exist
+      // for the same grid (SDG data is versioned by year).
+      const cityGridObjectIds = cityGridDocs.map((g) => g._id);
+      if (cityGridObjectIds.length > 0) {
+        try {
+          const sdgDocs = await SdgCityModel(tenant).aggregate([
+            { $match: { grid_id: { $in: cityGridObjectIds } } },
+            { $sort: { year: -1 } },
+            {
+              $group: {
+                _id: "$grid_id",
+                population: { $first: "$population" },
+                name: { $first: "$name" },
+              },
+            },
+          ]);
+          for (const doc of sdgDocs) {
+            sdgByGridId.set(doc._id.toString(), {
+              population: doc.population,
+              name: doc.name,
+            });
+          }
+        } catch (err) {
+          logger.warn(
+            `SDG population lookup skipped (non-fatal — data may not exist yet): ${err.message}`
+          );
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        `Grid city lookup skipped (non-fatal): ${err.message}`
+      );
+    }
+  }
+
+  // 6. Build unified city population map (lowercase city name → population).
+  //    Priority: CityPopulationRegistry (crowd-sourced) as base; SdgCity
+  //    values override when both exist for the same name — SdgCity is the
+  //    authoritative SDG source. Both fetches are non-fatal.
+  const populationByCity = new Map();
+  try {
+    const cityPopDocs = await CityPopulationRegistryModel(tenant)
+      .find({}, { city: 1, population: 1 })
+      .lean();
+    for (const doc of cityPopDocs) {
+      if (doc.city && doc.population != null) {
+        populationByCity.set(doc.city, doc.population);
+      }
+    }
+  } catch (err) {
+    logger.warn(
+      `City population registry lookup skipped (non-fatal): ${err.message}`
+    );
+  }
+  for (const sdgEntry of sdgByGridId.values()) {
+    if (sdgEntry.name && sdgEntry.population != null) {
+      populationByCity.set(
+        sdgEntry.name.trim().toLowerCase(),
+        sdgEntry.population
+      );
+    }
+  }
+
+  return {
+    airqoSites,
+    standaloneEntries,
+    registryBySiteId,
+    categoryBySiteId,
+    cityGridsBySiteId,
+    sdgByGridId,
+    populationByCity,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -552,8 +796,13 @@ const networkCoverageUtil = {
     try {
       const { tenant, search, activeOnly, types, network } = request.query;
 
-      const { airqoSites, standaloneEntries, registryBySiteId, categoryBySiteId } =
-        await fetchAllSources(tenant);
+      const {
+        airqoSites,
+        standaloneEntries,
+        registryBySiteId,
+        categoryBySiteId,
+        populationByCity,
+      } = await fetchAllSources(tenant);
 
       // Build monitor items from both sources
       const airqoMonitors = airqoSites.map((site) =>
@@ -567,10 +816,8 @@ const networkCoverageUtil = {
 
       const allMonitors = [...airqoMonitors, ...externalMonitors];
 
-      // Collect distinct network values before applying network filter so the
-      // caller always receives the full networks list regardless of the active
-      // filter — this lets the frontend populate the source dropdown in a single
-      // request without needing a separate endpoint.
+      // availableNetworks is derived before filtering so the source dropdown
+      // always shows every network regardless of the active filter.
       const availableNetworks = [
         ...new Set(
           allMonitors
@@ -588,15 +835,49 @@ const networkCoverageUtil = {
 
       const countries = groupByCountry(filtered);
 
+      // ── Impact stats (computed from the filtered set) ──────────────────────
+      const byType = { Reference: 0, LCS: 0, Inactive: 0 };
+      const byStatus = { active: 0, inactive: 0 };
+      const cityNamesSeen = new Set();
+
+      for (const monitor of filtered) {
+        if (byType[monitor.type] !== undefined) byType[monitor.type]++;
+        if (byStatus[monitor.status] !== undefined) byStatus[monitor.status]++;
+        if (monitor.city) cityNamesSeen.add(monitor.city.trim());
+      }
+
+      // Population: sum by city name from the unified populationByCity map
+      // (CityPopulationRegistry + SdgCity merged in fetchAllSources).
+      // null when no population data exists for any monitored city.
+      let totalPopulationReached = null;
+      let citiesWithPopulationData = 0;
+      if (populationByCity.size > 0) {
+        let popSum = 0;
+        for (const cityName of cityNamesSeen) {
+          const pop = populationByCity.get(cityName.toLowerCase());
+          if (pop != null) {
+            popSum += pop;
+            citiesWithPopulationData++;
+          }
+        }
+        if (citiesWithPopulationData > 0) totalPopulationReached = popSum;
+      }
+
       return {
         success: true,
         message: "Network coverage data retrieved successfully",
         data: {
           countries,
           meta: {
+            totalMonitors: filtered.length,
+            byType,
+            byStatus,
+            totalCities: cityNamesSeen.size,
             totalCountries: countries.length,
             monitoredCountries: countries.filter((c) => c.monitors.length > 0)
               .length,
+            totalPopulationReached,
+            citiesWithPopulationData,
             availableNetworks,
             generatedAt: new Date().toISOString(),
           },
@@ -921,6 +1202,82 @@ const networkCoverageUtil = {
   },
 
   /**
+   * GET /network-coverage/cities
+   * List crowd-sourced city population records, optionally filtered by
+   * country (lowercase match).
+   */
+  listCities: async (request) => {
+    try {
+      const { tenant, country } = request.query;
+      const filter = country
+        ? { country: country.trim().toLowerCase() }
+        : {};
+      const result = await CityPopulationRegistryModel(tenant).list(filter);
+      return result;
+    } catch (error) {
+      logger.error(
+        `🐛🐛 networkCoverageUtil.listCities: ${error.message}`
+      );
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+
+  /**
+   * POST /network-coverage/cities
+   * Submit or update a city population record.
+   * Always an upsert — one record per city-country pair.
+   */
+  upsertCity: async (request) => {
+    try {
+      const { tenant } = request.query;
+      const result = await CityPopulationRegistryModel(tenant).register(
+        request.body
+      );
+      return result;
+    } catch (error) {
+      logger.error(
+        `🐛🐛 networkCoverageUtil.upsertCity: ${error.message}`
+      );
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+
+  /**
+   * DELETE /network-coverage/cities/:cityId
+   * Remove a city population record by its _id.
+   */
+  deleteCity: async (request) => {
+    try {
+      const { tenant } = request.query;
+      const { cityId } = request.params;
+      const result = await CityPopulationRegistryModel(tenant).removeById(
+        cityId
+      );
+      return result;
+    } catch (error) {
+      logger.error(
+        `🐛🐛 networkCoverageUtil.deleteCity: ${error.message}`
+      );
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+
+  /**
    * DELETE /network-coverage/registry/:registryId
    * Remove a registry entry by its own _id.
    */
@@ -937,6 +1294,107 @@ const networkCoverageUtil = {
       logger.error(
         `🐛🐛 networkCoverageUtil.deleteRegistry: ${error.message}`
       );
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+
+  /**
+   * GET /network-coverage/impact
+   * Returns aggregate impact metrics only — no countries / monitors payload.
+   * Intended for grant reporting, dashboards, and partner communications that
+   * need headline numbers without downloading the full monitor list.
+   *
+   * Accepts the same query filters as /network-coverage (network, activeOnly,
+   * types, search) so stats always reflect the active filter.
+   *
+   * Response shape:
+   *   top-level fields  — overall stats for the filtered set
+   *   byCountry[]       — per-country breakdown (total, type, status)
+   *   byNetwork[]       — per-network breakdown with the full stats suite
+   *                       (byType, byStatus, totalCities, totalCountries,
+   *                        totalPopulationReached, citiesWithPopulationData,
+   *                        byCountry) so any source / manufacturer slice
+   *                       exposes identical metrics to the overall view.
+   *
+   * totalPopulationReached is null (not 0) when SDG data does not yet exist.
+   */
+  impact: async (request) => {
+    try {
+      const { tenant, search, activeOnly, types, network } = request.query;
+
+      const {
+        airqoSites,
+        standaloneEntries,
+        registryBySiteId,
+        categoryBySiteId,
+        populationByCity,
+      } = await fetchAllSources(tenant);
+
+      const airqoMonitors = airqoSites.map((site) =>
+        buildAirQoMonitorItem(
+          site,
+          registryBySiteId.get(String(site._id)),
+          categoryBySiteId.get(String(site._id))
+        )
+      );
+      const externalMonitors = standaloneEntries.map(
+        buildStandaloneMonitorItem
+      );
+      const allMonitors = [...airqoMonitors, ...externalMonitors];
+
+      const filtered = applyFilters(allMonitors, {
+        search,
+        activeOnly,
+        types,
+        network,
+      });
+
+      // Overall aggregate stats
+      const topLevel = computeMonitorStats(filtered, populationByCity);
+
+      // Per-manufacturer breakdown — group monitors by network slug (which
+      // maps to sensor manufacturer / data source), then run the full stats
+      // suite on each bucket so every manufacturer slice exposes identical
+      // metrics to the overall view.
+      const manufacturerBuckets = new Map();
+      for (const monitor of filtered) {
+        const key =
+          (monitor.network || "").trim().toLowerCase() || "unknown";
+        if (!manufacturerBuckets.has(key))
+          manufacturerBuckets.set(key, []);
+        manufacturerBuckets.get(key).push(monitor);
+      }
+
+      const bySensorManufacturer = Array.from(
+        manufacturerBuckets.entries()
+      )
+        .map(([manufacturer, mfgMonitors]) => ({
+          sensorManufacturer: manufacturer,
+          totalMonitors: mfgMonitors.length,
+          ...computeMonitorStats(mfgMonitors, populationByCity),
+        }))
+        .sort((a, b) =>
+          a.sensorManufacturer.localeCompare(b.sensorManufacturer)
+        );
+
+      return {
+        success: true,
+        message: "Impact summary retrieved successfully",
+        data: {
+          totalMonitors: filtered.length,
+          ...topLevel,
+          bySensorManufacturer,
+          generatedAt: new Date().toISOString(),
+        },
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 networkCoverageUtil.impact: ${error.message}`);
       return {
         success: false,
         message: "Internal Server Error",

--- a/src/device-registry/validators/network-coverage.validators.js
+++ b/src/device-registry/validators/network-coverage.validators.js
@@ -214,6 +214,65 @@ const networkCoverageValidations = {
   ],
 
   /**
+   * GET /network-coverage/impact
+   */
+  impact: [
+    commonTenant,
+    query("search").optional().isString().trim(),
+    activeOnlyFilter,
+    typesFilter,
+    networkFilter,
+  ],
+
+  /**
+   * GET /network-coverage/cities
+   */
+  listCities: [
+    commonTenant,
+    query("country").optional().isString().trim(),
+  ],
+
+  /**
+   * POST /network-coverage/cities
+   */
+  upsertCity: [
+    commonTenant,
+    body("city")
+      .isString()
+      .withMessage("city must be a string")
+      .bail()
+      .trim()
+      .notEmpty()
+      .withMessage("city is required"),
+    body("country")
+      .isString()
+      .withMessage("country must be a string")
+      .bail()
+      .trim()
+      .notEmpty()
+      .withMessage("country is required"),
+    body("population")
+      .isInt({ min: 1 })
+      .withMessage("population must be a positive integer"),
+    body("iso2")
+      .optional()
+      .isString()
+      .isLength({ min: 2, max: 2 })
+      .withMessage("iso2 must be a 2-character ISO country code"),
+    body("year")
+      .optional()
+      .isInt({ min: 1900, max: 2100 })
+      .withMessage("year must be a valid year between 1900 and 2100"),
+    body("source").optional().isString().trim(),
+    body("notes").optional().isString().trim(),
+  ],
+
+  /**
+   * DELETE /network-coverage/cities/:cityId
+   */
+  deleteCity: [commonTenant, validObjectId("cityId")],
+
+  /**
    * DELETE /network-coverage/registry/:registryId
    */
   deleteRegistry: [commonTenant, validObjectId("registryId")],


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

- Adds `GET /network-coverage/impact` — a lightweight aggregate stats endpoint returning `totalMonitors`, `byType`, `byStatus`, `totalCities`, `totalCountries`, `totalPopulationReached`, `byCountry[]`, `byCity[]`, and `bySensorManufacturer[]` (each manufacturer slice carries the full stats suite including population, byCountry, and byCity)
- Adds crowd-sourced city population endpoints (`GET / POST / DELETE /network-coverage/cities`) backed by a new `CityPopulationRegistry` model — same public-submission pattern as the monitor registry
- Unifies population lookup in `fetchAllSources` via a single `populationByCity` map (CityPopulationRegistry as base; SdgCity overrides when authoritative data exists), covering both AirQo pipeline and standalone external monitors
- Adds server-side `?network=` filter to all three GET endpoints (`/network-coverage`, `/countries/:id/monitors`, `/export.csv`) — previously filtering was client-side only
- Surfaces `availableNetworks[]` in the summary `meta` block so the source dropdown can be populated from the API without iterating monitor objects
- Adds a `stats` block per country entry in the main list response (`byType`, `byStatus`, `total`, `active`, `inactive`)

### Why is this change needed?

Partners and stakeholders were unable to retrieve impact metrics (total monitors, cities reached, estimated population) without downloading and aggregating the full monitor list. Grant applications, partner communications, and internal reporting all needed a single fast call that answers "how many sensors, in how many cities, covering how many people" — optionally scoped to a specific network or sensor manufacturer. Population data is now crowd-sourceable via the new `/cities` endpoints rather than relying on hardcoded estimates that mixed unverified data with API responses.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

All new endpoints manually verified via Postman against the staging API:
- `GET /impact` — confirmed correct `byType`, `byStatus`, `byCountry`, `byCity`, and `bySensorManufacturer` breakdowns; `totalPopulationReached` is `null` until city population records are seeded
- `GET /impact?network=airqo` — confirmed filter scopes all stats to AirQo monitors only
- `POST /cities` — confirmed upsert behaviour (second POST for same city updates, does not duplicate)
- `GET /cities?country=uganda` — confirmed country filter returns only matching records
- `DELETE /cities/:cityId` — confirmed removal and 404 on re-delete
- `GET /network-coverage?network=airqo` — confirmed server-side filter consistent with country drill-down endpoint
- `availableNetworks` in summary meta verified to reflect all networks pre-filter

---

## :boom: Breaking Changes

- [x] **No breaking changes**

All new response fields (`stats`, `availableNetworks`, `byCity`, `byCountry` with `population`) are additive. The `?network=` query parameter is optional — omitting it returns the same data as before. Existing frontend client-side network filtering continues to work unchanged until Ochieng wires the server-side parameter.

---

## :memo: Additional Notes

- **Population data is `null` (not `0`) when no city records exist** — frontend must render `null` as "–" or "coming soon", never as zero
- **`bySensorManufacturer[]` key is `sensorManufacturer`**, not `network`, to reflect that the field represents the sensor manufacturer / data source rather than a routing concept
- **SdgCity takes priority** over CityPopulationRegistry when both have data for the same city — the merge happens in `fetchAllSources` so callers always see a single unified `populationByCity` map
- Frontend integration notes (for Ochieng) are in `src/device-registry/network-coverage-frontend-notes.md`
- The `CityPopulationRegistry` collection (`city_population_registry`) is new — no migration needed; the collection is created on first write

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Network Coverage Impact** endpoint to retrieve filtered aggregate impact statistics (including breakdowns).
  * Added **City Population** endpoints to **list**, **create/update**, and **delete** city population records.
* **Enhancements**
  * Updated network coverage responses to **enrich results with city population context** and return **population-based impact figures** when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->