### PR TITLE
Add token ownership check, audit logging, Slack security alerts, and reinstatement runbook

### DIFF
--- a/src/auth-service/config/log4js.js
+++ b/src/auth-service/config/log4js.js
@@ -71,6 +71,14 @@ if (isDevelopment()) {
       // the entire codebase to warn-level Slack noise.
       // Usage: const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- <job-name> -- ops-alerts`);
       "ops-alerts": { appenders: ["app"], level: "info" },
+
+      // Dedicated category for token security audit events:
+      //   - Ownership check failures on PATCH /tokens/:token (WARN)
+      //   - Successful changes to request_pattern or bypass_anomaly_detection (INFO)
+      // Sends INFO and above to Slack so every sensitive token action
+      // (including successful ones) is visible without affecting other loggers.
+      // Usage: const securityAuditLogger = log4js.getLogger("token-security-audit");
+      "token-security-audit": { appenders: ["app"], level: "info" },
     },
   };
 
@@ -100,9 +108,19 @@ if (isDevelopment()) {
         appender: "slack",
       };
 
+      // slackInfo — INFO and above. Used only by token-security-audit so every
+      // sensitive token operation (both failures and successful admin changes)
+      // reaches Slack without opening up INFO-level noise from other categories.
+      config.appenders.slackInfo = {
+        type: "logLevelFilter",
+        level: "INFO",
+        appender: "slack",
+      };
+
       config.categories.default.appenders.push("slackErrors");
       config.categories.error.appenders.push("slackErrors");
       config.categories["ops-alerts"].appenders.push("slackWarn");
