### PR TITLE
feat: re-suspend reinstated tokens using strike-based compromise threshold

### DIFF
--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -84,6 +84,9 @@ const AccessTokenSchema = new mongoose.Schema(
       auto_suspended: { type: Boolean, default: false },
       suspension_reason: { type: String },
       suspended_at: { type: Date },
+      // Incremented on every auto-suspension; used to lower the re-suspension
+      // threshold for repeat offenders after reinstatement.
+      suspension_count: { type: Number, default: 0 },
     },
     // Origin binding — opt-in per client.
     // When enforce_origin is true on the parent Client, requests must carry

--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -84,7 +84,7 @@ const AccessTokenSchema = new mongoose.Schema(
       auto_suspended: { type: Boolean, default: false },
       suspension_reason: { type: String },
       suspended_at: { type: Date },
-      // Incremented on every auto-suspension; used to lower the re-suspension
+      // Incremented on high-compromise auto-suspension; used to lower the re-suspension
       // threshold for repeat offenders after reinstatement.
       suspension_count: { type: Number, default: 0 },
     },

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -853,7 +853,7 @@ const isIPBlacklistedHelper = async (
               const baseThreshold = constants.COMPROMISE_SUSPEND_THRESHOLD;
               const requestPattern = listTokenResponse.data[0].request_pattern || {};
 
-              // suspension_count is incremented on every auto-suspension. For tokens
+              // suspension_count is incremented on high-compromise auto-suspension. For tokens
               // suspended before this field was added, fall back to checking whether
               // suspended_at is set (meaning the token has been suspended at least once).
               const trackedCount = requestPattern.suspension_count ?? 0;
@@ -864,10 +864,14 @@ const isIPBlacklistedHelper = async (
                   ? 1
                   : 0;
 
-              // Halve the threshold for each prior suspension, floored at 20.
-              // priorSuspensions=0 → 50, =1 → 25, =2 → 20, =3+ → 20
+              // Halve the threshold for each prior suspension, floored at
+              // min(20, baseThreshold) so a configured baseThreshold below 20
+              // is never accidentally raised by the floor.
+              // e.g. base=50: priorSuspensions=0→50, =1→25, =2→20, =3+→20
+              //      base=10: priorSuspensions=0→10, =1→10, =2+→10
+              const floor = Math.min(20, baseThreshold);
               const effectiveThreshold = Math.max(
-                20,
+                floor,
                 Math.floor(baseThreshold / Math.pow(2, priorSuspensions))
               );
 
@@ -1351,6 +1355,17 @@ const token = {
         if (update.bypass_anomaly_detection !== undefined) {
           if (!isAdmin) {
             delete update.bypass_anomaly_detection;
+          }
+        }
+        // Expand request_pattern into dotted-path keys before passing to
+        // findByIdAndUpdate. Without this, Mongoose's implicit $set would
+        // replace the entire request_pattern subdocument, silently wiping
+        // suspension_count, suspended_at, and other tracking fields.
+        if (update.request_pattern && typeof update.request_pattern === "object") {
+          const rp = update.request_pattern;
+          delete update.request_pattern;
+          for (const [k, v] of Object.entries(rp)) {
+            update[`request_pattern.${k}`] = v;
           }
         }
         const updatedToken = await AccessTokenModel(tenant)

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -844,23 +844,49 @@ const isIPBlacklistedHelper = async (
           // Auto-suspend if this token has exceeded the high-compromise threshold.
           // Uses MongoDB countDocuments — no Redis dependency. Fire-and-forget; never
           // blocks the IP verdict returned to the current request.
+          //
+          // Repeat offenders (tokens reinstated after a prior auto-suspension) get a
+          // progressively lower threshold so chronic abuse triggers re-suspension even
+          // at lower unique-IP volumes. The floor is 20 unique IPs per 24 hours.
           Promise.resolve().then(async () => {
             try {
-              const threshold = constants.COMPROMISE_SUSPEND_THRESHOLD;
+              const baseThreshold = constants.COMPROMISE_SUSPEND_THRESHOLD;
+              const requestPattern = listTokenResponse.data[0].request_pattern || {};
+
+              // suspension_count is incremented on every auto-suspension. For tokens
+              // suspended before this field was added, fall back to checking whether
+              // suspended_at is set (meaning the token has been suspended at least once).
+              const trackedCount = requestPattern.suspension_count ?? 0;
+              const priorSuspensions =
+                trackedCount > 0
+                  ? trackedCount
+                  : requestPattern.suspended_at
+                  ? 1
+                  : 0;
+
+              // Halve the threshold for each prior suspension, floored at 20.
+              // priorSuspensions=0 → 50, =1 → 25, =2 → 20, =3+ → 20
+              const effectiveThreshold = Math.max(
+                20,
+                Math.floor(baseThreshold / Math.pow(2, priorSuspensions))
+              );
+
               const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
-              // Aggregation stops at `threshold` unique IPs — avoids materialising
-              // the full distinct-IP set in Node.js memory for high-volume tokens.
+              // Aggregation stops at effectiveThreshold unique IPs — avoids
+              // materialising the full distinct-IP set for high-volume tokens.
               const [countResult] = await CompromisedTokenLogModel("airqo").aggregate([
                 { $match: { tokenHash, timestamp: { $gte: since } } },
                 { $group: { _id: "$ip" } },
-                { $limit: threshold },
+                { $limit: effectiveThreshold },
                 { $count: "n" },
               ]);
               const recentCount = countResult?.n ?? 0;
-              if (recentCount < threshold) return;
+              if (recentCount < effectiveThreshold) return;
 
               const suspensionReason =
-                `High compromise activity: ${recentCount} unique IP events in 24 hours — token likely exposed in a public-facing application`;
+                priorSuspensions > 0
+                  ? `Repeat compromise activity: ${recentCount} unique IP events in 24 hours (reduced threshold of ${effectiveThreshold} applies — token has ${priorSuspensions} prior suspension(s))`
+                  : `High compromise activity: ${recentCount} unique IP events in 24 hours — token likely exposed in a public-facing application`;
               const suspendedAt = new Date();
 
               // Atomic update filtered on auto_suspended: {$ne: true} ensures exactly
@@ -874,6 +900,7 @@ const isIPBlacklistedHelper = async (
                     "request_pattern.suspension_reason": suspensionReason,
                     "request_pattern.suspended_at": suspendedAt,
                   },
+                  $inc: { "request_pattern.suspension_count": 1 },
                 },
                 { lean: true }
               );
@@ -896,7 +923,7 @@ const isIPBlacklistedHelper = async (
                 );
 
               logger.warn(
-                `🚨 Token auto-suspended (high compromise activity) — suffix=...${token.slice(-4)} events=${recentCount}`
+                `🚨 Token auto-suspended (high compromise activity) — suffix=...${token.slice(-4)} events=${recentCount} threshold=${effectiveThreshold} priorSuspensions=${priorSuspensions}`
               );
             } catch (e) {
               logger.error(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a strike-based re-suspension threshold for API tokens that have already been auto-suspended and reinstated. A new `suspension_count` field is tracked on each token's `request_pattern`. After reinstatement, the unique-IP threshold required to trigger the next auto-suspension is halved per prior suspension (floored at 20 unique IPs/24h), down from the default 50. Tokens suspended before this field was added are detected via the existing `suspended_at` field for backward compatibility.

### Why is this change needed?

The previous logic used a fixed threshold of 50 unique IPs in 24 hours regardless of suspension history. A token that was suspended for hitting 50+ IPs, reinstated by the owner, and then continued generating ~28 unique IP compromise events per day would never be re-suspended — the daily summary kept firing but no action was taken. This created a gap where chronic abuse went unaddressed after the first reinstatement.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified logic manually by tracing the threshold formula against a known reinstated token (`...6NZN`) that has `suspended_at` set and `suspension_count = 0`. The fallback correctly assigns `priorSuspensions = 1`, yielding an effective threshold of 25. The token's current activity of 28 unique IPs/24h exceeds this threshold, so re-suspension will fire on the next blacklisted request hit. No existing tests broken.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- `suspension_count` defaults to `0` so all existing tokens are unaffected on first deploy — no migration needed.
- The threshold ladder: 0 prior suspensions → 50 IPs, 1 → 25 IPs, 2+ → 20 IPs (floor).
- The suspension email reason string now states the reduced threshold and prior suspension count so the token owner understands why they were flagged again.
- The `$limit: effectiveThreshold` in the aggregation pipeline is updated in step with the threshold, so MongoDB still short-circuits and never materialises the full distinct-IP set.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic suspension behavior for compromised tokens so repeat incidents are handled with a lower threshold.
  * Repeat suspensions now use a different suspension reason, making account status easier to understand.
  * Added tracking so repeated auto-suspensions are counted over time, helping keep enforcement more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->