### PR TITLE
feat: add certificates, leaderboard, and course progress to Learn v2

### DIFF
--- a/src/device-registry/controllers/learn.controller.js
+++ b/src/device-registry/controllers/learn.controller.js
@@ -200,6 +200,135 @@ const learnController = {
   },
 
   // ---------------------------------------------------------------------------
+  // Option 3 — Certificates & Leaderboard
+  // ---------------------------------------------------------------------------
+
+  issueCertificate: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.issueCertificate(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.CREATED).json({
+          success: true,
+          ...result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  listCertificates: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.listCertificates(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          certificates: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  verifyCertificate: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.verifyCertificate(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          ...result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.NOT_FOUND).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  getLeaderboard: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.getLeaderboard(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          ...result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  getCourseProgress: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+      }
+      const result = await learnUtil.getCourseProgress(req, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          courses: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message,
+        errors: result.errors || { message: result.message },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
+  // ---------------------------------------------------------------------------
   // Admin — Course Authoring
   // ---------------------------------------------------------------------------
 

--- a/src/device-registry/models/LearnCertificate.js
+++ b/src/device-registry/models/LearnCertificate.js
@@ -75,6 +75,7 @@ learnCertificateSchema.statics = {
           response.message = "duplicate value";
         });
       } else if (!isEmpty(error.errors)) {
+        status = httpStatus.BAD_REQUEST;
         Object.entries(error.errors).forEach(([key, value]) => {
           response[key] = value.message;
           response.message = value.message;

--- a/src/device-registry/models/LearnCertificate.js
+++ b/src/device-registry/models/LearnCertificate.js
@@ -1,0 +1,117 @@
+const mongoose = require("mongoose");
+const { Schema } = require("mongoose");
+const uniqueValidator = require("mongoose-unique-validator");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const httpStatus = require("http-status");
+const { logObject, HttpError } = require("@utils/shared");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- learn-certificate-model`
+);
+
+const learnCertificateSchema = new Schema(
+  {
+    user_id: {
+      type: String,
+      required: [true, "user_id is required"],
+      trim: true,
+    },
+    course_id: {
+      type: Schema.Types.ObjectId,
+      ref: "learncourse",
+      required: [true, "course_id is required"],
+    },
+    learner_name: {
+      type: String,
+      required: [true, "learner_name is required"],
+      trim: true,
+    },
+    verification_code: {
+      type: String,
+      required: [true, "verification_code is required"],
+      unique: true,
+      trim: true,
+    },
+    share_url: {
+      type: String,
+      trim: true,
+    },
+  },
+  { timestamps: true }
+);
+
+// One certificate per user per course
+learnCertificateSchema.index({ user_id: 1, course_id: 1 }, { unique: true });
+learnCertificateSchema.plugin(uniqueValidator, { message: `{VALUE} already taken!` });
+
+learnCertificateSchema.statics = {
+  async register(args, next) {
+    try {
+      const created = await this.create({ ...args });
+      if (!isEmpty(created)) {
+        return {
+          success: true,
+          data: created._doc,
+          message: "certificate issued",
+          status: httpStatus.CREATED,
+        };
+      }
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: "certificate not created despite successful operation",
+        })
+      );
+    } catch (error) {
+      logObject("error", error);
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      let response = {};
+      let message = "validation errors for some of the provided fields";
+      let status = httpStatus.CONFLICT;
+      if (!isEmpty(error.keyPattern) && error.code === 11000) {
+        Object.entries(error.keyPattern).forEach(([key]) => {
+          response[key] = "duplicate value";
+          response.message = "duplicate value";
+        });
+      } else if (!isEmpty(error.errors)) {
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+          response.message = value.message;
+        });
+      }
+      next(new HttpError(message, status, response));
+    }
+  },
+
+  async list({ filter = {}, skip = 0, limit = 100 } = {}, next) {
+    try {
+      const certs = await this.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return {
+        success: true,
+        data: certs,
+        message: "successfully retrieved certificates",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+const LearnCertificateModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  return getModelByTenant(dbTenant, "learncertificate", learnCertificateSchema);
+};
+
+module.exports = LearnCertificateModel;

--- a/src/device-registry/models/LearnProgress.js
+++ b/src/device-registry/models/LearnProgress.js
@@ -51,6 +51,7 @@ const learnProgressSchema = new Schema(
 learnProgressSchema.index({ guest_id: 1 }, { sparse: true });
 learnProgressSchema.index({ user_id: 1 }, { sparse: true });
 learnProgressSchema.index({ device_id: 1 }, { unique: true });
+learnProgressSchema.index({ learner_type: 1, total_points: -1 });
 
 const STAGES = [
   { index: 0, name: "Curious" },

--- a/src/device-registry/routes/v2/learn.routes.js
+++ b/src/device-registry/routes/v2/learn.routes.js
@@ -25,10 +25,17 @@ router.put("/progress/lessons/:lesson_id", learnValidations.updateLessonProgress
 router.post("/progress/sync", learnValidations.syncProgress, learnController.syncProgress);
 
 // ---------------------------------------------------------------------------
-// Option 3 — Account linking (JWT enforced at nginx gateway)
+// Option 3 — Account linking, Certificates & Leaderboard (JWT enforced at nginx gateway)
 // ---------------------------------------------------------------------------
 
 router.post("/progress/link", learnValidations.linkGuestProgress, learnController.linkGuestProgress);
+router.get("/progress/courses", learnValidations.getCourseProgress, learnController.getCourseProgress);
+
+router.post("/certificates/named", learnValidations.issueCertificate, learnController.issueCertificate);
+router.get("/certificates", learnValidations.listCertificates, learnController.listCertificates);
+router.get("/certificates/verify/:verification_code", learnValidations.verifyCertificate, learnController.verifyCertificate);
+
+router.get("/leaderboard", learnValidations.getLeaderboard, learnController.getLeaderboard);
 
 // ---------------------------------------------------------------------------
 // Admin — Course Authoring (admin JWT enforced at nginx gateway)

--- a/src/device-registry/routes/v2/learn.routes.js
+++ b/src/device-registry/routes/v2/learn.routes.js
@@ -25,7 +25,7 @@ router.put("/progress/lessons/:lesson_id", learnValidations.updateLessonProgress
 router.post("/progress/sync", learnValidations.syncProgress, learnController.syncProgress);
 
 // ---------------------------------------------------------------------------
-// Option 3 — Account linking, Certificates & Leaderboard (JWT enforced at nginx gateway)
+// Option 3 — Account linking & Leaderboard (JWT), Certificates (JWT; verify is public), Course progress summary (guest or JWT)
 // ---------------------------------------------------------------------------
 
 router.post("/progress/link", learnValidations.linkGuestProgress, learnController.linkGuestProgress);

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -26,10 +26,9 @@ const STAGES = [
 function generateVerificationCode() {
   const year = new Date().getFullYear();
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  const bytes = crypto.randomBytes(8);
   let suffix = "";
   for (let i = 0; i < 8; i++) {
-    suffix += chars[bytes[i] % chars.length];
+    suffix += chars[crypto.randomInt(chars.length)];
   }
   return `AQ-${year}-LEARN-${suffix}`;
 }

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -5,6 +5,7 @@ const LearnLessonModel = require("@models/LearnLesson");
 const LearnActivityModel = require("@models/LearnActivity");
 const LearnGuestSessionModel = require("@models/LearnGuestSession");
 const LearnProgressModel = require("@models/LearnProgress");
+const LearnCertificateModel = require("@models/LearnCertificate");
 const constants = require("@config/constants");
 const { logObject, HttpError } = require("@utils/shared");
 const log4js = require("log4js");
@@ -20,6 +21,16 @@ const STAGES = [
   { index: 3, name: "Champion" },
   { index: 4, name: "Defender" },
 ];
+
+function generateVerificationCode() {
+  const year = new Date().getFullYear();
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let suffix = "";
+  for (let i = 0; i < 4; i++) {
+    suffix += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return `AQ-${year}-LEARN-${suffix}`;
+}
 
 function getTenant(request) {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
@@ -1316,6 +1327,434 @@ const learn = {
         { filter: { _id: course_id }, update: updates },
         next
       );
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+  // ---------------------------------------------------------------------------
+  // Option 3 — Certificates
+  // ---------------------------------------------------------------------------
+
+  issueCertificate: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const user_id = request.user?.id || null;
+
+      if (!user_id) {
+        return {
+          success: false,
+          message: "authentication required",
+          status: httpStatus.UNAUTHORIZED,
+        };
+      }
+
+      const { course_id, learner_name } = request.body;
+
+      const courseRes = await LearnCourseModel(tenant).list(
+        { filter: { _id: course_id, published: true } },
+        next
+      );
+      if (!courseRes?.success || !courseRes.data?.length) {
+        return { success: false, message: "course not found", status: httpStatus.NOT_FOUND };
+      }
+
+      // Idempotent — return existing certificate if already issued
+      const existingRes = await LearnCertificateModel(tenant).list(
+        { filter: { user_id, course_id } },
+        next
+      );
+      if (existingRes?.success && existingRes.data?.length) {
+        const cert = existingRes.data[0];
+        return {
+          success: true,
+          data: {
+            certificate_id: cert._id,
+            learner_name: cert.learner_name,
+            verification_code: cert.verification_code,
+            share_url: cert.share_url,
+            issued_at: cert.createdAt,
+          },
+          message: "certificate already issued",
+          status: httpStatus.OK,
+        };
+      }
+
+      // Verify all lessons in the course are completed
+      const unitsRes = await LearnUnitModel(tenant).list({ filter: { course_id } }, next);
+      if (!unitsRes?.success) {
+        return {
+          success: false,
+          message: "failed to verify course completion",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+      const unitIds = (unitsRes.data || []).map((u) => u._id);
+
+      const lessonIds = unitIds.length
+        ? await LearnLessonModel(tenant).distinct("_id", { unit_id: { $in: unitIds } })
+        : [];
+
+      if (!lessonIds.length) {
+        return {
+          success: false,
+          message: "course not complete — finish all lessons before requesting certificate",
+          status: httpStatus.UNPROCESSABLE_ENTITY,
+        };
+      }
+
+      const progressRes = await LearnProgressModel(tenant).findProgress({ user_id }, next);
+      const progressDoc = progressRes?.data || null;
+
+      if (!progressDoc) {
+        return {
+          success: false,
+          message: "course not complete — finish all lessons before requesting certificate",
+          status: httpStatus.UNPROCESSABLE_ENTITY,
+        };
+      }
+
+      const lessonsMap =
+        progressDoc.lessons instanceof Map
+          ? progressDoc.lessons
+          : new Map(Object.entries(progressDoc.lessons || {}));
+
+      const allComplete = lessonIds.every((lid) => {
+        const lp = lessonsMap.get(lid.toString());
+        return lp?.completed === true;
+      });
+
+      if (!allComplete) {
+        return {
+          success: false,
+          message: "course not complete — finish all lessons before requesting certificate",
+          status: httpStatus.UNPROCESSABLE_ENTITY,
+        };
+      }
+
+      // Generate a unique verification code
+      let verification_code;
+      for (let attempt = 0; attempt < 5; attempt++) {
+        const candidate = generateVerificationCode();
+        const collision = await LearnCertificateModel(tenant).list(
+          { filter: { verification_code: candidate } },
+          next
+        );
+        if (!collision?.data?.length) {
+          verification_code = candidate;
+          break;
+        }
+      }
+
+      if (!verification_code) {
+        return {
+          success: false,
+          message: "failed to generate a unique verification code — please retry",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+      }
+
+      const name =
+        learner_name ||
+        request.user?.displayName ||
+        request.user?.email ||
+        "Learner";
+
+      const certResult = await LearnCertificateModel(tenant).register(
+        {
+          user_id,
+          course_id,
+          learner_name: name,
+          verification_code,
+          share_url: `https://airqo.net/learn/cert/${verification_code}`,
+        },
+        next
+      );
+      if (!certResult?.success) return certResult;
+
+      const cert = certResult.data;
+      return {
+        success: true,
+        data: {
+          certificate_id: cert._id,
+          learner_name: cert.learner_name,
+          verification_code: cert.verification_code,
+          share_url: cert.share_url,
+          issued_at: cert.createdAt,
+        },
+        message: "certificate issued",
+        status: httpStatus.CREATED,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  listCertificates: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const user_id = request.user?.id || null;
+
+      if (!user_id) {
+        return {
+          success: false,
+          message: "authentication required",
+          status: httpStatus.UNAUTHORIZED,
+        };
+      }
+
+      const certsRes = await LearnCertificateModel(tenant).list(
+        { filter: { user_id } },
+        next
+      );
+      if (!certsRes?.success) return certsRes;
+
+      return {
+        success: true,
+        data: (certsRes.data || []).map((c) => ({
+          certificate_id: c._id,
+          course_id: c.course_id,
+          learner_name: c.learner_name,
+          verification_code: c.verification_code,
+          share_url: c.share_url,
+          issued_at: c.createdAt,
+        })),
+        message: "successfully retrieved certificates",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  verifyCertificate: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const { verification_code } = request.params;
+
+      const certsRes = await LearnCertificateModel(tenant).list(
+        { filter: { verification_code } },
+        next
+      );
+      if (!certsRes?.success || !certsRes.data?.length) {
+        return {
+          success: false,
+          message: "certificate not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      const cert = certsRes.data[0];
+      const courseRes = await LearnCourseModel(tenant).list(
+        { filter: { _id: cert.course_id } },
+        next
+      );
+      const course = courseRes?.data?.[0] || null;
+
+      return {
+        success: true,
+        data: {
+          certificate_id: cert._id,
+          learner_name: cert.learner_name,
+          verification_code: cert.verification_code,
+          course_title: course?.title || null,
+          share_url: cert.share_url,
+          issued_at: cert.createdAt,
+          valid: true,
+        },
+        message: "certificate is valid",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Option 3 — Leaderboard
+  // ---------------------------------------------------------------------------
+
+  getLeaderboard: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const user_id = request.user?.id || null;
+
+      if (!user_id) {
+        return {
+          success: false,
+          message:
+            "authentication required — create an account to view the leaderboard",
+          status: httpStatus.UNAUTHORIZED,
+        };
+      }
+
+      const limit = Math.min(parseInt(request.query.limit) || 20, 100);
+      const LearnProgress = LearnProgressModel(tenant);
+
+      const topLearners = await LearnProgress.find({
+        learner_type: "user",
+        total_points: { $gt: 0 },
+      })
+        .sort({ total_points: -1 })
+        .limit(limit)
+        .select("user_id total_points current_stage_index completed_lessons")
+        .lean();
+
+      // Determine caller's rank when they fall outside the top N
+      const currentUserInTop = topLearners.some((l) => l.user_id === user_id);
+      let currentUserRank = null;
+
+      if (!currentUserInTop) {
+        const userProgress = await LearnProgress.findOne({ user_id }).lean();
+        if (userProgress) {
+          const ahead = await LearnProgress.countDocuments({
+            learner_type: "user",
+            total_points: { $gt: userProgress.total_points },
+          });
+          currentUserRank = ahead + 1;
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          scope: "global",
+          entries: topLearners.map((l, i) => ({
+            rank: i + 1,
+            user_id: l.user_id,
+            total_points: l.total_points,
+            completed_lessons: l.completed_lessons,
+            current_stage: STAGES[l.current_stage_index] || STAGES[0],
+            is_current_user: l.user_id === user_id,
+          })),
+          current_user_rank: currentUserInTop
+            ? topLearners.findIndex((l) => l.user_id === user_id) + 1
+            : currentUserRank,
+        },
+        message: "successfully retrieved leaderboard",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  // Bonus — per-course progress summary
+  // ---------------------------------------------------------------------------
+
+  getCourseProgress: async (request, next) => {
+    try {
+      const tenant = getTenant(request);
+      const device_id = request.headers["x-device-id"];
+      const guest_id = request.headers["x-guest-id"] || null;
+      const user_id = request.user?.id || null;
+
+      if (!user_id && !device_id) {
+        return {
+          success: false,
+          message: "X-Device-Id header is required for guest progress",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      const progressRes = await LearnProgressModel(tenant).findProgress(
+        { device_id, guest_id, user_id },
+        next
+      );
+      const progressDoc = progressRes?.data || null;
+      const lessonsMap =
+        progressDoc?.lessons instanceof Map
+          ? progressDoc.lessons
+          : new Map(Object.entries(progressDoc?.lessons || {}));
+
+      const [coursesRes, unitsRes, lessonsRes] = await Promise.all([
+        LearnCourseModel(tenant).list({ filter: { published: true } }, next),
+        LearnUnitModel(tenant).list({ limit: 0 }, next),
+        LearnLessonModel(tenant).list({ limit: 0 }, next),
+      ]);
+
+      if (!coursesRes?.success) return coursesRes;
+
+      const unitsByCourse = {};
+      (unitsRes?.data || []).forEach((u) => {
+        const cid = u.course_id.toString();
+        if (!unitsByCourse[cid]) unitsByCourse[cid] = [];
+        unitsByCourse[cid].push(u._id.toString());
+      });
+
+      const lessonsByUnit = {};
+      (lessonsRes?.data || []).forEach((l) => {
+        const uid = l.unit_id.toString();
+        if (!lessonsByUnit[uid]) lessonsByUnit[uid] = [];
+        lessonsByUnit[uid].push(l._id.toString());
+      });
+
+      const courses = coursesRes.data.map((course) => {
+        const cid = course._id.toString();
+        const unitIds = unitsByCourse[cid] || [];
+        const allLessonIds = unitIds.flatMap((uid) => lessonsByUnit[uid] || []);
+        const total_lessons = allLessonIds.length;
+
+        let completed_lessons = 0;
+        let points_earned = 0;
+        let total_stars = 0;
+
+        allLessonIds.forEach((lid) => {
+          const lp = lessonsMap.get(lid);
+          if (lp?.completed) {
+            completed_lessons++;
+            points_earned += lp.points_earned || 0;
+            total_stars += lp.stars || 0;
+          }
+        });
+
+        return {
+          course_id: course._id,
+          title: course.title,
+          course_number: course.course_number,
+          cover_image_url: course.cover_image_url || null,
+          total_lessons,
+          completed_lessons,
+          points_earned,
+          is_complete: total_lessons > 0 && completed_lessons === total_lessons,
+          average_stars:
+            completed_lessons > 0
+              ? Math.round((total_stars / completed_lessons) * 10) / 10
+              : 0,
+        };
+      });
+
+      return {
+        success: true,
+        data: courses,
+        message: "successfully retrieved course progress",
+        status: httpStatus.OK,
+      };
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const httpStatus = require("http-status");
 const LearnCourseModel = require("@models/LearnCourse");
 const LearnUnitModel = require("@models/LearnUnit");
@@ -25,9 +26,10 @@ const STAGES = [
 function generateVerificationCode() {
   const year = new Date().getFullYear();
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const bytes = crypto.randomBytes(8);
   let suffix = "";
-  for (let i = 0; i < 4; i++) {
-    suffix += chars[Math.floor(Math.random() * chars.length)];
+  for (let i = 0; i < 8; i++) {
+    suffix += chars[bytes[i] % chars.length];
   }
   return `AQ-${year}-LEARN-${suffix}`;
 }
@@ -1459,10 +1461,7 @@ const learn = {
       }
 
       const name =
-        learner_name ||
-        request.user?.displayName ||
-        request.user?.email ||
-        "Learner";
+        learner_name || request.user?.displayName || "Learner";
 
       const certResult = await LearnCertificateModel(tenant).register(
         {
@@ -1470,7 +1469,7 @@ const learn = {
           course_id,
           learner_name: name,
           verification_code,
-          share_url: `https://airqo.net/learn/cert/${verification_code}`,
+          share_url: `https://airqo.net/learn/cert/${verification_code}?tenant=${tenant}`,
         },
         next
       );
@@ -1640,7 +1639,6 @@ const learn = {
           scope: "global",
           entries: topLearners.map((l, i) => ({
             rank: i + 1,
-            user_id: l.user_id,
             total_points: l.total_points,
             completed_lessons: l.completed_lessons,
             current_stage: STAGES[l.current_stage_index] || STAGES[0],
@@ -1686,6 +1684,7 @@ const learn = {
         { device_id, guest_id, user_id },
         next
       );
+      if (progressRes && !progressRes.success) return progressRes;
       const progressDoc = progressRes?.data || null;
       const lessonsMap =
         progressDoc?.lessons instanceof Map
@@ -1699,6 +1698,8 @@ const learn = {
       ]);
 
       if (!coursesRes?.success) return coursesRes;
+      if (!unitsRes?.success) return unitsRes;
+      if (!lessonsRes?.success) return lessonsRes;
 
       const unitsByCourse = {};
       (unitsRes?.data || []).forEach((u) => {

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -180,7 +180,14 @@ const learnValidations = {
       .bail()
       .isMongoId()
       .withMessage("course_id must be a valid MongoDB ObjectId"),
-    body("learner_name").optional().trim().notEmpty().withMessage("learner_name must not be empty if provided"),
+    body("learner_name")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("learner_name must not be empty if provided")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("learner_name must not exceed 100 characters"),
     validate,
   ],
 
@@ -194,7 +201,11 @@ const learnValidations = {
       .bail()
       .trim()
       .notEmpty()
-      .withMessage("verification_code must not be empty"),
+      .withMessage("verification_code must not be empty")
+      .bail()
+      .toUpperCase()
+      .matches(/^AQ-\d{4}-LEARN-[A-Z0-9]{8}$/)
+      .withMessage("verification_code must match format AQ-YYYY-LEARN-XXXXXXXX"),
     validate,
   ],
 

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -166,6 +166,50 @@ const learnValidations = {
   ],
 
   // -------------------------------------------------------------------------
+  // Option 3 — Certificates & Leaderboard
+  // -------------------------------------------------------------------------
+
+  issueCertificate: [
+    commonTenant,
+    body("course_id")
+      .exists()
+      .withMessage("course_id is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .bail()
+      .isMongoId()
+      .withMessage("course_id must be a valid MongoDB ObjectId"),
+    body("learner_name").optional().trim().notEmpty().withMessage("learner_name must not be empty if provided"),
+    validate,
+  ],
+
+  listCertificates: [commonTenant, validate],
+
+  verifyCertificate: [
+    commonTenant,
+    param("verification_code")
+      .exists()
+      .withMessage("verification_code is required")
+      .bail()
+      .trim()
+      .notEmpty()
+      .withMessage("verification_code must not be empty"),
+    validate,
+  ],
+
+  getLeaderboard: [
+    commonTenant,
+    query("limit")
+      .optional()
+      .isInt({ min: 1, max: 100 })
+      .withMessage("limit must be an integer between 1 and 100"),
+    validate,
+  ],
+
+  getCourseProgress: [commonTenant, validate],
+
+  // -------------------------------------------------------------------------
   // Admin — Course authoring
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Completes the Learn v2 Option 3 feature set by adding named certificates, certificate verification, a global leaderboard, and a per-course progress summary endpoint. Also adds a `LearnCertificate` model to back the certificate lifecycle. The `GET /progress/courses` endpoint is added as an appropriate bonus to give mobile clients a server-aggregated course-level progress view without requiring client-side catalog joins.

**New endpoints (all under `/api/v2/devices/learn`):**

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `POST` | `/certificates/named` | JWT | Issue named certificate after full course completion |
| `GET` | `/certificates` | JWT | List the caller's own certificates |
| `GET` | `/certificates/verify/:verification_code` | Public | Verify a certificate by code (powers share links) |
| `GET` | `/leaderboard` | JWT | Global ranked learners by total points; includes caller's rank |
| `GET` | `/progress/courses` | Guest or JWT | Per-course completion summary with `is_complete`, `completed_lessons`, `points_earned`, `average_stars` |

### Why is this change needed?
The initial Learn v2 implementation covered Option 1 (content) and Option 2 (guest progress) in full, but only the account-linking part of Option 3. Certificates and the leaderboard were missing, leaving the mobile app unable to ship the course completion and social ranking screens. The course progress summary endpoint fills a gap where the mobile home screen needed course-level aggregation that was otherwise impossible without a client-side catalog join.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — new `LearnCertificate` model; updates to routes, controller, validators, and utility layer

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Tested manually on staging. Verified:
- Certificate issuance blocked until all lessons in a course are marked complete
- Duplicate certificate requests return the existing certificate (idempotent)
- `GET /certificates/verify/:code` resolves without auth and returns course title
- Leaderboard ranks authenticated users correctly and returns `current_user_rank` for callers outside the top N
- `GET /progress/courses` returns correct `is_complete` and count data for both guest (X-Device-Id) and authenticated requests

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

**Guest vs authenticated support:**

| Endpoint | Guest (X-Device-Id) | Authenticated (JWT) |
|----------|--------------------|--------------------|
| `/certificates/named` | ❌ — prompts account creation | ✅ |
| `/certificates` | ❌ — prompts account creation | ✅ |
| `/certificates/verify/:code` | ✅ public | ✅ public |
| `/leaderboard` | ❌ — prompts account creation | ✅ |
| `/progress/courses` | ✅ | ✅ |

Certificates and the leaderboard intentionally require an authenticated identity — both features are meaningless without a stable, claimable user ID. This also serves as a natural account-creation prompt for guests.

**Certificate verification code format:** `AQ-{year}-LEARN-{4 uppercase alphanumeric chars}` (e.g. `AQ-2026-LEARN-8F3A`). Server-generated and guaranteed unique at issuance.

**Leaderboard scope:** Only `global` scope is supported in this release. `country` and `city` scopes require location data not yet stored on `LearnProgress` records — deferred to a future iteration.

**New MongoDB collection:** `learncertificates` — one document per `(user_id, course_id)` pair enforced by a compound unique index.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added certificates workflow: issue named certificates, list a user’s certificates, and verify certificates by code.
  - Added a leaderboard to display top learners and the requesting user’s rank.
  - Added per-course progress summaries, including completion status, completed lessons, points earned, and star ratings.
- **Bug Fixes**
  - Improved validation and consistent API error responses for the new learning features.
  - Returns clearer “not found/invalid” outcomes when certificate verification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->