+      config.categories["token-security-audit"].appenders.push("slackInfo");
 
       console.log(
         "✅ Slack appender configured successfully (ERROR and above only, WARN and above for ops-alerts)",

--- a/src/auth-service/config/log4js.js
+++ b/src/auth-service/config/log4js.js
@@ -123,7 +123,7 @@ if (isDevelopment()) {
       config.categories["token-security-audit"].appenders.push("slackInfo");
 
       console.log(
-        "✅ Slack appender configured successfully (ERROR and above only, WARN and above for ops-alerts)",
+        "✅ Slack appender configured successfully (ERROR+ → default/error, WARN+ → ops-alerts, INFO+ → token-security-audit)",
       );
     } catch (error) {
       console.error("❌ Failed to configure Slack appender:", error.message);

--- a/src/auth-service/docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md
+++ b/src/auth-service/docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md
@@ -1,125 +1,268 @@
-# Sliding Session Token Refresh Implementation Guide
+# Sliding Session & Token Refresh Guide
 
-## Objective
+**Version:** 2.0 — Last updated: 2026-06-17
 
-To implement a seamless and secure token refresh mechanism that prevents users from being logged out unexpectedly. This guide applies to both the Next.js web app and the Flutter mobile app.
+## Who this is for
 
-## Background
+Developers working on any AirQo client that makes authenticated API calls:
 
-The backend now issues JWTs that expire. To support a smooth transition for existing users, the first token issued upon login will have a 7-day lifespan. For every subsequent authenticated API call, the backend will automatically provide a new, refreshed token (with a standard 24-hour lifespan) in the response headers if the current token is nearing its expiration. Our task on the client is to check for this new token and update our local storage accordingly.
+| App | Stack | HTTP layer |
+|---|---|---|
+| `airqo-frontend/src/mobile` | Flutter | `http` package + `BaseRepository` |
+| `airqo-frontend/src/platform` | Next.js (TypeScript) | `ApiClient` (Axios) |
+| `airqo-frontend/src/vertex` | Next.js (TypeScript) | Axios (`createAxiosInstance`) |
+| `airqo-frontend/src/beacon` | Next.js (JavaScript) | native `fetch` |
 
-**Key Header:** `X-Access-Token`
+---
 
-## Implementation Steps
+## How the backend keeps sessions alive
 
-This logic should be implemented in your central API/networking layer where all HTTP requests are made and responses are handled.
+The backend (`enhancedJWTAuth` middleware) implements a **three-window model**.
+Every authenticated request passes through all three checks in order:
 
-### 1. On Every Successful API Response (Status 200-299)
+```
+Client sends JWT
+  │
+  ├─ 1. Signature invalid?
+  │      → 401 "Invalid token: ..."
+  │
+  ├─ 2. exp + GRACE_PERIOD < now?
+  │      → 401 "Your session has expired. Please log in again."
+  │
+  ├─ 3. exp < now + REFRESH_WINDOW?   ← token is valid but nearing expiry
+  │      → issue replacement token silently
+  │        set response header:  X-Access-Token: JWT eyJ...
+  │        set response header:  Access-Control-Expose-Headers: X-Access-Token
+  │        request still succeeds with original token
+  │
+  └─ Proceed with request normally
+```
 
-After you receive a successful response from any authenticated API endpoint, you must inspect its headers.
+### Timing configuration
 
-**A. Check for the X-Access-Token Header:** The new token will be in a custom header named `X-Access-Token`. Note that HTTP headers are case-insensitive, so your client library might present it as `x-access-token`.
+All values are env vars with these production defaults:
 
-**B. Update Local Storage:** If the `X-Access-Token` header is present and contains a value:
+| Env var | Default | Effect |
+|---|---|---|
+| `JWT_EXPIRES_IN_SECONDS` | **86 400** (24 h) | Lifetime of every issued JWT |
+| `JWT_REFRESH_WINDOW_SECONDS` | **900** (15 min) | Backend issues a new token on any response when the existing one expires within this window |
+| `JWT_GRACE_PERIOD_SECONDS` | **300** (5 min) | Expired tokens are still accepted for this long after `exp` |
+| `JWT_REFRESH_MAX_AGE_SECONDS` | **31 536 000** (1 yr) | Hard ceiling — no token survives longer than this regardless of activity |
 
-- Immediately replace the old JWT in your local storage (e.g., localStorage on web, Hive or FlutterSecureStorage on mobile) with the new token from the header.
-- Log a message for debugging purposes, e.g., "Successfully refreshed and stored new auth token."
+> **What this means in practice:** a user who opens the app at least once every
+> 24 h will never be logged out — each visit extends the session by another 24 h
+> via the `X-Access-Token` sliding window. The 1-year ceiling prevents truly
+> stale sessions from surviving forever.
 
-### 2. On API Error (Status 401 Unauthorized)
+---
 
-When an API call fails with a 401 Unauthorized status, it means the token is invalid or has definitively expired (and the grace period, if any, has passed).
+## Two mechanisms, one goal
 
-**A. Trigger Logout:** This is a hard failure. The application must treat this as a logout event.
+The backend provides two independent paths for clients to stay authenticated.
+Both should be implemented; each covers a different failure mode.
 
-**B. Clear All Session Data:**
+### Mechanism 1 — Sliding session header (server-push)
 
-- Delete the expired JWT from local storage.
-- Delete any stored user profile information.
-- Clear any other session-related state.
+On any **successful (2xx) response** where the token is within the 15-minute
+refresh window, the backend sets `X-Access-Token` in the response headers.
+The client must read this header and replace its stored token immediately.
 
-**C. Redirect to Login:**
+This is the primary keep-alive path for active users. It requires zero extra
+network calls.
 
-- Forcefully navigate the user to the login screen.
-- Display a clear message, such as: "Your session has expired. Please log in again."
+**API contract:**
+```
+Response header (when token is nearing expiry):
+  X-Access-Token: JWT eyJ...
+  Access-Control-Expose-Headers: X-Access-Token
+```
 
-## Platform-Specific Code Examples
+The new token value already includes the `JWT ` scheme prefix. Strip it before
+storage; re-add it when constructing `Authorization` headers.
 
-### For Flutter (in BaseRepository or HTTP client wrapper)
+### Mechanism 2 — Explicit refresh endpoint (client-pull)
 
-```dart
-// In your base_repository.dart or wherever you handle http.Response
+For cases where the client detects a locally expired token **before** making a
+request (e.g. on app resume after a long idle period), there is a dedicated
+refresh endpoint.
 
-Future<http.Response> makeRequest(String url, ...) async {
-  // ... existing request logic ...
-  final response = await http.get(uri, headers: authHeaders);
+**Request:**
+```
+POST /api/v2/users/token/refresh
+Authorization: JWT <expired-or-expiring-token>
+Content-Type: application/json
+```
 
-  // After getting a successful response:
-  if (response.statusCode >= 200 && response.statusCode < 300) {
-    final newAuthToken = response.headers['x-access-token']; // Headers are often lowercase
-    if (newAuthToken != null && newAuthToken.isNotEmpty) {
-      try {
-        // Save the new token to Hive or your preferred storage
-        await HiveRepository.saveData("token", newAuthToken, HiveBoxNames.authBox);
-        loggy.info("Successfully refreshed and stored new auth token.");
-      } catch (e) {
-        loggy.error("Failed to save refreshed token: $e");
-      }
-    }
-  }
-  else if (response.statusCode == 401) {
-    // Handle session expiry
-    // This should trigger a global logout event in your app's state management (e.g., AuthBloc)
-    // For example: context.read<AuthBloc>().add(LogoutEvent());
-  }
-
-  return response;
+**Success response (200):**
+```json
+{
+  "success": true,
+  "token": "eyJ...",
+  "expiresIn": 86400
 }
 ```
 
-### For Next.js (in an Axios interceptor or API client utility)
+**Failure response (401 or 4xx):** the token is beyond the grace period and
+cannot be recovered. The client must log the user out.
 
-```javascript
-// In your api.js or wherever you configure Axios
+> Always use `Authorization: JWT <token>` — not `Authorization: Bearer <token>`.
+> The auth-service only recognises the `JWT` scheme.
 
-import axios from "axios";
+---
 
-const apiClient = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
-});
+## The logout failure chain
 
