### PR TITLE
Allow airqo:// deep-link scheme as valid OAuth redirect_after target

### DIFF
--- a/src/auth-service/.env.development.template.json
+++ b/src/auth-service/.env.development.template.json
@@ -125,7 +125,7 @@
   "ANALYTICS_BASE_URL": "",
   "VERTEX_BASE_URL": "",
   "ALLOWED_REDIRECT_ORIGINS": "",
-  "ALLOWED_CUSTOM_SCHEME_PREFIXES": "vertex://,beacon://,dataflo://,analytics://",
+  "ALLOWED_CUSTOM_SCHEME_PREFIXES": "vertex://,beacon://,dataflo://,analytics://,airqo://",
 
   "ANALYTICS_PII_ENABLED": "false",
   "BYPASS_CAPTCHA": "false",

--- a/src/auth-service/.env.production.template.json
+++ b/src/auth-service/.env.production.template.json
@@ -122,7 +122,7 @@
   "ANALYTICS_BASE_URL": "",
   "VERTEX_BASE_URL": "",
   "ALLOWED_REDIRECT_ORIGINS": "",
-  "ALLOWED_CUSTOM_SCHEME_PREFIXES": "vertex://,beacon://,dataflo://,analytics://",
+  "ALLOWED_CUSTOM_SCHEME_PREFIXES": "vertex://,beacon://,dataflo://,analytics://,airqo://",
 
   "ANALYTICS_PII_ENABLED": "",
   "BYPASS_CAPTCHA": "",

--- a/src/auth-service/.env.staging.template.json
+++ b/src/auth-service/.env.staging.template.json
@@ -122,7 +122,7 @@
   "ANALYTICS_BASE_URL": "",
   "VERTEX_BASE_URL": "",
   "ALLOWED_REDIRECT_ORIGINS": "",
-  "ALLOWED_CUSTOM_SCHEME_PREFIXES": "vertex://,beacon://,dataflo://,analytics://",
+  "ALLOWED_CUSTOM_SCHEME_PREFIXES": "vertex://,beacon://,dataflo://,analytics://,airqo://",
 
   "ANALYTICS_PII_ENABLED": "",
   "BYPASS_CAPTCHA": "",

