### PR TITLE
Add per-network breakdown to daily network status summary

### DIFF
--- a/src/device-registry/bin/jobs/check-network-status-job.js
+++ b/src/device-registry/bin/jobs/check-network-status-job.js
@@ -74,6 +74,17 @@ const checkNetworkStatus = async () => {
     const totalDeployedDevices = total_monitors;
     const notTransmittingDevicesCount = not_transmitting;
 
+    // Fetch per-network breakdown (non-blocking — failure doesn't affect main alert)
+    let networkBreakdown = [];
+    try {
+      const perNetworkResult = await deviceUtil.getDeviceCountSummaryByNetwork(request);
+      if (perNetworkResult && perNetworkResult.success) {
+        networkBreakdown = perNetworkResult.data;
+      }
+    } catch (networkBreakdownError) {
+      logger.warn(`Could not fetch per-network breakdown: ${networkBreakdownError.message}`);
+    }
+
     if (totalDeployedDevices === 0) {
       logText("No deployed devices found");
       logger.warn("🙀🙀 No deployed devices found.");
@@ -147,6 +158,7 @@ const checkNetworkStatus = async () => {
       message,
       threshold_exceeded: notTransmittingPercentage >= UPTIME_THRESHOLD,
       threshold_value: UPTIME_THRESHOLD,
+      network_breakdown: networkBreakdown,
     };
 
     const alertResult = await networkStatusUtil.createAlert({
@@ -223,6 +235,27 @@ const dailyNetworkStatusSummary = async () => {
       const avgOp = Math.round(stats.avg_operational_count || 0);
       const avgTx = Math.round(stats.avg_transmitting_count || 0);
       const avgDa = Math.round(stats.avg_data_available_count || 0);
+
+      let perNetworkSection = "";
+      try {
+        const networkStats = await NetworkStatusAlertModel("airqo").getStatisticsByNetwork({ filter });
+        if (networkStats && networkStats.success && networkStats.data.length > 0) {
+          const networkLines = networkStats.data.map((n) => {
+            const name = (n._id || "unknown").toUpperCase();
+            const avgNtPct = (n.avg_not_transmitting_percentage || 0).toFixed(2);
+            const maxNtPct = (n.max_not_transmitting_percentage || 0).toFixed(2);
+            const minNtPct = (n.min_not_transmitting_percentage || 0).toFixed(2);
+            const avgOpN = Math.round(n.avg_operational_count || 0);
+            const avgTxN = Math.round(n.avg_transmitting_count || 0);
+            const avgTotal = Math.round(n.avg_total_monitors || 0);
+            return `  • ${name}: Total ~${avgTotal} | Avg Not Tx: ${avgNtPct}% (Max: ${maxNtPct}%, Min: ${minNtPct}%) | Avg Op: ${avgOpN} | Avg Tx: ${avgTxN}`;
+          });
+          perNetworkSection = `\n📡 Per-Network Breakdown:\n${networkLines.join("\n")}`;
+        }
+      } catch (networkStatsError) {
+        logger.warn(`Could not fetch per-network statistics: ${networkStatsError.message}`);
+      }
+
       const summaryMessage = `
 📊 Daily Network Status Summary (${moment(yesterday).format("YYYY-MM-DD")})
 Total Checks: ${stats.totalAlerts}
@@ -230,7 +263,7 @@ Avg Operational: ${avgOp} | Avg Transmitting: ${avgTx} | Avg Data Available: ${a
 Avg Not Transmitting %: ${stats.avg_not_transmitting_percentage.toFixed(2)}%
 Max Not Transmitting %: ${stats.max_not_transmitting_percentage.toFixed(2)}%
 Min Not Transmitting %: ${stats.min_not_transmitting_percentage.toFixed(2)}%
-Warning Checks: ${stats.warningCount} | Critical Checks: ${stats.criticalCount}
+Warning Checks: ${stats.warningCount} | Critical Checks: ${stats.criticalCount}${perNetworkSection}
       `;
 
       logText(summaryMessage);

--- a/src/device-registry/models/NetworkStatusAlert.js
+++ b/src/device-registry/models/NetworkStatusAlert.js
@@ -90,12 +90,17 @@ const networkStatusAlertSchema = new Schema(
     network_breakdown: [
       {
         network: { type: String },
-        total_monitors: { type: Number, default: 0 },
-        operational_count: { type: Number, default: 0 },
-        transmitting_count: { type: Number, default: 0 },
-        data_available_count: { type: Number, default: 0 },
-        not_transmitting_count: { type: Number, default: 0 },
-        not_transmitting_percentage: { type: Number, default: 0 },
+        total_monitors: { type: Number, default: 0, min: 0 },
+        operational_count: { type: Number, default: 0, min: 0 },
+        transmitting_count: { type: Number, default: 0, min: 0 },
+        data_available_count: { type: Number, default: 0, min: 0 },
+        not_transmitting_count: { type: Number, default: 0, min: 0 },
+        not_transmitting_percentage: {
+          type: Number,
+          default: 0,
+          min: 0,
+          max: 100,
+        },
       },
     ],
     // Additional metadata for future analysis
@@ -263,13 +268,15 @@ networkStatusAlertSchema.statics = {
       const stringifiedMessage = JSON.stringify(error || "");
       logger.error(`🐛🐛 Internal Server Error -- ${stringifiedMessage}`);
 
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message }
-        )
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message }
       );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
     }
   },
 
@@ -341,15 +348,17 @@ networkStatusAlertSchema.statics = {
         { $sort: { avg_not_transmitting_percentage: -1 } },
       ];
 
-      return this.executeAggregation({ pipeline }, next);
+      return await this.executeAggregation({ pipeline }, next);
     } catch (error) {
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message }
-        )
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message }
       );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
     }
   },
 