-// Add a response interceptor
-apiClient.interceptors.response.use(
-  (response) => {
-    // On successful response, check for the new token
-    const newToken = response.headers["x-access-token"];
-    if (newToken) {
-      console.log("Successfully refreshed and storing new auth token.");
-      // Replace the token in localStorage or your state management
-      localStorage.setItem("authToken", newToken);
-      // If you store the token in memory, update it there as well
-      apiClient.defaults.headers.common["Authorization"] = `JWT ${newToken}`;
-    }
-    return response;
-  },
-  (error) => {
-    // On error, check for 401 Unauthorized
-    if (error.response && error.response.status === 401) {
-      console.error("Session expired. Logging out.");
-      // Trigger logout logic
-      // For example:
-      // 1. Clear local storage
-      localStorage.removeItem("authToken");
-      localStorage.removeItem("userProfile");
-      // 2. Redirect to login page
-      window.location.href = "/user/login?session_expired=true";
-    }
-    return Promise.reject(error);
-  }
-);
+When a user is unexpectedly logged out, the failure is almost always one step
+in this chain. Use this as a diagnostic checklist:
 
-export default apiClient;
+```
+1. Client checks local token before request
+       │
+       ├─ Token not expired locally → skip to step 3
+       └─ Token expired locally → call POST /api/v2/users/token/refresh
+                                        │
+                                        ├─ 200 → store new token → proceed
+                                        └─ non-200 → fall back to stored token
+                                                            │
+2. Request is made with stored (expired) token
+       │
+3. Server checks token
+       │
+       ├─ exp + grace_period > now → server issues X-Access-Token silently → 200
+       └─ exp + grace_period < now → 401 "Your session has expired"
+                                            │
+4. Client handles 401
+       │
+       ├─ Retry with refreshed token (if not already retried) → back to step 3
+       └─ No retry / refresh failed → trigger logout
 ```
 
-## Conclusion
+The most common cause of unexpected logouts is the **client not reading and
+storing `X-Access-Token`** on 2xx responses. If the sliding session update is
+missed, the stored token is never extended and expires normally after 24 h.
 
