### PR TITLE
Fix migration duplicate key, Mailchimp address format, and undefined adminAlertService

### DIFF
--- a/src/auth-service/migrations/strip-system-permissions-from-org-roles.js
+++ b/src/auth-service/migrations/strip-system-permissions-from-org-roles.js
@@ -132,6 +132,15 @@ const runStripSystemPermissionsMigration = async (tenant = "airqo") => {
       permissionsStripped,
     });
   } catch (error) {
+    // E11000 means a document with this {name, tenant} already exists but didn't
+    // match the lease filter (e.g. another pod holds a fresh "running" lease).
+    // Treat as a lease conflict — not a migration failure.
+    if (error.code === 11000) {
+      logger.info(
+        `[${MIGRATION_NAME}] Lease already held by another instance — skipping.`,
+      );
+      return;
+    }
     logger.error(`[${MIGRATION_NAME}] Failed: ${error.message}`, error);
     await MigrationTrackerModel(tenant)
       .updateOne(

--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -766,3 +766,48 @@ describe("transactions.getSubscriptionStatus", () => {
     expect(result.errors.message).to.equal("Paddle API down");
   });
 });
+
+describe("transactions.notifyAdminOfTransactionError", () => {
+  let localTransactions;
+  let opsLoggerErrorStub;
+
+  before(() => {
+    // log4js.getLogger returns a new object per call, so we must intercept it
+    // *before* transaction.util.js binds opsLogger at module load time.
+    const log4js = require("log4js");
+    const fakeOpsLogger = { error: sinon.stub(), info: () => {}, warn: () => {} };
+    opsLoggerErrorStub = fakeOpsLogger.error;
+
+    const getLoggerStub = sinon.stub(log4js, "getLogger").callsFake(() => fakeOpsLogger);
+    delete require.cache[require.resolve("@utils/transaction.util")];
+    localTransactions = require("@utils/transaction.util");
+    getLoggerStub.restore();
+  });
+
+  afterEach(() => {
+    opsLoggerErrorStub.resetHistory();
+  });
+
+  it("logs TRANSACTION_COMPLETION_FAILED with message and transactionId via opsLogger", async () => {
+    const error = new Error("Payment gateway timeout");
+    const eventData = { id: "txn_abc123", customer_id: "cust_xyz" };
+
+    await localTransactions.notifyAdminOfTransactionError(error, eventData);
+
+    sinon.assert.calledOnce(opsLoggerErrorStub);
+    const [errorType, payload] = opsLoggerErrorStub.firstCall.args;
+    expect(errorType).to.equal("TRANSACTION_COMPLETION_FAILED");
+    expect(payload).to.deep.equal({
+      message: "Payment gateway timeout",
+      transactionId: "txn_abc123",
+    });
+  });
+
+  it("uses undefined transactionId when eventData is absent", async () => {
+    await localTransactions.notifyAdminOfTransactionError(new Error("Unknown failure"), undefined);
+
+    sinon.assert.calledOnce(opsLoggerErrorStub);
+    const [, payload] = opsLoggerErrorStub.firstCall.args;
+    expect(payload.transactionId).to.be.undefined;
+  });
+});

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -2001,6 +2001,55 @@ describe("create-user-util", function () {
         "Mailchimp update tags error"
       );
     });
