### PR TITLE
fix: include isOnline and rawOnlineStatus in my-devices response

### DIFF
--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -3324,7 +3324,7 @@ const deviceUtil = {
         DeviceModel(tenant)
           .find(filter)
           .select(
-            "name long_name status isActive deployment_date latitude longitude claim_status owner_id claimed_at createdAt groups site_id",
+            "name long_name status isActive isOnline rawOnlineStatus deployment_date latitude longitude claim_status owner_id claimed_at createdAt groups site_id",
           )
           .sort({ claimed_at: -1 })
           .skip(skip)

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -2865,6 +2865,7 @@ describe("Device Util", () => {
 
     let deviceCountStub;
     let deviceLeanStub;
+    let deviceSelectStub;
     let siteFindStub;
     let siteLeanStub;
 
@@ -2895,6 +2896,7 @@ describe("Device Util", () => {
 
       deviceCountStub = deviceModelMock.countDocuments;
       deviceLeanStub = deviceModelMock.lean;
+      deviceSelectStub = deviceModelMock.select;
       siteFindStub = siteModelMock.find;
       siteLeanStub = siteModelMock.lean;
 
@@ -3069,6 +3071,18 @@ describe("Device Util", () => {
       expect(result.data).to.have.lengthOf(0);
       expect(siteFindStub.called).to.be.false;
       expect(result.meta.total).to.equal(0);
+    });
+
+    it("should project isOnline and rawOnlineStatus in the device query", async () => {
+      const request = {
+        query: { tenant: "airqo", user_id: VALID_USER_ID },
+      };
+      await deviceUtil.getMyDevices(request, () => {});
+
+      expect(deviceSelectStub.calledOnce).to.be.true;
+      const projection = deviceSelectStub.firstCall.args[0];
+      expect(projection).to.include("isOnline");
+      expect(projection).to.include("rawOnlineStatus");
     });
   });
 });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds `isOnline` and `rawOnlineStatus` boolean fields to the `GET /devices/my-devices` endpoint response by including them in the Mongoose `.select()` projection.

### Why is this change needed?
The frontend relies on `isOnline` and `rawOnlineStatus` to filter devices by status and render the correct status badge on the My Devices page (`/devices/my-devices?status=...`). These fields were missing from the query projection, causing them to return as `undefined`. This made the frontend filter strip out all devices, resulting in an empty table even when the dashboard summary correctly counted devices under each status category.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `utils/device.util.js` (`getMyDevices`)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that `GET /devices/my-devices` now returns `isOnline` and `rawOnlineStatus` on every device object, consistent with the values used by the `/devices/summary/count` aggregation pipeline. Navigating to `/devices/my-devices?status=operational` (and other statuses) correctly lists the matching devices instead of showing an empty table.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The `isOnline` and `rawOnlineStatus` fields are stored directly on device documents in MongoDB. The summary count endpoint already uses them in `$match` stages (`{ isOnline: true, rawOnlineStatus: true }` for operational, etc.). Adding them to the `getMyDevices` `.select()` projection ensures full parity between the dashboard counts and the My Devices list.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
