### PR TITLE
Fix bot alert email deduplication to use 24-hour TTL window

### DIFF
--- a/src/auth-service/models/SentEmailLog.js
+++ b/src/auth-service/models/SentEmailLog.js
@@ -13,7 +13,14 @@ const SentEmailLogSchema = new mongoose.Schema(
     createdAt: {
       type: Date,
       default: Date.now,
-      expires: 300, // TTL: auto-delete after 5 minutes
+    },
+    // Per-document TTL: MongoDB deletes the document when this date is reached.
+    // expireAfterSeconds: 0 means "delete at the moment stored in this field",
+    // allowing each document to carry its own retention window.
+    expiresAt: {
+      type: Date,
+      required: true,
+      index: { expireAfterSeconds: 0 },
     },
   },
   { timestamps: false },

--- a/src/auth-service/utils/common/email-deduplication.util.js
+++ b/src/auth-service/utils/common/email-deduplication.util.js
@@ -54,16 +54,27 @@ class EmailDeduplicator {
    * Atomically check if an email was recently sent and mark it as sent if not.
    * Uses MongoDB's unique index as the distributed lock — safe across multiple pods.
    *
+   * @param {object} emailData
+   * @param {object} [opts]
+   * @param {string} [opts.overrideKey]   - Pre-computed dedup key (skips generateEmailKey)
+   * @param {string} [opts.tenant]        - Tenant to scope the log collection
+   * @param {number} [opts.ttlSeconds]    - How long to hold the dedup lock (default: class ttlSeconds)
    * @returns {Promise<boolean>} true = send the email, false = duplicate, skip it
    */
-  async checkAndMarkEmail(emailData, { overrideKey, tenant = "airqo" } = {}) {
+  async checkAndMarkEmail(
+    emailData,
+    { overrideKey, tenant = "airqo", ttlSeconds } = {},
+  ) {
     try {
       const key = overrideKey || this.generateEmailKey(emailData);
       const SentEmailLog = SentEmailLogModel(tenant);
+      const effectiveTtl =
+        ttlSeconds !== undefined ? ttlSeconds : this.ttlSeconds;
+      const expiresAt = new Date(Date.now() + effectiveTtl * 1000);
 
       // Atomic insert: succeeds only if `hash` is unique.
       // A duplicate key error (11000) means the email was already sent recently.
-      await new SentEmailLog({ hash: key }).save();
+      await new SentEmailLog({ hash: key, expiresAt }).save();
 
       if (this.enableMetrics) this.metrics.emailsSent++;
       return true; // New email — proceed with sending

--- a/src/auth-service/utils/common/email-deduplication.util.js
+++ b/src/auth-service/utils/common/email-deduplication.util.js
@@ -63,13 +63,12 @@ class EmailDeduplicator {
    */
   async checkAndMarkEmail(
     emailData,
-    { overrideKey, tenant = "airqo", ttlSeconds } = {},
+    { overrideKey, tenant, ttlSeconds } = {},
   ) {
     try {
       const key = overrideKey || this.generateEmailKey(emailData);
       const SentEmailLog = SentEmailLogModel(tenant);
-      const effectiveTtl =
-        ttlSeconds !== undefined ? ttlSeconds : this.ttlSeconds;
+      const effectiveTtl = ttlSeconds ?? this.ttlSeconds;
       const expiresAt = new Date(Date.now() + effectiveTtl * 1000);
 
       // Atomic insert: succeeds only if `hash` is unique.
@@ -102,7 +101,7 @@ class EmailDeduplicator {
    * Remove a deduplication key — useful for testing or manual overrides.
    * @returns {Promise<boolean>}
    */
-  async removeEmailKey(emailData, { overrideKey, tenant = "airqo" } = {}) {
+  async removeEmailKey(emailData, { overrideKey, tenant } = {}) {
     try {
       const key = overrideKey || this.generateEmailKey(emailData);
       const SentEmailLog = SentEmailLogModel(tenant);

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -1438,7 +1438,13 @@ const createAdminAlertFunction = (
           // each produce distinct keys and are not incorrectly collapsed together).
           // We deliberately do NOT use mailOptions.to here because that is now always
           // the SUPPORT_EMAIL placeholder and would collapse all bot IPs into one key.
-          const stableKeyContent = `${mailOptions.bcc}:${mailOptions.subject}:${otherParams.ip}`;
+          const normalizedBcc = (mailOptions.bcc || "")
+            .split(",")
+            .map((e) => e.trim().toLowerCase())
+            .filter(Boolean)
+            .sort()
+            .join(",");
+          const stableKeyContent = `${normalizedBcc}:${mailOptions.subject}:${otherParams.ip}`;
           const stableKey = crypto
             .createHash("md5")
             .update(stableKeyContent)

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -1444,6 +1444,9 @@ const createAdminAlertFunction = (
             .update(stableKeyContent)
             .digest("hex");
           dedupOptions.overrideKey = `email_dedup:${stableKey}`;
+          // Hold the dedup lock for 24 h — the IP is already blacklisted after the
+          // first alert, so a second email for the same IP within a day adds no value.
+          dedupOptions.ttlSeconds = 86400;
         }
 
         shouldSend = await emailDeduplicator.checkAndMarkEmail(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the bot-alert email deduplication system so that the same security alert for a given IP address cannot be sent more than once within a 24-hour window. This is achieved by:
- Replacing the model-level fixed 5-minute TTL on `SentEmailLog` with a per-document `expiresAt` field, allowing each email type to carry its own retention window.
- Threading a `ttlSeconds` option through `EmailDeduplicator.checkAndMarkEmail()` so callers can override the default lock duration at the call site.
- Passing `ttlSeconds: 86400` (24 h) in the `sendBotAlert` dedup options so the lock survives until the next day.

### Why is this change needed?
Admins were receiving the same "🚨 Security Alert: Automated Bot Activity Detected" email several hours apart for the same already-blacklisted IP. The root cause was a 5-minute deduplication TTL in `SentEmailLog` — once the document expired, the next re-trigger of `analyzeIPRequestPattern` for the same IP (before the blacklist cache blocked it) could send a second email, which the per-day rate limit of 2 still allowed through. Since the IP is blacklisted immediately after the first alert, any subsequent email for the same IP within 24 hours contains no new information.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`
  - `models/SentEmailLog.js`
  - `utils/common/email-deduplication.util.js`
  - `utils/common/mailer.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Existing unit tests for `emailDeduplicator.checkAndMarkEmail()` and the `sendBotAlert` mailer path should be verified to pass. The schema change requires dropping the old `createdAt_1` TTL index from the `sent_email_logs` collection on deployed environments before or after the release (see Breaking Changes below).

---

## :boom: Breaking Changes

- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

**Schema migration required:** The `SentEmailLog` model previously used a TTL index on `createdAt` (`expires: 300`). This PR removes that and replaces it with a per-document `expiresAt` field (`expireAfterSeconds: 0`). The old index (`createdAt_1`) will remain in MongoDB until manually dropped. Run the following against each tenant's `sent_email_log` collection after deploying:

```js
db.sent_email_logs.dropIndex("createdAt_1")
```

Documents created before this deploy have no `expiresAt` and will not be cleaned up by the new index — but since the old TTL was 5 minutes, all pre-deploy documents will have already expired and been deleted before the deploy window closes.

---

## :memo: Additional Notes

- The `ttlSeconds` option defaults to the `EmailDeduplicator` class-level value (300 s) when not supplied, so all other email types retain their existing 5-minute dedup window — only `sendBotAlert` is extended to 24 hours.
- The dedup key for bot alerts remains IP-scoped (`md5(bcc:subject:ip)`), so alerts for distinct IPs are still independent and will each send their first notification correctly.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot alert deduplication reliability by normalizing recipient lists.

* **Refactor**
  * Updated email log cleanup to use per-document expiration instead of fixed TTL.
  * Enhanced email deduplication system with configurable expiration timing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->