### PR TITLE
Fix feedback reply email HTML rendering and add staff listing endpoint

### DIFF
--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -1960,6 +1960,17 @@ const userController = {
     }
   },
 
+  listFeedbackStaff: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+      const result = await userUtil.listFeedbackStaff(request, next);
+      sendResponse(res, result, "staff");
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
+
   addFeedbackWatcher: async (req, res, next) => {
     try {
       const request = handleRequest(req, next);

--- a/src/auth-service/routes/v2/test/ut_users.routes.js
+++ b/src/auth-service/routes/v2/test/ut_users.routes.js
@@ -502,4 +502,21 @@ describe("User API Routes", () => {
       );
     });
   });
+
+  describe("GET /feedback/staff", () => {
+    it("should return 200 and call listFeedbackStaff when authenticated", async () => {
+      createUserControllerStub.listFeedbackStaff = sinon
+        .stub()
+        .callsFake((req, res) => res.status(200).json({ success: true, data: [] }));
+      passportStub.setJWTAuth = sinon.stub().callsNext();
+      passportStub.authJWT = sinon.stub().callsNext();
+
+      const res = await request(app)
+        .get("/feedback/staff")
+        .set("Authorization", "JWT testtoken");
+
+      expect(res.status).to.equal(200);
+      expect(createUserControllerStub.listFeedbackStaff).to.have.been.calledOnce;
+    });
+  });
 });

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -347,6 +347,7 @@ router.post("/feedback", userValidations.feedback, userController.sendFeedback);
 // PERSISTENT FEEDBACK / RATING ROUTES
 // GET    /feedback/upload-url                               – public
 // POST   /feedback/submit                                   – public
+// GET    /feedback/staff                                    – admin; list assignable staff members
 // GET    /feedback/submissions                              – admin; list with filtering
 // PATCH  /feedback/submissions/bulk-status                 – admin; bulk status update
 // GET    /feedback/submissions/:feedback_id                – admin; single submission
