### PR TITLE
Fix email-config create bug; drop redundant tenant field

### DIFF
--- a/src/auth-service/models/ApplicationEmailConfiguration.js
+++ b/src/auth-service/models/ApplicationEmailConfiguration.js
@@ -49,23 +49,37 @@ const ApplicationEmailConfigurationSchema = new Schema(
 
 ApplicationEmailConfigurationSchema.statics = {
   // Each tenant already gets its own physical database (see getModelByTenant),
-  // so this collection only ever needs to hold one document. Rather than
-  // relying on a document-level unique field to enforce that, register()
-  // atomically upserts against an empty filter: the first call inserts,
-  // every later call merges into that same row instead of erroring.
+  // so this collection is intended to be a per-tenant singleton. register()
+  // is a create-or-merge upsert (findOneAndUpdate with { upsert: true })
+  // rather than insert-then-catch-duplicate-key. This isn't airtight against
+  // two truly concurrent first-time writes -- see the 11000 retry below --
+  // but matches this model's real write pattern (infrequent, single-admin
+  // edits via the settings UI).
   async register(args, next) {
     try {
       const { applicationEmails, adminCCEmails } = args;
       const update = {};
 
       if (Array.isArray(applicationEmails) && applicationEmails.length > 0) {
-        update.$addToSet = {
-          applicationEmails: { $each: applicationEmails },
-        };
+        // The schema's `set` normalizer (lowercase/trim/dedupe) only runs on
+        // document assignment, not on update operators like $addToSet --
+        // applied manually here so it isn't silently bypassed.
+        const normalizedApplicationEmails = [
+          ...new Set(
+            applicationEmails.map((e) => String(e).toLowerCase().trim())
+          ),
+        ];
+        if (normalizedApplicationEmails.length > 0) {
+          update.$addToSet = {
+            applicationEmails: { $each: normalizedApplicationEmails },
+          };
+        }
       }
 
       if (adminCCEmails) {
-        const existing = await this.findOne({}).lean();
+        const existing = await this.findOne({})
+          .sort({ createdAt: 1 })
+          .lean();
         const merged = new Set(
           ((existing && existing.adminCCEmails) || "")
             .split(",")
@@ -89,12 +103,27 @@ ApplicationEmailConfigurationSchema.statics = {
       }
 
       const hadExisting = !!(await this.exists({}));
-      const saved = await this.findOneAndUpdate({}, update, {
+      const upsertOptions = {
         new: true,
-        upsert: true,
         runValidators: true,
         setDefaultsOnInsert: true,
-      });
+        sort: { createdAt: 1 },
+      };
+      let saved;
+      try {
+        saved = await this.findOneAndUpdate({}, update, {
+          ...upsertOptions,
+          upsert: true,
+        });
+      } catch (upsertErr) {
+        if (upsertErr.code !== 11000) {
+          throw upsertErr;
+        }
+        // Lost the upsert race to a concurrent first write (or the legacy
+        // tenant_1 index is still present on older deployments) -- the row
+        // exists now, so retry as a plain update instead of failing.
+        saved = await this.findOneAndUpdate({}, update, upsertOptions);
+      }
 
       return {
         success: true,

--- a/src/auth-service/models/ApplicationEmailConfiguration.js
+++ b/src/auth-service/models/ApplicationEmailConfiguration.js
@@ -14,7 +14,6 @@ const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
 const ApplicationEmailConfigurationSchema = new Schema(
   {
-    tenant: { type: String, required: true, unique: true, lowercase: true },
     // Emails belonging to applications (not real people). When system-generated
     // emails are sent to any of these addresses, admin CC emails are added automatically.
     applicationEmails: {
@@ -49,21 +48,61 @@ const ApplicationEmailConfigurationSchema = new Schema(
 );
 
 ApplicationEmailConfigurationSchema.statics = {
+  // Each tenant already gets its own physical database (see getModelByTenant),
+  // so this collection only ever needs to hold one document. Rather than
+  // relying on a document-level unique field to enforce that, register()
+  // atomically upserts against an empty filter: the first call inserts,
+  // every later call merges into that same row instead of erroring.
   async register(args, next) {
     try {
-      const created = await this.create({ ...args });
-      if (!isEmpty(created)) {
-        return {
-          success: true,
-          message: "Application email configuration created successfully",
-          data: created,
-          status: httpStatus.CREATED,
+      const { applicationEmails, adminCCEmails } = args;
+      const update = {};
+
+      if (Array.isArray(applicationEmails) && applicationEmails.length > 0) {
+        update.$addToSet = {
+          applicationEmails: { $each: applicationEmails },
         };
       }
+
+      if (adminCCEmails) {
+        const existing = await this.findOne({}).lean();
+        const merged = new Set(
+          ((existing && existing.adminCCEmails) || "")
+            .split(",")
+            .map((e) => e.trim())
+            .filter(Boolean)
+        );
+        adminCCEmails
+          .split(",")
+          .map((e) => e.trim())
+          .filter(Boolean)
+          .forEach((e) => merged.add(e));
+        update.adminCCEmails = Array.from(merged).join(", ");
+      }
+
+      if (isEmpty(update)) {
+        return {
+          success: false,
+          message: "Operation successful but configuration not created",
+          status: httpStatus.OK,
+        };
+      }
+
+      const hadExisting = !!(await this.exists({}));
+      const saved = await this.findOneAndUpdate({}, update, {
+        new: true,
+        upsert: true,
+        runValidators: true,
+        setDefaultsOnInsert: true,
+      });
+
       return {
-        success: false,
-        message: "Operation successful but configuration not created",
-        status: httpStatus.OK,
+        success: true,
+        message: hadExisting
+          ? "An application email configuration already existed -- the provided values were merged into it"
+          : "Application email configuration created successfully",
+        data: saved,
+        status: hadExisting ? httpStatus.OK : httpStatus.CREATED,
       };
     } catch (err) {
       logObject("the error", err);
@@ -71,12 +110,7 @@ ApplicationEmailConfigurationSchema.statics = {
       let errors = {};
       let message;
       let status;
-      if (err.code === 11000) {
-        errors["tenant"] =
-          "An application email configuration for this tenant already exists";
-        message = "Validation errors for some of the provided fields";
-        status = httpStatus.CONFLICT;
-      } else if (err.errors) {
+      if (err.errors) {
         Object.entries(err.errors).forEach(([k, v]) => (errors[k] = v.message));
         message = "Validation errors for some of the provided fields";
         status = httpStatus.UNPROCESSABLE_ENTITY;

--- a/src/auth-service/utils/application-email-config.util.js
+++ b/src/auth-service/utils/application-email-config.util.js
@@ -49,9 +49,6 @@ const applicationEmailConfig = {
       if (params.id) {
         filter._id = mongoose.Types.ObjectId(params.id);
       }
-      if (query.tenant) {
-        filter.tenant = tenant;
-      }
 
       const response = await ApplicationEmailConfigurationModel(tenant).list(
         { skip, limit, filter },

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -186,7 +186,7 @@ const _getApplicationEmailConfig = async (tenant) => {
   }
   try {
     const config = await ApplicationEmailConfigurationModel(normalizedTenant)
-      .findOne({ tenant: normalizedTenant })
+      .findOne({})
       .lean();
     _appEmailConfigCache.set(normalizedTenant, { data: config, fetchedAt: Date.now() });
     return config;

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -187,6 +187,7 @@ const _getApplicationEmailConfig = async (tenant) => {
   try {
     const config = await ApplicationEmailConfigurationModel(normalizedTenant)
       .findOne({})
+      .sort({ createdAt: 1 })
       .lean();
     _appEmailConfigCache.set(normalizedTenant, { data: config, fetchedAt: Date.now() });
     return config;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Removes the redundant `tenant` field (and its unique index) from the `ApplicationEmailConfiguration` model.
- Reworks `register()` to atomically upsert against an empty filter (`{}`) instead of inserting and catching a duplicate-key error — the first call creates the config, every later call merges new `applicationEmails`/`adminCCEmails` into the existing one.
- Updates `mailer.util.js` and `application-email-config.util.js` to stop querying/filtering by the now-removed `tenant` field, since each tenant already gets its own physical database via `getModelByTenant`.

### Why is this change needed?
Production was throwing `E11000 duplicate key error ... index: tenant_1` every time someone used the analytics UI's "Create configuration" flow on `/system/email-configs`, surfaced to users as "A record with these details already exists."

Root cause: the model enforced a unique index on `tenant`, but the database connection for this model is already tenant-scoped (`auth_prod_<tenant>`), so the field added no real isolation — it just meant the very first successful create permanently filled the only allowed slot. Since this deployment only ever uses the `airqo` tenant, every later create collided with that same `tenant: "airqo"` value regardless of which emails were submitted, which is also why the conflict happened even when the new payload looked nothing like the existing record (MongoDB's uniqueness check only compares the indexed field, not the rest of the document).

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [x] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `auth-service` only
- `models/ApplicationEmailConfiguration.js`
- `utils/application-email-config.util.js`
- `utils/common/mailer.util.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** No automated tests currently cover this model or its call sites. Verified via static checks (`node -c`) on all three changed files and manual code-path review (create-then-create, mailer CC resolution, list/update/delete paths). Manual end-to-end testing against a running instance is still pending — recommended before merge.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

API responses for this model no longer include a `tenant` key (it was never part of the documented contract). Existing clients that still send `tenant` in the request body are unaffected — Mongoose silently ignores fields not declared in the schema.

Note: the existing production document still has a leftover `tenant: "airqo"` field and the old `tenant_1` unique index in MongoDB (Mongoose's `autoIndex` only adds missing indexes, it never drops removed ones). Both are inert and don't need to be cleaned up for this change to work correctly, but can be removed afterward via the existing `POST /api/v2/users/admin/maintenance/db/drop-index` endpoint (`collectionName: "application_email_configurations"`, `indexName: "tenant_1"`).

---

## :memo: Additional Notes

This collection is a singleton by design (one config per tenant database). The new `register()` logic enforces that atomically via `findOneAndUpdate({}, update, { upsert: true })` rather than relying on a document-level unique field, which is what caused the original bug.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal email configuration management system for improved consistency in storage and retrieval of application email settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->