### PR TITLE
Enforce network field immutability on device and site updates

### DIFF
--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -1495,8 +1495,9 @@ const deviceController = {
       const { network_override, cohort_id, user_id } = req.body;
 
       if (network_override) {
+        const normalizedOverride = String(network_override).trim().toLowerCase();
         const knownNetworks = await validNetworks(tenant);
-        if (!knownNetworks.includes(network_override.toLowerCase())) {
+        if (!knownNetworks.includes(normalizedOverride)) {
           next(
             new HttpError("bad request errors", httpStatus.BAD_REQUEST, {
               message: `Invalid network_override "${network_override}". Valid networks are: ${knownNetworks.join(", ")}`,

--- a/src/device-registry/controllers/device.controller.js
+++ b/src/device-registry/controllers/device.controller.js
@@ -3,6 +3,7 @@ const iot = require("@google-cloud/iot");
 const client = new iot.v1.DeviceManagerClient();
 const createDeviceUtil = require("@utils/device.util");
 const { distance } = require("@utils/common");
+const { validNetworks } = require("@validators/common");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
@@ -1492,6 +1493,18 @@ const deviceController = {
       const defaultTenant = constants.DEFAULT_TENANT || "airqo";
       const tenant = isEmpty(req.query.tenant) ? defaultTenant : req.query.tenant;
       const { network_override, cohort_id, user_id } = req.body;
+
+      if (network_override) {
+        const knownNetworks = await validNetworks(tenant);
+        if (!knownNetworks.includes(network_override.toLowerCase())) {
+          next(
+            new HttpError("bad request errors", httpStatus.BAD_REQUEST, {
+              message: `Invalid network_override "${network_override}". Valid networks are: ${knownNetworks.join(", ")}`,
+            }),
+          );
+          return;
+        }
+      }
 
       let devices;
 

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -1805,7 +1805,7 @@ deviceSchema.statics = {
   async modify({ filter = {}, update = {}, opts = {} } = {}, next) {
     try {
       logText("we are now inside the modify function for devices....");
-      const invalidKeys = ["name", "_id", "writeKey", "readKey"];
+      const invalidKeys = ["name", "_id", "writeKey", "readKey", "network"];
       // Lifecycle fields may only be written by activity functions (deploy /
       // recall / maintain).  Block them here unless the caller explicitly opts
       // in via opts.allowLifecycleFields — activity callers set this flag.

--- a/src/device-registry/models/Device.js
+++ b/src/device-registry/models/Device.js
@@ -1814,16 +1814,18 @@ deviceSchema.statics = {
       }
       const sanitizedUpdate = sanitizeObject(update, invalidKeys);
 
-      // Also strip lifecycle fields nested inside Mongo update operators so a
+      // Also strip protected fields nested inside Mongo update operators so a
       // payload like { $set: { status: "deployed" } } cannot bypass the guard.
-      if (!opts.allowLifecycleFields) {
-        const UPDATE_OPERATORS = [
-          "$set", "$unset", "$setOnInsert", "$rename",
-          "$inc", "$mul", "$min", "$max",
-          "$push", "$pull", "$addToSet", "$pullAll", "$bit",
-        ];
-        for (const op of UPDATE_OPERATORS) {
-          if (sanitizedUpdate[op] && typeof sanitizedUpdate[op] === "object") {
+      const ALWAYS_PROTECTED = ["network", ...invalidKeys];
+      const UPDATE_OPERATORS = [
+        "$set", "$unset", "$setOnInsert", "$rename",
+        "$inc", "$mul", "$min", "$max",
+        "$push", "$pull", "$addToSet", "$pullAll", "$bit",
+      ];
+      for (const op of UPDATE_OPERATORS) {
+        if (sanitizedUpdate[op] && typeof sanitizedUpdate[op] === "object") {
+          ALWAYS_PROTECTED.forEach((f) => delete sanitizedUpdate[op][f]);
+          if (!opts.allowLifecycleFields) {
             constants.LIFECYCLE_FIELDS.forEach((f) => delete sanitizedUpdate[op][f]);
           }
         }

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -1209,7 +1209,14 @@ siteSchema.statics = {
     try {
       let options = { new: true, useFindAndModify: false, upsert: false };
 
-      const sanitizedUpdate = sanitizeObject({ ...update }, ["network", "_id"]);
+      const PROTECTED = ["network", "_id"];
+      const sanitizedUpdate = sanitizeObject({ ...update }, PROTECTED);
+      const UPDATE_OPERATORS = ["$set", "$unset", "$setOnInsert", "$rename"];
+      for (const op of UPDATE_OPERATORS) {
+        if (sanitizedUpdate[op] && typeof sanitizedUpdate[op] === "object") {
+          PROTECTED.forEach((f) => delete sanitizedUpdate[op][f]);
+        }
+      }
 
       let updatedSite = await this.findOneAndUpdate(
         filter,

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -1209,9 +1209,11 @@ siteSchema.statics = {
     try {
       let options = { new: true, useFindAndModify: false, upsert: false };
 
+      const sanitizedUpdate = sanitizeObject({ ...update }, ["network", "_id"]);
+
       let updatedSite = await this.findOneAndUpdate(
         filter,
-        update,
+        sanitizedUpdate,
         options,
       ).exec();
 

--- a/src/device-registry/validators/common/index.js
+++ b/src/device-registry/validators/common/index.js
@@ -1,4 +1,4 @@
-const { validateNetwork } = require("./network.validators");
+const { validateNetwork, validNetworks } = require("./network.validators");
 const { validateAdminLevels } = require("./admin-levels.validators");
 const headers = require("./headers.validators");
 const pagination = require("./pagination.validators");
@@ -13,6 +13,7 @@ const {
 
 module.exports = {
   validateNetwork,
+  validNetworks,
   validateAndFixPolygon,
   ensureClosedRing,
   validateCoordinates,

--- a/src/device-registry/validators/common/network.validators.js
+++ b/src/device-registry/validators/common/network.validators.js
@@ -29,4 +29,4 @@ const validateNetwork = async (value, { req }) => {
   }
 };
 
-module.exports = { validateNetwork };
+module.exports = { validateNetwork, validNetworks };

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -487,6 +487,12 @@ const validateCreateDevice = [
 ];
 
 const validateUpdateDevice = [
+  body("network")
+    .not()
+    .exists()
+    .withMessage(
+      "Cannot directly update network. The network field is set at device creation and cannot be changed.",
+    ),
   body("mobility")
     .not()
     .exists()

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -4,6 +4,7 @@ const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 const createSiteUtil = require("@utils/site.util");
 const Decimal = require("decimal.js");
+const { validateNetwork } = require("@validators/common");
 
 const countDecimalPlaces = (value) => {
   try {
@@ -320,6 +321,17 @@ const validateMandatorySiteIdentifier = oneOf([
 const validateCreateSite = [
   createCoordinateValidation("latitude", { isQuery: false }),
   createCoordinateValidation("longitude", { isQuery: false }),
+  body("network")
+    .exists()
+    .withMessage("network is missing in your request")
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage("network cannot be empty")
+    .bail()
+    .toLowerCase()
+    .custom(validateNetwork)
+    .withMessage("the network value is not among the expected ones"),
   body("name")
     .exists()
     .withMessage("the name is is missing in your request")
@@ -373,6 +385,12 @@ const validateSiteMetadata = [
 
 const validateUpdateSite = [
   createTenantValidation({ isOptional: true }),
+  body("network")
+    .not()
+    .exists()
+    .withMessage(
+      "Cannot directly update network. The network field is set at site creation and cannot be changed.",
+    ),
   body("name")
     .optional()
     .notEmpty()

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -322,12 +322,10 @@ const validateCreateSite = [
   createCoordinateValidation("latitude", { isQuery: false }),
   createCoordinateValidation("longitude", { isQuery: false }),
   body("network")
-    .exists()
-    .withMessage("network is missing in your request")
-    .bail()
+    .optional()
     .trim()
     .notEmpty()
-    .withMessage("network cannot be empty")
+    .withMessage("network cannot be empty if provided")
     .bail()
     .toLowerCase()
     .custom(validateNetwork)


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Locks the `network` field (sensor manufacturer identifier) against post-creation mutation on both devices and sites. Adds a mandatory enum-validated `network` field to site creation, and validates `network_override` in the CSV bulk-import endpoint.

**Specific changes:**
- `Device.modify()` — added `"network"` to `invalidKeys` so it is stripped from every update payload at the model layer
- `Site.modify()` — introduced `sanitizeObject` call (previously absent) to strip `"network"` and `"_id"` before the database write
- `validateUpdateDevice` — added `.not().exists()` rule for `network`; any PUT body containing the field returns HTTP 400
- `validateUpdateSite` — same `.not().exists()` guard added
- `validateCreateSite` — added optional DB enum check via `validateNetwork`; if `network` is provided it must be a known network, if absent the model default applies (backward compatible)
- `validNetworks` helper exported from `validators/common` so it can be called outside express-validator middleware
- `bulkCreateOnPlatform` controller — validates `network_override` against the DB-driven network list before any CSV parsing begins

### Why is this change needed?

The `network` field identifies which sensor manufacturer owns a device or site. Corrupt or accidentally overwritten values require tedious manual database cleaning and can silently break analytics, network coverage reporting, and manufacturer-level aggregations. Previously:
- Single device and site update endpoints had no guard on this field
- Site creation accepted any value without enum validation (silently defaulting)
- The CSV bulk-import `network_override` parameter was applied to all rows with no validation whatsoever

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :wrench: Enhancement/improvement
- [ ] :sparkles: New feature
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

Verified that:
1. `PUT /devices` with a `network` body field returns HTTP 400 with a descriptive message
2. `PUT /sites` with a `network` body field returns HTTP 400 with a descriptive message
3. `POST /sites` without a `network` field succeeds (defaults to `DEFAULT_NETWORK`, backward compatible)
4. `POST /sites` with an invalid `network` value returns HTTP 400 with the list of valid networks
5. `POST /devices/soft/bulk` with an invalid `network_override` returns HTTP 400 before CSV parsing begins
6. All existing create/update flows with valid or absent `network` continue to work normally

---

## :boom: Breaking Changes

- [x] **No breaking changes**

---

## :memo: Additional Notes

- The `network` field is intentionally **not** marked `immutable: true` at the Mongoose schema level to preserve the ability for trusted internal migration scripts to correct historical bad data if ever needed. The protection is enforced at the validator and model-method layers, which cover all API-exposed paths.
- Bulk update endpoints (`PUT /devices/bulk`, `PUT /sites/bulk`) were already safe — `network` was absent from their respective `allowedFields` lists. No changes needed there.
- Frontend (platform/vertex) already treats `network` as read-only display data — no frontend changes required.
- The website's `NetworkCoverageAddMonitorDialog` free-text `network` input is a separate frontend concern and is not addressed in this PR.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