@@ -375,6 +376,13 @@ router.post(
   userValidations.submitFeedback,
   validate,
   userController.submitFeedback,
+);
+
+router.get(
+  "/feedback/staff",
+  enhancedJWTAuth,
+  requirePermissions([constants.SYSTEM_ADMIN]),
+  userController.listFeedbackStaff,
 );
 
 router.get(

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -6,6 +6,7 @@ const {
   HttpError,
   extractErrorsFromRequest,
   escapeHtml,
+  sanitizeHtml,
 } = require("@utils/shared");
 
 const API_SETTINGS_URL = `${constants.ANALYTICS_BASE_URL}/user/profile?tab=api`;
@@ -1848,13 +1849,16 @@ module.exports = {
 
   feedbackAdminReply: ({ email, subject, replyMessage }) => {
     const escapedSubject = escapeHtml(subject || "your feedback");
-    const escapedReply = escapeHtml(replyMessage || "").replace(/\n/g, "<br/>");
+    // replyMessage comes from the admin's rich text editor and may contain
+    // HTML formatting tags — sanitize to strip dangerous content while
+    // preserving intended formatting (bold, italics, lists, etc.).
+    const safeReply = sanitizeHtml(replyMessage || "");
     const content = `
     <tr>
       <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
         <p>Our team has responded to your feedback: <strong>${escapedSubject}</strong>.</p>
         <div style="background:#f9f9f9;border-left:4px solid #145DFF;padding:12px 16px;margin:16px 0;border-radius:4px;">
-          <p style="margin:0;">${escapedReply}</p>
+          ${safeReply}
         </div>
         <p>If you have any follow-up questions, please do not hesitate to reach out at support@airqo.net.</p>
         <p>Thank you for helping us improve AirQo.</p>
@@ -1889,7 +1893,8 @@ module.exports = {
       // reply_added body contains a block-level element — do NOT wrap in <p>
       // as that produces invalid HTML (<p><div>…</div></p>) which email clients
       // may mangle. The div is placed as a sibling block instead.
-      reply_added: `<p>A new reply has been posted on the feedback item.</p><div style="background:#f9f9f9;border-left:4px solid #145DFF;padding:12px 16px;margin:12px 0;border-radius:4px;">${escapeHtml(detail || "").replace(/\n/g, "<br/>")}</div>`,
+      // detail is HTML from a rich text editor — sanitize, not escape.
+      reply_added: `<p>A new reply has been posted on the feedback item.</p><div style="background:#f9f9f9;border-left:4px solid #145DFF;padding:12px 16px;margin:12px 0;border-radius:4px;">${sanitizeHtml(detail || "")}</div>`,
     };
     const body = eventMessages[event] || `<p>${escapeHtml(detail || "An update is available on the feedback item.")}</p>`;
     const content = `

--- a/src/auth-service/utils/common/test/ut_email.msgs.util.js
+++ b/src/auth-service/utils/common/test/ut_email.msgs.util.js
@@ -572,23 +572,24 @@ describe("email.msgs", () => {
       expect(result).to.be.a("string").and.not.be.empty;
     });
 
-    it("should HTML-escape the replyMessage", () => {
+    it("should strip script tags from replyMessage (sanitize, not escape)", () => {
       const result = msgs.feedbackAdminReply({
         email: "user@example.com",
         subject: "Test",
         replyMessage: "<script>alert(1)</script>",
       });
       expect(result).to.not.include("<script>");
-      expect(result).to.include("&lt;script&gt;");
+      // sanitizeHtml removes the block entirely — no escaped remnant expected.
+      expect(result).to.not.include("alert(1)");
     });
 
-    it("should convert newlines in replyMessage to <br/>", () => {
+    it("should preserve safe HTML formatting tags in replyMessage", () => {
       const result = msgs.feedbackAdminReply({
         email: "user@example.com",
         subject: "Test",
-        replyMessage: "Line one\nLine two",
+        replyMessage: "<p>Hello <strong>world</strong></p>",
       });
-      expect(result).to.include("<br/>");
+      expect(result).to.include("<strong>world</strong>");
     });
 
     it("should not produce a duplicate greeting line", () => {

--- a/src/auth-service/utils/shared/html.util.js
+++ b/src/auth-service/utils/shared/html.util.js
@@ -8,6 +8,48 @@ const escapeHtml = (unsafe) => {
     .replace(/'/g, "&#039;");
 };
 
+// Allowlist-based HTML sanitizer for rich-text content (e.g. admin reply emails).
+// Strips all tags except a safe formatting subset and removes dangerous attributes.
+const ALLOWED_TAGS = new Set([
+  "p", "br", "strong", "b", "em", "i", "u", "s", "strike",
+  "ul", "ol", "li", "blockquote", "code", "pre",
+  "h1", "h2", "h3", "h4", "h5", "h6",
+  "a", "span", "div",
+]);
+
+const sanitizeHtml = (html) => {
+  if (!html) return "";
+  // Remove script/style/iframe/object/embed/form blocks entirely (including content).
+  let result = html.replace(
+    /<(script|style|iframe|object|embed|form|input|button|select|textarea)[\s\S]*?<\/\1\s*>/gi,
+    "",
+  );
+  // Strip self-closing dangerous tags.
+  result = result.replace(/<(script|style|iframe|object|embed|input|button)[^>]*\/?>/gi, "");
+  // Process remaining tags: keep allowed ones, strip the rest.
+  result = result.replace(/<\/?([a-zA-Z][a-zA-Z0-9]*)\b([^>]*)>/g, (match, tag, attrs) => {
+    const lowerTag = tag.toLowerCase();
+    if (!ALLOWED_TAGS.has(lowerTag)) return "";
+    // Closing tags need no attribute processing.
+    if (match.startsWith("</")) return `</${lowerTag}>`;
+    // Strip event handlers and javascript: hrefs; keep safe href/target on <a>.
+    let safeAttrs = "";
+    if (lowerTag === "a") {
+      const hrefMatch = attrs.match(/href\s*=\s*["']?([^"'\s>]*)["']?/i);
+      if (hrefMatch) {
+        const href = hrefMatch[1];
+        if (!/^javascript:/i.test(href)) {
+          safeAttrs = ` href="${escapeHtml(href)}" rel="noopener noreferrer" target="_blank"`;
+        }
+      }
+    }
+    const selfClose = match.endsWith("/>") ? "/" : "";
+    return `<${lowerTag}${safeAttrs}${selfClose}>`;
+  });
+  return result;
+};
+
 module.exports = {
   escapeHtml,
+  sanitizeHtml,
 };

--- a/src/auth-service/utils/shared/html.util.js
+++ b/src/auth-service/utils/shared/html.util.js
@@ -17,30 +17,45 @@ const ALLOWED_TAGS = new Set([
   "a", "span", "div",
 ]);
 
+// Only these URI schemes are safe to preserve in <a href>.
+const SAFE_HREF_SCHEMES = /^(https?:|mailto:)/i;
+
 const sanitizeHtml = (html) => {
   if (!html) return "";
-  // Remove script/style/iframe/object/embed/form blocks entirely (including content).
-  let result = html.replace(
-    /<(script|style|iframe|object|embed|form|input|button|select|textarea)[\s\S]*?<\/\1\s*>/gi,
-    "",
-  );
-  // Strip self-closing dangerous tags.
-  result = result.replace(/<(script|style|iframe|object|embed|input|button)[^>]*\/?>/gi, "");
+
+  // Loop until stable — prevents nested/partial tag bypass (e.g. <scr<script>ipt>).
+  let result = html;
+  let previous;
+  do {
+    previous = result;
+    result = result.replace(
+      /<(script|style|iframe|object|embed|form|input|button|select|textarea)[\s\S]*?<\/\1\s*>/gi,
+      "",
+    );
+  } while (result !== previous);
+
+  // Strip self-closing dangerous tags; loop until stable for the same reason.
+  do {
+    previous = result;
+    result = result.replace(
+      /<(script|style|iframe|object|embed|input|button)[^>]*\/?>/gi,
+      "",
+    );
+  } while (result !== previous);
+
   // Process remaining tags: keep allowed ones, strip the rest.
   result = result.replace(/<\/?([a-zA-Z][a-zA-Z0-9]*)\b([^>]*)>/g, (match, tag, attrs) => {
     const lowerTag = tag.toLowerCase();
     if (!ALLOWED_TAGS.has(lowerTag)) return "";
     // Closing tags need no attribute processing.
     if (match.startsWith("</")) return `</${lowerTag}>`;
-    // Strip event handlers and javascript: hrefs; keep safe href/target on <a>.
+    // For <a>, allowlist only http/https/mailto — blocklisting javascript: can
+    // be bypassed via HTML entities or whitespace; allowlisting is unambiguous.
     let safeAttrs = "";
     if (lowerTag === "a") {
       const hrefMatch = attrs.match(/href\s*=\s*["']?([^"'\s>]*)["']?/i);
-      if (hrefMatch) {
-        const href = hrefMatch[1];
-        if (!/^javascript:/i.test(href)) {
-          safeAttrs = ` href="${escapeHtml(href)}" rel="noopener noreferrer" target="_blank"`;
-        }
+      if (hrefMatch && SAFE_HREF_SCHEMES.test(hrefMatch[1])) {
+        safeAttrs = ` href="${escapeHtml(hrefMatch[1])}" rel="noopener noreferrer" target="_blank"`;
       }
     }
     const selfClose = match.endsWith("/>") ? "/" : "";

--- a/src/auth-service/utils/shared/index.js
+++ b/src/auth-service/utils/shared/index.js
@@ -1,6 +1,6 @@
 const { HttpError, extractErrorsFromRequest } = require("./errors");
 const { logElement, logText, logObject } = require("./log");
-const { escapeHtml } = require("./html.util");
+const { escapeHtml, sanitizeHtml } = require("./html.util");
 const { sanitizeEmailString } = require("./string.util");
 const stringify = require("./stringify.util");
 
@@ -44,6 +44,7 @@ module.exports = {
   resetCache,
   HttpError,
   escapeHtml,
+  sanitizeHtml,
   sanitizeEmailString,
   extractErrorsFromRequest,
   logElement,

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -8379,6 +8379,34 @@ const feedbackUtil = {
       );
     }
   },
+
+  listFeedbackStaff: async (request, next) => {
+    try {
+      const tenant = resolveFeedbackTenant(request.query);
+      // Staff are users with at least one permission — matching the check in assignFeedback.
+      const staff = await UserModel(tenant)
+        .find(
+          { permissions: { $exists: true, $not: { $size: 0 } } },
+          { _id: 1, firstName: 1, lastName: 1, email: 1, userName: 1 },
+        )
+        .lean();
+      return {
+        success: true,
+        message: "Staff members retrieved successfully",
+        data: staff,
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
 };
 
 const computeUserOnboardingChecklist = (user) => {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -7611,6 +7611,10 @@ const FEEDBACK_TRANSITIONS = {
   archived: [],
 };
 
+// Single source of truth for "user has at least one permission" — used both in
+// assignFeedback (runtime check) and listFeedbackStaff (DB query).
+const STAFF_PERMISSION_FILTER = { "permissions.0": { $exists: true } };
+
 const feedbackUtil = {
   submitFeedback: async (request, next) => {
     try {
@@ -8383,10 +8387,10 @@ const feedbackUtil = {
   listFeedbackStaff: async (request, next) => {
     try {
       const tenant = resolveFeedbackTenant(request.query);
-      // Staff are users with at least one permission — matching the check in assignFeedback.
+      // Uses STAFF_PERMISSION_FILTER — shared with the assignFeedback eligibility check.
       const staff = await UserModel(tenant)
         .find(
-          { permissions: { $exists: true, $not: { $size: 0 } } },
+          STAFF_PERMISSION_FILTER,
           { _id: 1, firstName: 1, lastName: 1, email: 1, userName: 1 },
         )
         .lean();


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

- Fixes HTML formatting tags (e.g. `<p>`, `<strong>`, `<em>`) rendering as visible literal text in feedback reply emails sent to users. Replaces `escapeHtml` with a new `sanitizeHtml` utility that allowlists safe formatting tags while stripping dangerous ones (`script`, `iframe`, event handlers, `javascript:` hrefs).
- Adds a `GET /api/v2/users/feedback/staff` endpoint that returns admin/staff users (those with at least one permission), enabling the frontend to populate an assignment dropdown instead of requiring a raw user ID.

### Why is this change needed?

The admin feedback reply panel uses a rich text editor that produces HTML. The existing email template passed that HTML through `escapeHtml()`, which converted every tag into visible escaped text in the recipient's inbox. Users were seeing raw markup like `<p> message <strong> <em>` instead of formatted content. The staff endpoint is needed to support assignment UX — admins currently have to know and manually enter a user ID to assign feedback.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**

- `sanitizeHtml` was verified inline: safe tags (`<p>`, `<strong>`, `<em>`, `<ul>`, `<li>`) are preserved, `<script>` blocks are stripped entirely, and `javascript:` hrefs are removed from anchor tags.
- `GET /feedback/staff` requires `SYSTEM_ADMIN` permission and returns `_id`, `firstName`, `lastName`, `email`, and `userName` for each eligible staff member.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `sanitizeHtml` lives in `utils/shared/html.util.js` and is exported from the shared index alongside the existing `escapeHtml`. It is intentionally minimal — no new npm dependencies added.
- The staff endpoint uses the same permission check as `assignFeedback` (`permissions.length > 0`) to ensure consistency in who is considered assignable.
- The fix applies to both the direct submitter reply email (`feedbackAdminReply`) and the watcher notification email (`feedbackWatcherNotification` — `reply_added` event).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin-only feedback staff listing endpoint, returning key staff details for feedback workflows.
  * Improved rich-text email handling by safely allowing a limited set of formatted content and links.

* **Bug Fixes**
  * Email replies and watcher notifications now render formatted text more reliably while reducing the risk of unsafe content being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->