--- a/src/auth-service/config/core/envs.js
+++ b/src/auth-service/config/core/envs.js
@@ -263,9 +263,9 @@ const envs = {
   // Comma-separated list of additional origins allowed as redirect_after targets
   // beyond ANALYTICS_BASE_URL and VERTEX_BASE_URL (which are always included).
   ALLOWED_REDIRECT_ORIGINS: process.env.ALLOWED_REDIRECT_ORIGINS,
-  // Comma-separated custom URL scheme prefixes (e.g. "vertex://") that are
-  // allowed as redirect_after targets. These are desktop-app deep-link schemes
-  // and cannot be exploited for web phishing. Defaults to "vertex://".
+  // Comma-separated custom URL scheme prefixes (e.g. "vertex://,airqo://") that are
+  // allowed as redirect_after targets. These are app deep-link schemes and cannot be
+  // exploited for web phishing. Defaults to "vertex://,airqo://".
   ALLOWED_CUSTOM_SCHEME_PREFIXES: process.env.ALLOWED_CUSTOM_SCHEME_PREFIXES,
 
   // ── API / network ──────────────────────────────────────────────────────────

--- a/src/auth-service/config/core/envs.js
+++ b/src/auth-service/config/core/envs.js
@@ -265,7 +265,7 @@ const envs = {
   ALLOWED_REDIRECT_ORIGINS: process.env.ALLOWED_REDIRECT_ORIGINS,
   // Comma-separated custom URL scheme prefixes (e.g. "vertex://,airqo://") that are
   // allowed as redirect_after targets. These are app deep-link schemes and cannot be
-  // exploited for web phishing. Defaults to "vertex://,airqo://".
+  // exploited for web phishing. (Defaults are enforced in the redirect validation logic.)
   ALLOWED_CUSTOM_SCHEME_PREFIXES: process.env.ALLOWED_CUSTOM_SCHEME_PREFIXES,
 
   // ── API / network ──────────────────────────────────────────────────────────

--- a/src/auth-service/controllers/test/ut_oauth_redirect_validation.js
+++ b/src/auth-service/controllers/test/ut_oauth_redirect_validation.js
@@ -25,7 +25,7 @@ const constantsStub = {
   ANALYTICS_BASE_URL: "https://analytics.airqo.net",
   VERTEX_BASE_URL: "https://vertex.airqo.net",
   ALLOWED_REDIRECT_ORIGINS: "",
-  ALLOWED_CUSTOM_SCHEME_PREFIXES: "vertex://,beacon://",
+  ALLOWED_CUSTOM_SCHEME_PREFIXES: "vertex://,beacon://,airqo://",
   OAUTH_COOKIE_DOMAIN: "",
   GMAIL_VERIFICATION_SUCCESS_REDIRECT: "https://analytics.airqo.net",
   GMAIL_VERIFICATION_FAILURE_REDIRECT: "https://analytics.airqo.net/user/login",
@@ -117,6 +117,14 @@ describe("googleCallback — custom-scheme redirect_after validation", () => {
       expect(res.redirect.firstCall.args[0]).to.match(/^beacon:\/\//);
     });
 
+    it("redirects to airqo:// deep-link when cookie is airqo://oauth", async () => {
+      req.cookies._oauth_redirect_after = "airqo://oauth";
+      await userController.googleCallback(req, res, next);
+      expect(res.redirect.calledOnce).to.be.true;
+      expect(res.redirect.firstCall.args[0]).to.match(/^airqo:\/\//);
+      expect(res.redirect.firstCall.args[0]).to.include("#token=");
+    });
+
     it("falls back to analytics URL for an unrecognised scheme (evil://hack)", async () => {
       req.cookies._oauth_redirect_after = "evil://hack";
       await userController.googleCallback(req, res, next);
@@ -159,5 +167,114 @@ describe("googleCallback — custom-scheme redirect_after validation", () => {
       expect(res.redirect.firstCall.args[0]).to.include("analytics.airqo.net");
       expect(res.redirect.firstCall.args[0]).not.to.include("evil.com");
     });
+  });
+});
+
+describe("googleCallback — custom-scheme allowlist default fallback", () => {
+  let userControllerWithDefaultSchemes;
+  let req, res, next;
+  const FAKE_TOKEN = "fake-jwt-token-default";
+
+  before(() => {
+    const fakeUser = {
+      _id: "user456",
+      email: "default@example.com",
+      toAuthJSON: sinon.stub().resolves({ token: FAKE_TOKEN }),
+    };
+
+    const userModelStub = sinon.stub().returns({
+      findById: sinon.stub().resolves(fakeUser),
+      findByIdAndUpdate: sinon.stub().resolves(),
+    });
+
+    const userUtilStub = {
+      ensureDefaultAirqoRole: sinon.stub().resolves(),
+      _getEffectiveTokenStrategy: sinon.stub(),
+    };
+
+    // Omit ALLOWED_CUSTOM_SCHEME_PREFIXES entirely so the code falls through
+    // to its hardcoded default of "vertex://,airqo://".
+    const constantsStubNoSchemes = {
+      ...constants,
+      ANALYTICS_BASE_URL: "https://analytics.airqo.net",
+      VERTEX_BASE_URL: "https://vertex.airqo.net",
+      ALLOWED_REDIRECT_ORIGINS: "",
+      ALLOWED_CUSTOM_SCHEME_PREFIXES: undefined,
+      OAUTH_COOKIE_DOMAIN: "",
+      GMAIL_VERIFICATION_SUCCESS_REDIRECT: "https://analytics.airqo.net",
+      GMAIL_VERIFICATION_FAILURE_REDIRECT: "https://analytics.airqo.net/user/login",
+      DEFAULT_TENANT: "airqo",
+      ENVIRONMENT: "test",
+    };
+
+    userControllerWithDefaultSchemes = proxyquire("@controllers/user.controller", {
+      "@models/User": userModelStub,
+      "@utils/user.util": userUtilStub,
+      "@utils/shared": {
+        HttpError: class extends Error {
+          constructor(message, statusCode, errors) {
+            super(message);
+            this.statusCode = statusCode;
+            this.errors = errors;
+          }
+        },
+        logObject: sinon.stub(),
+        logText: sinon.stub(),
+        logElement: sinon.stub(),
+        stringify: sinon.stub().returns(""),
+        extractErrorsFromRequest: sinon.stub().returns(null),
+      },
+      "@services/analytics.service": { track: sinon.stub() },
+      "@services/atf.service": { AbstractTokenFactory: sinon.stub() },
+      "@utils/token.util": {},
+      "@config/constants": constantsStubNoSchemes,
+    });
+  });
+
+  beforeEach(() => {
+    req = {
+      query: { tenant: "airqo" },
+      body: {},
+      cookies: {},
+      session: {},
+      user: {
+        _id: "user456",
+        email: "default@example.com",
+        analyticsVersion: 3,
+        verified: true,
+      },
+    };
+    res = {
+      clearCookie: sinon.stub(),
+      cookie: sinon.stub(),
+      redirect: sinon.stub(),
+      headersSent: false,
+    };
+    next = sinon.stub();
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("accepts airqo://oauth when ALLOWED_CUSTOM_SCHEME_PREFIXES is unset (default fallback)", async () => {
+    req.cookies._oauth_redirect_after = "airqo://oauth";
+    await userControllerWithDefaultSchemes.googleCallback(req, res, next);
+    expect(res.redirect.calledOnce).to.be.true;
+    expect(res.redirect.firstCall.args[0]).to.match(/^airqo:\/\//);
+    expect(res.redirect.firstCall.args[0]).to.include("#token=");
+  });
+
+  it("accepts vertex://login when ALLOWED_CUSTOM_SCHEME_PREFIXES is unset (default fallback)", async () => {
+    req.cookies._oauth_redirect_after = "vertex://login";
+    await userControllerWithDefaultSchemes.googleCallback(req, res, next);
+    expect(res.redirect.calledOnce).to.be.true;
+    expect(res.redirect.firstCall.args[0]).to.match(/^vertex:\/\//);
+    expect(res.redirect.firstCall.args[0]).to.include("#token=");
+  });
+
+  it("still rejects evil:// when ALLOWED_CUSTOM_SCHEME_PREFIXES is unset", async () => {
+    req.cookies._oauth_redirect_after = "evil://hack";
+    await userControllerWithDefaultSchemes.googleCallback(req, res, next);
+    expect(res.redirect.firstCall.args[0]).to.include("analytics.airqo.net");
+    expect(res.redirect.firstCall.args[0]).not.to.match(/^evil:\/\//);
   });
 });

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -60,10 +60,10 @@ function validateRedirectUrl(raw) {
   try {
     const parsed = new URL(raw);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      // Custom-scheme deep links (e.g. vertex://) are allowed against an explicit
-      // prefix list instead of origin comparison.
+      // Custom-scheme deep links (e.g. vertex://, airqo://) are allowed against an
+      // explicit prefix list instead of origin comparison.
       const allowedPrefixes = (
-        constants.ALLOWED_CUSTOM_SCHEME_PREFIXES || "vertex://"
+        constants.ALLOWED_CUSTOM_SCHEME_PREFIXES || "vertex://,airqo://"
       )
         .split(",")
         .map((s) => s.trim())

--- a/src/auth-service/middleware/passport.js
+++ b/src/auth-service/middleware/passport.js
@@ -1158,11 +1158,11 @@ function resolveAllowedRedirectOrigins() {
 // Computed once at module load — inputs are fixed env vars.
 const ALLOWED_ORIGINS = resolveAllowedRedirectOrigins();
 
-// Desktop-app deep-link scheme prefixes allowed as redirect_after targets.
-// Custom schemes (e.g. vertex://) cannot be exploited for web phishing since
-// the OS routes them to the registered desktop app, not a website.
+// Deep-link scheme prefixes allowed as redirect_after targets.
+// Custom schemes (e.g. vertex://, airqo://) cannot be exploited for web phishing since
+// the OS routes them to the registered app, not a website.
 const ALLOWED_CUSTOM_SCHEME_PREFIXES = (
-  constants.ALLOWED_CUSTOM_SCHEME_PREFIXES || "vertex://"
+  constants.ALLOWED_CUSTOM_SCHEME_PREFIXES || "vertex://,airqo://"
 )
   .split(",")
   .map((s) => s.trim())


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds `airqo://` to the default allowed custom URL scheme prefixes for OAuth `redirect_after` targets. Previously only `vertex://` was in the default, meaning mobile clients using `?redirect_after=airqo://oauth` were silently rejected and the backend fell back to the web redirect URL — breaking `flutter_web_auth_2` interception on mobile.

### Why is this change needed?
The AirQo Flutter app uses `flutter_web_auth_2` with `callbackUrlScheme: 'airqo'`, which means it can only intercept redirects to the `airqo://` scheme. Without this change, the backend ignores the `redirect_after=airqo://oauth` parameter and always redirects to `platform.airqo.net/user/home`, which the mobile in-app browser never hands back to the app. This fix unblocks mobile social login without requiring a new env-var deployment.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `src/auth-service/middleware/passport.js`, `src/auth-service/config/core/envs.js`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that `?redirect_after=airqo://oauth` is now accepted by `isAllowedRedirect()` via the updated `ALLOWED_CUSTOM_SCHEME_PREFIXES` default. The env var `ALLOWED_CUSTOM_SCHEME_PREFIXES` can still override the default (e.g. to restrict or extend the list) without any code change. Existing `vertex://` behaviour is unchanged.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`vertex://` remains in the default list. Deployments that already set `ALLOWED_CUSTOM_SCHEME_PREFIXES` explicitly are unaffected — the env var always takes full precedence over the default.

---

## :memo: Additional Notes

- The `redirect_after` flow was already fully implemented for `vertex://` (desktop app). This PR simply extends the same mechanism to `airqo://` (mobile app) by updating the hardcoded default in `passport.js` and the accompanying comment in `envs.js`.
- Mobile Flutter clients should initiate OAuth as:
  `GET /api/v2/users/auth/{provider}?redirect_after=airqo%3A%2F%2Foauth`
  On success the backend redirects to: `airqo://oauth?success={provider}#token=<JWT>`
- The Flutter doc sent to the mobile team also needs four corrections flagged in the review (missing GitHub provider, broken auth URL missing `redirect_after`, resolved deep-link section, inaccurate account-picker note).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded support for custom app redirect links so `airqo://` deep links are now accepted in development, staging, and production.
  * Improved redirect handling to recognize a broader set of allowed custom URL schemes, reducing failed sign-in or redirect flows for supported app links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->