### PR TITLE
Fix aggregation timeouts from unindexed $or activity lookups

### DIFF
--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -1186,7 +1186,15 @@ deviceSchema.statics = {
         })
         .addFields({
           activities: {
-            $slice: [{ $setUnion: ["$_act_by_id", "$_act_by_name"] }, maxActivities],
+            $slice: [
+              {
+                $sortArray: {
+                  input: { $setUnion: ["$_act_by_id", "$_act_by_name"] },
+                  sortBy: { createdAt: -1 },
+                },
+              },
+              maxActivities,
+            ],
           },
           latest_deployment_activity: {
             $slice: [{ $concatArrays: ["$_dep_by_id", "$_dep_by_name"] }, 1],

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -1074,18 +1074,9 @@ deviceSchema.statics = {
         })
         .lookup({
           from: "activities",
-          let: { deviceName: "$name", deviceId: "$_id" },
+          let: { deviceId: "$_id" },
           pipeline: [
-            {
-              $match: {
-                $expr: {
-                  $or: [
-                    { $eq: ["$device", "$$deviceName"] },
-                    { $eq: ["$device_id", "$$deviceId"] },
-                  ],
-                },
-              },
-            },
+            { $match: { $expr: { $eq: ["$device_id", "$$deviceId"] } } },
             { $sort: { createdAt: -1 } },
             {
               $project: {
@@ -1105,84 +1096,115 @@ deviceSchema.statics = {
             },
             { $limit: maxActivities },
           ],
-          as: "activities",
+          as: "_act_by_id",
         })
         .lookup({
           from: "activities",
-          let: { deviceName: "$name", deviceId: "$_id" },
+          let: { deviceName: "$name" },
           pipeline: [
+            { $match: { $expr: { $eq: ["$device", "$$deviceName"] } } },
+            { $sort: { createdAt: -1 } },
             {
-              $match: {
-                $expr: {
-                  $and: [
-                    {
-                      $or: [
-                        { $eq: ["$device", "$$deviceName"] },
-                        { $eq: ["$device_id", "$$deviceId"] },
-                      ],
-                    },
-                    { $eq: ["$activityType", "deployment"] },
-                  ],
-                },
+              $project: {
+                _id: 1,
+                site_id: 1,
+                device_id: 1,
+                device: 1,
+                activityType: 1,
+                maintenanceType: 1,
+                recallType: 1,
+                date: 1,
+                description: 1,
+                nextMaintenance: 1,
+                createdAt: 1,
+                tags: 1,
               },
             },
-            { $sort: { createdAt: -1 } },
-            { $limit: 1 },
+            { $limit: maxActivities },
           ],
-          as: "latest_deployment_activity",
+          as: "_act_by_name",
         })
         .lookup({
           from: "activities",
-          let: { deviceName: "$name", deviceId: "$_id" },
+          let: { deviceId: "$_id" },
           pipeline: [
-            {
-              $match: {
-                $expr: {
-                  $and: [
-                    {
-                      $or: [
-                        { $eq: ["$device", "$$deviceName"] },
-                        { $eq: ["$device_id", "$$deviceId"] },
-                      ],
-                    },
-                    { $eq: ["$activityType", "maintenance"] },
-                  ],
-                },
-              },
-            },
+            { $match: { $expr: { $eq: ["$device_id", "$$deviceId"] }, activityType: "deployment" } },
             { $sort: { createdAt: -1 } },
             { $limit: 1 },
           ],
-          as: "latest_maintenance_activity",
+          as: "_dep_by_id",
         })
         .lookup({
           from: "activities",
-          let: { deviceName: "$name", deviceId: "$_id" },
+          let: { deviceName: "$name" },
           pipeline: [
-            {
-              $match: {
-                $expr: {
-                  $and: [
-                    {
-                      $or: [
-                        { $eq: ["$device", "$$deviceName"] },
-                        { $eq: ["$device_id", "$$deviceId"] },
-                      ],
-                    },
-                    {
-                      $or: [
-                        { $eq: ["$activityType", "recall"] },
-                        { $eq: ["$activityType", "recallment"] },
-                      ],
-                    },
-                  ],
-                },
-              },
-            },
+            { $match: { $expr: { $eq: ["$device", "$$deviceName"] }, activityType: "deployment" } },
             { $sort: { createdAt: -1 } },
             { $limit: 1 },
           ],
-          as: "latest_recall_activity",
+          as: "_dep_by_name",
+        })
+        .lookup({
+          from: "activities",
+          let: { deviceId: "$_id" },
+          pipeline: [
+            { $match: { $expr: { $eq: ["$device_id", "$$deviceId"] }, activityType: "maintenance" } },
+            { $sort: { createdAt: -1 } },
+            { $limit: 1 },
+          ],
+          as: "_mnt_by_id",
+        })
+        .lookup({
+          from: "activities",
+          let: { deviceName: "$name" },
+          pipeline: [
+            { $match: { $expr: { $eq: ["$device", "$$deviceName"] }, activityType: "maintenance" } },
+            { $sort: { createdAt: -1 } },
+            { $limit: 1 },
+          ],
+          as: "_mnt_by_name",
+        })
+        .lookup({
+          from: "activities",
+          let: { deviceId: "$_id" },
+          pipeline: [
+            { $match: { $expr: { $eq: ["$device_id", "$$deviceId"] }, activityType: { $in: ["recall", "recallment"] } } },
+            { $sort: { createdAt: -1 } },
+            { $limit: 1 },
+          ],
+          as: "_rcl_by_id",
+        })
+        .lookup({
+          from: "activities",
+          let: { deviceName: "$name" },
+          pipeline: [
+            { $match: { $expr: { $eq: ["$device", "$$deviceName"] }, activityType: { $in: ["recall", "recallment"] } } },
+            { $sort: { createdAt: -1 } },
+            { $limit: 1 },
+          ],
+          as: "_rcl_by_name",
+        })
+        .addFields({
+          activities: {
+            $slice: [{ $setUnion: ["$_act_by_id", "$_act_by_name"] }, maxActivities],
+          },
+          latest_deployment_activity: {
+            $slice: [{ $concatArrays: ["$_dep_by_id", "$_dep_by_name"] }, 1],
+          },
+          latest_maintenance_activity: {
+            $slice: [{ $concatArrays: ["$_mnt_by_id", "$_mnt_by_name"] }, 1],
+          },
+          latest_recall_activity: {
+            $slice: [{ $concatArrays: ["$_rcl_by_id", "$_rcl_by_name"] }, 1],
+          },
+          _act_by_id: "$$REMOVE",
+          _act_by_name: "$$REMOVE",
+          _dep_by_id: "$$REMOVE",
+          _dep_by_name: "$$REMOVE",
+          _mnt_by_id: "$$REMOVE",
+          _mnt_by_name: "$$REMOVE",
+          _rcl_by_id: "$$REMOVE",
+          _rcl_by_name: "$$REMOVE",
         })
         .addFields({
           device_categories: {
@@ -1689,7 +1711,8 @@ deviceSchema.statics = {
         .project(exclusionProjection)
         .skip(_skip)
         .limit(_limit)
-        .allowDiskUse(true);
+        .allowDiskUse(true)
+        .option({ maxTimeMS: 60000 });
 
       const response = await pipeline;
 

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1529,7 +1529,15 @@ const deviceUtil = {
             {
               $addFields: {
                 activities: {
-                  $slice: [{ $setUnion: ["$_act_by_id", "$_act_by_name"] }, maxActivities],
+                  $slice: [
+                    {
+                      $sortArray: {
+                        input: { $setUnion: ["$_act_by_id", "$_act_by_name"] },
+                        sortBy: { createdAt: -1 },
+                      },
+                    },
+                    maxActivities,
+                  ],
                 },
                 _act_by_id: "$$REMOVE",
                 _act_by_name: "$$REMOVE",

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -1473,19 +1473,9 @@ const deviceUtil = {
             {
               $lookup: {
                 from: activitiesColl,
-                let: { deviceName: "$name", deviceId: "$_id" },
+                let: { deviceId: "$_id" },
                 pipeline: [
-                  {
-                    // Prioritize indexed device_id lookup, fall back to legacy device name for backwards compatibility
-                    $match: {
-                      $expr: {
-                        $or: [
-                          { $eq: ["$device_id", "$$deviceId"] },
-                          { $eq: ["$device", "$$deviceName"] },
-                        ],
-                      },
-                    },
-                  },
+                  { $match: { $expr: { $eq: ["$device_id", "$$deviceId"] } } },
                   { $sort: { createdAt: -1 } },
                   {
                     $project: {
@@ -1505,7 +1495,44 @@ const deviceUtil = {
                   },
                   { $limit: maxActivities },
                 ],
-                as: "activities",
+                as: "_act_by_id",
+              },
+            },
+            {
+              $lookup: {
+                from: activitiesColl,
+                let: { deviceName: "$name" },
+                pipeline: [
+                  { $match: { $expr: { $eq: ["$device", "$$deviceName"] } } },
+                  { $sort: { createdAt: -1 } },
+                  {
+                    $project: {
+                      _id: 1,
+                      site_id: 1,
+                      device_id: 1,
+                      device: 1,
+                      activityType: 1,
+                      maintenanceType: 1,
+                      recallType: 1,
+                      date: 1,
+                      description: 1,
+                      nextMaintenance: 1,
+                      createdAt: 1,
+                      tags: 1,
+                    },
+                  },
+                  { $limit: maxActivities },
+                ],
+                as: "_act_by_name",
+              },
+            },
+            {
+              $addFields: {
+                activities: {
+                  $slice: [{ $setUnion: ["$_act_by_id", "$_act_by_name"] }, maxActivities],
+                },
+                _act_by_id: "$$REMOVE",
+                _act_by_name: "$$REMOVE",
               },
             },
             getDeviceCategoriesAddFieldsStage(),


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces unindexed `$or`-in-`$expr` activity lookup patterns in `device.util.js` and `Device.js` with two separate single-equality lookups (one by `device_id`, one by `device` name), merged with `$setUnion`/`$concatArrays`. Also adds a `maxTimeMS: 60000` guard to the `Device` model's `list()` aggregation.

### Why is this change needed?
Production was throwing repeated `PlanExecutor error during aggregation :: caused by :: operation exceeded time limit` errors for `device-util` and `site-util`. The root cause was `$expr: { $or: [{ $eq: ["$device_id", ...] }, { $eq: ["$device", ...] }] }` inside `$lookup` sub-pipelines — MongoDB cannot use index intersection for `$or` inside `$expr`, forcing a full collection scan of the activities collection for every device in the result set. With a default limit of 1,000 devices, this was 1,000+ collection scans per request, reliably breaching the 45-second aggregation timeout.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — `utils/device.util.js`, `models/Device.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified that the existing `{ device_id: 1, createdAt: -1 }`, `{ device: 1, createdAt: -1 }`, `{ device_id: 1, activityType: 1, createdAt: -1 }`, and `{ device: 1, activityType: 1, createdAt: -1 }` indexes on the `activities` collection are now exercised by each split lookup. The `$setUnion` merge deduplicates documents that appear in both paths. `$$REMOVE` cleans up temp fields in the same `$addFields` stage, avoiding extra pipeline stages.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The `site-util` timeout was separately resolved in the previous commit (`e4abaa8`) by removing a similar `$or` index bypass on `site_id` in `site.util.js`.
- The `activities` array returned per device is no longer guaranteed to be sorted by `createdAt` (due to `$setUnion` not preserving order), but all downstream consumers (`activities_by_type`, `latest_activities_by_type`) derive their values via `$reduce`/iteration and are order-independent.
- For the three typed activity lookups (`latest_deployment_activity`, `latest_maintenance_activity`, `latest_recall_activity`), `$concatArrays` puts the `device_id` match first so `$slice(1)` always prefers the more reliable identifier when both paths return a result.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved device activity data retrieval mechanisms with enhanced deduplication, execution time limits, and backward compatibility support to ensure more reliable data consistency and performance when accessing device activity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->