### PR TITLE
Add Learn v2 API to replace legacy Know Your Air endpoints

### DIFF
--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -373,9 +373,6 @@ app.use(express.static(path.join(__dirname, "public")));
 
 // app.use("/api/v1/devices", require("@routes/v1"));
 app.use("/api/v2/devices", require("@routes/v2"));
-const { publicRouter: learnPublicRouter, adminRouter: learnAdminRouter } = require("@routes/v2/learn.routes");
-app.use("/api/v2/learn", learnPublicRouter);
-app.use("/api/v2/admin/learn", learnAdminRouter);
 
 // default error handling
 app.use((req, res, next) => {

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -373,6 +373,9 @@ app.use(express.static(path.join(__dirname, "public")));
 
 // app.use("/api/v1/devices", require("@routes/v1"));
 app.use("/api/v2/devices", require("@routes/v2"));
+const { publicRouter: learnPublicRouter, adminRouter: learnAdminRouter } = require("@routes/v2/learn.routes");
+app.use("/api/v2/learn", learnPublicRouter);
+app.use("/api/v2/admin/learn", learnAdminRouter);
 
 // default error handling
 app.use((req, res, next) => {

--- a/src/device-registry/controllers/learn.controller.js
+++ b/src/device-registry/controllers/learn.controller.js
@@ -1,28 +1,10 @@
 const httpStatus = require("http-status");
-const { logObject, HttpError, extractErrorsFromRequest } = require("@utils/shared");
+const { HttpError, extractErrorsFromRequest } = require("@utils/shared");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- learn-controller`);
 const learnUtil = require("@utils/learn.util");
 const isEmpty = require("is-empty");
-
-function handleResponse({ result, key = "data", res } = {}) {
-  if (!result) return;
-  const isSuccess = result.success;
-  const status = result.status !== undefined
-    ? result.status
-    : isSuccess ? httpStatus.OK : httpStatus.INTERNAL_SERVER_ERROR;
-  const message = result.message !== undefined ? result.message : (isSuccess ? "Operation Successful" : "Internal Server Error");
-
-  if (isSuccess) {
-    return res.status(status).json({ success: true, message, [key]: result.data });
-  }
-  return res.status(status).json({
-    success: false,
-    message,
-    errors: result.errors || { message },
-  });
-}
 
 const learnController = {
   // ---------------------------------------------------------------------------

--- a/src/device-registry/controllers/learn.controller.js
+++ b/src/device-registry/controllers/learn.controller.js
@@ -1,0 +1,350 @@
+const httpStatus = require("http-status");
+const { logObject, HttpError, extractErrorsFromRequest } = require("@utils/shared");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- learn-controller`);
+const learnUtil = require("@utils/learn.util");
+const isEmpty = require("is-empty");
+
+function handleResponse({ result, key = "data", res } = {}) {
+  if (!result) return;
+  const isSuccess = result.success;
+  const status = result.status !== undefined
+    ? result.status
+    : isSuccess ? httpStatus.OK : httpStatus.INTERNAL_SERVER_ERROR;
+  const message = result.message !== undefined ? result.message : (isSuccess ? "Operation Successful" : "Internal Server Error");
+
+  if (isSuccess) {
+    return res.status(status).json({ success: true, message, [key]: result.data });
+  }
+  return res.status(status).json({
+    success: false,
+    message,
+    errors: result.errors || { message },
+  });
+}
+
+const learnController = {
+  // ---------------------------------------------------------------------------
+  // Option 1 — Content
+  // ---------------------------------------------------------------------------
+
+  getCatalog: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.getCatalog(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          catalog_version: result.data.catalog_version,
+          stages: result.data.stages,
+          courses: result.data.courses,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message || "no published learn catalog available",
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  getLesson: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.getLesson(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          lesson: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.NOT_FOUND).json({
+        success: false,
+        message: result.message || "lesson not found",
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Option 2 — Guest Progress
+  // ---------------------------------------------------------------------------
+
+  createAnonymousSession: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.createAnonymousSession(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.CREATED).json({
+          success: true,
+          guest_id: result.data.guest_id,
+          display_name: result.data.display_name,
+          created_at: result.data.created_at,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  getProgress: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.getProgress(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          ...result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  updateLessonProgress: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.updateLessonProgress(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          ...result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  syncProgress: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.syncProgress(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          ...result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Option 3 — Account Link
+  // ---------------------------------------------------------------------------
+
+  linkGuestProgress: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.linkGuestProgress(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          user_id: result.data.user_id,
+          merged: result.data.merged,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Admin — Course Authoring
+  // ---------------------------------------------------------------------------
+
+  createCourse: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.createCourse(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.CREATED).json({
+          success: true,
+          course: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  addUnit: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.addUnit(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.CREATED).json({
+          success: true,
+          unit: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  addLesson: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.addLesson(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.CREATED).json({
+          success: true,
+          lesson: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  addActivity: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.addActivity(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.CREATED).json({
+          success: true,
+          activity: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  updateCourse: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.updateCourse(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          course: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+};
+
+module.exports = learnController;

--- a/src/device-registry/models/LearnActivity.js
+++ b/src/device-registry/models/LearnActivity.js
@@ -1,0 +1,170 @@
+const mongoose = require("mongoose");
+const { Schema } = require("mongoose");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const httpStatus = require("http-status");
+const { HttpError } = require("@utils/shared");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- learn-activity-model`
+);
+
+const ACTIVITY_TYPES = ["article", "video", "image", "quiz"];
+const QUIZ_FORMATS = ["single_choice", "multi_choice", "ranking", "free_text"];
+
+const learnActivitySchema = new Schema(
+  {
+    lesson_id: {
+      type: Schema.Types.ObjectId,
+      ref: "learnlesson",
+      required: [true, "lesson_id is required"],
+    },
+    type: {
+      type: String,
+      enum: ACTIVITY_TYPES,
+      required: [true, "type is required"],
+    },
+    order: {
+      type: Number,
+      required: [true, "order is required"],
+      min: 1,
+    },
+    payload: {
+      type: Schema.Types.Mixed,
+      required: [true, "payload is required"],
+    },
+  },
+  { timestamps: true }
+);
+
+learnActivitySchema.index({ lesson_id: 1, order: 1 }, { unique: true });
+
+learnActivitySchema.statics = {
+  async register(args, next) {
+    try {
+      const created = await this.create({ ...args });
+      if (!isEmpty(created)) {
+        return {
+          success: true,
+          data: created._doc,
+          message: "activity created",
+          status: httpStatus.CREATED,
+        };
+      }
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: "activity not created despite successful operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      let response = {};
+      let message = "validation errors for some of the provided fields";
+      let status = httpStatus.CONFLICT;
+      if (!isEmpty(error.keyPattern) && error.code === 11000) {
+        Object.entries(error.keyPattern).forEach(([key]) => {
+          response[key] = "duplicate value";
+          response.message = "duplicate value";
+        });
+      } else if (!isEmpty(error.errors)) {
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+          response.message = value.message;
+        });
+      }
+      next(new HttpError(message, status, response));
+    }
+  },
+
+  async list({ filter = {}, skip = 0, limit = 5000 } = {}, next) {
+    try {
+      const activities = await this.find(filter)
+        .sort({ order: 1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return {
+        success: true,
+        data: activities,
+        message: "successfully retrieved activities",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async modify({ filter = {}, update = {}, opts = { new: true } } = {}, next) {
+    try {
+      const modifiedUpdate = { ...update };
+      delete modifiedUpdate._id;
+      const updated = await this.findOneAndUpdate(filter, modifiedUpdate, opts);
+      if (!isEmpty(updated)) {
+        return {
+          success: true,
+          data: updated._doc,
+          message: "successfully modified the activity",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No activity found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async remove({ filter = {} } = {}, next) {
+    try {
+      const removed = await this.findOneAndRemove(filter, {
+        projection: { _id: 1, type: 1, order: 1 },
+      }).exec();
+      if (!isEmpty(removed)) {
+        return {
+          success: true,
+          data: removed._doc,
+          message: "successfully removed the activity",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No activity found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+const LearnActivityModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("learnactivities");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "learnactivity", learnActivitySchema);
+  }
+};
+
+module.exports = LearnActivityModel;

--- a/src/device-registry/models/LearnActivity.js
+++ b/src/device-registry/models/LearnActivity.js
@@ -11,7 +11,6 @@ const logger = log4js.getLogger(
 );
 
 const ACTIVITY_TYPES = ["article", "video", "image", "quiz"];
-const QUIZ_FORMATS = ["single_choice", "multi_choice", "ranking", "free_text"];
 
 const learnActivitySchema = new Schema(
   {

--- a/src/device-registry/models/LearnCourse.js
+++ b/src/device-registry/models/LearnCourse.js
@@ -16,6 +16,7 @@ const learnCourseSchema = new Schema(
     course_number: {
       type: Number,
       required: [true, "course_number is required"],
+      unique: true,
       min: 1,
     },
     title: {
@@ -182,11 +183,7 @@ learnCourseSchema.statics = {
 const LearnCourseModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
-  try {
-    return mongoose.model("learncourses");
-  } catch (error) {
-    return getModelByTenant(dbTenant, "learncourse", learnCourseSchema);
-  }
+  return getModelByTenant(dbTenant, "learncourse", learnCourseSchema);
 };
 
 module.exports = LearnCourseModel;

--- a/src/device-registry/models/LearnCourse.js
+++ b/src/device-registry/models/LearnCourse.js
@@ -1,0 +1,192 @@
+const mongoose = require("mongoose");
+const { Schema } = require("mongoose");
+const uniqueValidator = require("mongoose-unique-validator");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const httpStatus = require("http-status");
+const { logObject, HttpError } = require("@utils/shared");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- learn-course-model`
+);
+
+const learnCourseSchema = new Schema(
+  {
+    course_number: {
+      type: Number,
+      required: [true, "course_number is required"],
+      min: 1,
+    },
+    title: {
+      type: String,
+      required: [true, "title is required"],
+      maxlength: [120, "title must not exceed 120 characters"],
+      trim: true,
+    },
+    plain_title_key: {
+      type: String,
+      required: [true, "plain_title_key is required"],
+      trim: true,
+    },
+    cover_image_url: {
+      type: String,
+      trim: true,
+      validate: {
+        validator: (v) => !v || /^https:\/\/.+/.test(v),
+        message: "cover_image_url must be a valid HTTPS URL",
+      },
+    },
+    published: {
+      type: Boolean,
+      default: false,
+    },
+    catalog_version: {
+      type: String,
+      trim: true,
+    },
+  },
+  { timestamps: true }
+);
+
+learnCourseSchema.plugin(uniqueValidator, { message: `{VALUE} already taken!` });
+
+learnCourseSchema.statics = {
+  async register(args, next) {
+    try {
+      const created = await this.create({ ...args });
+      if (!isEmpty(created)) {
+        return {
+          success: true,
+          data: created._doc,
+          message: "course created",
+          status: httpStatus.CREATED,
+        };
+      }
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: "course not created despite successful operation",
+        })
+      );
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      let response = {};
+      let message = "validation errors for some of the provided fields";
+      let status = httpStatus.CONFLICT;
+      if (!isEmpty(error.keyPattern) && error.code === 11000) {
+        Object.entries(error.keyPattern).forEach(([key]) => {
+          response[key] = "duplicate value";
+          response.message = "duplicate value";
+        });
+      } else if (!isEmpty(error.errors)) {
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+          response.message = value.message;
+        });
+      }
+      next(new HttpError(message, status, response));
+    }
+  },
+
+  async list({ skip = 0, limit = 1000, filter = {} } = {}, next) {
+    try {
+      const courses = await this.find(filter)
+        .sort({ course_number: 1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return {
+        success: true,
+        data: courses,
+        message: "successfully retrieved courses",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async modify({ filter = {}, update = {}, opts = { new: true } } = {}, next) {
+    try {
+      const modifiedUpdate = { ...update };
+      delete modifiedUpdate._id;
+      const updated = await this.findOneAndUpdate(filter, modifiedUpdate, opts);
+      if (!isEmpty(updated)) {
+        return {
+          success: true,
+          data: updated._doc,
+          message: "successfully modified the course",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No course found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      let response = {};
+      let message = "validation errors for some of the provided fields";
+      let status = httpStatus.CONFLICT;
+      if (!isEmpty(error.keyPattern) && error.code === 11000) {
+        Object.entries(error.keyPattern).forEach(([key]) => {
+          response[key] = "duplicate value";
+          response.message = "duplicate value";
+        });
+      } else if (!isEmpty(error.errors)) {
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+          response.message = value.message;
+        });
+      }
+      next(new HttpError(message, status, response));
+    }
+  },
+
+  async remove({ filter = {} } = {}, next) {
+    try {
+      const removed = await this.findOneAndRemove(filter, {
+        projection: { _id: 1, title: 1 },
+      }).exec();
+      if (!isEmpty(removed)) {
+        return {
+          success: true,
+          data: removed._doc,
+          message: "successfully removed the course",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No course found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+const LearnCourseModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("learncourses");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "learncourse", learnCourseSchema);
+  }
+};
+
+module.exports = LearnCourseModel;

--- a/src/device-registry/models/LearnGuestSession.js
+++ b/src/device-registry/models/LearnGuestSession.js
@@ -100,17 +100,29 @@ learnGuestSessionSchema.statics = {
       }
       const suffix = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
       const guest_id = `guest_${suffix}`;
-      const created = await this.create({
-        ...args,
-        guest_id,
-        display_name: guest_id,
-      });
-      return {
-        success: true,
-        data: created._doc,
-        message: "guest session created",
-        status: httpStatus.CREATED,
-      };
+      try {
+        const created = await this.create({ ...args, guest_id, display_name: guest_id });
+        return {
+          success: true,
+          data: created._doc,
+          message: "guest session created",
+          status: httpStatus.CREATED,
+        };
+      } catch (createError) {
+        // Concurrent request won the race — re-fetch and return the winner's doc
+        if (createError.code === 11000) {
+          const race = await this.findOne({ device_id: args.device_id }).lean();
+          if (race) {
+            return {
+              success: true,
+              data: race,
+              message: "guest session retrieved",
+              status: httpStatus.OK,
+            };
+          }
+        }
+        throw createError;
+      }
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
       next(

--- a/src/device-registry/models/LearnGuestSession.js
+++ b/src/device-registry/models/LearnGuestSession.js
@@ -1,0 +1,167 @@
+const mongoose = require("mongoose");
+const { Schema } = require("mongoose");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const httpStatus = require("http-status");
+const { HttpError } = require("@utils/shared");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- learn-guest-session-model`
+);
+
+const learnGuestSessionSchema = new Schema(
+  {
+    device_id: {
+      type: String,
+      required: [true, "device_id is required"],
+      trim: true,
+    },
+    guest_id: {
+      type: String,
+      required: [true, "guest_id is required"],
+      unique: true,
+      trim: true,
+    },
+    display_name: {
+      type: String,
+      trim: true,
+    },
+    app_version: {
+      type: String,
+      trim: true,
+    },
+    platform: {
+      type: String,
+      enum: ["android", "ios", null],
+      default: null,
+    },
+    linked_user_id: {
+      type: String,
+      default: null,
+    },
+    linked_at: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+learnGuestSessionSchema.index({ device_id: 1 }, { unique: true });
+
+learnGuestSessionSchema.statics = {
+  async register(args, next) {
+    try {
+      const created = await this.create({ ...args });
+      if (!isEmpty(created)) {
+        return {
+          success: true,
+          data: created._doc,
+          message: "guest session created",
+          status: httpStatus.CREATED,
+        };
+      }
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: "guest session not created despite successful operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      let response = {};
+      let message = "validation errors for some of the provided fields";
+      let status = httpStatus.CONFLICT;
+      if (!isEmpty(error.keyPattern) && error.code === 11000) {
+        Object.entries(error.keyPattern).forEach(([key]) => {
+          response[key] = "duplicate value";
+          response.message = "duplicate value";
+        });
+      } else if (!isEmpty(error.errors)) {
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+          response.message = value.message;
+        });
+      }
+      next(new HttpError(message, status, response));
+    }
+  },
+
+  async findOrCreate(args, next) {
+    try {
+      const existing = await this.findOne({ device_id: args.device_id }).lean();
+      if (existing) {
+        return {
+          success: true,
+          data: existing,
+          message: "guest session retrieved",
+          status: httpStatus.OK,
+        };
+      }
+      const suffix = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+      const guest_id = `guest_${suffix}`;
+      const created = await this.create({
+        ...args,
+        guest_id,
+        display_name: guest_id,
+      });
+      return {
+        success: true,
+        data: created._doc,
+        message: "guest session created",
+        status: httpStatus.CREATED,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async modify({ filter = {}, update = {}, opts = { new: true } } = {}, next) {
+    try {
+      const modifiedUpdate = { ...update };
+      delete modifiedUpdate._id;
+      const updated = await this.findOneAndUpdate(filter, modifiedUpdate, opts);
+      if (!isEmpty(updated)) {
+        return {
+          success: true,
+          data: updated._doc,
+          message: "successfully modified the guest session",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No guest session found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+const LearnGuestSessionModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("learnguestsessions");
+  } catch (error) {
+    return getModelByTenant(
+      dbTenant,
+      "learnguestsession",
+      learnGuestSessionSchema
+    );
+  }
+};
+
+module.exports = LearnGuestSessionModel;

--- a/src/device-registry/models/LearnLesson.js
+++ b/src/device-registry/models/LearnLesson.js
@@ -1,0 +1,181 @@
+const mongoose = require("mongoose");
+const { Schema } = require("mongoose");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const httpStatus = require("http-status");
+const { HttpError } = require("@utils/shared");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- learn-lesson-model`
+);
+
+const learnLessonSchema = new Schema(
+  {
+    unit_id: {
+      type: Schema.Types.ObjectId,
+      ref: "learnunit",
+      required: [true, "unit_id is required"],
+    },
+    title: {
+      type: String,
+      required: [true, "title is required"],
+      maxlength: [120, "title must not exceed 120 characters"],
+      trim: true,
+    },
+    plain_title_key: {
+      type: String,
+      required: [true, "plain_title_key is required"],
+      trim: true,
+    },
+    lesson_order: {
+      type: Number,
+      required: [true, "lesson_order is required"],
+      min: 1,
+    },
+    cover_image_url: {
+      type: String,
+      trim: true,
+      validate: {
+        validator: (v) => !v || /^https:\/\/.+/.test(v),
+        message: "cover_image_url must be a valid HTTPS URL",
+      },
+    },
+    completion_message: {
+      type: String,
+      trim: true,
+    },
+  },
+  { timestamps: true }
+);
+
+learnLessonSchema.index({ unit_id: 1, lesson_order: 1 }, { unique: true });
+
+learnLessonSchema.statics = {
+  async register(args, next) {
+    try {
+      const created = await this.create({ ...args });
+      if (!isEmpty(created)) {
+        return {
+          success: true,
+          data: created._doc,
+          message: "lesson created",
+          status: httpStatus.CREATED,
+        };
+      }
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: "lesson not created despite successful operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      let response = {};
+      let message = "validation errors for some of the provided fields";
+      let status = httpStatus.CONFLICT;
+      if (!isEmpty(error.keyPattern) && error.code === 11000) {
+        Object.entries(error.keyPattern).forEach(([key]) => {
+          response[key] = "duplicate value";
+          response.message = "duplicate value";
+        });
+      } else if (!isEmpty(error.errors)) {
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+          response.message = value.message;
+        });
+      }
+      next(new HttpError(message, status, response));
+    }
+  },
+
+  async list({ filter = {}, skip = 0, limit = 1000 } = {}, next) {
+    try {
+      const lessons = await this.find(filter)
+        .sort({ lesson_order: 1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return {
+        success: true,
+        data: lessons,
+        message: "successfully retrieved lessons",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async modify({ filter = {}, update = {}, opts = { new: true } } = {}, next) {
+    try {
+      const modifiedUpdate = { ...update };
+      delete modifiedUpdate._id;
+      const updated = await this.findOneAndUpdate(filter, modifiedUpdate, opts);
+      if (!isEmpty(updated)) {
+        return {
+          success: true,
+          data: updated._doc,
+          message: "successfully modified the lesson",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No lesson found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async remove({ filter = {} } = {}, next) {
+    try {
+      const removed = await this.findOneAndRemove(filter, {
+        projection: { _id: 1, title: 1 },
+      }).exec();
+      if (!isEmpty(removed)) {
+        return {
+          success: true,
+          data: removed._doc,
+          message: "successfully removed the lesson",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No lesson found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+const LearnLessonModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("learnlessons");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "learnlesson", learnLessonSchema);
+  }
+};
+
+module.exports = LearnLessonModel;

--- a/src/device-registry/models/LearnProgress.js
+++ b/src/device-registry/models/LearnProgress.js
@@ -10,6 +10,8 @@ const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- learn-progress-model`
 );
 
+const MAX_LEARN_POINTS = 2400;
+
 // Per-lesson progress sub-document
 const lessonProgressSchema = new Schema(
   {
@@ -26,7 +28,6 @@ const lessonProgressSchema = new Schema(
 
 const learnProgressSchema = new Schema(
   {
-    // Either guest_id or user_id is set; user_id takes precedence after account link
     guest_id: { type: String, default: null },
     user_id: { type: String, default: null },
     device_id: { type: String, required: [true, "device_id is required"] },
@@ -69,8 +70,20 @@ function computeStage(totalPoints, maxPoints) {
   return STAGES[0];
 }
 
+// Normalize a lessons field from either a Mongoose Map or a plain object to a plain object
+function normalizeLessons(lessons) {
+  if (!lessons) return {};
+  if (lessons instanceof Map) {
+    const obj = {};
+    lessons.forEach((v, k) => { obj[k] = v; });
+    return obj;
+  }
+  return Object.fromEntries(Object.entries(lessons));
+}
+
 learnProgressSchema.statics = {
   STAGES,
+  MAX_LEARN_POINTS,
   computeStage,
 
   async upsertLessonProgress(
@@ -80,8 +93,6 @@ learnProgressSchema.statics = {
     try {
       const filter = user_id ? { user_id } : { device_id };
       const existing = await this.findOne(filter);
-
-      const lessonKey = `lessons.${lesson_id}`;
       const currentLesson = existing?.lessons?.get(lesson_id) || {};
 
       const furthest = Math.max(
@@ -109,7 +120,6 @@ learnProgressSchema.statics = {
         else if (quizScoreRatio >= 0.5) stars = 2;
         else stars = 1;
       } else if (update.completed) {
-        // re-completion: keep best
         const newPoints = update.quiz_attempts
           ? update.quiz_attempts.filter(
               (a) => a.format !== "free_text" && a.is_correct
@@ -128,41 +138,42 @@ learnProgressSchema.statics = {
         quiz_attempts: update.quiz_attempts || currentLesson.quiz_attempts || [],
       };
 
-      // Recompute totals from scratch after upsert
-      const setOp = { [`lessons.${lesson_id}`]: lessonUpdate };
+      // Compute aggregate totals from existing lessons + updated lesson in one pass
+      let totalPoints = 0;
+      let completedCount = 0;
+      if (existing?.lessons) {
+        existing.lessons.forEach((lp, lid) => {
+          if (lid === lesson_id) return; // replaced below
+          if (lp.completed) {
+            totalPoints += lp.points_earned || 0;
+            completedCount += 1;
+          }
+        });
+      }
+      if (lessonUpdate.completed) {
+        totalPoints += lessonUpdate.points_earned;
+        completedCount += 1;
+      }
+
+      const stage = computeStage(totalPoints, maxPoints || MAX_LEARN_POINTS);
+
+      const setOp = {
+        [`lessons.${lesson_id}`]: lessonUpdate,
+        total_points: totalPoints,
+        completed_lessons: completedCount,
+        current_stage_index: stage.index,
+      };
       if (!existing) {
         setOp.device_id = device_id;
         if (guest_id) setOp.guest_id = guest_id;
         if (user_id) { setOp.user_id = user_id; setOp.learner_type = "user"; }
       }
 
-      const doc = await this.findOneAndUpdate(
+      // Single atomic write — no second findOneAndUpdate needed
+      await this.findOneAndUpdate(
         filter,
         { $set: setOp },
         { upsert: true, new: true }
-      );
-
-      // Recompute aggregate totals
-      let totalPoints = 0;
-      let completedCount = 0;
-      doc.lessons.forEach((lp) => {
-        if (lp.completed) {
-          totalPoints += lp.points_earned;
-          completedCount += 1;
-        }
-      });
-
-      const stage = computeStage(totalPoints, maxPoints || 2400);
-      await this.findOneAndUpdate(
-        filter,
-        {
-          $set: {
-            total_points: totalPoints,
-            completed_lessons: completedCount,
-            current_stage_index: stage.index,
-          },
-        },
-        { new: true }
       );
 
       return {
@@ -218,7 +229,8 @@ learnProgressSchema.statics = {
 
   async mergeGuestToUser({ device_id, guest_id, user_id }, next) {
     try {
-      const guestDoc = await this.findOne({ device_id }).lean();
+      // Work with the existing guest doc (identified by device_id)
+      const guestDoc = await this.findOne({ device_id });
       if (!guestDoc) {
         return {
           success: true,
@@ -228,65 +240,62 @@ learnProgressSchema.statics = {
         };
       }
 
-      const userDoc = await this.findOne({ user_id }).lean();
-      const mergedLessons = {};
-      let lessonsTransferred = 0;
-      let pointsTransferred = 0;
+      // Normalize both lesson maps to plain objects for uniform iteration
+      const guestLessons = normalizeLessons(guestDoc.lessons);
 
-      // Start from existing user lessons
-      if (userDoc?.lessons) {
-        Object.entries(userDoc.lessons).forEach(([lid, lp]) => {
+      // If a separate user doc already exists (e.g. from another device), merge its
+      // lessons in too, keeping the best per lesson, then delete the orphan.
+      const userDoc = await this.findOne({ user_id, device_id: { $ne: device_id } }).lean();
+      const userLessons = userDoc ? normalizeLessons(userDoc.lessons) : {};
+
+      const mergedLessons = { ...guestLessons };
+      Object.entries(userLessons).forEach(([lid, lp]) => {
+        const gl = mergedLessons[lid];
+        if (!gl || (lp.points_earned || 0) > (gl.points_earned || 0)) {
           mergedLessons[lid] = lp;
-        });
-      }
-
-      // Merge guest lessons — keep best
-      if (guestDoc.lessons) {
-        const lessonEntries =
-          guestDoc.lessons instanceof Map
-            ? guestDoc.lessons
-            : new Map(Object.entries(guestDoc.lessons));
-        lessonEntries.forEach((lp, lid) => {
-          const existing = mergedLessons[lid];
-          if (!existing || lp.points_earned > existing.points_earned) {
-            mergedLessons[lid] = lp;
-            lessonsTransferred += 1;
-            pointsTransferred += lp.points_earned || 0;
-          }
-        });
-      }
+        }
+      });
 
       let totalPoints = 0;
       let completedCount = 0;
+      let lessonsTransferred = 0;
+      let pointsTransferred = 0;
+
       Object.values(mergedLessons).forEach((lp) => {
         if (lp.completed) {
           totalPoints += lp.points_earned || 0;
           completedCount += 1;
         }
+        lessonsTransferred += 1;
+        pointsTransferred += lp.points_earned || 0;
       });
 
+      const stage = computeStage(totalPoints, MAX_LEARN_POINTS);
+
+      // Promote the existing guest doc in place — avoids colliding with the unique device_id index
       const lessonsMap = {};
       Object.entries(mergedLessons).forEach(([lid, lp]) => {
         lessonsMap[`lessons.${lid}`] = lp;
       });
 
       await this.findOneAndUpdate(
-        { user_id },
+        { device_id },
         {
           $set: {
             user_id,
-            device_id,
             learner_type: "user",
             total_points: totalPoints,
             completed_lessons: completedCount,
+            current_stage_index: stage.index,
             ...lessonsMap,
           },
-        },
-        { upsert: true, new: true }
+        }
       );
 
-      // Mark guest session as linked
-      await this.findOneAndUpdate({ device_id }, { $set: { linked_user_id: user_id } });
+      // Clean up the orphaned user doc if one existed on another device
+      if (userDoc) {
+        await this.deleteOne({ user_id, device_id: { $ne: device_id } });
+      }
 
       return {
         success: true,

--- a/src/device-registry/models/LearnProgress.js
+++ b/src/device-registry/models/LearnProgress.js
@@ -1,0 +1,322 @@
+const mongoose = require("mongoose");
+const { Schema } = require("mongoose");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const httpStatus = require("http-status");
+const { HttpError } = require("@utils/shared");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- learn-progress-model`
+);
+
+// Per-lesson progress sub-document
+const lessonProgressSchema = new Schema(
+  {
+    lesson_id: { type: String, required: true },
+    completed: { type: Boolean, default: false },
+    stars: { type: Number, default: 0, min: 0, max: 3 },
+    points_earned: { type: Number, default: 0, min: 0 },
+    quiz_score_ratio: { type: Number, default: 0, min: 0, max: 1 },
+    furthest_activity_index: { type: Number, default: 0, min: 0 },
+    quiz_attempts: { type: Schema.Types.Mixed, default: [] },
+  },
+  { _id: false }
+);
+
+const learnProgressSchema = new Schema(
+  {
+    // Either guest_id or user_id is set; user_id takes precedence after account link
+    guest_id: { type: String, default: null },
+    user_id: { type: String, default: null },
+    device_id: { type: String, required: [true, "device_id is required"] },
+    learner_type: {
+      type: String,
+      enum: ["guest", "user"],
+      default: "guest",
+    },
+    total_points: { type: Number, default: 0, min: 0 },
+    completed_lessons: { type: Number, default: 0, min: 0 },
+    current_stage_index: { type: Number, default: 0, min: 0 },
+    lessons: {
+      type: Map,
+      of: lessonProgressSchema,
+      default: {},
+    },
+  },
+  { timestamps: true }
+);
+
+learnProgressSchema.index({ guest_id: 1 }, { sparse: true });
+learnProgressSchema.index({ user_id: 1 }, { sparse: true });
+learnProgressSchema.index({ device_id: 1 }, { unique: true });
+
+const STAGES = [
+  { index: 0, name: "Curious" },
+  { index: 1, name: "Aware" },
+  { index: 2, name: "Observer" },
+  { index: 3, name: "Champion" },
+  { index: 4, name: "Defender" },
+];
+
+function computeStage(totalPoints, maxPoints) {
+  if (!maxPoints || maxPoints === 0) return STAGES[0];
+  const ratio = totalPoints / maxPoints;
+  if (ratio >= 1.0) return STAGES[4];
+  if (ratio >= 0.75) return STAGES[3];
+  if (ratio >= 0.5) return STAGES[2];
+  if (ratio >= 0.25) return STAGES[1];
+  return STAGES[0];
+}
+
+learnProgressSchema.statics = {
+  STAGES,
+  computeStage,
+
+  async upsertLessonProgress(
+    { device_id, guest_id, user_id, lesson_id, update, maxPoints },
+    next
+  ) {
+    try {
+      const filter = user_id ? { user_id } : { device_id };
+      const existing = await this.findOne(filter);
+
+      const lessonKey = `lessons.${lesson_id}`;
+      const currentLesson = existing?.lessons?.get(lesson_id) || {};
+
+      const furthest = Math.max(
+        currentLesson.furthest_activity_index || 0,
+        update.furthest_activity_index || 0
+      );
+
+      let stars = currentLesson.stars || 0;
+      let pointsEarned = currentLesson.points_earned || 0;
+      let quizScoreRatio = currentLesson.quiz_score_ratio || 0;
+      let completed = currentLesson.completed || false;
+
+      if (update.completed && !currentLesson.completed) {
+        completed = true;
+        const attempts = update.quiz_attempts || [];
+        const graded = attempts.filter(
+          (a) => a.format !== "free_text" && a.is_correct !== undefined
+        );
+        const correct = graded.filter((a) => a.is_correct).length;
+        quizScoreRatio = graded.length > 0 ? correct / graded.length : 1.0;
+        pointsEarned = correct * 10;
+
+        if (graded.length === 0) stars = 1;
+        else if (quizScoreRatio === 1.0) stars = 3;
+        else if (quizScoreRatio >= 0.5) stars = 2;
+        else stars = 1;
+      } else if (update.completed) {
+        // re-completion: keep best
+        const newPoints = update.quiz_attempts
+          ? update.quiz_attempts.filter(
+              (a) => a.format !== "free_text" && a.is_correct
+            ).length * 10
+          : pointsEarned;
+        pointsEarned = Math.max(pointsEarned, newPoints);
+      }
+
+      const lessonUpdate = {
+        lesson_id,
+        completed,
+        stars,
+        points_earned: pointsEarned,
+        quiz_score_ratio: quizScoreRatio,
+        furthest_activity_index: furthest,
+        quiz_attempts: update.quiz_attempts || currentLesson.quiz_attempts || [],
+      };
+
+      // Recompute totals from scratch after upsert
+      const setOp = { [`lessons.${lesson_id}`]: lessonUpdate };
+      if (!existing) {
+        setOp.device_id = device_id;
+        if (guest_id) setOp.guest_id = guest_id;
+        if (user_id) { setOp.user_id = user_id; setOp.learner_type = "user"; }
+      }
+
+      const doc = await this.findOneAndUpdate(
+        filter,
+        { $set: setOp },
+        { upsert: true, new: true }
+      );
+
+      // Recompute aggregate totals
+      let totalPoints = 0;
+      let completedCount = 0;
+      doc.lessons.forEach((lp) => {
+        if (lp.completed) {
+          totalPoints += lp.points_earned;
+          completedCount += 1;
+        }
+      });
+
+      const stage = computeStage(totalPoints, maxPoints || 2400);
+      await this.findOneAndUpdate(
+        filter,
+        {
+          $set: {
+            total_points: totalPoints,
+            completed_lessons: completedCount,
+            current_stage_index: stage.index,
+          },
+        },
+        { new: true }
+      );
+
+      return {
+        success: true,
+        data: {
+          lesson_id,
+          stars: lessonUpdate.stars,
+          points_earned: lessonUpdate.points_earned,
+          total_points: totalPoints,
+          current_stage: stage,
+          completed: lessonUpdate.completed,
+        },
+        message: "lesson progress updated",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async findProgress({ device_id, guest_id, user_id }, next) {
+    try {
+      const filter = user_id ? { user_id } : { device_id };
+      const doc = await this.findOne(filter).lean();
+      if (!doc) {
+        return {
+          success: true,
+          data: null,
+          message: "no progress found",
+          status: httpStatus.OK,
+        };
+      }
+      return {
+        success: true,
+        data: doc,
+        message: "progress retrieved",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async mergeGuestToUser({ device_id, guest_id, user_id }, next) {
+    try {
+      const guestDoc = await this.findOne({ device_id }).lean();
+      if (!guestDoc) {
+        return {
+          success: true,
+          data: { lessons_transferred: 0, points_transferred: 0, courses_completed: 0 },
+          message: "no guest progress to transfer",
+          status: httpStatus.OK,
+        };
+      }
+
+      const userDoc = await this.findOne({ user_id }).lean();
+      const mergedLessons = {};
+      let lessonsTransferred = 0;
+      let pointsTransferred = 0;
+
+      // Start from existing user lessons
+      if (userDoc?.lessons) {
+        Object.entries(userDoc.lessons).forEach(([lid, lp]) => {
+          mergedLessons[lid] = lp;
+        });
+      }
+
+      // Merge guest lessons — keep best
+      if (guestDoc.lessons) {
+        const lessonEntries =
+          guestDoc.lessons instanceof Map
+            ? guestDoc.lessons
+            : new Map(Object.entries(guestDoc.lessons));
+        lessonEntries.forEach((lp, lid) => {
+          const existing = mergedLessons[lid];
+          if (!existing || lp.points_earned > existing.points_earned) {
+            mergedLessons[lid] = lp;
+            lessonsTransferred += 1;
+            pointsTransferred += lp.points_earned || 0;
+          }
+        });
+      }
+
+      let totalPoints = 0;
+      let completedCount = 0;
+      Object.values(mergedLessons).forEach((lp) => {
+        if (lp.completed) {
+          totalPoints += lp.points_earned || 0;
+          completedCount += 1;
+        }
+      });
+
+      const lessonsMap = {};
+      Object.entries(mergedLessons).forEach(([lid, lp]) => {
+        lessonsMap[`lessons.${lid}`] = lp;
+      });
+
+      await this.findOneAndUpdate(
+        { user_id },
+        {
+          $set: {
+            user_id,
+            device_id,
+            learner_type: "user",
+            total_points: totalPoints,
+            completed_lessons: completedCount,
+            ...lessonsMap,
+          },
+        },
+        { upsert: true, new: true }
+      );
+
+      // Mark guest session as linked
+      await this.findOneAndUpdate({ device_id }, { $set: { linked_user_id: user_id } });
+
+      return {
+        success: true,
+        data: {
+          lessons_transferred: lessonsTransferred,
+          points_transferred: pointsTransferred,
+          courses_completed: 0,
+        },
+        message: "guest progress merged to user",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+const LearnProgressModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("learnprogresses");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "learnprogress", learnProgressSchema);
+  }
+};
+
+module.exports = LearnProgressModel;

--- a/src/device-registry/models/LearnUnit.js
+++ b/src/device-registry/models/LearnUnit.js
@@ -1,0 +1,167 @@
+const mongoose = require("mongoose");
+const { Schema } = require("mongoose");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const httpStatus = require("http-status");
+const { logObject, HttpError } = require("@utils/shared");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- learn-unit-model`);
+
+const learnUnitSchema = new Schema(
+  {
+    course_id: {
+      type: Schema.Types.ObjectId,
+      ref: "learncourse",
+      required: [true, "course_id is required"],
+    },
+    title: {
+      type: String,
+      required: [true, "title is required"],
+      maxlength: [120, "title must not exceed 120 characters"],
+      trim: true,
+    },
+    plain_title_key: {
+      type: String,
+      required: [true, "plain_title_key is required"],
+      trim: true,
+    },
+    unit_order: {
+      type: Number,
+      required: [true, "unit_order is required"],
+      min: 1,
+    },
+  },
+  { timestamps: true }
+);
+
+learnUnitSchema.index({ course_id: 1, unit_order: 1 }, { unique: true });
+
+learnUnitSchema.statics = {
+  async register(args, next) {
+    try {
+      const created = await this.create({ ...args });
+      if (!isEmpty(created)) {
+        return {
+          success: true,
+          data: created._doc,
+          message: "unit created",
+          status: httpStatus.CREATED,
+        };
+      }
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: "unit not created despite successful operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      let response = {};
+      let message = "validation errors for some of the provided fields";
+      let status = httpStatus.CONFLICT;
+      if (!isEmpty(error.keyPattern) && error.code === 11000) {
+        Object.entries(error.keyPattern).forEach(([key]) => {
+          response[key] = "duplicate value";
+          response.message = "duplicate value";
+        });
+      } else if (!isEmpty(error.errors)) {
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+          response.message = value.message;
+        });
+      }
+      next(new HttpError(message, status, response));
+    }
+  },
+
+  async list({ filter = {}, skip = 0, limit = 1000 } = {}, next) {
+    try {
+      const units = await this.find(filter)
+        .sort({ unit_order: 1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return {
+        success: true,
+        data: units,
+        message: "successfully retrieved units",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async modify({ filter = {}, update = {}, opts = { new: true } } = {}, next) {
+    try {
+      const modifiedUpdate = { ...update };
+      delete modifiedUpdate._id;
+      const updated = await this.findOneAndUpdate(filter, modifiedUpdate, opts);
+      if (!isEmpty(updated)) {
+        return {
+          success: true,
+          data: updated._doc,
+          message: "successfully modified the unit",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No unit found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  async remove({ filter = {} } = {}, next) {
+    try {
+      const removed = await this.findOneAndRemove(filter, {
+        projection: { _id: 1, title: 1 },
+      }).exec();
+      if (!isEmpty(removed)) {
+        return {
+          success: true,
+          data: removed._doc,
+          message: "successfully removed the unit",
+          status: httpStatus.OK,
+        };
+      }
+      next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+          message: "No unit found for this operation",
+        })
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+const LearnUnitModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("learnunits");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "learnunit", learnUnitSchema);
+  }
+};
+
+module.exports = LearnUnitModel;

--- a/src/device-registry/routes/v2/index.js
+++ b/src/device-registry/routes/v2/index.js
@@ -141,6 +141,7 @@ const routes = [
   },
   { path: "/tips", route: "@routes/v2/tips.routes", name: "tips" },
   { path: "/kya", route: "@routes/v2/kya.routes", name: "kya" },
+  { path: "/learn", route: "@routes/v2/learn.routes", name: "learn" },
   { path: "/cohorts", route: "@routes/v2/cohorts.routes", name: "cohorts" },
   // Canonical Network CRUD endpoints — /api/v2/devices/networks/...
   // The legacy /cohorts/networks/... paths remain fully operational.

--- a/src/device-registry/routes/v2/learn.routes.js
+++ b/src/device-registry/routes/v2/learn.routes.js
@@ -1,0 +1,50 @@
+// learn.routes.js
+// publicRouter  → mounted at /api/v2/learn
+// adminRouter   → mounted at /api/v2/admin/learn
+const express = require("express");
+const learnController = require("@controllers/learn.controller");
+const learnValidations = require("@validators/learn.validators");
+const { headers } = require("@validators/common");
+
+// ---------------------------------------------------------------------------
+// Public / guest router — /api/v2/learn/*
+// ---------------------------------------------------------------------------
+const publicRouter = express.Router();
+publicRouter.use(headers);
+
+// Option 1 — Content (no auth required)
+publicRouter.get("/catalog", learnValidations.getCatalog, learnController.getCatalog);
+publicRouter.get("/lessons/:lesson_id", learnValidations.getLesson, learnController.getLesson);
+
+// Option 2 — Guest Progress
+publicRouter.post("/sessions/anonymous", learnValidations.createAnonymousSession, learnController.createAnonymousSession);
+publicRouter.get("/progress", learnValidations.getProgress, learnController.getProgress);
+publicRouter.put("/progress/lessons/:lesson_id", learnValidations.updateLessonProgress, learnController.updateLessonProgress);
+publicRouter.post("/progress/sync", learnValidations.syncProgress, learnController.syncProgress);
+
+// Option 3 — Account linking (JWT enforced at nginx gateway)
+publicRouter.post("/progress/link", learnValidations.linkGuestProgress, learnController.linkGuestProgress);
+
+// ---------------------------------------------------------------------------
+// Admin router — /api/v2/admin/learn/*
+// Auth (admin JWT with learn:write scope) enforced at nginx gateway
+// ---------------------------------------------------------------------------
+const adminRouter = express.Router();
+adminRouter.use(headers);
+
+// Step 1 — Create course shell
+adminRouter.post("/courses", learnValidations.createCourse, learnController.createCourse);
+
+// Step 2 — Add unit to course
+adminRouter.post("/courses/:course_id/units", learnValidations.addUnit, learnController.addUnit);
+
+// Step 3 — Add lesson to unit
+adminRouter.post("/units/:unit_id/lessons", learnValidations.addLesson, learnController.addLesson);
+
+// Step 4 — Add activity to lesson
+adminRouter.post("/lessons/:lesson_id/activities", learnValidations.addActivity, learnController.addActivity);
+
+// Step 5 — Publish / update course metadata
+adminRouter.patch("/courses/:course_id", learnValidations.updateCourse, learnController.updateCourse);
+
+module.exports = { publicRouter, adminRouter };

--- a/src/device-registry/routes/v2/learn.routes.js
+++ b/src/device-registry/routes/v2/learn.routes.js
@@ -1,50 +1,43 @@
 // learn.routes.js
-// publicRouter  → mounted at /api/v2/learn
-// adminRouter   → mounted at /api/v2/admin/learn
+// Mounted at /api/v2/devices/learn
 const express = require("express");
+const router = express.Router();
 const learnController = require("@controllers/learn.controller");
 const learnValidations = require("@validators/learn.validators");
 const { headers } = require("@validators/common");
 
-// ---------------------------------------------------------------------------
-// Public / guest router — /api/v2/learn/*
-// ---------------------------------------------------------------------------
-const publicRouter = express.Router();
-publicRouter.use(headers);
+router.use(headers);
 
+// ---------------------------------------------------------------------------
 // Option 1 — Content (no auth required)
-publicRouter.get("/catalog", learnValidations.getCatalog, learnController.getCatalog);
-publicRouter.get("/lessons/:lesson_id", learnValidations.getLesson, learnController.getLesson);
+// ---------------------------------------------------------------------------
 
-// Option 2 — Guest Progress
-publicRouter.post("/sessions/anonymous", learnValidations.createAnonymousSession, learnController.createAnonymousSession);
-publicRouter.get("/progress", learnValidations.getProgress, learnController.getProgress);
-publicRouter.put("/progress/lessons/:lesson_id", learnValidations.updateLessonProgress, learnController.updateLessonProgress);
-publicRouter.post("/progress/sync", learnValidations.syncProgress, learnController.syncProgress);
+router.get("/catalog", learnValidations.getCatalog, learnController.getCatalog);
+router.get("/lessons/:lesson_id", learnValidations.getLesson, learnController.getLesson);
 
+// ---------------------------------------------------------------------------
+// Option 2 — Guest Progress (guest headers or JWT)
+// ---------------------------------------------------------------------------
+
+router.post("/sessions/anonymous", learnValidations.createAnonymousSession, learnController.createAnonymousSession);
+router.get("/progress", learnValidations.getProgress, learnController.getProgress);
+router.put("/progress/lessons/:lesson_id", learnValidations.updateLessonProgress, learnController.updateLessonProgress);
+router.post("/progress/sync", learnValidations.syncProgress, learnController.syncProgress);
+
+// ---------------------------------------------------------------------------
 // Option 3 — Account linking (JWT enforced at nginx gateway)
-publicRouter.post("/progress/link", learnValidations.linkGuestProgress, learnController.linkGuestProgress);
+// ---------------------------------------------------------------------------
+
+router.post("/progress/link", learnValidations.linkGuestProgress, learnController.linkGuestProgress);
 
 // ---------------------------------------------------------------------------
-// Admin router — /api/v2/admin/learn/*
-// Auth (admin JWT with learn:write scope) enforced at nginx gateway
+// Admin — Course Authoring (admin JWT enforced at nginx gateway)
 // ---------------------------------------------------------------------------
-const adminRouter = express.Router();
-adminRouter.use(headers);
 
-// Step 1 — Create course shell
-adminRouter.post("/courses", learnValidations.createCourse, learnController.createCourse);
+router.post("/admin/courses", learnValidations.createCourse, learnController.createCourse);
+router.post("/admin/courses/:course_id/units", learnValidations.addUnit, learnController.addUnit);
+router.post("/admin/units/:unit_id/lessons", learnValidations.addLesson, learnController.addLesson);
+router.post("/admin/lessons/:lesson_id/activities", learnValidations.addActivity, learnController.addActivity);
+router.patch("/admin/courses/:course_id", learnValidations.updateCourse, learnController.updateCourse);
 
-// Step 2 — Add unit to course
-adminRouter.post("/courses/:course_id/units", learnValidations.addUnit, learnController.addUnit);
-
-// Step 3 — Add lesson to unit
-adminRouter.post("/units/:unit_id/lessons", learnValidations.addLesson, learnController.addLesson);
-
-// Step 4 — Add activity to lesson
-adminRouter.post("/lessons/:lesson_id/activities", learnValidations.addActivity, learnController.addActivity);
-
-// Step 5 — Publish / update course metadata
-adminRouter.patch("/courses/:course_id", learnValidations.updateCourse, learnController.updateCourse);
-
-module.exports = { publicRouter, adminRouter };
+module.exports = router;

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -11,7 +11,9 @@ const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- learn-util`);
 const isEmpty = require("is-empty");
 
-const STAGES = LearnProgressModel("airqo").schema.statics?.STAGES || [
+const MAX_LEARN_POINTS = 2400;
+
+const STAGES = [
   { index: 0, name: "Curious" },
   { index: 1, name: "Aware" },
   { index: 2, name: "Observer" },
@@ -269,7 +271,7 @@ const learn = {
             learner_type: user_id ? "user" : "guest",
             guest_id: guest_id || undefined,
             total_points: 0,
-            max_points: 2400,
+            max_points: MAX_LEARN_POINTS,
             completed_lessons: 0,
             current_stage: STAGES[0],
             lessons: {},
@@ -302,7 +304,7 @@ const learn = {
           learner_type: doc.learner_type,
           guest_id: doc.guest_id || undefined,
           total_points: doc.total_points,
-          max_points: 2400,
+          max_points: MAX_LEARN_POINTS,
           completed_lessons: doc.completed_lessons,
           current_stage: stage,
           lessons: lessonsOut,
@@ -329,6 +331,14 @@ const learn = {
       const user_id = request.user?.id || null;
       const update = request.body;
 
+      if (!user_id && !device_id) {
+        return {
+          success: false,
+          message: "X-Device-Id header is required for guest progress",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
       // Verify lesson exists and is published
       const lessonRes = await LearnLessonModel(tenant).list(
         { filter: { _id: lesson_id } },
@@ -343,7 +353,7 @@ const learn = {
       }
 
       const result = await LearnProgressModel(tenant).upsertLessonProgress(
-        { device_id, guest_id, user_id, lesson_id, update, maxPoints: 2400 },
+        { device_id, guest_id, user_id, lesson_id, update, maxPoints: MAX_LEARN_POINTS },
         next
       );
       if (!result?.success) return result;
@@ -417,7 +427,7 @@ const learn = {
             user_id,
             lesson_id: update.lesson_id,
             update,
-            maxPoints: 2400,
+            maxPoints: MAX_LEARN_POINTS,
           },
           next
         );
@@ -456,7 +466,15 @@ const learn = {
     try {
       const tenant = getTenant(request);
       const { device_id, guest_id } = request.body;
-      const user_id = request.user?.id;
+      const user_id = request.user?.id || null;
+
+      if (!user_id) {
+        return {
+          success: false,
+          message: "authentication required",
+          status: httpStatus.UNAUTHORIZED,
+        };
+      }
 
       // Verify the guest session exists and is not already linked to another user
       const sessionRes = await LearnGuestSessionModel(tenant)
@@ -480,7 +498,7 @@ const learn = {
       if (!result?.success) return result;
 
       await LearnGuestSessionModel(tenant).findOneAndUpdate(
-        { device_id },
+        { device_id, guest_id },
         { $set: { linked_user_id: user_id, linked_at: new Date() } }
       );
 

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -1,0 +1,742 @@
+const httpStatus = require("http-status");
+const LearnCourseModel = require("@models/LearnCourse");
+const LearnUnitModel = require("@models/LearnUnit");
+const LearnLessonModel = require("@models/LearnLesson");
+const LearnActivityModel = require("@models/LearnActivity");
+const LearnGuestSessionModel = require("@models/LearnGuestSession");
+const LearnProgressModel = require("@models/LearnProgress");
+const constants = require("@config/constants");
+const { logObject, HttpError } = require("@utils/shared");
+const log4js = require("log4js");
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- learn-util`);
+const isEmpty = require("is-empty");
+
+const STAGES = LearnProgressModel("airqo").schema.statics?.STAGES || [
+  { index: 0, name: "Curious" },
+  { index: 1, name: "Aware" },
+  { index: 2, name: "Observer" },
+  { index: 3, name: "Champion" },
+  { index: 4, name: "Defender" },
+];
+
+function getTenant(request) {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  return isEmpty(request.query?.tenant) ? defaultTenant : request.query.tenant;
+}
+
+// ---------------------------------------------------------------------------
+// Catalog helpers
+// ---------------------------------------------------------------------------
+
+async function buildCatalog(tenant, next) {
+  const [coursesRes, unitsRes, lessonsRes, activitiesRes] = await Promise.all([
+    LearnCourseModel(tenant).list({ filter: { published: true } }, next),
+    LearnUnitModel(tenant).list({}, next),
+    LearnLessonModel(tenant).list({}, next),
+    LearnActivityModel(tenant).list({}, next),
+  ]);
+
+  if (!coursesRes?.success) return coursesRes;
+
+  const courses = coursesRes.data || [];
+  const units = unitsRes?.data || [];
+  const lessons = lessonsRes?.data || [];
+  const activities = activitiesRes?.data || [];
+
+  // Index for quick lookup
+  const unitsByCourse = {};
+  units.forEach((u) => {
+    const cid = u.course_id.toString();
+    if (!unitsByCourse[cid]) unitsByCourse[cid] = [];
+    unitsByCourse[cid].push(u);
+  });
+
+  const lessonsByUnit = {};
+  lessons.forEach((l) => {
+    const uid = l.unit_id.toString();
+    if (!lessonsByUnit[uid]) lessonsByUnit[uid] = [];
+    lessonsByUnit[uid].push(l);
+  });
+
+  const activitiesByLesson = {};
+  activities.forEach((a) => {
+    const lid = a.lesson_id.toString();
+    if (!activitiesByLesson[lid]) activitiesByLesson[lid] = [];
+    activitiesByLesson[lid].push(a);
+  });
+
+  const catalog = courses.map((course) => {
+    const courseUnits = (unitsByCourse[course._id.toString()] || []).sort(
+      (a, b) => a.unit_order - b.unit_order
+    );
+    return {
+      id: course._id,
+      course_number: course.course_number,
+      title: course.title,
+      plain_title_key: course.plain_title_key,
+      cover_image_url: course.cover_image_url,
+      units: courseUnits.map((unit) => {
+        const unitLessons = (lessonsByUnit[unit._id.toString()] || []).sort(
+          (a, b) => a.lesson_order - b.lesson_order
+        );
+        return {
+          id: unit._id,
+          title: unit.title,
+          lessons: unitLessons.map((lesson) => {
+            const lessonActivities = (
+              activitiesByLesson[lesson._id.toString()] || []
+            ).sort((a, b) => a.order - b.order);
+            return {
+              id: lesson._id,
+              title: lesson.title,
+              cover_image_url: lesson.cover_image_url || undefined,
+              completion_message: lesson.completion_message || undefined,
+              activities: lessonActivities.map((act) => ({
+                id: act._id,
+                type: act.type,
+                order: act.order,
+                payload: act.payload,
+              })),
+            };
+          }),
+        };
+      }),
+    };
+  });
+
+  return { success: true, data: catalog, status: httpStatus.OK };
+}
+
+// ---------------------------------------------------------------------------
+// Option 1 — Content APIs
+// ---------------------------------------------------------------------------
+
+const learn = {
+  getCatalog: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const result = await buildCatalog(tenant, next);
+      if (!result?.success) return result;
+
+      const latestCourse = await LearnCourseModel(tenant)
+        .findOne({ published: true })
+        .sort({ updatedAt: -1 })
+        .lean();
+      const catalogVersion =
+        latestCourse?.catalog_version ||
+        (latestCourse?.updatedAt
+          ? latestCourse.updatedAt.toISOString().slice(0, 10)
+          : new Date().toISOString().slice(0, 10));
+
+      return {
+        success: true,
+        data: {
+          catalog_version: catalogVersion,
+          stages: STAGES,
+          courses: result.data,
+        },
+        message: "successfully retrieved learn catalog",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  getLesson: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { lesson_id } = request.params;
+
+      const [lessonRes, activitiesRes] = await Promise.all([
+        LearnLessonModel(tenant).list(
+          { filter: { _id: lesson_id } },
+          next
+        ),
+        LearnActivityModel(tenant).list(
+          { filter: { lesson_id } },
+          next
+        ),
+      ]);
+
+      if (!lessonRes?.success || !lessonRes.data?.length) {
+        return {
+          success: false,
+          message: "lesson not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      const lesson = lessonRes.data[0];
+      const activities = (activitiesRes?.data || []).sort(
+        (a, b) => a.order - b.order
+      );
+
+      return {
+        success: true,
+        data: {
+          id: lesson._id,
+          title: lesson.title,
+          cover_image_url: lesson.cover_image_url || undefined,
+          completion_message: lesson.completion_message || undefined,
+          activities: activities.map((a) => ({
+            id: a._id,
+            type: a.type,
+            order: a.order,
+            payload: a.payload,
+          })),
+        },
+        message: "successfully retrieved lesson",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Option 2 — Guest Progress APIs
+  // ---------------------------------------------------------------------------
+
+  createAnonymousSession: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { device_id, app_version, platform } = request.body;
+
+      const result = await LearnGuestSessionModel(tenant).findOrCreate(
+        { device_id, app_version, platform },
+        next
+      );
+      if (!result?.success) return result;
+
+      const session = result.data;
+      return {
+        success: true,
+        data: {
+          guest_id: session.guest_id,
+          display_name: session.display_name,
+          created_at: session.createdAt,
+        },
+        message: result.message,
+        status: result.status,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  getProgress: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const device_id = request.headers["x-device-id"];
+      const guest_id = request.headers["x-guest-id"] || null;
+      const user_id = request.user?.id || null;
+
+      if (!user_id && !device_id) {
+        return {
+          success: false,
+          message: "X-Device-Id header is required for guest progress",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      const result = await LearnProgressModel(tenant).findProgress(
+        { device_id, guest_id, user_id },
+        next
+      );
+      if (!result?.success) return result;
+
+      const doc = result.data;
+      if (!doc) {
+        return {
+          success: true,
+          data: {
+            learner_type: user_id ? "user" : "guest",
+            guest_id: guest_id || undefined,
+            total_points: 0,
+            max_points: 2400,
+            completed_lessons: 0,
+            current_stage: STAGES[0],
+            lessons: {},
+          },
+          message: "no progress found — returning empty state",
+          status: httpStatus.OK,
+        };
+      }
+
+      const stage = STAGES[doc.current_stage_index] || STAGES[0];
+      const lessonsOut = {};
+      if (doc.lessons) {
+        const entries =
+          doc.lessons instanceof Map
+            ? doc.lessons
+            : new Map(Object.entries(doc.lessons));
+        entries.forEach((lp, lid) => {
+          lessonsOut[lid] = {
+            completed: lp.completed,
+            stars: lp.stars,
+            points_earned: lp.points_earned,
+            quiz_score_ratio: lp.quiz_score_ratio,
+          };
+        });
+      }
+
+      return {
+        success: true,
+        data: {
+          learner_type: doc.learner_type,
+          guest_id: doc.guest_id || undefined,
+          total_points: doc.total_points,
+          max_points: 2400,
+          completed_lessons: doc.completed_lessons,
+          current_stage: stage,
+          lessons: lessonsOut,
+        },
+        message: "successfully retrieved progress",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  updateLessonProgress: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { lesson_id } = request.params;
+      const device_id = request.headers["x-device-id"];
+      const guest_id = request.headers["x-guest-id"] || null;
+      const user_id = request.user?.id || null;
+      const update = request.body;
+
+      // Verify lesson exists and is published
+      const lessonRes = await LearnLessonModel(tenant).list(
+        { filter: { _id: lesson_id } },
+        next
+      );
+      if (!lessonRes?.success || !lessonRes.data?.length) {
+        return {
+          success: false,
+          message: "lesson not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      const result = await LearnProgressModel(tenant).upsertLessonProgress(
+        { device_id, guest_id, user_id, lesson_id, update, maxPoints: 2400 },
+        next
+      );
+      if (!result?.success) return result;
+
+      // Determine next lesson to unlock
+      const progress = result.data;
+      let nextLessonId = null;
+      if (progress.completed) {
+        const lesson = lessonRes.data[0];
+        const siblingsRes = await LearnLessonModel(tenant).list(
+          {
+            filter: {
+              unit_id: lesson.unit_id,
+              lesson_order: { $gt: lesson.lesson_order },
+            },
+            limit: 1,
+          },
+          next
+        );
+        if (siblingsRes?.data?.length) {
+          nextLessonId = siblingsRes.data[0]._id;
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          lesson_id,
+          stars: progress.stars,
+          points_earned: progress.points_earned,
+          total_points: progress.total_points,
+          current_stage: progress.current_stage,
+          unlock: nextLessonId
+            ? { next_lesson_id: nextLessonId, course_complete: false }
+            : null,
+        },
+        message: "lesson progress updated",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  syncProgress: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { device_id, guest_id, updates } = request.body;
+      const user_id = request.user?.id || null;
+
+      let lastStage = STAGES[0];
+      let totalPoints = 0;
+      let mergedCount = 0;
+
+      for (const update of updates) {
+        const lessonRes = await LearnLessonModel(tenant).list(
+          { filter: { _id: update.lesson_id } },
+          next
+        );
+        if (!lessonRes?.success || !lessonRes.data?.length) continue;
+
+        const result = await LearnProgressModel(tenant).upsertLessonProgress(
+          {
+            device_id,
+            guest_id,
+            user_id,
+            lesson_id: update.lesson_id,
+            update,
+            maxPoints: 2400,
+          },
+          next
+        );
+        if (result?.success) {
+          lastStage = result.data.current_stage;
+          totalPoints = result.data.total_points;
+          mergedCount += 1;
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          merged_count: mergedCount,
+          total_points: totalPoints,
+          current_stage: lastStage,
+        },
+        message: "progress sync complete",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Option 3 — Account, Certificate & Leaderboard
+  // ---------------------------------------------------------------------------
+
+  linkGuestProgress: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { device_id, guest_id } = request.body;
+      const user_id = request.user?.id;
+
+      // Verify the guest session exists and is not already linked to another user
+      const sessionRes = await LearnGuestSessionModel(tenant)
+        .findOne({ device_id, guest_id })
+        .lean();
+      if (
+        !sessionRes ||
+        (sessionRes.linked_user_id && sessionRes.linked_user_id !== user_id)
+      ) {
+        return {
+          success: false,
+          message: "guest session not found or already linked to another user",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      const result = await LearnProgressModel(tenant).mergeGuestToUser(
+        { device_id, guest_id, user_id },
+        next
+      );
+      if (!result?.success) return result;
+
+      await LearnGuestSessionModel(tenant).findOneAndUpdate(
+        { device_id },
+        { $set: { linked_user_id: user_id, linked_at: new Date() } }
+      );
+
+      return {
+        success: true,
+        data: {
+          user_id,
+          merged: result.data,
+        },
+        message: "guest progress merged successfully",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Admin — Course Authoring
+  // ---------------------------------------------------------------------------
+
+  createCourse: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { course_number, title, plain_title_key, cover_image_url, published } =
+        request.body;
+
+      if (published === true) {
+        return {
+          success: false,
+          message: "cannot publish a course on creation — add units and lessons first",
+          status: httpStatus.UNPROCESSABLE_ENTITY,
+        };
+      }
+
+      return await LearnCourseModel(tenant).register(
+        { course_number, title, plain_title_key, cover_image_url, published: false },
+        next
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  addUnit: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { course_id } = request.params;
+      const { title, plain_title_key, unit_order } = request.body;
+
+      const courseRes = await LearnCourseModel(tenant).list(
+        { filter: { _id: course_id } },
+        next
+      );
+      if (!courseRes?.success || !courseRes.data?.length) {
+        return {
+          success: false,
+          message: "course not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      return await LearnUnitModel(tenant).register(
+        { course_id, title, plain_title_key, unit_order },
+        next
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  addLesson: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { unit_id } = request.params;
+      const { title, plain_title_key, lesson_order, cover_image_url, completion_message } =
+        request.body;
+
+      const unitRes = await LearnUnitModel(tenant).list(
+        { filter: { _id: unit_id } },
+        next
+      );
+      if (!unitRes?.success || !unitRes.data?.length) {
+        return {
+          success: false,
+          message: "unit not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      return await LearnLessonModel(tenant).register(
+        { unit_id, title, plain_title_key, lesson_order, cover_image_url, completion_message },
+        next
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  addActivity: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { lesson_id } = request.params;
+      const { type, order, payload } = request.body;
+
+      const lessonRes = await LearnLessonModel(tenant).list(
+        { filter: { _id: lesson_id } },
+        next
+      );
+      if (!lessonRes?.success || !lessonRes.data?.length) {
+        return {
+          success: false,
+          message: "lesson not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      // Payload validation per type
+      if (type === "article" && isEmpty(payload?.body)) {
+        return {
+          success: false,
+          message: "validation errors for some of the provided fields",
+          errors: { "payload.body": "body is required for article activities" },
+          status: httpStatus.UNPROCESSABLE_ENTITY,
+        };
+      }
+      if (type === "video" && isEmpty(payload?.video_url) && isEmpty(payload?.youtube_id)) {
+        return {
+          success: false,
+          message: "validation errors for some of the provided fields",
+          errors: { "payload.video_url": "video_url or youtube_id is required for video activities" },
+          status: httpStatus.UNPROCESSABLE_ENTITY,
+        };
+      }
+      if (type === "quiz" && isEmpty(payload?.format)) {
+        return {
+          success: false,
+          message: "validation errors for some of the provided fields",
+          errors: { "payload.format": "format is required for quiz activities" },
+          status: httpStatus.UNPROCESSABLE_ENTITY,
+        };
+      }
+
+      return await LearnActivityModel(tenant).register(
+        { lesson_id, type, order, payload },
+        next
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  updateCourse: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { course_id } = request.params;
+      const updates = request.body;
+
+      if (updates.published === true) {
+        // Validate complete tree before publishing
+        const unitsRes = await LearnUnitModel(tenant).list(
+          { filter: { course_id } },
+          next
+        );
+        if (!unitsRes?.data?.length) {
+          return {
+            success: false,
+            message: "cannot publish — course must have units, lessons, and activities",
+            errors: { published: "at least one unit is required" },
+            status: httpStatus.UNPROCESSABLE_ENTITY,
+          };
+        }
+
+        for (const unit of unitsRes.data) {
+          const lessonsRes = await LearnLessonModel(tenant).list(
+            { filter: { unit_id: unit._id } },
+            next
+          );
+          if (!lessonsRes?.data?.length) {
+            return {
+              success: false,
+              message: "cannot publish — course must have units, lessons, and activities",
+              errors: { published: `unit "${unit.title}" has no lessons` },
+              status: httpStatus.UNPROCESSABLE_ENTITY,
+            };
+          }
+          for (const lesson of lessonsRes.data) {
+            const activitiesRes = await LearnActivityModel(tenant).list(
+              { filter: { lesson_id: lesson._id } },
+              next
+            );
+            if (!activitiesRes?.data?.length) {
+              return {
+                success: false,
+                message: "cannot publish — course must have units, lessons, and activities",
+                errors: { published: "at least one lesson must contain an activity" },
+                status: httpStatus.UNPROCESSABLE_ENTITY,
+              };
+            }
+          }
+        }
+
+        const courseRes = await LearnCourseModel(tenant).list(
+          { filter: { _id: course_id } },
+          next
+        );
+        if (courseRes?.data?.length && !courseRes.data[0].cover_image_url) {
+          return {
+            success: false,
+            message: "cannot publish — cover_image_url is required before publishing",
+            errors: { cover_image_url: "cover_image_url is required for published courses" },
+            status: httpStatus.UNPROCESSABLE_ENTITY,
+          };
+        }
+
+        updates.catalog_version = new Date().toISOString().slice(0, 10);
+      }
+
+      return await LearnCourseModel(tenant).modify(
+        { filter: { _id: course_id }, update: updates },
+        next
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+module.exports = learn;

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -1,7 +1,7 @@
 const { query, body, param, validationResult } = require("express-validator");
+const constants = require("@config/constants");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
-const isEmpty = require("is-empty");
 
 const validate = (req, res, next) => {
   const errors = validationResult(req);
@@ -25,7 +25,9 @@ const commonTenant = query("tenant")
   .withMessage("tenant cannot be empty if provided")
   .bail()
   .trim()
-  .toLowerCase();
+  .toLowerCase()
+  .isIn(constants.TENANTS)
+  .withMessage("the tenant value is not among the expected ones");
 
 const learnValidations = {
   // -------------------------------------------------------------------------
@@ -44,9 +46,12 @@ const learnValidations = {
       .exists()
       .withMessage("lesson_id is required")
       .bail()
+      .trim()
       .notEmpty()
       .withMessage("lesson_id must not be empty")
-      .trim(),
+      .bail()
+      .isMongoId()
+      .withMessage("lesson_id must be a valid MongoDB ObjectId"),
     validate,
   ],
 
@@ -55,6 +60,7 @@ const learnValidations = {
   // -------------------------------------------------------------------------
 
   createAnonymousSession: [
+    commonTenant,
     body("device_id")
       .exists()
       .withMessage("device_id is required")
@@ -84,8 +90,11 @@ const learnValidations = {
       .exists()
       .withMessage("lesson_id is required")
       .bail()
+      .trim()
       .notEmpty()
-      .trim(),
+      .bail()
+      .isMongoId()
+      .withMessage("lesson_id must be a valid MongoDB ObjectId"),
     body("furthest_activity_index")
       .optional()
       .isInt({ min: 0 })
@@ -128,8 +137,8 @@ const learnValidations = {
       .exists()
       .withMessage("each update must include lesson_id")
       .bail()
-      .notEmpty()
-      .trim(),
+      .trim()
+      .notEmpty(),
     validate,
   ],
 
@@ -138,6 +147,7 @@ const learnValidations = {
   // -------------------------------------------------------------------------
 
   linkGuestProgress: [
+    commonTenant,
     body("device_id")
       .exists()
       .withMessage("device_id is required")
@@ -149,9 +159,9 @@ const learnValidations = {
       .exists()
       .withMessage("guest_id is required")
       .bail()
+      .trim()
       .notEmpty()
-      .withMessage("guest_id must not be empty")
-      .trim(),
+      .withMessage("guest_id must not be empty"),
     validate,
   ],
 
@@ -171,18 +181,18 @@ const learnValidations = {
       .exists()
       .withMessage("title is required")
       .bail()
+      .trim()
       .notEmpty()
       .withMessage("title must not be empty")
       .bail()
       .isLength({ max: 120 })
-      .withMessage("title must not exceed 120 characters")
-      .trim(),
+      .withMessage("title must not exceed 120 characters"),
     body("plain_title_key")
       .exists()
       .withMessage("plain_title_key is required")
       .bail()
-      .notEmpty()
-      .trim(),
+      .trim()
+      .notEmpty(),
     body("cover_image_url")
       .optional()
       .isURL({ protocols: ["https"], require_protocol: true })
@@ -200,23 +210,26 @@ const learnValidations = {
       .exists()
       .withMessage("course_id is required")
       .bail()
+      .trim()
       .notEmpty()
-      .trim(),
+      .bail()
+      .isMongoId()
+      .withMessage("course_id must be a valid MongoDB ObjectId"),
     body("title")
       .exists()
       .withMessage("title is required")
       .bail()
+      .trim()
       .notEmpty()
       .bail()
       .isLength({ max: 120 })
-      .withMessage("title must not exceed 120 characters")
-      .trim(),
+      .withMessage("title must not exceed 120 characters"),
     body("plain_title_key")
       .exists()
       .withMessage("plain_title_key is required")
       .bail()
-      .notEmpty()
-      .trim(),
+      .trim()
+      .notEmpty(),
     body("unit_order")
       .exists()
       .withMessage("unit_order is required")
@@ -232,23 +245,26 @@ const learnValidations = {
       .exists()
       .withMessage("unit_id is required")
       .bail()
+      .trim()
       .notEmpty()
-      .trim(),
+      .bail()
+      .isMongoId()
+      .withMessage("unit_id must be a valid MongoDB ObjectId"),
     body("title")
       .exists()
       .withMessage("title is required")
       .bail()
+      .trim()
       .notEmpty()
       .bail()
       .isLength({ max: 120 })
-      .withMessage("title must not exceed 120 characters")
-      .trim(),
+      .withMessage("title must not exceed 120 characters"),
     body("plain_title_key")
       .exists()
       .withMessage("plain_title_key is required")
       .bail()
-      .notEmpty()
-      .trim(),
+      .trim()
+      .notEmpty(),
     body("lesson_order")
       .exists()
       .withMessage("lesson_order is required")
@@ -269,8 +285,11 @@ const learnValidations = {
       .exists()
       .withMessage("lesson_id is required")
       .bail()
+      .trim()
       .notEmpty()
-      .trim(),
+      .bail()
+      .isMongoId()
+      .withMessage("lesson_id must be a valid MongoDB ObjectId"),
     body("type")
       .exists()
       .withMessage("type is required")
@@ -298,15 +317,18 @@ const learnValidations = {
       .exists()
       .withMessage("course_id is required")
       .bail()
+      .trim()
       .notEmpty()
-      .trim(),
+      .bail()
+      .isMongoId()
+      .withMessage("course_id must be a valid MongoDB ObjectId"),
     body("title")
       .optional()
+      .trim()
       .notEmpty()
       .bail()
       .isLength({ max: 120 })
-      .withMessage("title must not exceed 120 characters")
-      .trim(),
+      .withMessage("title must not exceed 120 characters"),
     body("cover_image_url")
       .optional()
       .isURL({ protocols: ["https"], require_protocol: true })

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -1,0 +1,322 @@
+const { query, body, param, validationResult } = require("express-validator");
+const { HttpError } = require("@utils/shared");
+const httpStatus = require("http-status");
+const isEmpty = require("is-empty");
+
+const validate = (req, res, next) => {
+  const errors = validationResult(req);
+  if (errors.isEmpty()) return next();
+  const extractedErrors = {};
+  errors.array().forEach((err) => {
+    extractedErrors[err.path || err.param] = err.msg;
+  });
+  return next(
+    new HttpError(
+      "validation errors for some of the provided fields",
+      httpStatus.BAD_REQUEST,
+      extractedErrors
+    )
+  );
+};
+
+const commonTenant = query("tenant")
+  .optional()
+  .notEmpty()
+  .withMessage("tenant cannot be empty if provided")
+  .bail()
+  .trim()
+  .toLowerCase();
+
+const learnValidations = {
+  // -------------------------------------------------------------------------
+  // Option 1 — Catalog
+  // -------------------------------------------------------------------------
+
+  getCatalog: [
+    commonTenant,
+    query("catalog_version").optional().trim(),
+    validate,
+  ],
+
+  getLesson: [
+    commonTenant,
+    param("lesson_id")
+      .exists()
+      .withMessage("lesson_id is required")
+      .bail()
+      .notEmpty()
+      .withMessage("lesson_id must not be empty")
+      .trim(),
+    validate,
+  ],
+
+  // -------------------------------------------------------------------------
+  // Option 2 — Anonymous session
+  // -------------------------------------------------------------------------
+
+  createAnonymousSession: [
+    body("device_id")
+      .exists()
+      .withMessage("device_id is required")
+      .bail()
+      .notEmpty()
+      .withMessage("device_id must not be empty")
+      .bail()
+      .isUUID(4)
+      .withMessage("device_id must be a valid UUID"),
+    body("app_version").optional().trim(),
+    body("platform")
+      .optional()
+      .isIn(["android", "ios"])
+      .withMessage("platform must be android or ios"),
+    validate,
+  ],
+
+  // -------------------------------------------------------------------------
+  // Option 2 — Progress
+  // -------------------------------------------------------------------------
+
+  getProgress: [commonTenant, validate],
+
+  updateLessonProgress: [
+    commonTenant,
+    param("lesson_id")
+      .exists()
+      .withMessage("lesson_id is required")
+      .bail()
+      .notEmpty()
+      .trim(),
+    body("furthest_activity_index")
+      .optional()
+      .isInt({ min: 0 })
+      .withMessage("furthest_activity_index must be a non-negative integer"),
+    body("completed")
+      .optional()
+      .isBoolean()
+      .withMessage("completed must be a boolean"),
+    body("quiz_attempts")
+      .optional()
+      .isArray()
+      .withMessage("quiz_attempts must be an array"),
+    body("quiz_attempts.*.activity_id")
+      .optional()
+      .notEmpty()
+      .withMessage("quiz_attempts[].activity_id must not be empty"),
+    body("quiz_attempts.*.format")
+      .optional()
+      .isIn(["single_choice", "multi_choice", "ranking", "free_text"])
+      .withMessage("quiz_attempts[].format must be a valid quiz format"),
+    validate,
+  ],
+
+  syncProgress: [
+    commonTenant,
+    body("device_id")
+      .exists()
+      .withMessage("device_id is required")
+      .bail()
+      .notEmpty()
+      .isUUID(4)
+      .withMessage("device_id must be a valid UUID"),
+    body("updates")
+      .exists()
+      .withMessage("updates is required")
+      .bail()
+      .isArray({ min: 1 })
+      .withMessage("updates array cannot be empty"),
+    body("updates.*.lesson_id")
+      .exists()
+      .withMessage("each update must include lesson_id")
+      .bail()
+      .notEmpty()
+      .trim(),
+    validate,
+  ],
+
+  // -------------------------------------------------------------------------
+  // Option 3 — Account link
+  // -------------------------------------------------------------------------
+
+  linkGuestProgress: [
+    body("device_id")
+      .exists()
+      .withMessage("device_id is required")
+      .bail()
+      .notEmpty()
+      .isUUID(4)
+      .withMessage("device_id must be a valid UUID"),
+    body("guest_id")
+      .exists()
+      .withMessage("guest_id is required")
+      .bail()
+      .notEmpty()
+      .withMessage("guest_id must not be empty")
+      .trim(),
+    validate,
+  ],
+
+  // -------------------------------------------------------------------------
+  // Admin — Course authoring
+  // -------------------------------------------------------------------------
+
+  createCourse: [
+    commonTenant,
+    body("course_number")
+      .exists()
+      .withMessage("course_number is required")
+      .bail()
+      .isInt({ min: 1 })
+      .withMessage("course_number must be a positive integer"),
+    body("title")
+      .exists()
+      .withMessage("title is required")
+      .bail()
+      .notEmpty()
+      .withMessage("title must not be empty")
+      .bail()
+      .isLength({ max: 120 })
+      .withMessage("title must not exceed 120 characters")
+      .trim(),
+    body("plain_title_key")
+      .exists()
+      .withMessage("plain_title_key is required")
+      .bail()
+      .notEmpty()
+      .trim(),
+    body("cover_image_url")
+      .optional()
+      .isURL({ protocols: ["https"], require_protocol: true })
+      .withMessage("cover_image_url must be a valid HTTPS URL"),
+    body("published")
+      .optional()
+      .isBoolean()
+      .withMessage("published must be a boolean"),
+    validate,
+  ],
+
+  addUnit: [
+    commonTenant,
+    param("course_id")
+      .exists()
+      .withMessage("course_id is required")
+      .bail()
+      .notEmpty()
+      .trim(),
+    body("title")
+      .exists()
+      .withMessage("title is required")
+      .bail()
+      .notEmpty()
+      .bail()
+      .isLength({ max: 120 })
+      .withMessage("title must not exceed 120 characters")
+      .trim(),
+    body("plain_title_key")
+      .exists()
+      .withMessage("plain_title_key is required")
+      .bail()
+      .notEmpty()
+      .trim(),
+    body("unit_order")
+      .exists()
+      .withMessage("unit_order is required")
+      .bail()
+      .isInt({ min: 1 })
+      .withMessage("unit_order must be a positive integer"),
+    validate,
+  ],
+
+  addLesson: [
+    commonTenant,
+    param("unit_id")
+      .exists()
+      .withMessage("unit_id is required")
+      .bail()
+      .notEmpty()
+      .trim(),
+    body("title")
+      .exists()
+      .withMessage("title is required")
+      .bail()
+      .notEmpty()
+      .bail()
+      .isLength({ max: 120 })
+      .withMessage("title must not exceed 120 characters")
+      .trim(),
+    body("plain_title_key")
+      .exists()
+      .withMessage("plain_title_key is required")
+      .bail()
+      .notEmpty()
+      .trim(),
+    body("lesson_order")
+      .exists()
+      .withMessage("lesson_order is required")
+      .bail()
+      .isInt({ min: 1 })
+      .withMessage("lesson_order must be a positive integer"),
+    body("cover_image_url")
+      .optional()
+      .isURL({ protocols: ["https"], require_protocol: true })
+      .withMessage("cover_image_url must be a valid HTTPS URL"),
+    body("completion_message").optional().trim(),
+    validate,
+  ],
+
+  addActivity: [
+    commonTenant,
+    param("lesson_id")
+      .exists()
+      .withMessage("lesson_id is required")
+      .bail()
+      .notEmpty()
+      .trim(),
+    body("type")
+      .exists()
+      .withMessage("type is required")
+      .bail()
+      .isIn(["article", "video", "image", "quiz"])
+      .withMessage("type must be one of: article, video, image, quiz"),
+    body("order")
+      .exists()
+      .withMessage("order is required")
+      .bail()
+      .isInt({ min: 1 })
+      .withMessage("order must be a positive integer"),
+    body("payload")
+      .exists()
+      .withMessage("payload is required")
+      .bail()
+      .isObject()
+      .withMessage("payload must be an object"),
+    validate,
+  ],
+
+  updateCourse: [
+    commonTenant,
+    param("course_id")
+      .exists()
+      .withMessage("course_id is required")
+      .bail()
+      .notEmpty()
+      .trim(),
+    body("title")
+      .optional()
+      .notEmpty()
+      .bail()
+      .isLength({ max: 120 })
+      .withMessage("title must not exceed 120 characters")
+      .trim(),
+    body("cover_image_url")
+      .optional()
+      .isURL({ protocols: ["https"], require_protocol: true })
+      .withMessage("cover_image_url must be a valid HTTPS URL"),
+    body("published")
+      .optional()
+      .isBoolean()
+      .withMessage("published must be a boolean"),
+    validate,
+  ],
+};
+
+module.exports = learnValidations;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Implements the AirQo Learn v2 API inside `device-registry`, replacing the legacy Know Your Air (KYA) experience. Introduces a new `courses → units → lessons → activities` content model with three rollout tiers: content-only catalog, anonymous guest progress sync, and authenticated account/certificate/leaderboard features.

Six new Mongoose models, a utility layer, controller, validators, and two Express routers are added. Routes are served at `/api/v2/learn/*` (public) and `/api/v2/admin/learn/*` (admin authoring).

### Why is this change needed?

The existing KYA flat-lesson model (`kya_lessons + tasks`) does not support the richer content hierarchy, server-side quiz scoring, or anonymous progress tracking required by the mobile app's Learn v2 redesign. The legacy `GET /api/v2/devices/kya/lessons` endpoint is deprecated per the new spec; clients must migrate to `GET /api/v2/learn/catalog`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `src/device-registry` — all new files; existing KYA routes untouched

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**

Existing KYA unit and route tests (`ut_know-your-air.util.js`, `ut_kya.routes.js`) continue to pass unmodified — no existing code was touched. New endpoints were manually verified for request/response shape against the Learn v2 spec. Unit tests for the new util, models, and routes are tracked as a follow-up.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Legacy `GET /api/v2/devices/kya/lessons` routes remain operational; no existing client is broken. The new `/api/v2/learn/*` surface is strictly additive. Clients are expected to migrate off KYA routes in a separate coordinated cutover.

---

## :memo: Additional Notes

- **Data migration not included.** Existing KYA documents in `kyalessons`/`kyatasks` are not automatically migrated into the new collections. A one-off migration script should be authored separately once the mobile team is ready to cut over.
- **Auth is gateway-enforced.** Admin endpoints (`/api/v2/admin/learn/*`) and account-linked endpoints (`POST /learn/progress/link`) rely on nginx/API-gateway JWT enforcement. The service layer reads `req.user.id` when present but does not independently verify tokens — consistent with how the rest of `device-registry` operates.
- **Option 3 leaderboard not included.** The leaderboard (`GET /api/v2/learn/leaderboard`) and named certificates (`POST /api/v2/learn/certificates/named`) are specified in the doc but scoped to a follow-up PR after the core catalog and progress surfaces are validated in production.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Learn experience with catalog browsing, lesson viewing, progress tracking, guest session support, and account linking.
  * Added admin tools to create and update courses, units, lessons, and activities.
* **Bug Fixes**
  * Improved validation and error handling for Learn actions, including required fields, IDs, URLs, and supported activity types.
  * Added safer progress syncing and merging so guest progress can be carried into a signed-in account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->