-By following this guide, your applications will provide a secure and seamless user experience, gracefully handling token expirations without any disruption.
+---
+
+## Per-app implementation status and what to do
+
+### Mobile — `airqo-frontend/src/mobile`
+
+**Status: both mechanisms implemented.**
+
+| Component | File | What it does |
+|---|---|---|
+| `AuthTokenStorage.saveTokenFromHeaders()` | `auth/services/auth_token_storage.dart` | Reads `x-access-token` on every 2xx response (Mechanism 1) |
+| `AuthHelper.refreshTokenIfNeeded()` / `_doRefresh()` | `auth/services/auth_helper.dart` | Calls `/api/v2/users/token/refresh` if local token is expired (Mechanism 2); serialises concurrent refresh calls |
+| `BaseRepository._getToken()` | `shared/repository/base_repository.dart` | Calls `refreshTokenIfNeeded()` before every request; falls back to stored token if refresh fails |
+| `BaseRepository._handleTokenRefresh()` | same | Calls `saveTokenFromHeaders()` on every 2xx |
+| `BaseRepository._isSessionRelated401()` | same | Distinguishes JWT 401s from API-key 401s before triggering logout |
+| `GlobalAuthManager.notifySessionExpired()` | `shared/repository/global_auth_manager.dart` | Fires `SessionExpired` event at most once per session; subsequent concurrent 401s are deduplicated |
+
+**If users are still being logged out:** the failure is almost certainly in
+`AuthHelper._doRefresh()`. Check whether `POST /api/v2/users/token/refresh`
+is returning 200 for your environment. If it returns non-200, the fallback
+path uses the stored expired token → 401 → logout.
+
+---
+
+### Platform — `airqo-frontend/src/platform`
+
+**Status: Mechanism 2 implemented. Mechanism 1 (X-Access-Token) not read.**
+
+The `ApiClient` class in `shared/services/apiClient.ts` has:
+
+- **Request interceptor:** if the token expires within 2 minutes (`JWT_REFRESH_SKEW_MS = 120 000`), it calls `_refreshAuthToken()` → `POST /api/v2/users/token/refresh` before the request goes out.
+- **Response interceptor (401):** on a 401, retries the original request once with a freshly refreshed token (`_retry` guard prevents loops). Falls back to dispatching `auth:unauthorized` on the window if the retry also fails.
+- **Concurrent refresh queue:** a `_pendingQueue` ensures that multiple simultaneous requests all wait for one shared refresh instead of issuing duplicates.
+- **Custom events:** dispatches `auth:token-refreshed` (token updated) and `auth:unauthorized` (session terminated) on `window` — listen for these at the app root to drive UI state (e.g. redirect to login).
+
+**Missing: `X-Access-Token` is not read from 2xx responses.** The response
+interceptor handles performance tracking and error logging but does not call
+`saveTokenFromHeaders` or equivalent. Add reading of `response.headers['x-access-token']`
+in the success branch of the response interceptor to enable Mechanism 1.
+
+**Token format note:** tokens are normalised through `normalizeOAuthAccessToken()`
+before use. The `Authorization` header is always constructed as `JWT ${token}`.
+
+---
+
+### Vertex — `airqo-frontend/src/vertex`
+
+**Status: neither mechanism fully implemented.**
+
+The `createAxiosInstance()` in `core/apis/axiosConfig.ts` has:
+
+- **Request interceptor:** reads `session.accessToken` from NextAuth and sets
+  `config.headers['Authorization'] = token`. The token value from NextAuth
+  may already include `JWT ` as a prefix — verify that the final header is
+  `Authorization: JWT eyJ...` and not `Authorization: JWT JWT eyJ...`.
+- **Response interceptor:** detects `x-access-token` in the response and logs
+  a warning: *"Received a refreshed auth token, but client-side update is not
+  implemented. The new token will be ignored."* — this is a known stub.
+- **On 401:** calls `clearSessionData()` and redirects to `/login?session_expired=true`.
+  There is no refresh attempt before logging out.
+
+**What needs to be added:**
+1. In the response interceptor success branch, store the `x-access-token` value
+   (Mechanism 1) — replacing the logged warning with actual storage.
+2. On 401, attempt `POST /api/v2/users/token/refresh` once before triggering
+   logout (Mechanism 2). Only redirect if the refresh also fails.
+
+---
+
+### Beacon — `airqo-frontend/src/beacon`
+
+**Status: no session refresh mechanism.**
+
+Beacon uses native `fetch` calls in `lib/api.js` with `authService.getToken()`
+for the token. There is no interceptor layer, no `X-Access-Token` handling, and
+no explicit refresh call. Most internal routes are proxied through Next.js API
+routes (`/api/devices/...`), which may handle auth server-side.
+
+**What needs to be added depends on architecture:**
+- If Beacon proxies all AirQo API calls through its own Next.js API routes,
+  token refresh should be handled server-side in those route handlers, reading
+  `X-Access-Token` from the upstream AirQo API response and forwarding it to
+  the browser client.
+- If Beacon makes direct browser-to-API calls, a centralised fetch wrapper
+  (analogous to `BaseRepository` on mobile or `ApiClient` on platform) is
+  needed, implementing both mechanisms.
+
+---
+
+## Quick reference
+
+### Authorization header format
+
+```
+Authorization: JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+Never use `Bearer`. The auth-service only accepts the `JWT` scheme.
+
+### Sliding session — what to read on every 2xx response
+
+```
+X-Access-Token: JWT eyJ...
+```
+
+Strip the `JWT ` prefix before storing; prepend it again when constructing
+the `Authorization` header.
+
+### Explicit refresh endpoint
+
+```
+POST /api/v2/users/token/refresh
+Authorization: JWT <current-or-expired-token>
+
+→ 200: { "success": true, "token": "eyJ...", "expiresIn": 86400 }
+→ 401: session cannot be recovered — log the user out
+```
+
+### On 401 from a non-refresh endpoint
+
+1. Was this a first attempt? → call `POST /api/v2/users/token/refresh`, then retry.
+2. Was this already a retry, or did the refresh also 401? → log the user out.
+
+Do not redirect to login on every 401 without attempting a refresh first —
+that is the primary cause of users being logged out prematurely.

--- a/src/auth-service/docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md
+++ b/src/auth-service/docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md
@@ -1,0 +1,310 @@
+# API Token Reinstatement Guide
+
+**Version:** 1.1 — Last updated: 2026-06-17
+
+## Background
+
+API tokens can be automatically suspended by the behavioural anomaly detector
+in `utils/token.util.js`. The detector scores each token on two signals:
+
+| Signal | Score delta | Suspend threshold |
+|---|---|---|
+| User-Agent change between requests | +2 | 10 (env: `ANOMALY_SUSPEND_THRESHOLD`) |
+| Hourly rate spike (> 5× 7-day average) | +3 | same |
+
+When the cumulative `anomaly_score` reaches the threshold, the token's
+`request_pattern.auto_suspended` is set to `true` and an email is sent to the
+owner. All subsequent requests using that token receive **401 Unauthorized**
+immediately, before any other checks run.
+
+Legitimate service accounts — IoT sensor fleets, server-side apps, mobile
+backend tokens — are especially prone to false positives because they often
+span multiple devices or User-Agent strings. The fix is to reinstate the token
+and mark it as a service account (`bypass_anomaly_detection: true`).
+
+---
+
+## Who can perform reinstatement
+
+The PATCH endpoint enforces two independent access controls:
+
+### Ownership check (all callers)
+
+Any authenticated user can reinstate their **own** token. The endpoint verifies
+that the JWT's user ID matches the `user_id` on the client linked to the token
+being patched. A mismatch returns **403 Forbidden** — no other information is
+disclosed.
+
+Super-admins (see below) bypass this check and can patch any token.
+
+### Admin-only fields
+
+`bypass_anomaly_detection` can only be set by a user whose email is in the
+`SUPER_ADMIN_EMAIL_ALLOWLIST` environment variable:
+
+```
+SUPER_ADMIN_EMAIL_ALLOWLIST=alice@airqo.net,bob@airqo.net
+```
+
+Parsed as a comma-separated list in
+[`config/core/static-lists.js`](../../../config/core/static-lists.js).
+Non-admin JWTs attempting to set this field have it silently dropped — the rest
+of the PATCH still proceeds.
+
+### Permission summary
+
+| Action | Token owner | Super-admin |
+|---|---|---|
+| Reinstate own token (`auto_suspended: false`) | ✅ | ✅ |
+| Reinstate another user's token | ❌ 403 | ✅ |
+| Set `bypass_anomaly_detection` | ❌ (field silently dropped) | ✅ |
+
+### Audit trail
+
+Every change to `request_pattern` or `bypass_anomaly_detection` is logged at
+`INFO` level with the caller's email, token ID, client ID, and the exact fields
+changed. Check the auth-service application logs to confirm a reinstatement was
+applied and by whom.
+
+**Obtaining an admin JWT:** Log in to `analytics.airqo.net`, open DevTools →
+Network, make any API call, and copy the `Authorization` header value. It looks
+like `JWT eyJ...`.
+
+---
+
+## Known traps — read before starting
+
+**`token_status: "active"` does not mean the token is unsuspended.**
+The `GET /api/v2/users/tokens/:token` endpoint computes `token_status` solely
+from the token's `expires` date — a suspended token with a future expiry still
+shows `token_status: "active"`. Always check `request_pattern.auto_suspended`
+directly (Step 2 below).
+
+**A PATCH that returns `success: true` may have changed nothing.**
+Sending `auto_suspended` as a flat top-level field — `{"auto_suspended": false}`
+— is silently dropped by Mongoose's strict schema mode. The API still returns
+`"success": true` and bumps `updatedAt`, but the field is never written.
+Always use the nested form and verify the response body (Step 3 below).
+
+**Token expiry is unrelated to suspension.**
+`verifyToken` never loads the `expires` field during auth-request verification.
+A token with an August expiry date can still be fully blocked by
+`auto_suspended: true`.
+
+---
+
+## Step 1 — Find the full token value
+
+The token value shown in suspension alert emails is **masked** (e.g.
+`ZPH6CW1J...F3NV`). You need the full plaintext string.
+
+Retrieve it from the admin client endpoint using the client ID, or search by
+client name or owner email:
+
+```bash
+# By client ID
+curl -s \
+  "https://api.airqo.net/api/v2/users/clients/<CLIENT_ID>" \
+  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
+  | jq '.access_token.token'
+
+# By owner email — lists all clients
+curl -s \
+  "https://api.airqo.net/api/v2/users/clients?email=<OWNER_EMAIL>" \
+  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
+  | jq '.[].access_token | {name, token, auto_suspended: .request_pattern.auto_suspended}'
+```
+
+For service deployments the token may also be in a Kubernetes secret:
+
+```bash
+kubectl get secret -n production <secret-name> \
+  -o jsonpath='{.data.AIRQO_API_TOKEN}' | base64 -d
+```
+
+---
+
+## Step 2 — Confirm and inspect the suspension
+
+Read `request_pattern` directly from the client endpoint. This is the
+authoritative source.
+
+```bash
+curl -s \
+  "https://api.airqo.net/api/v2/users/clients/<CLIENT_ID>" \
+  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
+  | jq '.access_token | {
+      auto_suspended:    .request_pattern.auto_suspended,
+      anomaly_score:     .request_pattern.anomaly_score,
+      suspension_reason: .request_pattern.suspension_reason,
+      suspended_at:      .request_pattern.suspended_at,
+      bypass:            .bypass_anomaly_detection
+    }'
+```
+
+**Decision table:**
+
+| `auto_suspended` | `bypass_anomaly_detection` | Action |
+|---|---|---|
+| `true` | `false` | Reinstate (Step 3) then set bypass (Step 4) |
+| `true` | `true` | Reinstate only (Step 3) — bypass already set |
+| `false` | `false` | Token not suspended — investigate other gates (IP block? Client inactive? Scope?) |
+| `false` | `true` | No action needed |
+
+Secondary smoke-test using a documented public endpoint (confirms but does not diagnose):
+
+```bash
+# Cohort-based access (partners and organisations)
+curl -s -o /dev/null -w "%{http_code}" \
+  "https://api.airqo.net/api/v2/devices/measurements/cohorts/<COHORT_ID>?token=<TOKEN_VALUE>"
+
+# Grid-based access (cities and municipalities)
+curl -s -o /dev/null -w "%{http_code}" \
+  "https://api.airqo.net/api/v2/devices/measurements/grids/<GRID_ID>?token=<TOKEN_VALUE>"
+
+# 401 → suspended or invalid    200 or 429 → active
+```
+
+Reference: [Recent Measurements (Cohort)](https://docs.airqo.net/api/for-partners/recent-measurements) ·
+[Recent Measurements (Grid)](https://docs.airqo.net/api/for-cities/recent-measurements)
+
+---
+
+## Step 3 — Reinstate the token
+
+The body **must** nest `auto_suspended` inside `request_pattern`. The flat form
+is silently ignored — see "Known traps" above.
+
+```bash
+curl -s -X PATCH \
+  "https://api.airqo.net/api/v2/users/tokens/<TOKEN_VALUE>" \
+  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{ "request_pattern": { "auto_suspended": false } }'
+```
+
+**Verify the response body** — not just the top-level message:
+
+```json
+{
+  "message": "Successfully updated the token's metadata",
+  "updated_token": {
+    "request_pattern": { "auto_suspended": false },
+    ...
+  }
+}
+```
+
+If `updated_token.request_pattern.auto_suspended` is still `true`, the body
+shape was wrong or the wrong token value was used. Re-check and retry.
+
+> `updatedAt` ticks forward on every PATCH regardless of whether any field
+> actually changed — a bumped `updatedAt` alone does **not** confirm
+> reinstatement.
+
+---
+
+## Step 4 — Mark service accounts as bypass (admin only)
+
+For any token that legitimately spans multiple devices, User-Agent strings, or
+server-side processes — IoT fleets, mobile backend tokens, shared integrations —
+set `bypass_anomaly_detection: true` immediately after reinstatement, before the
+application resumes traffic. This disables all behavioural scoring permanently
+so the token cannot be auto-suspended again by rate spikes or UA changes.
+
+This field requires the caller's JWT email to be in `SUPER_ADMIN_EMAIL_ALLOWLIST`.
+A non-admin JWT receives 403 even if the rest of the PATCH body is valid.
+
+```bash
+curl -s -X PATCH \
+  "https://api.airqo.net/api/v2/users/tokens/<TOKEN_VALUE>" \
+  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{ "bypass_anomaly_detection": true }'
+```
+
+Confirm it is persisted in the response:
+
+```json
+{ "updated_token": { "bypass_anomaly_detection": true, ... } }
+```
+
+> **Security tradeoff:** bypass disables *all* behavioural anomaly scoring for
+> this token — both UA-change and rate-spike signals. Honeypot traps, IP
+> blacklisting, and manual suspension remain active. Notify the token owner
+> when this flag is applied (see Step 6).
+
+---
+
+## Step 5 — Smoke-test
+
+Use whichever documented public endpoint matches the token's access pattern:
+
+```bash
+# Cohort-based access (partners and organisations)
+curl -s -o /dev/null -w "%{http_code}" \
+  "https://api.airqo.net/api/v2/devices/measurements/cohorts/<COHORT_ID>?token=<TOKEN_VALUE>"
+
+# Grid-based access (cities and municipalities)
+curl -s -o /dev/null -w "%{http_code}" \
+  "https://api.airqo.net/api/v2/devices/measurements/grids/<GRID_ID>?token=<TOKEN_VALUE>"
+
+# Expect: 200 (or 429 if rate-limited, but not 401)
+```
+
+Re-query the client endpoint and confirm both `auto_suspended: false` and
+`bypass_anomaly_detection: true` are persisted before notifying the owner.
+
+---
+
+## Step 6 — Notify the token owner
+
+Send a brief message covering:
+
+1. **What happened** — the token was suspended by the anomaly detector due to
+   `<suspension_reason>` (from `request_pattern.suspension_reason`). This is a
+   false positive caused by [multi-device usage / UA variation / rate spike].
+2. **What was done** — it has been reinstated and marked as a service account
+   so the same heuristic will not trigger again.
+3. **Security recommendation** — because behavioural monitoring is now reduced
+   for this token, they should consider enabling **"Require client secret on
+   every request"** on their API client card under Settings › API. When enabled,
+   every request must also send `X-Client-Secret: <secret>` in the headers,
+   providing defense-in-depth that does not depend on heuristics.
+4. **Invite them to test** and report any remaining 401s.
+
+---
+
+## Troubleshooting
+
+**PATCH returns `success: true` but token is still blocked.**
+Inspect `updated_token.request_pattern.auto_suspended` in the response body. If
+it is still `true`, the body was sent flat instead of nested. Resend with the
+nested form (`{ "request_pattern": { "auto_suspended": false } }`) and verify
+the field in the response body.
+
+**403 on the PATCH.**
+The JWT email is not in `SUPER_ADMIN_EMAIL_ALLOWLIST` on the auth-service
+production env. Ask a super-admin to perform the PATCH, or have DevOps add the
+email to the env var.
+
+**`token_status` says `"active"` but the token still 401s.**
+`token_status` only reflects expiry. Check `request_pattern.auto_suspended` on
+the client endpoint (Step 2).
+
+**Token has a future expiry date but is still blocked.**
+Expiry and suspension are independent. `verifyToken` never loads `expires`
+during auth-request verification. Fix the suspension via Step 3.
+
+**Smoke test returns 500, not 200 or 401.**
+A gateway-level 500 (especially an HTML error page) indicates an
+infrastructure issue upstream of the application — nginx, ingress, or a
+cold-start timeout. Retry; these are usually transient. If it persists, check
+device-registry and auth-service logs around that timestamp.
+
+**Token gets suspended again shortly after reinstatement.**
+`bypass_anomaly_detection: true` was not set, or was set after the application
+had already resumed traffic. The anomaly detector runs asynchronously on every
+passing request — a handful of UA-mismatched calls can push `anomaly_score`
+back above the threshold before the bypass write lands. Always apply bypass
+immediately after reinstatement, before the application makes any calls.

--- a/src/auth-service/docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md
+++ b/src/auth-service/docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md
@@ -213,7 +213,7 @@ application resumes traffic. This disables all behavioural scoring permanently
 so the token cannot be auto-suspended again by rate spikes or UA changes.
 
 This field requires the caller's JWT email to be in `SUPER_ADMIN_EMAIL_ALLOWLIST`.
-A non-admin JWT receives 403 even if the rest of the PATCH body is valid.
+A non-admin JWT will have this field silently dropped — the PATCH still returns 200 if other fields are valid.
 
 ```bash
 curl -s -X PATCH \

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -754,7 +754,7 @@ module.exports = {
     const reasonLine = suspensionReason
       ? `<p><strong>Reason detected:</strong> ${escapeHtml(suspensionReason)}</p>`
       : "";
-    const API_SETTINGS_URL = `${constants.ANALYTICS_BASE_URL}/user/settings`;
+    const API_SETTINGS_URL = `${constants.ANALYTICS_BASE_URL}/user/profile`;
     const content = `
     <tr>
       <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1261,12 +1261,15 @@ const token = {
 
         if (!isEmpty(updatedToken)) {
           // Audit trail — log every sensitive field change with caller identity.
+          // Read from updatedToken (what Mongo persisted) not from update (the
+          // request payload), so the log reflects actual stored values after any
+          // Mongoose coercion or subdocument replacement.
           const auditFields = [];
           if (update.request_pattern !== undefined) {
-            auditFields.push(`request_pattern=${JSON.stringify(update.request_pattern)}`);
+            auditFields.push(`request_pattern=${JSON.stringify(updatedToken.request_pattern)}`);
           }
           if (update.bypass_anomaly_detection !== undefined) {
-            auditFields.push(`bypass_anomaly_detection=${update.bypass_anomaly_detection}`);
+            auditFields.push(`bypass_anomaly_detection=${updatedToken.bypass_anomaly_detection}`);
           }
           if (auditFields.length > 0) {
             securityAuditLogger.info(

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -42,6 +42,7 @@ const moment = require("moment-timezone");
 const ObjectId = mongoose.Types.ObjectId;
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- token-util`);
+const securityAuditLogger = log4js.getLogger("token-security-audit");
 
 const async = require("async");
 const { Kafka } = require("kafkajs");
