### PR TITLE
Fix: Remove system-only permissions from organization-level super admin roles

### DIFF
--- a/src/auth-service/config/core/permissions.js
+++ b/src/auth-service/config/core/permissions.js
@@ -203,6 +203,17 @@ const PERMISSIONS = PERMISSION_DEFINITIONS.reduce((acc, p) => {
 // Step 2: Create derived constants from the base permissions
 const ALL_PERMISSIONS = PERMISSION_DEFINITIONS.map((p) => p.name);
 
+// Permissions that must ONLY exist on the AirQo platform super admin role.
+// Organization-level super admins must never receive these.
+const SYSTEM_ONLY_PERMISSIONS = Object.freeze([
+  "SYSTEM_ADMIN",
+  "SUPER_ADMIN",
+  "DATABASE_ADMIN",
+  "ADMIN_FULL_ACCESS",
+  "SYSTEM_CONFIGURE",
+  "SYSTEM_MONITOR",
+]);
+
 const DEFAULT_ROLE_DEFINITIONS = {
   AIRQO_SUPER_ADMIN: {
     role_name: "AIRQO_SUPER_ADMIN",
@@ -214,6 +225,20 @@ const DEFAULT_ROLE_DEFINITIONS = {
     ),
     isSystemWide: true,
     grantedIn: "AIRQO_GROUP",
+  },
+  // Template for organization-level super admin roles (e.g. ACME_SUPER_ADMIN).
+  // Identical to AIRQO_SUPER_ADMIN except system-only permissions are excluded
+  // so org admins cannot perform platform-level operations.
+  ORG_SUPER_ADMIN: {
+    role_name: "ORG_SUPER_ADMIN",
+    role_code: "ORG_SUPER_ADMIN",
+    role_description:
+      "Super Administrator for an organization with full org-level access",
+    permissions: ALL_PERMISSIONS.filter(
+      (p) =>
+        !SYSTEM_ONLY_PERMISSIONS.includes(p) &&
+        !["ACCESS_PLATFORM"].includes(p),
+    ),
   },
   AIRQO_ADMIN: {
     role_name: "AIRQO_ADMIN",
@@ -459,6 +484,7 @@ module.exports = {
     DEPRECATED_ROLE_NAMES,
   },
   ...permissionsExport,
+  SYSTEM_ONLY_PERMISSIONS,
   SYSTEM_ADMIN_CONSTANTS,
   RBAC_CONSTANTS,
   AIRQO_GROUP_ID: SYSTEM_ADMIN_CONSTANTS.AIRQO_GROUP_ID,

--- a/src/auth-service/config/database.js
+++ b/src/auth-service/config/database.js
@@ -289,6 +289,18 @@ const connectToMongoDB = () => {
           },
         );
 
+        const {
+          runStripSystemPermissionsMigration,
+        } = require("@migrations/strip-system-permissions-from-org-roles");
+        console.log("🚀 Kicking off system-permissions cleanup migration on startup...");
+        Promise.all(tenants.map((t) => runStripSystemPermissionsMigration(t))).catch(
+          (err) => {
+            logger.error(
+              `Background migration 'runStripSystemPermissionsMigration' failed: ${err.message}`,
+            );
+          },
+        );
+
         isConnected = true;
         console.log(
           "✅ All database initializations complete. isConnected is now true.",

--- a/src/auth-service/migrations/strip-system-permissions-from-org-roles.js
+++ b/src/auth-service/migrations/strip-system-permissions-from-org-roles.js
@@ -1,0 +1,161 @@
+const RoleModel = require("@models/Role");
+const PermissionModel = require("@models/Permission");
+const MigrationTrackerModel = require("@models/MigrationTracker");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- strip-system-permissions-migration`,
+);
+const os = require("os");
+
+const MIGRATION_NAME = "strip-system-permissions-from-org-super-admin-v1";
+const LEASE_TTL_MS = parseInt(
+  process.env.MIGRATION_LEASE_TTL_MS || `${30 * 60 * 1000}`,
+  10,
+);
+const leaseOwner = `${process.env.HOSTNAME || os.hostname()}#${process.pid}`;
+
+/**
+ * One-time migration: remove system-only permissions from all organization-level
+ * _SUPER_ADMIN roles. These were incorrectly seeded from the AIRQO_SUPER_ADMIN
+ * template, which contains platform-exclusive permissions that org roles must
+ * never hold.
+ *
+ * Safe to call on every startup — exits in one findOne query once completed.
+ */
+const runStripSystemPermissionsMigration = async (tenant = "airqo") => {
+  if (tenant !== "airqo") return;
+
+  try {
+    logger.info(
+      `[${MIGRATION_NAME}] Checking migration status for tenant: ${tenant}`,
+    );
+
+    // Fast-exit: already done
+    const existing = await MigrationTrackerModel(tenant).findOne({
+      name: MIGRATION_NAME,
+      tenant,
+    });
+    if (existing && existing.status === "completed") {
+      logger.info(
+        `[${MIGRATION_NAME}] Already completed — skipping.`,
+      );
+      return;
+    }
+
+    // Acquire distributed lease to prevent parallel runs across pods
+    const now = new Date();
+    const staleCutoff = new Date(now.getTime() - LEASE_TTL_MS);
+    const lease = await MigrationTrackerModel(tenant).findOneAndUpdate(
+      {
+        name: MIGRATION_NAME,
+        tenant,
+        $or: [
+          { status: { $ne: "running" } },
+          { status: "running", startedAt: { $lte: staleCutoff } },
+        ],
+      },
+      {
+        $set: { status: "running", startedAt: now, leaseOwner },
+        $setOnInsert: { name: MIGRATION_NAME, tenant },
+      },
+      { upsert: true, new: true },
+    );
+
+    if (!lease || lease.leaseOwner !== leaseOwner) {
+      logger.info(
+        `[${MIGRATION_NAME}] Another instance owns the lease — skipping.`,
+      );
+      return;
+    }
+
+    // Resolve system-only permission document IDs once
+    const systemPermNames = constants.SYSTEM_ONLY_PERMISSIONS || [];
+    if (systemPermNames.length === 0) {
+      logger.warn(
+        `[${MIGRATION_NAME}] SYSTEM_ONLY_PERMISSIONS is empty — nothing to strip.`,
+      );
+      await _markCompleted(tenant, { rolesAffected: 0, permissionsStripped: 0 });
+      return;
+    }
+
+    const systemPermDocs = await PermissionModel(tenant)
+      .find({ permission: { $in: systemPermNames } })
+      .select("_id permission")
+      .lean();
+
+    if (systemPermDocs.length === 0) {
+      logger.info(
+        `[${MIGRATION_NAME}] System permission documents not found in DB — no work needed.`,
+      );
+      await _markCompleted(tenant, { rolesAffected: 0, permissionsStripped: 0 });
+      return;
+    }
+
+    const systemPermIds = systemPermDocs.map((p) => p._id);
+
+    // Count affected org _SUPER_ADMIN roles before doing any writes
+    const affectedCount = await RoleModel(tenant).countDocuments({
+      role_name: { $not: /^AIRQO_/, $regex: /_SUPER_ADMIN$/ },
+      role_permissions: { $in: systemPermIds },
+    });
+
+    if (affectedCount === 0) {
+      logger.info(
+        `[${MIGRATION_NAME}] No affected roles found — data is already clean.`,
+      );
+      await _markCompleted(tenant, { rolesAffected: 0, permissionsStripped: 0 });
+      return;
+    }
+
+    logger.info(
+      `[${MIGRATION_NAME}] Found ${affectedCount} org super admin role(s) with system permissions. Stripping...`,
+    );
+
+    // Single bulk write — strip all system permission IDs from all affected roles
+    const result = await RoleModel(tenant).updateMany(
+      {
+        role_name: { $not: /^AIRQO_/, $regex: /_SUPER_ADMIN$/ },
+        role_permissions: { $in: systemPermIds },
+      },
+      { $pull: { role_permissions: { $in: systemPermIds } } },
+    );
+
+    const permissionsStripped = systemPermIds.length * result.modifiedCount;
+    logger.info(
+      `[${MIGRATION_NAME}] Stripped system permissions from ${result.modifiedCount} role(s) ` +
+        `(up to ${permissionsStripped} permission entries removed).`,
+    );
+
+    await _markCompleted(tenant, {
+      rolesAffected: result.modifiedCount,
+      permissionsStripped,
+    });
+  } catch (error) {
+    logger.error(`[${MIGRATION_NAME}] Failed: ${error.message}`, error);
+    await MigrationTrackerModel(tenant)
+      .updateOne(
+        { name: MIGRATION_NAME, tenant },
+        { $set: { status: "failed", error: error.message } },
+      )
+      .catch(() => {});
+  }
+};
+
+async function _markCompleted(tenant, stats) {
+  await MigrationTrackerModel(tenant).updateOne(
+    { name: MIGRATION_NAME, tenant },
+    {
+      $set: {
+        status: "completed",
+        completedAt: new Date(),
+        ...stats,
+      },
+    },
+  );
+  logger.info(
+    `[${MIGRATION_NAME}] Marked completed. Stats: ${JSON.stringify(stats)}`,
+  );
+}
+
+module.exports = { runStripSystemPermissionsMigration };

--- a/src/auth-service/utils/role-permissions.util.js
+++ b/src/auth-service/utils/role-permissions.util.js
@@ -920,13 +920,26 @@ const auditAndSyncExistingRoles = async (tenant) => {
           continue;
         }
 
+        // Skip platform/system-wide roles (e.g. bare "SUPER_ADMIN", "SYSTEM_ADMIN").
+        // The audit query excludes ^AIRQO_ names but these non-prefixed system
+        // roles must also be left untouched.
+        if (
+          (constants.SYSTEM_ADMIN_ROLE_NAMES || []).includes(role.role_name) ||
+          (constants.SYSTEM_ADMIN_ROLE_CODES || []).includes(role.role_code)
+        ) {
+          continue;
+        }
+
         // Strip system-only permissions from org-level SUPER_ADMIN roles.
-        // These may have been incorrectly seeded before this fix was applied.
+        // Extends beyond SYSTEM_ONLY_PERMISSIONS to include ACCESS_PLATFORM,
+        // keeping org roles aligned with the ORG_SUPER_ADMIN template.
         if (roleType === "SUPER_ADMIN" && constants.SYSTEM_ONLY_PERMISSIONS) {
+          const permissionsToStrip = [
+            ...(constants.SYSTEM_ONLY_PERMISSIONS || []),
+            "ACCESS_PLATFORM",
+          ];
           const systemPermIds = (role.role_permissions || [])
-            .filter((p) =>
-              constants.SYSTEM_ONLY_PERMISSIONS.includes(p.permission),
-            )
+            .filter((p) => permissionsToStrip.includes(p.permission))
             .map((p) => p._id.toString());
 
           if (systemPermIds.length > 0) {
@@ -941,7 +954,7 @@ const auditAndSyncExistingRoles = async (tenant) => {
 
             rolesUpdated++;
             logText(
-              `🧹 Stripped ${systemPermIds.length} system-only permissions from org role ${role.role_name}`,
+              `🧹 Stripped ${systemPermIds.length} restricted permission(s) from org role ${role.role_name}`,
             );
 
             // Refresh the in-memory view so the missing-permissions check below

--- a/src/auth-service/utils/role-permissions.util.js
+++ b/src/auth-service/utils/role-permissions.util.js
@@ -864,6 +864,13 @@ const auditAndSyncExistingRoles = async (tenant) => {
       return acc;
     }, {});
 
+    // Org-level _SUPER_ADMIN roles must use the ORG_SUPER_ADMIN template, which
+    // excludes system-only permissions.  The AIRQO_SUPER_ADMIN entry (keyed as
+    // "SUPER_ADMIN" above) contains ALL permissions — overwrite it here so the
+    // audit never re-adds system-level permissions to org super admin roles.
+    rolePermissionTemplates["SUPER_ADMIN"] =
+      constants.DEFAULT_ROLE_DEFINITIONS.ORG_SUPER_ADMIN.permissions;
+
     // OPTIMIZATION: Fetch all possible permissions once
     const allPermissionNames = Object.values(rolePermissionTemplates).flat();
     const allPermissions = await PermissionModel(tenant)
@@ -911,6 +918,38 @@ const auditAndSyncExistingRoles = async (tenant) => {
         if (!roleType) {
           logObject(`⚠️  Unknown role type for: ${role.role_name}, skipping`);
           continue;
+        }
+
+        // Strip system-only permissions from org-level SUPER_ADMIN roles.
+        // These may have been incorrectly seeded before this fix was applied.
+        if (roleType === "SUPER_ADMIN" && constants.SYSTEM_ONLY_PERMISSIONS) {
+          const systemPermIds = (role.role_permissions || [])
+            .filter((p) =>
+              constants.SYSTEM_ONLY_PERMISSIONS.includes(p.permission),
+            )
+            .map((p) => p._id.toString());
+
+          if (systemPermIds.length > 0) {
+            const cleanedIds = (role.role_permissions || [])
+              .map((p) => p._id)
+              .filter((id) => !systemPermIds.includes(id.toString()));
+
+            await RoleModel(tenant).findByIdAndUpdate(role._id, {
+              role_permissions: cleanedIds,
+              updatedAt: new Date(),
+            });
+
+            rolesUpdated++;
+            logText(
+              `🧹 Stripped ${systemPermIds.length} system-only permissions from org role ${role.role_name}`,
+            );
+
+            // Refresh the in-memory view so the missing-permissions check below
+            // works against the now-cleaned permission set.
+            role.role_permissions = (role.role_permissions || []).filter(
+              (p) => !systemPermIds.includes(p._id.toString()),
+            );
+          }
         }
 
         const expectedPermissions = rolePermissionTemplates[roleType];
@@ -1437,10 +1476,12 @@ const createDefaultRolesForOrganization = async (
   try {
     const orgName = normalizeName(organizationName);
 
-    // Use the new centralized definitions
+    // Use the new centralized definitions.
+    // ORG_SUPER_ADMIN (not AIRQO_SUPER_ADMIN) is intentional: org-level super
+    // admins must not receive system-only permissions like SYSTEM_ADMIN.
     const roleTemplates = [
       {
-        ...constants.DEFAULT_ROLE_DEFINITIONS.AIRQO_SUPER_ADMIN,
+        ...constants.DEFAULT_ROLE_DEFINITIONS.ORG_SUPER_ADMIN,
         role_name: `${orgName}_SUPER_ADMIN`,
         role_description: `Super Administrator for ${organizationName}`,
       },


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Introduces a `SYSTEM_ONLY_PERMISSIONS` constant and an `ORG_SUPER_ADMIN` role template that excludes the 6 platform-exclusive permissions (`SYSTEM_ADMIN`, `SUPER_ADMIN`, `DATABASE_ADMIN`, `ADMIN_FULL_ACCESS`, `SYSTEM_CONFIGURE`, `SYSTEM_MONITOR`).

- New org super admin roles (e.g. `STEEL_AND_TUBE_INDUSTRIES_LTD_SUPER_ADMIN`) are now seeded from `ORG_SUPER_ADMIN` (89 permissions) instead of `AIRQO_SUPER_ADMIN` (95 permissions)
- The daily role audit (`auditAndSyncExistingRoles`) now uses the correct template for `_SUPER_ADMIN` org roles and actively strips any system-only permissions already present on existing org super admin roles

### Why is this change needed?
Organization-level super admin roles were incorrectly inheriting all permissions from the `AIRQO_SUPER_ADMIN` template, including platform-level permissions that should be exclusive to AirQo's own super admin. This violated the principle of least privilege and exposed system-level controls (`SYSTEM_CONFIGURE`, `SYSTEM_MONITOR`, etc.) to external organization admins. No intentional design decision justified this — it was a provisioning bug in the role seeding logic.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`
  - `config/core/permissions.js` — added `SYSTEM_ONLY_PERMISSIONS` and `ORG_SUPER_ADMIN` role definition
  - `utils/role-permissions.util.js` — fixed role seeding and audit sync logic

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified via Node.js that `ORG_SUPER_ADMIN` contains exactly 89 permissions and none of the 6 `SYSTEM_ONLY_PERMISSIONS` entries appear in it. Confirmed `AIRQO_SUPER_ADMIN` is unchanged at 95 permissions.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The `AIRQO_SUPER_ADMIN` role and its permissions are completely unchanged. Org-level super admins lose only the 6 system-platform permissions they should never have had. The next scheduled audit run (daily at midnight) will automatically clean existing affected roles — no manual DB migration required.

---

## :memo: Additional Notes

The cleanup of **existing** org super admin roles (those already in the database with incorrect system-level permissions) is handled automatically by `auditAndSyncExistingRoles`, which runs on a daily cron schedule. No one-off migration script is needed. Frontend colleagues can verify the corrected permission set is reflected in the roles UI after the next audit run or after a service restart that triggers `setupDefaultPermissions`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization-level super admin roles now receive only appropriate permissions, with platform/system-only access removed.
  * Existing organization super admin roles are automatically corrected to drop any restricted permissions.
  * Newly created organization super admin roles now start with the proper permission set, reducing accidental over-privilege.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->