+
+    it("should send ADDRESS as a structured object when all components are provided", async () => {
+      const setListMemberStub = sinon
+        .stub(mailchimp.lists, "setListMember")
+        .resolves({ tags: [] });
+      sinon.stub(mailchimp.lists, "updateListMemberTags").resolves(null);
+
+      await subscribeToNewsLetter({
+        body: {
+          email: "user@example.com",
+          tags: ["tag1"],
+          firstName: "Jane",
+          lastName: "Doe",
+          address: "123 Main St",
+          city: "Kampala",
+          state: "Central",
+          zipCode: "00256",
+        },
+      });
+
+      const callArgs = setListMemberStub.firstCall.args[2];
+      expect(callArgs.merge_fields).to.have.property("ADDRESS").that.deep.equals({
+        addr1: "123 Main St",
+        city: "Kampala",
+        state: "Central",
+        zip: "00256",
+      });
+    });
+
+    it("should omit ADDRESS from merge_fields when any address component is missing", async () => {
+      const setListMemberStub = sinon
+        .stub(mailchimp.lists, "setListMember")
+        .resolves({ tags: [] });
+      sinon.stub(mailchimp.lists, "updateListMemberTags").resolves(null);
+
+      // city is absent — ADDRESS must be omitted
+      await subscribeToNewsLetter({
+        body: {
+          email: "user@example.com",
+          tags: ["tag1"],
+          address: "123 Main St",
+          state: "Central",
+          zipCode: "00256",
+        },
+      });
+
+      const callArgs = setListMemberStub.firstCall.args[2];
+      expect(callArgs.merge_fields).to.not.have.property("ADDRESS");
+    });
   });
   describe("deleteMobileUserData", () => {
     afterEach(() => {

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -553,18 +553,10 @@ const transactions = {
     // Email notification not yet implemented.
   },
   notifyAdminOfTransactionError: async (error, eventData) => {
-    try {
-      // Implement admin notification mechanism
-      await adminAlertService.sendErrorAlert({
-        errorType: "TRANSACTION_COMPLETION_FAILED",
-        details: {
-          message: error.message,
-          transactionId: eventData?.id,
-        },
-      });
-    } catch (notificationError) {
-      logger.error("Failed to send admin notification", notificationError);
-    }
+    opsLogger.error("TRANSACTION_COMPLETION_FAILED", {
+      message: error.message,
+      transactionId: eventData?.id,
+    });
   },
   handleFailedTransaction: async (eventData) => {
     try {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -5225,10 +5225,16 @@ const createUserModule = {
       const mergeFields = {
         ...(firstName && { FNAME: firstName }),
         ...(lastName && { LNAME: lastName }),
-        ...(address && { ADDRESS: address }),
         ...(city && { CITY: city }),
         ...(state && { STATE: state }),
         ...(zipCode && { ZIP: zipCode }),
+        // ADDRESS requires a complete structured object; omit it when city/state/zip are missing
+        ...(address &&
+          city &&
+          state &&
+          zipCode && {
+            ADDRESS: { addr1: address, city, state, zip: zipCode },
+          }),
       };
 
       const responseFromMailChimp = await mailchimp.lists.setListMember(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Fixes a duplicate key (`E11000`) crash in the startup migration tracker that caused the `strip-system-permissions-from-org-super-admin-v1` migration to log a failure on every pod restart after it had already run.
- Fixes a Mailchimp `400 Invalid Resource` error caused by sending `ADDRESS` as a plain string instead of the required structured object `{ addr1, city, state, zip }`.
- Fixes a `ReferenceError: adminAlertService is not defined` crash in `notifyAdminOfTransactionError`, replacing the unimplemented stub with the existing `opsLogger`.

### Why is this change needed?
All three issues were producing `[ERROR]` noise in production and staging logs on every service cycle. The migration crash was a false failure (the migration had already completed successfully). The Mailchimp error was silently dropping newsletter subscribers who provided an address. The `adminAlertService` error was masking real payment failure context with a `ReferenceError`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
All three fixes are defensive guards against observable runtime errors. The migration fix was validated by reproducing the E11000 scenario (existing `running` document + concurrent upsert). The Mailchimp fix was validated against the API's documented `ADDRESS` merge field schema. The `adminAlertService` fix removes a `ReferenceError` against an undefined variable with a drop-in replacement using an already-imported logger.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- **Migration fix** (`strip-system-permissions-from-org-roles.js`): MongoDB upserts with a unique index throw `E11000` when the document exists but doesn't match the query filter (e.g. status is `running` with a non-stale lease from a previously crashed pod). The fix catches error code `11000` and exits gracefully as a lease conflict instead of logging it as a migration failure.
- **Mailchimp fix** (`user.util.js`): `ADDRESS` is now only included in `merge_fields` when all required components (`address`, `city`, `state`, `zipCode`) are present, and is sent as `{ addr1, city, state, zip }`. Individual `CITY`, `STATE`, `ZIP` fields are still sent separately.
- **Transaction fix** (`transaction.util.js`): `adminAlertService` was a placeholder that was never implemented or imported. Replaced with `opsLogger` (already imported at the top of the file as `log4js.getLogger("ops-alerts")`).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration now treats duplicate-key conflicts as a lease contention instead of a failure, reducing false migration errors.
  * Transaction error handling now records a clearer operational log entry when completion fails.
  * Newsletter signup now sends address details only when a full address is available, improving contact data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->