### PR TITLE
feat: add admin CRUD endpoints for Learn course authoring

### DIFF
--- a/src/device-registry/controllers/learn.controller.js
+++ b/src/device-registry/controllers/learn.controller.js
@@ -303,6 +303,231 @@ const learnController = {
     }
   },
 
+  listCourses: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.listCourses(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          courses: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  getCourse: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.getCourse(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          course: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.NOT_FOUND).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  deleteCourse: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.deleteCourse(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  updateUnit: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.updateUnit(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          unit: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  deleteUnit: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.deleteUnit(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  updateLesson: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.updateLesson(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          lesson: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  deleteLesson: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.deleteLesson(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  updateActivity: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.updateActivity(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          activity: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  deleteActivity: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.deleteActivity(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
   updateCourse: async (req, res, next) => {
     try {
       const errors = extractErrorsFromRequest(req);

--- a/src/device-registry/routes/v2/learn.routes.js
+++ b/src/device-registry/routes/v2/learn.routes.js
@@ -34,10 +34,22 @@ router.post("/progress/link", learnValidations.linkGuestProgress, learnControlle
 // Admin — Course Authoring (admin JWT enforced at nginx gateway)
 // ---------------------------------------------------------------------------
 
+router.get("/admin/courses", learnValidations.listCourses, learnController.listCourses);
 router.post("/admin/courses", learnValidations.createCourse, learnController.createCourse);
-router.post("/admin/courses/:course_id/units", learnValidations.addUnit, learnController.addUnit);
-router.post("/admin/units/:unit_id/lessons", learnValidations.addLesson, learnController.addLesson);
-router.post("/admin/lessons/:lesson_id/activities", learnValidations.addActivity, learnController.addActivity);
+router.get("/admin/courses/:course_id", learnValidations.getCourse, learnController.getCourse);
 router.patch("/admin/courses/:course_id", learnValidations.updateCourse, learnController.updateCourse);
+router.delete("/admin/courses/:course_id", learnValidations.deleteCourse, learnController.deleteCourse);
+
+router.post("/admin/courses/:course_id/units", learnValidations.addUnit, learnController.addUnit);
+router.patch("/admin/units/:unit_id", learnValidations.updateUnit, learnController.updateUnit);
+router.delete("/admin/units/:unit_id", learnValidations.deleteUnit, learnController.deleteUnit);
+
+router.post("/admin/units/:unit_id/lessons", learnValidations.addLesson, learnController.addLesson);
+router.patch("/admin/lessons/:lesson_id", learnValidations.updateLesson, learnController.updateLesson);
+router.delete("/admin/lessons/:lesson_id", learnValidations.deleteLesson, learnController.deleteLesson);
+
+router.post("/admin/lessons/:lesson_id/activities", learnValidations.addActivity, learnController.addActivity);
+router.patch("/admin/activities/:activity_id", learnValidations.updateActivity, learnController.updateActivity);
+router.delete("/admin/activities/:activity_id", learnValidations.deleteActivity, learnController.deleteActivity);
 
 module.exports = router;

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -676,6 +676,513 @@ const learn = {
     }
   },
 
+  // ---------------------------------------------------------------------------
+  // Admin — Read & Delete (Course / Unit / Lesson / Activity)
+  // ---------------------------------------------------------------------------
+
+  listCourses: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const [coursesRes, unitsRes, lessonsRes, activitiesRes] = await Promise.all([
+        LearnCourseModel(tenant).list({}, next),
+        LearnUnitModel(tenant).list({}, next),
+        LearnLessonModel(tenant).list({}, next),
+        LearnActivityModel(tenant).list({}, next),
+      ]);
+
+      if (!coursesRes?.success) return coursesRes;
+
+      const unitIdToCourseId = {};
+      const unitCountByCourse = {};
+      (unitsRes?.data || []).forEach((u) => {
+        const cid = u.course_id.toString();
+        unitIdToCourseId[u._id.toString()] = cid;
+        unitCountByCourse[cid] = (unitCountByCourse[cid] || 0) + 1;
+      });
+
+      const lessonIdToCourseId = {};
+      const lessonCountByCourse = {};
+      (lessonsRes?.data || []).forEach((l) => {
+        const cid = unitIdToCourseId[l.unit_id.toString()];
+        if (cid) {
+          lessonIdToCourseId[l._id.toString()] = cid;
+          lessonCountByCourse[cid] = (lessonCountByCourse[cid] || 0) + 1;
+        }
+      });
+
+      const activityCountByCourse = {};
+      (activitiesRes?.data || []).forEach((a) => {
+        const cid = lessonIdToCourseId[a.lesson_id.toString()];
+        if (cid) activityCountByCourse[cid] = (activityCountByCourse[cid] || 0) + 1;
+      });
+
+      const courses = coursesRes.data.map((c) => {
+        const cid = c._id.toString();
+        return {
+          _id: c._id,
+          course_number: c.course_number,
+          title: c.title,
+          plain_title_key: c.plain_title_key,
+          cover_image_url: c.cover_image_url || null,
+          published: c.published,
+          catalog_version: c.catalog_version || null,
+          unit_count: unitCountByCourse[cid] || 0,
+          lesson_count: lessonCountByCourse[cid] || 0,
+          activity_count: activityCountByCourse[cid] || 0,
+          created_at: c.createdAt,
+          updated_at: c.updatedAt,
+        };
+      });
+
+      return {
+        success: true,
+        data: courses,
+        message: "successfully retrieved courses",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  getCourse: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { course_id } = request.params;
+
+      const courseRes = await LearnCourseModel(tenant).list(
+        { filter: { _id: course_id } },
+        next
+      );
+      if (!courseRes?.success || !courseRes.data?.length) {
+        return { success: false, message: "course not found", status: httpStatus.NOT_FOUND };
+      }
+
+      const course = courseRes.data[0];
+      const unitsRes = await LearnUnitModel(tenant).list({ filter: { course_id } }, next);
+      const units = (unitsRes?.data || []).sort((a, b) => a.unit_order - b.unit_order);
+      const unitIds = units.map((u) => u._id);
+
+      const lessonsRes = await LearnLessonModel(tenant).list(
+        { filter: { unit_id: { $in: unitIds } } },
+        next
+      );
+      const lessons = lessonsRes?.data || [];
+      const lessonIds = lessons.map((l) => l._id);
+
+      const activitiesRes = await LearnActivityModel(tenant).list(
+        { filter: { lesson_id: { $in: lessonIds } } },
+        next
+      );
+      const activities = activitiesRes?.data || [];
+
+      const lessonsByUnit = {};
+      lessons.forEach((l) => {
+        const uid = l.unit_id.toString();
+        if (!lessonsByUnit[uid]) lessonsByUnit[uid] = [];
+        lessonsByUnit[uid].push(l);
+      });
+
+      const activitiesByLesson = {};
+      activities.forEach((a) => {
+        const lid = a.lesson_id.toString();
+        if (!activitiesByLesson[lid]) activitiesByLesson[lid] = [];
+        activitiesByLesson[lid].push(a);
+      });
+
+      return {
+        success: true,
+        data: {
+          _id: course._id,
+          course_number: course.course_number,
+          title: course.title,
+          plain_title_key: course.plain_title_key,
+          cover_image_url: course.cover_image_url || null,
+          published: course.published,
+          catalog_version: course.catalog_version || null,
+          units: units.map((unit) => {
+            const unitLessons = (lessonsByUnit[unit._id.toString()] || []).sort(
+              (a, b) => a.lesson_order - b.lesson_order
+            );
+            return {
+              _id: unit._id,
+              title: unit.title,
+              plain_title_key: unit.plain_title_key,
+              unit_order: unit.unit_order,
+              lessons: unitLessons.map((lesson) => {
+                const lessonActivities = (
+                  activitiesByLesson[lesson._id.toString()] || []
+                ).sort((a, b) => a.order - b.order);
+                return {
+                  _id: lesson._id,
+                  title: lesson.title,
+                  plain_title_key: lesson.plain_title_key,
+                  lesson_order: lesson.lesson_order,
+                  cover_image_url: lesson.cover_image_url || null,
+                  completion_message: lesson.completion_message || null,
+                  activities: lessonActivities.map((act) => ({
+                    _id: act._id,
+                    type: act.type,
+                    order: act.order,
+                    payload: act.payload,
+                  })),
+                };
+              }),
+            };
+          }),
+        },
+        message: "successfully retrieved course",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  deleteCourse: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { course_id } = request.params;
+
+      const courseRes = await LearnCourseModel(tenant).list(
+        { filter: { _id: course_id } },
+        next
+      );
+      if (!courseRes?.success || !courseRes.data?.length) {
+        return { success: false, message: "course not found", status: httpStatus.NOT_FOUND };
+      }
+
+      if (courseRes.data[0].published) {
+        return {
+          success: false,
+          message: "cannot delete a published course — unpublish it first",
+          status: httpStatus.CONFLICT,
+        };
+      }
+
+      const unitsRes = await LearnUnitModel(tenant).list({ filter: { course_id } }, next);
+      const unitIds = (unitsRes?.data || []).map((u) => u._id);
+
+      if (unitIds.length) {
+        const lessonsRes = await LearnLessonModel(tenant).list(
+          { filter: { unit_id: { $in: unitIds } } },
+          next
+        );
+        const lessonIds = (lessonsRes?.data || []).map((l) => l._id);
+
+        if (lessonIds.length) {
+          await LearnActivityModel(tenant).deleteMany({ lesson_id: { $in: lessonIds } });
+        }
+        await LearnLessonModel(tenant).deleteMany({ unit_id: { $in: unitIds } });
+        await LearnUnitModel(tenant).deleteMany({ course_id });
+      }
+
+      await LearnCourseModel(tenant).remove({ filter: { _id: course_id } }, next);
+
+      return {
+        success: true,
+        data: {},
+        message: "course deleted successfully",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  updateUnit: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { unit_id } = request.params;
+      const updates = request.body;
+
+      const unitRes = await LearnUnitModel(tenant).list({ filter: { _id: unit_id } }, next);
+      if (!unitRes?.success || !unitRes.data?.length) {
+        return { success: false, message: "unit not found", status: httpStatus.NOT_FOUND };
+      }
+
+      return await LearnUnitModel(tenant).modify(
+        { filter: { _id: unit_id }, update: updates },
+        next
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  deleteUnit: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { unit_id } = request.params;
+
+      const unitRes = await LearnUnitModel(tenant).list({ filter: { _id: unit_id } }, next);
+      if (!unitRes?.success || !unitRes.data?.length) {
+        return { success: false, message: "unit not found", status: httpStatus.NOT_FOUND };
+      }
+
+      const unit = unitRes.data[0];
+      const courseRes = await LearnCourseModel(tenant).list(
+        { filter: { _id: unit.course_id } },
+        next
+      );
+      if (courseRes?.data?.length && courseRes.data[0].published) {
+        return {
+          success: false,
+          message: "cannot delete a unit from a published course — unpublish the course first",
+          status: httpStatus.CONFLICT,
+        };
+      }
+
+      const lessonsRes = await LearnLessonModel(tenant).list({ filter: { unit_id } }, next);
+      const lessonIds = (lessonsRes?.data || []).map((l) => l._id);
+
+      if (lessonIds.length) {
+        await LearnActivityModel(tenant).deleteMany({ lesson_id: { $in: lessonIds } });
+        await LearnLessonModel(tenant).deleteMany({ unit_id });
+      }
+
+      await LearnUnitModel(tenant).remove({ filter: { _id: unit_id } }, next);
+
+      return {
+        success: true,
+        data: {},
+        message: "unit deleted successfully",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  updateLesson: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { lesson_id } = request.params;
+      const updates = request.body;
+
+      const lessonRes = await LearnLessonModel(tenant).list(
+        { filter: { _id: lesson_id } },
+        next
+      );
+      if (!lessonRes?.success || !lessonRes.data?.length) {
+        return { success: false, message: "lesson not found", status: httpStatus.NOT_FOUND };
+      }
+
+      return await LearnLessonModel(tenant).modify(
+        { filter: { _id: lesson_id }, update: updates },
+        next
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  deleteLesson: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { lesson_id } = request.params;
+
+      const lessonRes = await LearnLessonModel(tenant).list(
+        { filter: { _id: lesson_id } },
+        next
+      );
+      if (!lessonRes?.success || !lessonRes.data?.length) {
+        return { success: false, message: "lesson not found", status: httpStatus.NOT_FOUND };
+      }
+
+      const lesson = lessonRes.data[0];
+      const unitRes = await LearnUnitModel(tenant).list(
+        { filter: { _id: lesson.unit_id } },
+        next
+      );
+      if (unitRes?.data?.length) {
+        const courseRes = await LearnCourseModel(tenant).list(
+          { filter: { _id: unitRes.data[0].course_id } },
+          next
+        );
+        if (courseRes?.data?.length && courseRes.data[0].published) {
+          return {
+            success: false,
+            message: "cannot delete a lesson from a published course — unpublish the course first",
+            status: httpStatus.CONFLICT,
+          };
+        }
+      }
+
+      await LearnActivityModel(tenant).deleteMany({ lesson_id });
+      await LearnLessonModel(tenant).remove({ filter: { _id: lesson_id } }, next);
+
+      return {
+        success: true,
+        data: {},
+        message: "lesson deleted successfully",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  updateActivity: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { activity_id } = request.params;
+      const { type, order, payload } = request.body;
+
+      const activityRes = await LearnActivityModel(tenant).list(
+        { filter: { _id: activity_id } },
+        next
+      );
+      if (!activityRes?.success || !activityRes.data?.length) {
+        return { success: false, message: "activity not found", status: httpStatus.NOT_FOUND };
+      }
+
+      const effectiveType = type || activityRes.data[0].type;
+
+      if (payload !== undefined) {
+        if (effectiveType === "article" && isEmpty(payload?.body)) {
+          return {
+            success: false,
+            message: "validation errors for some of the provided fields",
+            errors: { "payload.body": "body is required for article activities" },
+            status: httpStatus.UNPROCESSABLE_ENTITY,
+          };
+        }
+        if (
+          effectiveType === "video" &&
+          isEmpty(payload?.video_url) &&
+          isEmpty(payload?.youtube_id)
+        ) {
+          return {
+            success: false,
+            message: "validation errors for some of the provided fields",
+            errors: {
+              "payload.video_url": "video_url or youtube_id is required for video activities",
+            },
+            status: httpStatus.UNPROCESSABLE_ENTITY,
+          };
+        }
+        if (effectiveType === "quiz" && isEmpty(payload?.format)) {
+          return {
+            success: false,
+            message: "validation errors for some of the provided fields",
+            errors: { "payload.format": "format is required for quiz activities" },
+            status: httpStatus.UNPROCESSABLE_ENTITY,
+          };
+        }
+      }
+
+      const updates = {};
+      if (type !== undefined) updates.type = type;
+      if (order !== undefined) updates.order = order;
+      if (payload !== undefined) updates.payload = payload;
+
+      return await LearnActivityModel(tenant).modify(
+        { filter: { _id: activity_id }, update: updates },
+        next
+      );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  deleteActivity: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { activity_id } = request.params;
+
+      const activityRes = await LearnActivityModel(tenant).list(
+        { filter: { _id: activity_id } },
+        next
+      );
+      if (!activityRes?.success || !activityRes.data?.length) {
+        return { success: false, message: "activity not found", status: httpStatus.NOT_FOUND };
+      }
+
+      const activity = activityRes.data[0];
+      const lessonRes = await LearnLessonModel(tenant).list(
+        { filter: { _id: activity.lesson_id } },
+        next
+      );
+      if (lessonRes?.data?.length) {
+        const unitRes = await LearnUnitModel(tenant).list(
+          { filter: { _id: lessonRes.data[0].unit_id } },
+          next
+        );
+        if (unitRes?.data?.length) {
+          const courseRes = await LearnCourseModel(tenant).list(
+            { filter: { _id: unitRes.data[0].course_id } },
+            next
+          );
+          if (courseRes?.data?.length && courseRes.data[0].published) {
+            return {
+              success: false,
+              message:
+                "cannot delete an activity from a published course — unpublish the course first",
+              status: httpStatus.CONFLICT,
+            };
+          }
+        }
+      }
+
+      await LearnActivityModel(tenant).remove({ filter: { _id: activity_id } }, next);
+
+      return {
+        success: true,
+        data: {},
+        message: "activity deleted successfully",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
   updateCourse: async (request, next) => {
     try {
       const tenant = getTenant(request);

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -685,12 +685,19 @@ const learn = {
       const tenant = getTenant(request);
       const [coursesRes, unitsRes, lessonsRes, activitiesRes] = await Promise.all([
         LearnCourseModel(tenant).list({}, next),
-        LearnUnitModel(tenant).list({}, next),
-        LearnLessonModel(tenant).list({}, next),
-        LearnActivityModel(tenant).list({}, next),
+        LearnUnitModel(tenant).list({ limit: 0 }, next),
+        LearnLessonModel(tenant).list({ limit: 0 }, next),
+        LearnActivityModel(tenant).list({ limit: 0 }, next),
       ]);
 
       if (!coursesRes?.success) return coursesRes;
+      if (!unitsRes?.success || !lessonsRes?.success || !activitiesRes?.success) {
+        return {
+          success: false,
+          message: "failed to retrieve course count data",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
 
       const unitIdToCourseId = {};
       const unitCountByCourse = {};
@@ -764,19 +771,22 @@ const learn = {
       }
 
       const course = courseRes.data[0];
-      const unitsRes = await LearnUnitModel(tenant).list({ filter: { course_id } }, next);
+      const unitsRes = await LearnUnitModel(tenant).list(
+        { filter: { course_id }, limit: 0 },
+        next
+      );
       const units = (unitsRes?.data || []).sort((a, b) => a.unit_order - b.unit_order);
       const unitIds = units.map((u) => u._id);
 
       const lessonsRes = await LearnLessonModel(tenant).list(
-        { filter: { unit_id: { $in: unitIds } } },
+        { filter: { unit_id: { $in: unitIds } }, limit: 0 },
         next
       );
       const lessons = lessonsRes?.data || [];
       const lessonIds = lessons.map((l) => l._id);
 
       const activitiesRes = await LearnActivityModel(tenant).list(
-        { filter: { lesson_id: { $in: lessonIds } } },
+        { filter: { lesson_id: { $in: lessonIds } }, limit: 0 },
         next
       );
       const activities = activitiesRes?.data || [];
@@ -870,15 +880,12 @@ const learn = {
         };
       }
 
-      const unitsRes = await LearnUnitModel(tenant).list({ filter: { course_id } }, next);
-      const unitIds = (unitsRes?.data || []).map((u) => u._id);
+      const unitIds = await LearnUnitModel(tenant).distinct("_id", { course_id });
 
       if (unitIds.length) {
-        const lessonsRes = await LearnLessonModel(tenant).list(
-          { filter: { unit_id: { $in: unitIds } } },
-          next
-        );
-        const lessonIds = (lessonsRes?.data || []).map((l) => l._id);
+        const lessonIds = await LearnLessonModel(tenant).distinct("_id", {
+          unit_id: { $in: unitIds },
+        });
 
         if (lessonIds.length) {
           await LearnActivityModel(tenant).deleteMany({ lesson_id: { $in: lessonIds } });
@@ -909,12 +916,17 @@ const learn = {
     try {
       const tenant = getTenant(request);
       const { unit_id } = request.params;
-      const updates = request.body;
+      const { title, plain_title_key, unit_order } = request.body;
 
       const unitRes = await LearnUnitModel(tenant).list({ filter: { _id: unit_id } }, next);
       if (!unitRes?.success || !unitRes.data?.length) {
         return { success: false, message: "unit not found", status: httpStatus.NOT_FOUND };
       }
+
+      const updates = {};
+      if (title !== undefined) updates.title = title;
+      if (plain_title_key !== undefined) updates.plain_title_key = plain_title_key;
+      if (unit_order !== undefined) updates.unit_order = unit_order;
 
       return await LearnUnitModel(tenant).modify(
         { filter: { _id: unit_id }, update: updates },
@@ -945,7 +957,14 @@ const learn = {
         { filter: { _id: unit.course_id } },
         next
       );
-      if (courseRes?.data?.length && courseRes.data[0].published) {
+      if (!courseRes?.success) {
+        return {
+          success: false,
+          message: "failed to verify parent course status",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+      if (courseRes.data?.length && courseRes.data[0].published) {
         return {
           success: false,
           message: "cannot delete a unit from a published course — unpublish the course first",
@@ -983,7 +1002,8 @@ const learn = {
     try {
       const tenant = getTenant(request);
       const { lesson_id } = request.params;
-      const updates = request.body;
+      const { title, plain_title_key, lesson_order, cover_image_url, completion_message } =
+        request.body;
 
       const lessonRes = await LearnLessonModel(tenant).list(
         { filter: { _id: lesson_id } },
@@ -992,6 +1012,13 @@ const learn = {
       if (!lessonRes?.success || !lessonRes.data?.length) {
         return { success: false, message: "lesson not found", status: httpStatus.NOT_FOUND };
       }
+
+      const updates = {};
+      if (title !== undefined) updates.title = title;
+      if (plain_title_key !== undefined) updates.plain_title_key = plain_title_key;
+      if (lesson_order !== undefined) updates.lesson_order = lesson_order;
+      if (cover_image_url !== undefined) updates.cover_image_url = cover_image_url;
+      if (completion_message !== undefined) updates.completion_message = completion_message;
 
       return await LearnLessonModel(tenant).modify(
         { filter: { _id: lesson_id }, update: updates },
@@ -1025,12 +1052,26 @@ const learn = {
         { filter: { _id: lesson.unit_id } },
         next
       );
-      if (unitRes?.data?.length) {
+      if (!unitRes?.success) {
+        return {
+          success: false,
+          message: "failed to verify parent course status",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+      if (unitRes.data?.length) {
         const courseRes = await LearnCourseModel(tenant).list(
           { filter: { _id: unitRes.data[0].course_id } },
           next
         );
-        if (courseRes?.data?.length && courseRes.data[0].published) {
+        if (!courseRes?.success) {
+          return {
+            success: false,
+            message: "failed to verify parent course status",
+            status: httpStatus.INTERNAL_SERVER_ERROR,
+          };
+        }
+        if (courseRes.data?.length && courseRes.data[0].published) {
           return {
             success: false,
             message: "cannot delete a lesson from a published course — unpublish the course first",
@@ -1073,9 +1114,11 @@ const learn = {
       }
 
       const effectiveType = type || activityRes.data[0].type;
+      const effectivePayload =
+        payload !== undefined ? payload : activityRes.data[0].payload;
 
-      if (payload !== undefined) {
-        if (effectiveType === "article" && isEmpty(payload?.body)) {
+      if (payload !== undefined || type !== undefined) {
+        if (effectiveType === "article" && isEmpty(effectivePayload?.body)) {
           return {
             success: false,
             message: "validation errors for some of the provided fields",
@@ -1085,8 +1128,8 @@ const learn = {
         }
         if (
           effectiveType === "video" &&
-          isEmpty(payload?.video_url) &&
-          isEmpty(payload?.youtube_id)
+          isEmpty(effectivePayload?.video_url) &&
+          isEmpty(effectivePayload?.youtube_id)
         ) {
           return {
             success: false,
@@ -1097,7 +1140,7 @@ const learn = {
             status: httpStatus.UNPROCESSABLE_ENTITY,
           };
         }
-        if (effectiveType === "quiz" && isEmpty(payload?.format)) {
+        if (effectiveType === "quiz" && isEmpty(effectivePayload?.format)) {
           return {
             success: false,
             message: "validation errors for some of the provided fields",
@@ -1144,17 +1187,38 @@ const learn = {
         { filter: { _id: activity.lesson_id } },
         next
       );
-      if (lessonRes?.data?.length) {
+      if (!lessonRes?.success) {
+        return {
+          success: false,
+          message: "failed to verify parent course status",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+      if (lessonRes.data?.length) {
         const unitRes = await LearnUnitModel(tenant).list(
           { filter: { _id: lessonRes.data[0].unit_id } },
           next
         );
-        if (unitRes?.data?.length) {
+        if (!unitRes?.success) {
+          return {
+            success: false,
+            message: "failed to verify parent course status",
+            status: httpStatus.INTERNAL_SERVER_ERROR,
+          };
+        }
+        if (unitRes.data?.length) {
           const courseRes = await LearnCourseModel(tenant).list(
             { filter: { _id: unitRes.data[0].course_id } },
             next
           );
-          if (courseRes?.data?.length && courseRes.data[0].published) {
+          if (!courseRes?.success) {
+            return {
+              success: false,
+              message: "failed to verify parent course status",
+              status: httpStatus.INTERNAL_SERVER_ERROR,
+            };
+          }
+          if (courseRes.data?.length && courseRes.data[0].published) {
             return {
               success: false,
               message:

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -972,8 +972,7 @@ const learn = {
         };
       }
 
-      const lessonsRes = await LearnLessonModel(tenant).list({ filter: { unit_id } }, next);
-      const lessonIds = (lessonsRes?.data || []).map((l) => l._id);
+      const lessonIds = await LearnLessonModel(tenant).distinct("_id", { unit_id });
 
       if (lessonIds.length) {
         await LearnActivityModel(tenant).deleteMany({ lesson_id: { $in: lessonIds } });

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -359,7 +359,11 @@ const learnValidations = {
       .bail()
       .isLength({ max: 120 })
       .withMessage("title must not exceed 120 characters"),
-    body("plain_title_key").optional().trim().notEmpty(),
+    body("plain_title_key")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("plain_title_key must not be empty"),
     body("unit_order")
       .optional()
       .isInt({ min: 1 })
@@ -399,7 +403,11 @@ const learnValidations = {
       .bail()
       .isLength({ max: 120 })
       .withMessage("title must not exceed 120 characters"),
-    body("plain_title_key").optional().trim().notEmpty(),
+    body("plain_title_key")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("plain_title_key must not be empty"),
     body("lesson_order")
       .optional()
       .isInt({ min: 1 })

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -311,6 +311,158 @@ const learnValidations = {
     validate,
   ],
 
+  listCourses: [commonTenant, validate],
+
+  getCourse: [
+    commonTenant,
+    param("course_id")
+      .exists()
+      .withMessage("course_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("course_id must be a valid MongoDB ObjectId"),
+    validate,
+  ],
+
+  deleteCourse: [
+    commonTenant,
+    param("course_id")
+      .exists()
+      .withMessage("course_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("course_id must be a valid MongoDB ObjectId"),
+    validate,
+  ],
+
+  updateUnit: [
+    commonTenant,
+    param("unit_id")
+      .exists()
+      .withMessage("unit_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("unit_id must be a valid MongoDB ObjectId"),
+    body("title")
+      .optional()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isLength({ max: 120 })
+      .withMessage("title must not exceed 120 characters"),
+    body("plain_title_key").optional().trim().notEmpty(),
+    body("unit_order")
+      .optional()
+      .isInt({ min: 1 })
+      .withMessage("unit_order must be a positive integer"),
+    validate,
+  ],
+
+  deleteUnit: [
+    commonTenant,
+    param("unit_id")
+      .exists()
+      .withMessage("unit_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("unit_id must be a valid MongoDB ObjectId"),
+    validate,
+  ],
+
+  updateLesson: [
+    commonTenant,
+    param("lesson_id")
+      .exists()
+      .withMessage("lesson_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("lesson_id must be a valid MongoDB ObjectId"),
+    body("title")
+      .optional()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isLength({ max: 120 })
+      .withMessage("title must not exceed 120 characters"),
+    body("plain_title_key").optional().trim().notEmpty(),
+    body("lesson_order")
+      .optional()
+      .isInt({ min: 1 })
+      .withMessage("lesson_order must be a positive integer"),
+    body("cover_image_url")
+      .optional()
+      .isURL({ protocols: ["https"], require_protocol: true })
+      .withMessage("cover_image_url must be a valid HTTPS URL"),
+    body("completion_message").optional().trim(),
+    validate,
+  ],
+
+  deleteLesson: [
+    commonTenant,
+    param("lesson_id")
+      .exists()
+      .withMessage("lesson_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("lesson_id must be a valid MongoDB ObjectId"),
+    validate,
+  ],
+
+  updateActivity: [
+    commonTenant,
+    param("activity_id")
+      .exists()
+      .withMessage("activity_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("activity_id must be a valid MongoDB ObjectId"),
+    body("type")
+      .optional()
+      .isIn(["article", "video", "image", "quiz"])
+      .withMessage("type must be one of: article, video, image, quiz"),
+    body("order")
+      .optional()
+      .isInt({ min: 1 })
+      .withMessage("order must be a positive integer"),
+    body("payload").optional().isObject().withMessage("payload must be an object"),
+    validate,
+  ],
+
+  deleteActivity: [
+    commonTenant,
+    param("activity_id")
+      .exists()
+      .withMessage("activity_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("activity_id must be a valid MongoDB ObjectId"),
+    validate,
+  ],
+
   updateCourse: [
     commonTenant,
     param("course_id")


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds 9 missing admin endpoints for the Learn feature covering read, update, and delete operations across all four content levels (courses, units, lessons, activities). The existing admin surface only had create and course-publish endpoints; this completes the full CRUD surface needed for the admin dashboard.

### Why is this change needed?
The Analytics web app maintainer flagged that the admin dashboard cannot be built without read and mutation endpoints for existing content. The initial implementation only covered the mobile app authoring workflow (create + publish). The dashboard needs to list, inspect, edit, and delete content at every level of the course tree.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — routes, controller, validators, and utility layer

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Endpoints tested manually on staging against the existing Learn dataset. Verified cascade deletes remove all child documents, published-course guard returns `409` on destructive operations, and `GET /admin/courses` returns accurate counts.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**New endpoints (all under `/api/v2/devices/learn/admin`, JWT required):**

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/courses` | List all courses with unit/lesson/activity counts |
| `GET` | `/courses/:course_id` | Fetch full course tree (units → lessons → activities) |
| `DELETE` | `/courses/:course_id` | Delete course and all children (blocks if published) |
| `PATCH` | `/units/:unit_id` | Update unit title, key, or order |
| `DELETE` | `/units/:unit_id` | Delete unit and all children (blocks if parent course published) |
| `PATCH` | `/lessons/:lesson_id` | Update lesson metadata |
| `DELETE` | `/lessons/:lesson_id` | Delete lesson and all activities (blocks if parent course published) |
| `PATCH` | `/activities/:activity_id` | Update activity type, order, or payload |
| `DELETE` | `/activities/:activity_id` | Delete activity (blocks if parent course published) |

All delete operations that would mutate a published course return `409 Conflict` — the course must be unpublished first.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the admin course authoring experience with full viewing, editing, and deletion options for courses, units, lessons, and activities.
  * Added course listing with summary counts and support for viewing complete course details in a nested structure.

* **Bug Fixes**
  * Prevented deletion or changes to published course content where not allowed, returning clear conflict responses.
  * Improved update handling so changes are applied more consistently and only to provided fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->