### PR TITLE
Add server-side status filtering to the getMyDevices endpoint

### DIFF
--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -3368,7 +3368,7 @@ const deviceUtil = {
 
   getMyDevices: async (request, next) => {
     try {
-      const { user_id, cohort_ids, group_ids } = request.query;
+      const { user_id, cohort_ids, group_ids, status } = request.query;
       const { tenant } = request.query;
       const skip = request.query.skip || 0;
       const limit = request.query.limit || 30;
@@ -3439,6 +3439,18 @@ const deviceUtil = {
 
       if (allCohortIds.length > 0) {
         filter.$or.push({ cohorts: { $in: allCohortIds } });
+      }
+
+      // 4. Apply optional status filter (isOnline + rawOnlineStatus combination)
+      const STATUS_FILTER_MAP = {
+        operational: { isOnline: true, rawOnlineStatus: true },
+        transmitting: { isOnline: false, rawOnlineStatus: true },
+        not_transmitting: { isOnline: false, rawOnlineStatus: false },
+        data_available: { isOnline: true, rawOnlineStatus: false },
+      };
+
+      if (status && STATUS_FILTER_MAP[status]) {
+        Object.assign(filter, STATUS_FILTER_MAP[status]);
       }
 
       const [total, rawDevices] = await Promise.all([

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -3256,5 +3256,73 @@ describe("Device Util", () => {
       expect(projection).to.include("isOnline");
       expect(projection).to.include("rawOnlineStatus");
     });
+
+    describe("status filter", () => {
+      const STATUS_CASES = [
+        {
+          status: "transmitting",
+          expected: { isOnline: false, rawOnlineStatus: true },
+        },
+        {
+          status: "data_available",
+          expected: { isOnline: true, rawOnlineStatus: false },
+        },
+        {
+          status: "operational",
+          expected: { isOnline: true, rawOnlineStatus: true },
+        },
+        {
+          status: "not_transmitting",
+          expected: { isOnline: false, rawOnlineStatus: false },
+        },
+      ];
+
+      STATUS_CASES.forEach(({ status, expected }) => {
+        it(`should add ${JSON.stringify(expected)} to the filter when status=${status}`, async () => {
+          const request = {
+            query: { tenant: "airqo", user_id: VALID_USER_ID, status },
+          };
+          await deviceUtil.getMyDevices(request, () => {});
+
+          const filter = deviceCountStub.firstCall.args[0];
+          expect(filter.isOnline).to.equal(expected.isOnline);
+          expect(filter.rawOnlineStatus).to.equal(expected.rawOnlineStatus);
+        });
+
+        it(`should preserve the $or ownership filter alongside the status filter when status=${status}`, async () => {
+          const request = {
+            query: { tenant: "airqo", user_id: VALID_USER_ID, status },
+          };
+          await deviceUtil.getMyDevices(request, () => {});
+
+          const filter = deviceCountStub.firstCall.args[0];
+          expect(filter).to.have.property("$or");
+          expect(filter.$or).to.be.an("array").with.length.greaterThan(0);
+          expect(filter.$or[0]).to.have.property("owner_id");
+        });
+      });
+
+      it("should not add isOnline or rawOnlineStatus to the filter when status is absent", async () => {
+        const request = {
+          query: { tenant: "airqo", user_id: VALID_USER_ID },
+        };
+        await deviceUtil.getMyDevices(request, () => {});
+
+        const filter = deviceCountStub.firstCall.args[0];
+        expect(filter).to.not.have.property("isOnline");
+        expect(filter).to.not.have.property("rawOnlineStatus");
+      });
+
+      it("should not add isOnline or rawOnlineStatus to the filter when status is unrecognised", async () => {
+        const request = {
+          query: { tenant: "airqo", user_id: VALID_USER_ID, status: "unknown_status" },
+        };
+        await deviceUtil.getMyDevices(request, () => {});
+
+        const filter = deviceCountStub.firstCall.args[0];
+        expect(filter).to.not.have.property("isOnline");
+        expect(filter).to.not.have.property("rawOnlineStatus");
+      });
+    });
   });
 });

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -1265,6 +1265,14 @@ const validateGetMyDevices = [
     .withMessage("organization_id must be a valid MongoDB ObjectId")
     .bail()
     .customSanitizer((value) => ObjectId(value)),
+
+  query("status")
+    .optional()
+    .trim()
+    .isIn(["operational", "transmitting", "not_transmitting", "data_available"])
+    .withMessage(
+      "status must be one of: operational, transmitting, not_transmitting, data_available"
+    ),
 ];
 
 const validateDeviceAvailability = [


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds an optional `status` query parameter to the `GET /devices/my-devices` endpoint. When provided, the endpoint filters devices server-side by their `isOnline` and `rawOnlineStatus` field combination before returning results, rather than relying on the client to filter after the fact.

Two files changed:
- `validators/device.validators.js` — added `status` field validation to `validateGetMyDevices` (accepts `operational`, `transmitting`, `not_transmitting`, `data_available`)
- `utils/device.util.js` — extracted `status` from `request.query` in `getMyDevices` and applies the corresponding `isOnline`/`rawOnlineStatus` filter to the MongoDB query when present

### Why is this change needed?

The Vertex dashboard displays device counts per status category (e.g. "3 Transmitting"). Clicking a card navigates to `/devices/my-devices?status=transmitting`, which was performing client-side filtering on a server-paginated result. Because the dashboard count and the device list are fetched at different times and cached independently, the two sources could diverge — particularly for `transmitting` and `data_available`, which are transient states that exist only during the ~10-minute window between two backend cron jobs that update `rawOnlineStatus` (`:35`) and `isOnline` (`:45`) on separate schedules. The result was an empty device list despite the card showing a non-zero count. Moving the filter server-side ensures the list and the total count reflect the same point-in-time database state.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Tested `GET /devices/my-devices?user_id=<id>&status=transmitting` and `?status=data_available` against the local device-registry instance. Verified that:
- Requests without `status` return the same results as before (no regression)
- Requests with a valid `status` value return only devices matching the corresponding `isOnline`/`rawOnlineStatus` combination
- Requests with an invalid `status` value are rejected with a `400 Bad Request` from the validator

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `status` parameter is entirely optional. All existing calls to `GET /devices/my-devices` without it behave identically to before.

---

## :memo: Additional Notes

- The two cron jobs (`update-raw-online-status-job` at `:35` and `update-online-status-job` at `:45`) were intentionally left unchanged. They operate on different data sources (live device API pings vs. processed measurement events) and the separation is by design. A full diagnosis of the bug and the reasoning behind this decision is documented in `docs/VERTEX_DEVICE_STATUS_FILTER_BUG.md`.
- Complementary frontend changes are still pending on the Vertex side: the `useMyDevices` hook needs to accept and forward a `status` param, the `my-devices` page needs to pass it for both personal and org scopes, and the `useDevices` query key needs `filterStatus` added to prevent cache collisions.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `status` filtering parameter for device retrieval, supporting `operational`, `transmitting`, `not_transmitting`, and `data_available` filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->