### PR TITLE
Fix offline detection timeout and site aggregation query index bypass

### DIFF
--- a/src/device-registry/bin/jobs/update-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-online-status-job.js
@@ -493,10 +493,12 @@ async function updateOfflineEntitiesWithAccuracy(
     // Add processed entity IDs to prevent race conditions
     const processedInThisRun = new Set(activeEntityIds);
 
-    // Find ALL devices that should be offline
+    // Find ALL devices that should be offline. The $nin on processedInThisRun
+    // was removed: active devices have a fresh lastActive and won't match the
+    // $lt filter anyway, so the exclusion is redundant and causes a full
+    // collection scan when the set is large.
     const entitiesToCheck = await Model.find(
       {
-        _id: { $nin: Array.from(processedInThisRun) },
         $or: [
           { lastActive: { $lt: thresholdTime } },
           { lastActive: { $exists: false }, createdAt: { $lt: thresholdTime } },
@@ -511,7 +513,9 @@ async function updateOfflineEntitiesWithAccuracy(
         "onlineStatusAccuracy.correctChecks": 1,
         "onlineStatusAccuracy.incorrectChecks": 1,
       },
-    ).lean();
+    )
+      .maxTimeMS(15000)
+      .lean();
 
     if (entitiesToCheck.length === 0) {
       return {
@@ -1229,7 +1233,7 @@ async function updateOnlineStatusAndAccuracy() {
     if (!processor.shouldStopExecution()) {
       try {
         const OFFLINE_TIMEOUT = 20000;
-        const [deviceOfflineResult, siteOfflineResult] = await Promise.all([
+        const [deviceOfflineResult, siteOfflineResult] = await Promise.allSettled([
           Promise.race([
             updateOfflineEntitiesWithAccuracy(
               DeviceModel("airqo"),

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -1681,17 +1681,7 @@ const createSite = {
               pipeline: [
                 {
                   $match: {
-                    $expr: {
-                      $or: [
-                        { $eq: ["$site_id", "$$siteId"] },
-                        {
-                          $eq: [
-                            { $toString: "$site_id" },
-                            { $toString: "$$siteId" },
-                          ],
-                        },
-                      ],
-                    },
+                    $expr: { $eq: ["$site_id", "$$siteId"] },
                   },
                 },
                 { $sort: { createdAt: -1 } },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Removes the `$nin` exclusion from the offline device detection query in `update-online-status-job.js` and adds a `.maxTimeMS(15000)` guard so the query fails fast instead of stalling the JS-level race timer
- Switches `Promise.all` to `Promise.allSettled` for the offline detection step so a Device timeout no longer kills the Site detection path (and vice versa)
- Simplifies the activities `$lookup` in `site.util.js` by removing the `$toString`-based `$expr` fallback, allowing MongoDB to use the index on `activities.site_id`

### Why is this change needed?
Production logs on 2026-06-14 showed two recurring errors in device-registry:
1. `Error in offline detection: Device offline timeout` — the `$nin: Array.from(processedInThisRun)` filter on the offline detection query was forcing a full collection scan every run as the active-device set grew. Active devices already have a fresh `lastActive` timestamp and can never match `lastActive < thresholdTime`, so the exclusion was redundant but expensive. Additionally, `Promise.all` meant a single timeout silently killed the sibling operation.
2. `PlanExecutor error during aggregation :: caused by :: operation exceeded time limit` — the `full` detail site listing ran a `$lookup` against the activities collection using `$expr: { $or: [eq, eq-with-$toString] }`. The `$toString` call inside `$expr` blocked index use on `site_id`, causing a full collection scan per site and exceeding the 45 s `maxTimeMS`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`
  - `bin/jobs/update-online-status-job.js`
  - `utils/site.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Changes are query-level fixes with no logic alterations. The `$nin` removal is safe because active devices (`lastActive >= thresholdTime`) cannot match the offline filter; removing it only avoids the collection scan. The `Promise.allSettled` switch aligns the result shape with how the code was already reading `.value` / `.reason`. The `$expr` simplification requires that `activities.site_id` is stored as ObjectId (expected schema); legacy string values would simply not join rather than causing errors.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `Promise.all` → `Promise.allSettled` change also fixes a pre-existing bug where the `accuracyReport.offlineDetection` block accessed `.value` and `.reason` on results that `Promise.all` never wraps in that shape, meaning `offlineDetection.devices` was always `{ error: undefined }` on success.
- If any activities documents have a string `site_id` (legacy data), those records will no longer join to their site in the `full` detail view. A one-off migration to cast those to ObjectId is recommended if that data is still relevant.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