--- a/src/device-registry/models/NetworkStatusAlert.js
+++ b/src/device-registry/models/NetworkStatusAlert.js
@@ -86,6 +86,18 @@ const networkStatusAlertSchema = new Schema(
       type: String,
       required: true,
     },
+    // Per-network breakdown captured at check time
+    network_breakdown: [
+      {
+        network: { type: String },
+        total_monitors: { type: Number, default: 0 },
+        operational_count: { type: Number, default: 0 },
+        transmitting_count: { type: Number, default: 0 },
+        data_available_count: { type: Number, default: 0 },
+        not_transmitting_count: { type: Number, default: 0 },
+        not_transmitting_percentage: { type: Number, default: 0 },
+      },
+    ],
     // Additional metadata for future analysis
     day_of_week: {
       type: Number,
@@ -289,6 +301,44 @@ networkStatusAlertSchema.statics = {
             },
           },
         },
+      ];
+
+      return this.executeAggregation({ pipeline }, next);
+    } catch (error) {
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  async getStatisticsByNetwork({ filter = {} } = {}, next) {
+    try {
+      const pipeline = [
+        { $match: filter },
+        {
+          $unwind: {
+            path: "$network_breakdown",
+            preserveNullAndEmptyArrays: false,
+          },
+        },
+        {
+          $group: {
+            _id: "$network_breakdown.network",
+            totalChecks: { $sum: 1 },
+            avg_total_monitors: { $avg: "$network_breakdown.total_monitors" },
+            avg_operational_count: { $avg: "$network_breakdown.operational_count" },
+            avg_transmitting_count: { $avg: "$network_breakdown.transmitting_count" },
+            avg_data_available_count: { $avg: "$network_breakdown.data_available_count" },
+            avg_not_transmitting_percentage: { $avg: "$network_breakdown.not_transmitting_percentage" },
+            max_not_transmitting_percentage: { $max: "$network_breakdown.not_transmitting_percentage" },
+            min_not_transmitting_percentage: { $min: "$network_breakdown.not_transmitting_percentage" },
+          },
+        },
+        { $sort: { avg_not_transmitting_percentage: -1 } },
       ];
 
       return this.executeAggregation({ pipeline }, next);

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -598,6 +598,91 @@ const deviceUtil = {
       );
     }
   },
+  getDeviceCountSummaryByNetwork: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const filter = generateFilter.devices(request, next);
+
+      const pipeline = [
+        { $match: filter },
+        {
+          $group: {
+            _id: { $ifNull: [{ $toLower: "$network" }, "unknown"] },
+            total: { $sum: 1 },
+            operational: {
+              $sum: {
+                $cond: [
+                  { $and: [{ $eq: ["$isOnline", true] }, { $eq: ["$rawOnlineStatus", true] }] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            transmitting: {
+              $sum: {
+                $cond: [
+                  { $and: [{ $eq: ["$isOnline", false] }, { $eq: ["$rawOnlineStatus", true] }] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            data_available: {
+              $sum: {
+                $cond: [
+                  { $and: [{ $eq: ["$isOnline", true] }, { $eq: ["$rawOnlineStatus", false] }] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            not_transmitting: {
+              $sum: {
+                $cond: [
+                  { $and: [{ $eq: ["$isOnline", false] }, { $eq: ["$rawOnlineStatus", false] }] },
+                  1,
+                  0,
+                ],
+              },
+            },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ];
+
+      const results = await DeviceModel(tenant)
+        .aggregate(pipeline)
+        .option({ maxTimeMS: 45000 })
+        .allowDiskUse(true);
+
+      return {
+        success: true,
+        message: "Successfully retrieved per-network health summary.",
+        data: results.map((r) => ({
+          network: r._id,
+          total_monitors: r.total,
+          operational_count: r.operational,
+          transmitting_count: r.transmitting,
+          data_available_count: r.data_available,
+          not_transmitting_count: r.not_transmitting,
+          not_transmitting_percentage:
+            r.total > 0
+              ? parseFloat(((r.not_transmitting / r.total) * 100).toFixed(2))
+              : 0,
+        })),
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🪲🪲 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
   getDeviceById: async (req, next) => {
     try {
       const { id } = req.params;

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -674,13 +674,15 @@ const deviceUtil = {
       };
     } catch (error) {
       logger.error(`🪲🪲 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message },
-        ),
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message },
       );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
     }
   },
   getDeviceById: async (req, next) => {

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -130,6 +130,150 @@ describe("Device Util", () => {
       expect(error.message).to.equal("Internal Server Error");
     });
   });
+  describe("getDeviceCountSummaryByNetwork", () => {
+    let sandbox;
+    let aggregateStub;
+    let generateFilterStub;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      const deviceModelMock = {
+        aggregate: sinon.stub(),
+      };
+      sandbox.stub(DeviceModel, "default").returns(deviceModelMock);
+      aggregateStub = deviceModelMock.aggregate;
+      generateFilterStub = sandbox.stub(generateFilter, "devices");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should group results by network and compute percentages", async () => {
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+
+      aggregateStub.resolves([
+        {
+          _id: "airqo",
+          total: 100,
+          operational: 70,
+          transmitting: 15,
+          data_available: 5,
+          not_transmitting: 10,
+        },
+        {
+          _id: "iqair",
+          total: 50,
+          operational: 20,
+          transmitting: 5,
+          data_available: 0,
+          not_transmitting: 25,
+        },
+      ]);
+
+      const result = await deviceUtil.getDeviceCountSummaryByNetwork(request);
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.OK);
+      expect(result.data).to.deep.equal([
+        {
+          network: "airqo",
+          total_monitors: 100,
+          operational_count: 70,
+          transmitting_count: 15,
+          data_available_count: 5,
+          not_transmitting_count: 10,
+          not_transmitting_percentage: 10,
+        },
+        {
+          network: "iqair",
+          total_monitors: 50,
+          operational_count: 20,
+          transmitting_count: 5,
+          data_available_count: 0,
+          not_transmitting_count: 25,
+          not_transmitting_percentage: 50,
+        },
+      ]);
+    });
+
+    it("should group devices with null/empty network under 'unknown'", async () => {
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+
+      aggregateStub.resolves([
+        {
+          _id: "unknown",
+          total: 10,
+          operational: 0,
+          transmitting: 0,
+          data_available: 0,
+          not_transmitting: 10,
+        },
+      ]);
+
+      const result = await deviceUtil.getDeviceCountSummaryByNetwork(request);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal([
+        {
+          network: "unknown",
+          total_monitors: 10,
+          operational_count: 0,
+          transmitting_count: 0,
+          data_available_count: 0,
+          not_transmitting_count: 10,
+          not_transmitting_percentage: 100,
+        },
+      ]);
+    });
+
+    it("should return an empty array when no devices match the filter", async () => {
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+      aggregateStub.resolves([]);
+
+      const result = await deviceUtil.getDeviceCountSummaryByNetwork(request);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal([]);
+    });
+
+    it("should call next with an HttpError when next is provided and aggregation fails", async () => {
+      const request = { query: { tenant: "airqo" } };
+      const next = sinon.spy();
+      generateFilterStub.returns({});
+      const dbError = new Error("Database connection failed");
+      aggregateStub.rejects(dbError);
+
+      await deviceUtil.getDeviceCountSummaryByNetwork(request, next);
+
+      expect(next.calledOnce).to.be.true;
+      const error = next.firstCall.args[0];
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+      expect(error.message).to.equal("Internal Server Error");
+    });
+
+    it("should throw instead of crashing when next is not provided and aggregation fails", async () => {
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+      const dbError = new Error("Database connection failed");
+      aggregateStub.rejects(dbError);
+
+      let thrown;
+      try {
+        await deviceUtil.getDeviceCountSummaryByNetwork(request);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).to.be.an.instanceOf(Error);
+      expect(thrown.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+      expect(thrown.message).to.equal("Internal Server Error");
+    });
+  });
   describe("createOnPlatform", () => {
     let deviceRegisterStub,
       cohortFindByIdStub,

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -135,6 +135,15 @@ describe("Device Util", () => {
     let aggregateStub;
     let generateFilterStub;
 
+    // Mirrors the real DeviceModel(tenant).aggregate(pipeline).option(...).allowDiskUse(true) chain
+    const createAggregateChain = (result, error) => ({
+      option: sinon.stub().returns({
+        allowDiskUse: sinon
+          .stub()
+          .returns(error ? Promise.reject(error) : Promise.resolve(result)),
+      }),
+    });
+
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       const deviceModelMock = {
@@ -153,24 +162,26 @@ describe("Device Util", () => {
       const request = { query: { tenant: "airqo" } };
       generateFilterStub.returns({});
 
-      aggregateStub.resolves([
-        {
-          _id: "airqo",
-          total: 100,
-          operational: 70,
-          transmitting: 15,
-          data_available: 5,
-          not_transmitting: 10,
-        },
-        {
-          _id: "iqair",
-          total: 50,
-          operational: 20,
-          transmitting: 5,
-          data_available: 0,
-          not_transmitting: 25,
-        },
-      ]);
+      aggregateStub.returns(
+        createAggregateChain([
+          {
+            _id: "airqo",
+            total: 100,
+            operational: 70,
+            transmitting: 15,
+            data_available: 5,
+            not_transmitting: 10,
+          },
+          {
+            _id: "iqair",
+            total: 50,
+            operational: 20,
+            transmitting: 5,
+            data_available: 0,
+            not_transmitting: 25,
+          },
+        ]),
+      );
 
       const result = await deviceUtil.getDeviceCountSummaryByNetwork(request);
 
@@ -198,20 +209,37 @@ describe("Device Util", () => {
       ]);
     });
 
-    it("should group devices with null/empty network under 'unknown'", async () => {
+    it("should build the $group._id expression to fall back to 'unknown' for missing/empty network", async () => {
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+      aggregateStub.returns(createAggregateChain([]));
+
+      await deviceUtil.getDeviceCountSummaryByNetwork(request);
+
+      expect(aggregateStub.calledOnce).to.be.true;
+      const pipeline = aggregateStub.getCall(0).args[0];
+      const groupStage = pipeline.find((stage) => stage.$group);
+      expect(groupStage.$group._id).to.deep.equal({
+        $ifNull: [{ $toLower: "$network" }, "unknown"],
+      });
+    });
+
+    it("should map an already-grouped 'unknown' bucket through to the output", async () => {
       const request = { query: { tenant: "airqo" } };
       generateFilterStub.returns({});
 
-      aggregateStub.resolves([
-        {
-          _id: "unknown",
-          total: 10,
-          operational: 0,
-          transmitting: 0,
-          data_available: 0,
-          not_transmitting: 10,
-        },
-      ]);
+      aggregateStub.returns(
+        createAggregateChain([
+          {
+            _id: "unknown",
+            total: 10,
+            operational: 0,
+            transmitting: 0,
+            data_available: 0,
+            not_transmitting: 10,
+          },
+        ]),
+      );
 
       const result = await deviceUtil.getDeviceCountSummaryByNetwork(request);
 
@@ -232,7 +260,7 @@ describe("Device Util", () => {
     it("should return an empty array when no devices match the filter", async () => {
       const request = { query: { tenant: "airqo" } };
       generateFilterStub.returns({});
-      aggregateStub.resolves([]);
+      aggregateStub.returns(createAggregateChain([]));
 
       const result = await deviceUtil.getDeviceCountSummaryByNetwork(request);
 
@@ -245,14 +273,14 @@ describe("Device Util", () => {
       const next = sinon.spy();
       generateFilterStub.returns({});
       const dbError = new Error("Database connection failed");
-      aggregateStub.rejects(dbError);
+      aggregateStub.returns(createAggregateChain(null, dbError));
 
       await deviceUtil.getDeviceCountSummaryByNetwork(request, next);
 
       expect(next.calledOnce).to.be.true;
       const error = next.firstCall.args[0];
       expect(error).to.be.an.instanceOf(Error);
-      expect(error.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+      expect(error.statusCode).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
       expect(error.message).to.equal("Internal Server Error");
     });
 
@@ -260,7 +288,7 @@ describe("Device Util", () => {
       const request = { query: { tenant: "airqo" } };
       generateFilterStub.returns({});
       const dbError = new Error("Database connection failed");
-      aggregateStub.rejects(dbError);
+      aggregateStub.returns(createAggregateChain(null, dbError));
 
       let thrown;
       try {
@@ -270,7 +298,7 @@ describe("Device Util", () => {
       }
 
       expect(thrown).to.be.an.instanceOf(Error);
-      expect(thrown.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+      expect(thrown.statusCode).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
       expect(thrown.message).to.equal("Internal Server Error");
     });
   });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Extends the daily network uptime status summary (sent at 08:00 EAT via Slack) to include a per-network (sensor manufacturer) breakdown. Each bi-hourly check now captures device counts grouped by the `network` field and stores them as an embedded `network_breakdown` array in the alert record. The daily summary aggregates those per-network snapshots and appends a ranked breakdown section to the existing Slack message.

### Why is this change needed?
The current summary reports aggregate stats across all networks, making it impossible to identify which sensor manufacturer network is driving uptime degradation. Separating by network enables faster diagnosis and targeted response during incidents.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`
  - `utils/device.util.js` — new `getDeviceCountSummaryByNetwork` method
  - `models/NetworkStatusAlert.js` — added `network_breakdown` schema field and `getStatisticsByNetwork` static
  - `bin/jobs/check-network-status-job.js` — fetch and store per-network breakdown on each check; render per-network section in daily summary

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Per-network fetch is wrapped in an isolated try/catch — if the breakdown query fails, the main alert still saves normally with an empty `network_breakdown: []`. Existing alert records without the field are skipped cleanly by `$unwind` with `preserveNullAndEmptyArrays: false`, so historical days are unaffected.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `network_breakdown` field is optional in the schema (no `required: true`) with all sub-fields defaulting to `0`. Existing stored alert documents without this field remain fully valid and queryable.

---

## :memo: Additional Notes

- The per-network section only appears in the daily summary once at least one check after this deploy has run (i.e., from the next bi-hourly check onward).
- Networks are sorted in the summary by worst `avg_not_transmitting_percentage` descending, so the most degraded network always appears first.
- The `getDeviceCountSummaryByNetwork` aggregation uses the same `maxTimeMS: 45000` and `allowDiskUse: true` options as the existing summary query.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-network device count breakdowns to network status alerts, including not-transmitting metrics and percentages.
  * Enhanced the daily network status summary with a “Per-Network Breakdown” section showing per-network health and transmission stats.
* **Bug Fixes**
  * Network status reporting now degrades gracefully: warnings are logged and summaries proceed when per-network statistics fetches fail.
* **Tests**
  * Added unit tests covering per-network device count aggregation, unknown/missing networks, empty results, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->