@@ -1201,7 +1202,42 @@ const token = {
           }),
         );
       } else {
-        const tokenId = tokenDetails[0]._id;
+        const tokenRecord = tokenDetails[0];
+        const tokenId = tokenRecord._id;
+
+        // Ownership check — the requesting user must own the client that issued
+        // this token, OR be a super-admin.  Prevents any authenticated user from
+        // reinstating (or otherwise patching) a token they do not own.
+        const callerEmail = ((request.user && request.user.email) || "").toLowerCase();
+        const isAdmin = (constants.SUPER_ADMIN_EMAIL_ALLOWLIST || [])
+          .some(e => e.toLowerCase() === callerEmail);
+
+        if (!isAdmin) {
+          const linkedClient = await ClientModel(tenant)
+            .findById(tokenRecord.client_id)
+            .select("user_id")
+            .lean();
+
+          const ownerId = linkedClient && linkedClient.user_id
+            ? linkedClient.user_id.toString()
+            : null;
+          const callerId = request.user && (request.user._id || request.user.id)
+            ? (request.user._id || request.user.id).toString()
+            : null;
+
+          if (!ownerId || !callerId || ownerId !== callerId) {
+            securityAuditLogger.warn(
+              `🚫 Ownership check failed on token update — caller=${callerEmail} ` +
+              `tokenId=${tokenId} clientId=${tokenRecord.client_id}`
+            );
+            return next(
+              new HttpError("Forbidden", httpStatus.FORBIDDEN, {
+                message: "You do not have permission to update this token",
+              }),
+            );
+          }
+        }
+
         let update = Object.assign({}, body);
         if (update.token) {
           delete update.token;
@@ -1215,9 +1251,6 @@ const token = {
         // bypass_anomaly_detection is admin-only — non-super-admins cannot set it
         // via the public PATCH endpoint even if the validator accepts the field.
         if (update.bypass_anomaly_detection !== undefined) {
-          const userEmail = ((request.user && request.user.email) || "").toLowerCase();
-          const isAdmin = (constants.SUPER_ADMIN_EMAIL_ALLOWLIST || [])
-            .some(e => e.toLowerCase() === userEmail);
           if (!isAdmin) {
             delete update.bypass_anomaly_detection;
           }
@@ -1227,6 +1260,22 @@ const token = {
           .lean();
 
         if (!isEmpty(updatedToken)) {
+          // Audit trail — log every sensitive field change with caller identity.
+          const auditFields = [];
+          if (update.request_pattern !== undefined) {
+            auditFields.push(`request_pattern=${JSON.stringify(update.request_pattern)}`);
+          }
+          if (update.bypass_anomaly_detection !== undefined) {
+            auditFields.push(`bypass_anomaly_detection=${update.bypass_anomaly_detection}`);
+          }
+          if (auditFields.length > 0) {
+            securityAuditLogger.info(
+              `Token metadata updated — caller=${callerEmail} ` +
+              `tokenId=${tokenId} clientId=${tokenRecord.client_id} ` +
+              `changes=[${auditFields.join(", ")}]`
+            );
+          }
+
           return {
             success: true,
             message: "Successfully updated the token's metadata",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Closes two security gaps on the `PATCH /api/v2/users/tokens/:token` endpoint and adds
operational visibility for sensitive token operations:

- **Ownership check** (`utils/token.util.js`) — `updateAccessToken` now verifies the
  requesting user owns the client linked to the token being patched. Non-owners receive
  403 Forbidden. Super-admins (via `SUPER_ADMIN_EMAIL_ALLOWLIST`) bypass this check and
  can patch any token for support purposes.
- **Audit trail** (`utils/token.util.js`) — every successful change to
  `request_pattern` or `bypass_anomaly_detection` is logged with the caller's email,
  token ID, client ID, and exact field values after the write succeeds.
- **Dedicated Slack alerts** (`config/log4js.js`) — a new `token-security-audit` log4js
  category with a `slackInfo` appender (INFO-level filter) routes all audit events
  — including successful admin changes, not just failures — to Slack without affecting
  any other logger.
- **Email link fix** (`utils/common/email.msgs.util.js`) — the "Settings › API" link
  in the auto-suspension email pointed to `/user/settings` (non-existent route);
  corrected to `/user/profile` where the API tab actually lives.
- **Docs** — new `TOKEN_REINSTATEMENT_GUIDE.md` runbook and an updated
  `SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md` with per-app implementation status, accurate
  token timing, and a logout failure-chain diagnostic.

### Why is this change needed?

- **No ownership check existed** — any registered AirQo user with a valid JWT could
  reinstate or modify another user's suspended token if they knew the token string.
- **No audit trail existed** — there was no record of who changed which token's security
  fields or when, making incident investigation impossible.
- **Security events were invisible in Slack** — ownership failures and admin token
  changes went only to the file log, buried alongside routine traffic.
- **The email link was broken** — users clicking "Settings › API" in the suspension
  alert were sent to a 404 route instead of their API client card.
- **The reinstatement runbook was app-specific and contained undocumented traps** — the
  flat-body silent no-op (sending `{"auto_suspended": false}` instead of the nested
  form) caused three consecutive failed reinstatement attempts that looked successful,
  and the `token_status: "active"` field on `GET /tokens/:token` misleadingly shows
  "active" even for a fully suspended token.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix (email link `/user/settings` → `/user/profile`)
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement (ownership check, audit trail, Slack routing)
- [x] :books: Documentation update (reinstatement runbook, session refresh guide)
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/auth-service` — `utils/token.util.js`, `config/log4js.js`,
  `utils/common/email.msgs.util.js`,
  `docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md`,
  `docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Verified against the live token PATCH endpoint and the documented public measurements
API (`GET /api/v2/devices/measurements/cohorts/:id` and
`GET /api/v2/devices/measurements/grids/:id`):

| Scenario | Expected | Observed |
|---|---|---|
| Token owner sends `{ "request_pattern": { "auto_suspended": false } }` | 200, field updated | ✅ |
| Non-owner sends same PATCH | 403 Forbidden | ✅ |
| Super-admin patches another user's token | 200, field updated | ✅ |
| Non-admin sends `{ "bypass_anomaly_detection": true }` | 200, field silently dropped | ✅ |
| Super-admin sends `{ "bypass_anomaly_detection": true }` | 200, field persisted | ✅ |
| Cohort measurements endpoint with reinstated token | 200 | ✅ |
| Cohort measurements endpoint with still-suspended token | 401 | ✅ |
| Audit log entry on sensitive change | INFO in `token-security-audit` logger | ✅ |
| Ownership failure | WARN in `token-security-audit` logger | ✅ |

---

## :boom: Breaking Changes

- [x] **Has breaking changes**

The ownership check on `PATCH /api/v2/users/tokens/:token` is a **behaviour change**.
Previously any authenticated user could patch any token. Non-owners now receive
`403 Forbidden`.

**Who is affected:** any internal tool, script, or integration that uses a JWT
belonging to a different user than the token owner when calling this endpoint. Super-admin
JWTs are unaffected. Token owners patching their own tokens are unaffected.

**Migration:** ensure the JWT used in PATCH calls belongs to the same user account that
created the API client, or use a super-admin JWT for cross-account operations.

---

## :memo: Additional Notes

- The `slackInfo` appender is wired **only** to the `token-security-audit` category.
  No other logger is affected, so there is no risk of INFO-level Slack noise from
  the general codebase.
- In development (`isDevelopment() === true`) the `token-security-audit` category is
  absent from the dev config, so no Slack calls are made locally.
- The `securityAuditLogger` uses `log4js.getLogger("token-security-audit")` (exact
  category name match) — not the `${ENVIRONMENT} -- ...` prefix convention used by
  general loggers, which fall through to `default`. This follows the same pattern as
  `log4js.getLogger("ops-alerts")` in `utils/transaction.util.js`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ownership verification for token update operations with audit logging.

* **Documentation**
  * Added token refresh mechanism guide documenting sliding-session behavior and client integration requirements.
  * Added API token reinstatement guide with suspension recovery procedures and troubleshooting.

* **Bug Fixes**
  * Corrected navigation link in token suspension notification emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->