### PR TITLE
Rewrite token and session guides for API consumers, removing internal implementation details

### DIFF
--- a/src/auth-service/docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md
+++ b/src/auth-service/docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md
@@ -101,13 +101,19 @@ if (response.statusCode >= 200 && response.statusCode < 300) {
 
 **JavaScript / TypeScript:**
 ```js
-// In your Axios response interceptor or fetch wrapper
-const newToken = response.headers['x-access-token'];
+// Axios response interceptor
+const newToken = response.headers['x-access-token'];        // Axios: plain object
 if (newToken) {
   const clean = newToken.replace(/^JWT\s+/i, '').trim();
   localStorage.setItem('authToken', clean);
-  // Update your HTTP client's default Authorization header
   apiClient.defaults.headers.common['Authorization'] = `JWT ${clean}`;
+}
+
+// Native fetch (response.headers is a Headers object — use .get())
+const newToken = response.headers.get('x-access-token');    // fetch: Headers API
+if (newToken) {
+  const clean = newToken.replace(/^JWT\s+/i, '').trim();
+  localStorage.setItem('authToken', clean);
 }
 ```
 
@@ -155,7 +161,12 @@ async function getValidToken() {
   const token = localStorage.getItem('authToken');
   if (!token) return null;
 
-  const payload = JSON.parse(atob(token.split('.')[1]));
+  // JWT payloads are base64url-encoded — normalise before decoding
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/').padEnd(
+    Math.ceil(base64Url.length / 4) * 4, '='
+  );
+  const payload = JSON.parse(atob(base64));
   const isExpired = payload.exp * 1000 < Date.now();
 
   if (isExpired) {

--- a/src/auth-service/docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md
+++ b/src/auth-service/docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md
@@ -1,99 +1,70 @@
-# Sliding Session & Token Refresh Guide
+# Session Management & Token Refresh
 
-**Version:** 2.0 — Last updated: 2026-06-17
+**Version:** 3.0 — Last updated: 2026-06-17
 
 ## Who this is for
 
-Developers working on any AirQo client that makes authenticated API calls:
-
-| App | Stack | HTTP layer |
-|---|---|---|
-| `airqo-frontend/src/mobile` | Flutter | `http` package + `BaseRepository` |
-| `airqo-frontend/src/platform` | Next.js (TypeScript) | `ApiClient` (Axios) |
-| `airqo-frontend/src/vertex` | Next.js (TypeScript) | Axios (`createAxiosInstance`) |
-| `airqo-frontend/src/beacon` | Next.js (JavaScript) | native `fetch` |
+Developers building applications that authenticate users against the AirQo API
+using JWTs — whether a mobile app, a web dashboard, or a server-side integration.
 
 ---
 
-## How the backend keeps sessions alive
+## How sessions work
 
-The backend (`enhancedJWTAuth` middleware) implements a **three-window model**.
-Every authenticated request passes through all three checks in order:
+When a user logs in to AirQo, they receive a JWT that is valid for **24 hours**.
+The API is designed so that active users never have to log in again, even across
+multiple days — as long as your application correctly handles token renewal.
 
-```
-Client sends JWT
-  │
-  ├─ 1. Signature invalid?
-  │      → 401 "Invalid token: ..."
-  │
-  ├─ 2. exp + GRACE_PERIOD < now?
-  │      → 401 "Your session has expired. Please log in again."
-  │
-  ├─ 3. exp < now + REFRESH_WINDOW?   ← token is valid but nearing expiry
-  │      → issue replacement token silently
-  │        set response header:  X-Access-Token: JWT eyJ...
-  │        set response header:  Access-Control-Expose-Headers: X-Access-Token
-  │        request still succeeds with original token
-  │
-  └─ Proceed with request normally
-```
+The session lifetime is governed by three windows:
 
-### Timing configuration
-
-All values are env vars with these production defaults:
-
-| Env var | Default | Effect |
+| Window | Duration | What happens |
 |---|---|---|
-| `JWT_EXPIRES_IN_SECONDS` | **86 400** (24 h) | Lifetime of every issued JWT |
-| `JWT_REFRESH_WINDOW_SECONDS` | **900** (15 min) | Backend issues a new token on any response when the existing one expires within this window |
-| `JWT_GRACE_PERIOD_SECONDS` | **300** (5 min) | Expired tokens are still accepted for this long after `exp` |
-| `JWT_REFRESH_MAX_AGE_SECONDS` | **31 536 000** (1 yr) | Hard ceiling — no token survives longer than this regardless of activity |
+| **Token lifetime** | 24 hours | The JWT is valid for this long after issue |
+| **Refresh window** | Last 15 minutes of the token's life | The API silently issues a replacement token on any successful response |
+| **Grace period** | 5 minutes after expiry | Requests with an expired token are still accepted; no new token is issued |
+| **Hard ceiling** | 1 year of activity | No session survives longer than this regardless of renewal activity |
 
-> **What this means in practice:** a user who opens the app at least once every
-> 24 h will never be logged out — each visit extends the session by another 24 h
-> via the `X-Access-Token` sliding window. The 1-year ceiling prevents truly
-> stale sessions from surviving forever.
+**In practice:** a user who makes at least one API call every 24 hours will never
+be logged out. Each call within the refresh window extends the session by another
+24 hours automatically.
 
 ---
 
-## Two mechanisms, one goal
+## Two ways tokens are renewed
 
-The backend provides two independent paths for clients to stay authenticated.
-Both should be implemented; each covers a different failure mode.
+The API provides two independent renewal paths. Implementing both gives your
+application the smoothest possible session experience.
 
-### Mechanism 1 — Sliding session header (server-push)
+### 1. Sliding session — automatic renewal on every response
 
-On any **successful (2xx) response** where the token is within the 15-minute
-refresh window, the backend sets `X-Access-Token` in the response headers.
-The client must read this header and replace its stored token immediately.
+Whenever an authenticated request is made while the token is within its final
+15-minute window, the API includes a fresh token in the response:
 
-This is the primary keep-alive path for active users. It requires zero extra
-network calls.
-
-**API contract:**
 ```
-Response header (when token is nearing expiry):
+Response header:
   X-Access-Token: JWT eyJ...
   Access-Control-Expose-Headers: X-Access-Token
 ```
 
-The new token value already includes the `JWT ` scheme prefix. Strip it before
-storage; re-add it when constructing `Authorization` headers.
+Your application must read this header on every successful (2xx) response and
+replace the stored token immediately. This costs zero extra network calls.
 
-### Mechanism 2 — Explicit refresh endpoint (client-pull)
+The value already includes the `JWT ` prefix. Strip it before storage and
+re-add it when building your `Authorization` header.
 
-For cases where the client detects a locally expired token **before** making a
-request (e.g. on app resume after a long idle period), there is a dedicated
-refresh endpoint.
+### 2. Explicit refresh — on-demand renewal before a request
 
-**Request:**
+When your application detects that the stored token has already expired (e.g.
+the user re-opens the app after an overnight idle period), call the refresh
+endpoint **before** making the actual request:
+
 ```
-POST /api/v2/users/token/refresh
+POST https://api.airqo.net/api/v2/users/token/refresh
 Authorization: JWT <expired-or-expiring-token>
 Content-Type: application/json
 ```
 
-**Success response (200):**
+**Success (200):**
 ```json
 {
   "success": true,
@@ -102,167 +73,211 @@ Content-Type: application/json
 }
 ```
 
-**Failure response (401 or 4xx):** the token is beyond the grace period and
-cannot be recovered. The client must log the user out.
+Store the new token and use it for the request you were about to make.
 
-> Always use `Authorization: JWT <token>` — not `Authorization: Bearer <token>`.
-> The auth-service only recognises the `JWT` scheme.
+**Failure (401):** the token is too old to be renewed. The user must log in again.
+
+> Always send `Authorization: JWT <token>`. Using `Bearer` instead of `JWT`
+> will result in a 401 on every request.
 
 ---
 
-## The logout failure chain
+## What to implement
 
-When a user is unexpectedly logged out, the failure is almost always one step
-in this chain. Use this as a diagnostic checklist:
+### On every successful (2xx) API response
 
-```
-1. Client checks local token before request
-       │
-       ├─ Token not expired locally → skip to step 3
-       └─ Token expired locally → call POST /api/v2/users/token/refresh
-                                        │
-                                        ├─ 200 → store new token → proceed
-                                        └─ non-200 → fall back to stored token
-                                                            │
-2. Request is made with stored (expired) token
-       │
-3. Server checks token
-       │
-       ├─ exp + grace_period > now → server issues X-Access-Token silently → 200
-       └─ exp + grace_period < now → 401 "Your session has expired"
-                                            │
-4. Client handles 401
-       │
-       ├─ Retry with refreshed token (if not already retried) → back to step 3
-       └─ No retry / refresh failed → trigger logout
+Check for the `X-Access-Token` header. If present, save the new token and use
+it for all subsequent requests.
+
+**Flutter:**
+```dart
+if (response.statusCode >= 200 && response.statusCode < 300) {
+  final newToken = response.headers['x-access-token'];
+  if (newToken != null && newToken.isNotEmpty) {
+    await storage.write(key: 'auth_token', value: stripJwtPrefix(newToken));
+  }
+}
 ```
 
-The most common cause of unexpected logouts is the **client not reading and
-storing `X-Access-Token`** on 2xx responses. If the sliding session update is
-missed, the stored token is never extended and expires normally after 24 h.
+**JavaScript / TypeScript:**
+```js
+// In your Axios response interceptor or fetch wrapper
+const newToken = response.headers['x-access-token'];
+if (newToken) {
+  const clean = newToken.replace(/^JWT\s+/i, '').trim();
+  localStorage.setItem('authToken', clean);
+  // Update your HTTP client's default Authorization header
+  apiClient.defaults.headers.common['Authorization'] = `JWT ${clean}`;
+}
+```
+
+### Before making a request when the stored token is expired
+
+Check the token expiry locally. If expired, call the refresh endpoint first.
+
+**Flutter:**
+```dart
+Future<String?> getValidToken() async {
+  final token = await storage.read(key: 'auth_token');
+  if (token == null) return null;
+
+  if (JwtDecoder.isExpired(token)) {
+    final refreshed = await refreshToken(token);
+    return refreshed; // null if refresh failed — let the 401 handle it
+  }
+
+  return token;
+}
+
+Future<String?> refreshToken(String expiredToken) async {
+  final response = await http.post(
+    Uri.parse('https://api.airqo.net/api/v2/users/token/refresh'),
+    headers: {
+      'Authorization': 'JWT $expiredToken',
+      'Content-Type': 'application/json',
+    },
+  );
+
+  if (response.statusCode == 200) {
+    final body = json.decode(response.body);
+    final newToken = body['token'] as String;
+    await storage.write(key: 'auth_token', value: newToken);
+    return newToken;
+  }
+
+  return null; // Token too old — user must log in again
+}
+```
+
+**JavaScript / TypeScript:**
+```js
+async function getValidToken() {
+  const token = localStorage.getItem('authToken');
+  if (!token) return null;
+
+  const payload = JSON.parse(atob(token.split('.')[1]));
+  const isExpired = payload.exp * 1000 < Date.now();
+
+  if (isExpired) {
+    return await refreshToken(token);
+  }
+
+  return token;
+}
+
+async function refreshToken(expiredToken) {
+  try {
+    const response = await fetch(
+      'https://api.airqo.net/api/v2/users/token/refresh',
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `JWT ${expiredToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (response.ok) {
+      const body = await response.json();
+      const newToken = body.token;
+      localStorage.setItem('authToken', newToken);
+      return newToken;
+    }
+  } catch (_) {}
+
+  return null; // Token too old — user must log in again
+}
+```
+
+### On 401 Unauthorized
+
+A 401 from a non-refresh endpoint means the token was rejected. Before logging
+the user out, try refreshing once:
+
+```js
+// In your error handler / interceptor
+if (response.status === 401 && !request._alreadyRetried) {
+  request._alreadyRetried = true;
+  const newToken = await refreshToken(getCurrentToken());
+  if (newToken) {
+    request.headers['Authorization'] = `JWT ${newToken}`;
+    return retryRequest(request); // retry original call
+  }
+}
+
+// Refresh failed or already retried — log out
+clearSession();
+redirectToLogin();
+```
 
 ---
 
-## Per-app implementation status and what to do
+## Why users get logged out unexpectedly
 
-### Mobile — `airqo-frontend/src/mobile`
+Unexpected logouts follow one predictable chain. Use this to identify where
+your implementation is breaking:
 
-**Status: both mechanisms implemented.**
+```
+1. App opens — stored token is checked
+   │
+   ├─ Not expired → proceed
+   └─ Expired → call POST /api/v2/users/token/refresh
+                    │
+                    ├─ 200 → store new token → proceed
+                    └─ non-200 → use expired token anyway (fallback)
+                                     │
+2. Request sent with expired token
+   │
+3. Server checks the token
+   │
+   ├─ Within 5-minute grace period → succeeds, may issue X-Access-Token
+   └─ Beyond grace period → 401 "Your session has expired"
+                                 │
+4. Client handles the 401
+   │
+   ├─ Tries refresh → retries original request → succeeds
+   └─ No retry / refresh also fails → logout
+```
 
-| Component | File | What it does |
-|---|---|---|
-| `AuthTokenStorage.saveTokenFromHeaders()` | `auth/services/auth_token_storage.dart` | Reads `x-access-token` on every 2xx response (Mechanism 1) |
-| `AuthHelper.refreshTokenIfNeeded()` / `_doRefresh()` | `auth/services/auth_helper.dart` | Calls `/api/v2/users/token/refresh` if local token is expired (Mechanism 2); serialises concurrent refresh calls |
-| `BaseRepository._getToken()` | `shared/repository/base_repository.dart` | Calls `refreshTokenIfNeeded()` before every request; falls back to stored token if refresh fails |
-| `BaseRepository._handleTokenRefresh()` | same | Calls `saveTokenFromHeaders()` on every 2xx |
-| `BaseRepository._isSessionRelated401()` | same | Distinguishes JWT 401s from API-key 401s before triggering logout |
-| `GlobalAuthManager.notifySessionExpired()` | `shared/repository/global_auth_manager.dart` | Fires `SessionExpired` event at most once per session; subsequent concurrent 401s are deduplicated |
-
-**If users are still being logged out:** the failure is almost certainly in
-`AuthHelper._doRefresh()`. Check whether `POST /api/v2/users/token/refresh`
-is returning 200 for your environment. If it returns non-200, the fallback
-path uses the stored expired token → 401 → logout.
-
----
-
-### Platform — `airqo-frontend/src/platform`
-
-**Status: Mechanism 2 implemented. Mechanism 1 (X-Access-Token) not read.**
-
-The `ApiClient` class in `shared/services/apiClient.ts` has:
-
-- **Request interceptor:** if the token expires within 2 minutes (`JWT_REFRESH_SKEW_MS = 120 000`), it calls `_refreshAuthToken()` → `POST /api/v2/users/token/refresh` before the request goes out.
-- **Response interceptor (401):** on a 401, retries the original request once with a freshly refreshed token (`_retry` guard prevents loops). Falls back to dispatching `auth:unauthorized` on the window if the retry also fails.
-- **Concurrent refresh queue:** a `_pendingQueue` ensures that multiple simultaneous requests all wait for one shared refresh instead of issuing duplicates.
-- **Custom events:** dispatches `auth:token-refreshed` (token updated) and `auth:unauthorized` (session terminated) on `window` — listen for these at the app root to drive UI state (e.g. redirect to login).
-
-**Missing: `X-Access-Token` is not read from 2xx responses.** The response
-interceptor handles performance tracking and error logging but does not call
-`saveTokenFromHeaders` or equivalent. Add reading of `response.headers['x-access-token']`
-in the success branch of the response interceptor to enable Mechanism 1.
-
-**Token format note:** tokens are normalised through `normalizeOAuthAccessToken()`
-before use. The `Authorization` header is always constructed as `JWT ${token}`.
-
----
-
-### Vertex — `airqo-frontend/src/vertex`
-
-**Status: neither mechanism fully implemented.**
-
-The `createAxiosInstance()` in `core/apis/axiosConfig.ts` has:
-
-- **Request interceptor:** reads `session.accessToken` from NextAuth and sets
-  `config.headers['Authorization'] = token`. The token value from NextAuth
-  may already include `JWT ` as a prefix — verify that the final header is
-  `Authorization: JWT eyJ...` and not `Authorization: JWT JWT eyJ...`.
-- **Response interceptor:** detects `x-access-token` in the response and logs
-  a warning: *"Received a refreshed auth token, but client-side update is not
-  implemented. The new token will be ignored."* — this is a known stub.
-- **On 401:** calls `clearSessionData()` and redirects to `/login?session_expired=true`.
-  There is no refresh attempt before logging out.
-
-**What needs to be added:**
-1. In the response interceptor success branch, store the `x-access-token` value
-   (Mechanism 1) — replacing the logged warning with actual storage.
-2. On 401, attempt `POST /api/v2/users/token/refresh` once before triggering
-   logout (Mechanism 2). Only redirect if the refresh also fails.
-
----
-
-### Beacon — `airqo-frontend/src/beacon`
-
-**Status: no session refresh mechanism.**
-
-Beacon uses native `fetch` calls in `lib/api.js` with `authService.getToken()`
-for the token. There is no interceptor layer, no `X-Access-Token` handling, and
-no explicit refresh call. Most internal routes are proxied through Next.js API
-routes (`/api/devices/...`), which may handle auth server-side.
-
-**What needs to be added depends on architecture:**
-- If Beacon proxies all AirQo API calls through its own Next.js API routes,
-  token refresh should be handled server-side in those route handlers, reading
-  `X-Access-Token` from the upstream AirQo API response and forwarding it to
-  the browser client.
-- If Beacon makes direct browser-to-API calls, a centralised fetch wrapper
-  (analogous to `BaseRepository` on mobile or `ApiClient` on platform) is
-  needed, implementing both mechanisms.
+**The most common cause** is not reading the `X-Access-Token` header on
+successful responses. If this header is ignored, the stored token is never
+extended and expires normally after 24 hours, logging out every user who has
+been active for more than a day without triggering a proactive refresh.
 
 ---
 
 ## Quick reference
 
-### Authorization header format
+### Authorization header
 
 ```
 Authorization: JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
-Never use `Bearer`. The auth-service only accepts the `JWT` scheme.
+Use `JWT`, not `Bearer`.
 
-### Sliding session — what to read on every 2xx response
+### Sliding session header (read on every 2xx response)
 
 ```
 X-Access-Token: JWT eyJ...
 ```
 
-Strip the `JWT ` prefix before storing; prepend it again when constructing
-the `Authorization` header.
-
-### Explicit refresh endpoint
+### Refresh endpoint
 
 ```
-POST /api/v2/users/token/refresh
-Authorization: JWT <current-or-expired-token>
+POST https://api.airqo.net/api/v2/users/token/refresh
+Authorization: JWT <token>
 
-→ 200: { "success": true, "token": "eyJ...", "expiresIn": 86400 }
-→ 401: session cannot be recovered — log the user out
+200 → { "success": true, "token": "eyJ...", "expiresIn": 86400 }
+401 → session cannot be recovered — prompt login
 ```
 
-### On 401 from a non-refresh endpoint
+### On 401 from any other endpoint
 
-1. Was this a first attempt? → call `POST /api/v2/users/token/refresh`, then retry.
-2. Was this already a retry, or did the refresh also 401? → log the user out.
+1. Try `POST /api/v2/users/token/refresh` once
+2. On success, retry the original request with the new token
+3. On failure, clear the session and redirect to login
 
-Do not redirect to login on every 401 without attempting a refresh first —
-that is the primary cause of users being logged out prematurely.
+Never redirect to login immediately on a 401 without attempting a refresh —
+this is the most common cause of premature logouts.

--- a/src/auth-service/docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md
+++ b/src/auth-service/docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md
@@ -1,189 +1,71 @@
-# API Token Reinstatement Guide
+# API Token Suspension & Recovery
 
-**Version:** 1.1 — Last updated: 2026-06-17
+**Version:** 2.0 — Last updated: 2026-06-17
 
-## Background
+## Why tokens get suspended
 
-API tokens can be automatically suspended by the behavioural anomaly detector
-in `utils/token.util.js`. The detector scores each token on two signals:
+The AirQo API monitors usage patterns on every token to detect unusual activity.
+A token is automatically suspended when either of the following is detected:
 
-| Signal | Score delta | Suspend threshold |
-|---|---|---|
-| User-Agent change between requests | +2 | 10 (env: `ANOMALY_SUSPEND_THRESHOLD`) |
-| Hourly rate spike (> 5× 7-day average) | +3 | same |
+- **User-Agent change** — the same token is used from different clients or
+  applications in a short window (common signal of token sharing or leakage).
+- **Unusual request rate** — the hourly request volume spikes sharply compared
+  to the token's recent average.
 
-When the cumulative `anomaly_score` reaches the threshold, the token's
-`request_pattern.auto_suspended` is set to `true` and an email is sent to the
-owner. All subsequent requests using that token receive **401 Unauthorized**
-immediately, before any other checks run.
-
-Legitimate service accounts — IoT sensor fleets, server-side apps, mobile
-backend tokens — are especially prone to false positives because they often
-span multiple devices or User-Agent strings. The fix is to reinstate the token
-and mark it as a service account (`bypass_anomaly_detection: true`).
+When a token is suspended you will receive an email with the reason and the
+timestamp of the suspension. All API requests using that token will return
+**401 Unauthorized** until the token is recovered.
 
 ---
 
-## Who can perform reinstatement
+## What the suspension email tells you
 
-The PATCH endpoint enforces two independent access controls:
+The email includes:
 
-### Ownership check (all callers)
+- The masked token value (e.g. `ZPH6CW1J...F3NV`) and its name
+- The time of suspension
+- The reason detected (e.g. "User-Agent change detected")
 
-Any authenticated user can reinstate their **own** token. The endpoint verifies
-that the JWT's user ID matches the `user_id` on the client linked to the token
-being patched. A mismatch returns **403 Forbidden** — no other information is
-disclosed.
-
-Super-admins (see below) bypass this check and can patch any token.
-
-### Admin-only fields
-
-`bypass_anomaly_detection` can only be set by a user whose email is in the
-`SUPER_ADMIN_EMAIL_ALLOWLIST` environment variable:
-
-```
-SUPER_ADMIN_EMAIL_ALLOWLIST=alice@airqo.net,bob@airqo.net
-```
-
-Parsed as a comma-separated list in
-[`config/core/static-lists.js`](../../../config/core/static-lists.js).
-Non-admin JWTs attempting to set this field have it silently dropped — the rest
-of the PATCH still proceeds.
-
-### Permission summary
-
-| Action | Token owner | Super-admin |
-|---|---|---|
-| Reinstate own token (`auto_suspended: false`) | ✅ | ✅ |
-| Reinstate another user's token | ❌ 403 | ✅ |
-| Set `bypass_anomaly_detection` | ❌ (field silently dropped) | ✅ |
-
-### Audit trail
-
-Every change to `request_pattern` or `bypass_anomaly_detection` is logged at
-`INFO` level with the caller's email, token ID, client ID, and the exact fields
-changed. Check the auth-service application logs to confirm a reinstatement was
-applied and by whom.
-
-**Obtaining an admin JWT:** Log in to `analytics.airqo.net`, open DevTools →
-Network, make any API call, and copy the `Authorization` header value. It looks
-like `JWT eyJ...`.
+> **Note:** A suspended token is not the same as an expired token. A token can
+> have a valid future expiry date and still be suspended. The expiry date shown
+> in your API client settings is unrelated to whether the token is currently
+> active.
 
 ---
 
-## Known traps — read before starting
+## How to recover your token
 
-**`token_status: "active"` does not mean the token is unsuspended.**
-The `GET /api/v2/users/tokens/:token` endpoint computes `token_status` solely
-from the token's `expires` date — a suspended token with a future expiry still
-shows `token_status: "active"`. Always check `request_pattern.auto_suspended`
-directly (Step 2 below).
+You have two options. Use whichever fits your workflow.
 
-**A PATCH that returns `success: true` may have changed nothing.**
-Sending `auto_suspended` as a flat top-level field — `{"auto_suspended": false}`
-— is silently dropped by Mongoose's strict schema mode. The API still returns
-`"success": true` and bumps `updatedAt`, but the field is never written.
-Always use the nested form and verify the response body (Step 3 below).
+### Option A — AirQo Analytics (recommended)
 
-**Token expiry is unrelated to suspension.**
-`verifyToken` never loads the `expires` field during auth-request verification.
-A token with an August expiry date can still be fully blocked by
-`auto_suspended: true`.
+1. Log in to [analytics.airqo.net](https://analytics.airqo.net)
+2. Go to **Settings › API**
+3. Find the affected token on your API client card
+4. If it shows as suspended, click **Reinstate** to restore it
+5. Alternatively, click **Regenerate Token** to issue a fresh token without
+   creating a new client — this is the safest choice if you suspect the token
+   may have been compromised
 
----
+### Option B — API (for developers)
 
-## Step 1 — Find the full token value
+If you prefer to reinstate programmatically, use your own AirQo JWT (obtained
+by logging in to the platform — see [Authentication →](../api/getting-started/authentication.md)).
 
-The token value shown in suspension alert emails is **masked** (e.g.
-`ZPH6CW1J...F3NV`). You need the full plaintext string.
-
-Retrieve it from the admin client endpoint using the client ID, or search by
-client name or owner email:
-
-```bash
-# By client ID
-curl -s \
-  "https://api.airqo.net/api/v2/users/clients/<CLIENT_ID>" \
-  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
-  | jq '.access_token.token'
-
-# By owner email — lists all clients
-curl -s \
-  "https://api.airqo.net/api/v2/users/clients?email=<OWNER_EMAIL>" \
-  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
-  | jq '.[].access_token | {name, token, auto_suspended: .request_pattern.auto_suspended}'
-```
-
-For service deployments the token may also be in a Kubernetes secret:
-
-```bash
-kubectl get secret -n production <secret-name> \
-  -o jsonpath='{.data.AIRQO_API_TOKEN}' | base64 -d
-```
-
----
-
-## Step 2 — Confirm and inspect the suspension
-
-Read `request_pattern` directly from the client endpoint. This is the
-authoritative source.
-
-```bash
-curl -s \
-  "https://api.airqo.net/api/v2/users/clients/<CLIENT_ID>" \
-  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
-  | jq '.access_token | {
-      auto_suspended:    .request_pattern.auto_suspended,
-      anomaly_score:     .request_pattern.anomaly_score,
-      suspension_reason: .request_pattern.suspension_reason,
-      suspended_at:      .request_pattern.suspended_at,
-      bypass:            .bypass_anomaly_detection
-    }'
-```
-
-**Decision table:**
-
-| `auto_suspended` | `bypass_anomaly_detection` | Action |
-|---|---|---|
-| `true` | `false` | Reinstate (Step 3) then set bypass (Step 4) |
-| `true` | `true` | Reinstate only (Step 3) — bypass already set |
-| `false` | `false` | Token not suspended — investigate other gates (IP block? Client inactive? Scope?) |
-| `false` | `true` | No action needed |
-
-Secondary smoke-test using a documented public endpoint (confirms but does not diagnose):
-
-```bash
-# Cohort-based access (partners and organisations)
-curl -s -o /dev/null -w "%{http_code}" \
-  "https://api.airqo.net/api/v2/devices/measurements/cohorts/<COHORT_ID>?token=<TOKEN_VALUE>"
-
-# Grid-based access (cities and municipalities)
-curl -s -o /dev/null -w "%{http_code}" \
-  "https://api.airqo.net/api/v2/devices/measurements/grids/<GRID_ID>?token=<TOKEN_VALUE>"
-
-# 401 → suspended or invalid    200 or 429 → active
-```
-
-Reference: [Recent Measurements (Cohort)](https://docs.airqo.net/api/for-partners/recent-measurements) ·
-[Recent Measurements (Grid)](https://docs.airqo.net/api/for-cities/recent-measurements)
-
----
-
-## Step 3 — Reinstate the token
-
-The body **must** nest `auto_suspended` inside `request_pattern`. The flat form
-is silently ignored — see "Known traps" above.
+**Step 1 — Reinstate the token**
 
 ```bash
 curl -s -X PATCH \
-  "https://api.airqo.net/api/v2/users/tokens/<TOKEN_VALUE>" \
-  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
+  "https://api.airqo.net/api/v2/users/tokens/<YOUR_TOKEN_VALUE>" \
+  -H "Authorization: JWT <YOUR_AIRQO_JWT>" \
   -H "Content-Type: application/json" \
   -d '{ "request_pattern": { "auto_suspended": false } }'
 ```
 
-**Verify the response body** — not just the top-level message:
+**Important:** the field must be nested exactly as shown. Sending
+`{ "auto_suspended": false }` flat at the top level will appear to succeed
+(the API returns `success: true`) but will not change anything. Always verify
+the response body:
 
 ```json
 {
@@ -195,116 +77,94 @@ curl -s -X PATCH \
 }
 ```
 
-If `updated_token.request_pattern.auto_suspended` is still `true`, the body
-shape was wrong or the wrong token value was used. Re-check and retry.
+If `updated_token.request_pattern.auto_suspended` is still `true` in the
+response, the body shape was wrong. Re-check and retry with the nested form.
 
-> `updatedAt` ticks forward on every PATCH regardless of whether any field
-> actually changed — a bumped `updatedAt` alone does **not** confirm
-> reinstatement.
+> You can only reinstate tokens that belong to your own account. Attempting to
+> patch a token from a different account returns 403 Forbidden.
 
----
-
-## Step 4 — Mark service accounts as bypass (admin only)
-
-For any token that legitimately spans multiple devices, User-Agent strings, or
-server-side processes — IoT fleets, mobile backend tokens, shared integrations —
-set `bypass_anomaly_detection: true` immediately after reinstatement, before the
-application resumes traffic. This disables all behavioural scoring permanently
-so the token cannot be auto-suspended again by rate spikes or UA changes.
-
-This field requires the caller's JWT email to be in `SUPER_ADMIN_EMAIL_ALLOWLIST`.
-A non-admin JWT will have this field silently dropped — the PATCH still returns 200 if other fields are valid.
-
-```bash
-curl -s -X PATCH \
-  "https://api.airqo.net/api/v2/users/tokens/<TOKEN_VALUE>" \
-  -H "Authorization: JWT <YOUR_ADMIN_JWT>" \
-  -H "Content-Type: application/json" \
-  -d '{ "bypass_anomaly_detection": true }'
-```
-
-Confirm it is persisted in the response:
-
-```json
-{ "updated_token": { "bypass_anomaly_detection": true, ... } }
-```
-
-> **Security tradeoff:** bypass disables *all* behavioural anomaly scoring for
-> this token — both UA-change and rate-spike signals. Honeypot traps, IP
-> blacklisting, and manual suspension remain active. Notify the token owner
-> when this flag is applied (see Step 6).
-
----
-
-## Step 5 — Smoke-test
-
-Use whichever documented public endpoint matches the token's access pattern:
+**Step 2 — Verify the token is working**
 
 ```bash
 # Cohort-based access (partners and organisations)
 curl -s -o /dev/null -w "%{http_code}" \
-  "https://api.airqo.net/api/v2/devices/measurements/cohorts/<COHORT_ID>?token=<TOKEN_VALUE>"
+  "https://api.airqo.net/api/v2/devices/measurements/cohorts/<YOUR_COHORT_ID>?token=<YOUR_TOKEN_VALUE>"
 
 # Grid-based access (cities and municipalities)
 curl -s -o /dev/null -w "%{http_code}" \
-  "https://api.airqo.net/api/v2/devices/measurements/grids/<GRID_ID>?token=<TOKEN_VALUE>"
-
-# Expect: 200 (or 429 if rate-limited, but not 401)
+  "https://api.airqo.net/api/v2/devices/measurements/grids/<YOUR_GRID_ID>?token=<YOUR_TOKEN_VALUE>"
 ```
 
-Re-query the client endpoint and confirm both `auto_suspended: false` and
-`bypass_anomaly_detection: true` are persisted before notifying the owner.
+Expect `200`. A `401` means the token is still suspended. A `429` means the
+token is active but rate-limited.
+
+Reference:
+[Recent Measurements (Cohort)](https://docs.airqo.net/api/for-partners/recent-measurements) ·
+[Recent Measurements (Grid)](https://docs.airqo.net/api/for-cities/recent-measurements)
 
 ---
 
-## Step 6 — Notify the token owner
+## If the token keeps getting suspended
 
-Send a brief message covering:
+If your token is reinstated but suspended again within minutes, it is because
+the same pattern that triggered the original suspension (e.g. requests from
+multiple devices with different User-Agent strings) is still occurring.
 
-1. **What happened** — the token was suspended by the anomaly detector due to
-   `<suspension_reason>` (from `request_pattern.suspension_reason`). This is a
-   false positive caused by [multi-device usage / UA variation / rate spike].
-2. **What was done** — it has been reinstated and marked as a service account
-   so the same heuristic will not trigger again.
-3. **Security recommendation** — because behavioural monitoring is now reduced
-   for this token, they should consider enabling **"Require client secret on
-   every request"** on their API client card under Settings › API. When enabled,
-   every request must also send `X-Client-Secret: <secret>` in the headers,
-   providing defense-in-depth that does not depend on heuristics.
-4. **Invite them to test** and report any remaining 401s.
+This is common for:
+- IoT sensor fleets where multiple physical devices share one token
+- Server-side apps alongside a browser or mobile client using the same token
+- Applications that were recently updated and changed their HTTP client or SDK
+
+**What to do:** contact [support@airqo.net](mailto:support@airqo.net) and
+request that your token be marked as a service account. This disables the
+automated suspension heuristics for your token permanently so high-volume or
+multi-device usage is no longer flagged. Other security protections remain
+active.
 
 ---
 
-## Troubleshooting
+## Security recommendation
 
-**PATCH returns `success: true` but token is still blocked.**
-Inspect `updated_token.request_pattern.auto_suspended` in the response body. If
-it is still `true`, the body was sent flat instead of nested. Resend with the
-nested form (`{ "request_pattern": { "auto_suspended": false } }`) and verify
-the field in the response body.
+If your token was suspended due to a User-Agent change, consider enabling the
+**"Require client secret on every request"** option on your API client card
+under Settings › API.
 
-**403 on the PATCH.**
-The JWT email is not in `SUPER_ADMIN_EMAIL_ALLOWLIST` on the auth-service
-production env. Ask a super-admin to perform the PATCH, or have DevOps add the
-email to the env var.
+When enabled, every API request must also include a `X-Client-Secret` header
+alongside your token:
 
-**`token_status` says `"active"` but the token still 401s.**
-`token_status` only reflects expiry. Check `request_pattern.auto_suspended` on
-the client endpoint (Step 2).
+```
+X-Client-Secret: <your-client-secret>
+```
 
-**Token has a future expiry date but is still blocked.**
-Expiry and suspension are independent. `verifyToken` never loads `expires`
-during auth-request verification. Fix the suspension via Step 3.
+This means that even if your token is exposed, it cannot be used without also
+knowing your client secret — providing an extra layer of protection that does
+not depend on usage monitoring.
 
-**Smoke test returns 500, not 200 or 401.**
-A gateway-level 500 (especially an HTML error page) indicates an
-infrastructure issue upstream of the application — nginx, ingress, or a
-cold-start timeout. Retry; these are usually transient. If it persists, check
-device-registry and auth-service logs around that timestamp.
+---
 
-**Token gets suspended again shortly after reinstatement.**
-`bypass_anomaly_detection: true` was not set, or was set after the application
-had already resumed traffic. The anomaly detector runs asynchronously on every
-passing request — a handful of UA-mismatched calls can push `anomaly_score`
-back above the threshold before the bypass write lands. Always apply bypass
-immediately after reinstatement, before the application makes any calls.
+## Frequently asked questions
+
+**My token shows as active in Settings › API but requests still return 401.**
+The "active" status shown in the UI reflects whether your token has expired —
+it does not reflect suspension. If you are seeing 401s, your token may be
+suspended even if the UI shows it as active. Use the Reinstate option as
+described above.
+
+**I used the PATCH endpoint and got `success: true` but the token is still blocked.**
+The body was almost certainly sent flat (`{ "auto_suspended": false }`) instead
+of nested (`{ "request_pattern": { "auto_suspended": false } }`). Check the
+`updated_token.request_pattern.auto_suspended` field in the response body — if
+it is still `true`, resend with the correct nested form.
+
+**My token expiry date is months away — can it still be suspended?**
+Yes. Expiry and suspension are independent. A token with a future expiry date
+can still be suspended by the anomaly detector. Reinstating restores access
+regardless of the expiry date.
+
+**I got 403 when trying to reinstate via the API.**
+You can only reinstate your own tokens. If you need to reinstate a token
+belonging to another account, contact [support@airqo.net](mailto:support@airqo.net).
+
+**The smoke test returned 500, not 200 or 401.**
+A 500 from the gateway is usually a transient infrastructure issue. Wait a
+minute and retry. If it persists, contact support.

--- a/src/auth-service/docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md
+++ b/src/auth-service/docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md
@@ -50,7 +50,7 @@ You have two options. Use whichever fits your workflow.
 ### Option B — API (for developers)
 
 If you prefer to reinstate programmatically, use your own AirQo JWT (obtained
-by logging in to the platform — see [Authentication →](../api/getting-started/authentication.md)).
+by logging in to the platform).
 
 **Step 1 — Reinstate the token**
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Rewrites two developer-facing guides in `src/auth-service/docs/access-control/`
from an internal maintainer perspective to an API consumer perspective:

**`TOKEN_REINSTATEMENT_GUIDE.md` (v1.x → v2.0)**
- Reframed from an admin runbook into a self-service recovery guide for token owners
- Replaced all internal references (`utils/token.util.js`, env var names,
  MongoDB field paths, Mongoose schema behavior, nginx/ingress) with plain-English
  explanations
- Removed admin-only kubectl/jq lookup steps — token owners know their own token
- PATCH reinstatement is now presented as a developer self-service option (not
  an admin operation), consistent with the ownership check added in the previous PR
- The service-account bypass step is replaced with a "contact support" instruction,
  since `bypass_anomaly_detection` requires AirQo admin access the token owner does not have
- FAQ answers rewritten in observable terms — no code-path explanations

**`SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md` (v2.0 → v3.0)**
- Removed the entire per-app internal status table referencing
  `airqo-frontend/src/mobile`, `src/platform`, `src/vertex`, `src/beacon`
  with internal file paths and class names
- Removed all env var names (`JWT_EXPIRES_IN_SECONDS` etc.) — replaced with
  plain human values (24 h, 15 min, 5 min, 1 yr)
- Removed internal middleware and class references (`enhancedJWTAuth`,
  `BaseRepository`, `ApiClient`, `createAxiosInstance`, `AuthTokenStorage`)
- Code examples are now generic and self-contained (Flutter + JS/TS),
  copy-pasteable by any developer integrating with the AirQo API
- Logout failure chain retained but expressed as observable API behaviour,
  not internal middleware flow

### Why is this change needed?

Both guides were written during an internal debugging session and contained
implementation details intended for engineers maintaining the auth-service
(internal file paths, Mongoose schema behaviour, log4js category names,
Kubernetes commands, env var names). As shared references for external API
consumers and integration developers, this content is irrelevant at best and
confusing at worst. The rewrites make both documents usable by the intended
audience without requiring knowledge of AirQo's internal stack.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/auth-service` —
  `docs/access-control/TOKEN_REINSTATEMENT_GUIDE.md`,
  `docs/access-control/SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md`

No application code changed.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Documentation-only change. Verified that all API endpoints, request/response
shapes, and header names referenced in both guides match the live API. Code
examples were manually traced against the auth-service behaviour confirmed in
the previous PR.

---

## :boom: Breaking Changes

- [x] **No breaking changes**

Documentation update only. No application behaviour is affected.

---

## :memo: Additional Notes

- The internal maintainer context (admin runbook steps, per-app implementation
  status, env var tuning) that was removed from these guides is preserved in
  git history and remains accessible if needed by the engineering team.
- Both guides now version-bump their header lines to reflect the rewrite date
  (`TOKEN_REINSTATEMENT_GUIDE.md` → v2.0, `SLIDING_SESSION_TOKEN_REFRESH_GUIDE.md` → v3.0).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review
