### PR TITLE
Add single retry on duplicate key collision during access token creation

### DIFF
--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1928,11 +1928,10 @@ const token = {
       const tokenModel = AccessTokenModel(tenant.toLowerCase());
       const expires = tokenCreationBody.expires || Date.now() + API_TOKEN_TTL_MS;
 
-      let replacedDoc;
-      try {
-        replacedDoc = await tokenModel.findOneAndReplace(
+      const _attemptReplace = async (body) =>
+        tokenModel.findOneAndReplace(
           { client_id: ObjectId(client_id) },
-          { ...tokenCreationBody, expires },
+          { ...body, expires },
           {
             upsert: true,
             new: true,
@@ -1940,16 +1939,33 @@ const token = {
             setDefaultsOnInsert: true,
           },
         );
+
+      let replacedDoc;
+      try {
+        replacedDoc = await _attemptReplace(tokenCreationBody);
       } catch (replaceErr) {
-        if (replaceErr.code === 11000) {
-          return {
-            success: false,
-            message: "A token already exists for one of the provided unique fields",
-            status: httpStatus.CONFLICT,
-            errors: { token: "the token must be unique" },
-          };
+        if (replaceErr.code !== 11000) throw replaceErr;
+        // Astronomically unlikely collision — regenerate and retry once.
+        logger.warn(
+          `Non-critical: token collision on insert for client ${client_id} — regenerating and retrying`
+        );
+        const retryToken = accessCodeGenerator
+          .generate(constants.RANDOM_PASSWORD_CONFIGURATION(constants.TOKEN_LENGTH))
+          .toUpperCase();
+        tokenCreationBody.token = retryToken;
+        try {
+          replacedDoc = await _attemptReplace(tokenCreationBody);
+        } catch (retryErr) {
+          if (retryErr.code === 11000) {
+            return {
+              success: false,
+              message: "A token already exists for one of the provided unique fields",
+              status: httpStatus.CONFLICT,
+              errors: { token: "the token must be unique" },
+            };
+          }
+          throw retryErr;
         }
-        throw replaceErr;
       }
 
       if (!replacedDoc) {

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1940,12 +1940,33 @@ const token = {
           },
         );
 
+      // Resolve which field caused a 11000 from keyPattern (most reliable),
+      // falling back to keyValue if keyPattern is absent.
+      const _collisionField = (err) =>
+        err.keyPattern
+          ? Object.keys(err.keyPattern)[0]
+          : err.keyValue
+          ? Object.keys(err.keyValue)[0]
+          : null;
+
       let replacedDoc;
       try {
         replacedDoc = await _attemptReplace(tokenCreationBody);
       } catch (replaceErr) {
         if (replaceErr.code !== 11000) throw replaceErr;
-        // Astronomically unlikely collision — regenerate and retry once.
+        const conflictField = _collisionField(replaceErr);
+        if (conflictField !== null && conflictField !== "token") {
+          // Definitively not a token collision — retrying won't help.
+          return {
+            success: false,
+            message: "A token already exists for one of the provided unique fields",
+            status: httpStatus.CONFLICT,
+            errors: {
+              [conflictField]: `the ${conflictField} must be unique`,
+            },
+          };
+        }
+        // Astronomically unlikely token collision — regenerate and retry once.
         logger.warn(
           `Non-critical: token collision on insert for client ${client_id} — regenerating and retrying`
         );
@@ -1957,11 +1978,14 @@ const token = {
           replacedDoc = await _attemptReplace(tokenCreationBody);
         } catch (retryErr) {
           if (retryErr.code === 11000) {
+            const retryConflictField = _collisionField(retryErr);
             return {
               success: false,
               message: "A token already exists for one of the provided unique fields",
               status: httpStatus.CONFLICT,
-              errors: { token: "the token must be unique" },
+              errors: {
+                [retryConflictField || "token"]: `the ${retryConflictField || "token"} must be unique`,
+              },
             };
           }
           throw retryErr;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a one-shot retry in `createAccessToken` when MongoDB returns a duplicate key error (`11000`) on the `token` field. On collision, a fresh token is generated via `accessCodeGenerator` and the `findOneAndReplace` is attempted once more. If the retry also collides, the original conflict response is returned. A warning is logged on the first collision to make the event observable.

### Why is this change needed?
The unique index on the `token` field in the `AccessToken` schema was already the correct guard against duplicates, but on the practically-impossible collision the service was returning a `409 Conflict` to the caller with no recovery path. Since token generation uses a CSPRNG with ~80 bits of output entropy (~32^16 possible values), a collision will almost never occur — but if it does, the caller should not have to retry the entire request. A single transparent retry inside the service is the right fix.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `utils/token.util.js` (`createAccessToken`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
No new test cases are strictly required given the ~1-in-10²⁴ collision probability. The retry branch is a two-line code path that mirrors the original insert, so existing `createAccessToken` integration tests continue to cover the happy path. A future unit test could mock `findOneAndReplace` to throw `{code: 11000}` on the first call and succeed on the second to exercise the retry branch explicitly.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- The helper `_attemptReplace` is intentionally scoped inside `createAccessToken` to avoid polluting the module and keep the retry logic self-contained.
- The warning log (`Non-critical: token collision on insert for client ...`) is the only observable side-effect of a collision, making it easy to monitor if this ever fires in production.
- The `regenerateAccessToken` path (currently disabled / returns 503) does not get this retry since it is unreachable. It can be updated if/when that endpoint is re-enabled.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token generation reliability with retry logic for handling duplicate key conflicts. When a token collision is detected, the system now regenerates a new token value and retries once before returning a conflict response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->