### PR TITLE
Fix onboarding checklist persistence and missing defaults in auth service

### DIFF
--- a/src/auth-service/models/Group.js
+++ b/src/auth-service/models/Group.js
@@ -369,6 +369,7 @@ GroupSchema.methods = {
       grp_timezone: this.grp_timezone,
       grp_image: this.grp_image,
       cohorts: this.cohorts,
+      onboarding_checklist: this.onboarding_checklist,
     };
   },
 };

--- a/src/auth-service/models/Group.js
+++ b/src/auth-service/models/Group.js
@@ -369,7 +369,7 @@ GroupSchema.methods = {
       grp_timezone: this.grp_timezone,
       grp_image: this.grp_image,
       cohorts: this.cohorts,
-      onboarding_checklist: this.onboarding_checklist,
+      onboarding_checklist: this.onboarding_checklist || { is_dismissed: false, completed_steps: [] },
     };
   },
 };

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -1025,6 +1025,9 @@ UserSchema.statics = {
           },
           permissions: { $first: "$permissions" },
           my_groups: { $first: "$my_groups" },
+          onboarding_checklist: { $first: "$onboarding_checklist" },
+          devices: { $first: "$devices" },
+          cohorts: { $first: "$cohorts" },
           createdAt: { $first: "$createdAt" },
           updatedAt: {
             $first: {
@@ -1602,6 +1605,7 @@ UserSchema.methods = {
       cohort_ids: this.cohorts,
       subscriptionTier: this.subscriptionTier,
       apiRateLimits: this.apiRateLimits,
+      onboarding_checklist: this.onboarding_checklist,
     };
   },
 };

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -1605,7 +1605,7 @@ UserSchema.methods = {
       cohort_ids: this.cohorts,
       subscriptionTier: this.subscriptionTier,
       apiRateLimits: this.apiRateLimits,
-      onboarding_checklist: this.onboarding_checklist,
+      onboarding_checklist: this.onboarding_checklist || { is_dismissed: false, completed_steps: [] },
     };
   },
 };

--- a/src/auth-service/models/test/ut_user.model.js
+++ b/src/auth-service/models/test/ut_user.model.js
@@ -106,6 +106,31 @@ describe("UserSchema static methods", () => {
       });
     });
 
+    it("should include onboarding_checklist, devices, and cohorts in the $group stage", async () => {
+      const mockAggregation = {
+        match: sandbox.stub().returnsThis(),
+        lookup: sandbox.stub().returnsThis(),
+        addFields: sandbox.stub().returnsThis(),
+        unwind: sandbox.stub().returnsThis(),
+        group: sandbox.stub().returnsThis(),
+        project: sandbox.stub().returnsThis(),
+        sort: sandbox.stub().returnsThis(),
+        skip: sandbox.stub().returnsThis(),
+        limit: sandbox.stub().returnsThis(),
+        allowDiskUse: sandbox.stub().resolves([]),
+      };
+
+      sandbox.stub(UserModel, "aggregate").returns(mockAggregation);
+      sandbox.stub(UserModel, "countDocuments").returns({ exec: sandbox.stub().resolves(0) });
+
+      await UserModel.list({ filter: {} });
+
+      const groupArg = mockAggregation.group.args[0][0];
+      expect(groupArg).to.have.nested.property("onboarding_checklist.$first", "$onboarding_checklist");
+      expect(groupArg).to.have.nested.property("devices.$first", "$devices");
+      expect(groupArg).to.have.nested.property("cohorts.$first", "$cohorts");
+    });
+
     // Add more test cases here for different scenarios (e.g., empty response, error handling, etc.)
   });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes two onboarding checklist bugs in the auth service:

1. **PATCH `/api/v2/users/onboarding` not persisting** — the update was being written to the database correctly, but `GET /api/v2/users` uses a MongoDB aggregation pipeline with a `$group` stage that did not accumulate `onboarding_checklist`, `devices`, or `cohorts`. After `$group`, those fields were silently dropped, causing `computeUserOnboardingChecklist` to always fall back to the hardcoded default regardless of what was in the DB.

2. **`onboarding_checklist` missing from creation responses** — both `UserSchema.methods.toJSON()` and `GroupSchema.methods.toJSON()` did not include `onboarding_checklist`. Since Express's `res.json()` triggers `toJSON()` on Mongoose documents, the field was stripped from every login, registration, and group-creation response before reaching the frontend.

### Why is this change needed?
The frontend relies entirely on the backend to provide the default `onboarding_checklist` object. If the field is absent or `undefined` in any API response, the frontend hides the onboarding widget entirely. Users were unable to permanently dismiss the checklist or mark steps complete because every page reload reset the state to the default.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
1. `PATCH /api/v2/users/onboarding` with `action: "dismiss_checklist"` → subsequent `GET /api/v2/users` returns `is_dismissed: true`.
2. `PATCH /api/v2/users/onboarding` with `action: "mark_step_complete"` → subsequent `GET /api/v2/users` returns the step in `completed_steps`.
3. New user registration response includes `onboarding_checklist: { is_dismissed: false, completed_steps: [] }`.
4. New group creation response includes `onboarding_checklist: { is_dismissed: false, completed_steps: [] }`.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Files changed:**

| File | Change |
|---|---|
| `src/auth-service/models/User.js` | Added `onboarding_checklist`, `devices`, and `cohorts` as `$first` accumulators in the `list()` aggregation `$group` stage so the DB-stored values survive the pipeline |
| `src/auth-service/models/User.js` | Added `onboarding_checklist: this.onboarding_checklist` to `toJSON()` so user creation and login responses include the field |
| `src/auth-service/models/Group.js` | Added `onboarding_checklist: this.onboarding_checklist` to `toJSON()` so group creation responses include the field |

The `computeUserOnboardingChecklist` and `computeOnboardingChecklist` helper functions already had correct fallback logic (`|| { is_dismissed: false, completed_steps: [] }`) — they were just never receiving the real DB value due to these two gaps.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User profiles now expose additional data fields: onboarding checklist status and progress, device information, and cohort assignments.
  * Onboarding checklist automatically defaults to a valid state with dismissed status and completed steps tracking when not previously configured.

* **Tests**
  * Added test coverage for user profile data aggregation to ensure new fields are correctly included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->