### PR TITLE
feat: add per-network filtering and breakdown endpoint to network-status API

### DIFF
--- a/src/device-registry/controllers/network-status.controller.js
+++ b/src/device-registry/controllers/network-status.controller.js
@@ -166,6 +166,16 @@ const networkStatusController = {
       "summary"
     );
   },
+
+  getNetworkBreakdown: async (req, res, next) => {
+    await handleControllerAction(
+      req,
+      res,
+      next,
+      networkStatusUtil.getNetworkBreakdown,
+      "data"
+    );
+  },
 };
 
 module.exports = networkStatusController;

--- a/src/device-registry/models/NetworkStatusAlert.js
+++ b/src/device-registry/models/NetworkStatusAlert.js
@@ -156,6 +156,7 @@ networkStatusAlertSchema.methods = {
       environment: this.environment,
       day_of_week: this.day_of_week,
       hour_of_day: this.hour_of_day,
+      network_breakdown: this.network_breakdown,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };
@@ -327,7 +328,7 @@ networkStatusAlertSchema.statics = {
     }
   },
 
-  async getStatisticsByNetwork({ filter = {} } = {}, next) {
+  async getStatisticsByNetwork({ filter = {}, network } = {}, next) {
     try {
       const pipeline = [
         { $match: filter },
@@ -337,6 +338,9 @@ networkStatusAlertSchema.statics = {
             preserveNullAndEmptyArrays: false,
           },
         },
+        ...(network
+          ? [{ $match: { "network_breakdown.network": network.toLowerCase() } }]
+          : []),
         {
           $group: {
             _id: "$network_breakdown.network",
@@ -354,6 +358,100 @@ networkStatusAlertSchema.statics = {
       ];
 
       return await this.executeAggregation({ pipeline }, next);
+    } catch (error) {
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message }
+      );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
+    }
+  },
+
+  async getHourlyTrendsByNetwork({ filter = {}, network } = {}, next) {
+    try {
+      const pipeline = [
+        { $match: filter },
+        {
+          $unwind: {
+            path: "$network_breakdown",
+            preserveNullAndEmptyArrays: false,
+          },
+        },
+        { $match: { "network_breakdown.network": network.toLowerCase() } },
+        {
+          $group: {
+            _id: {
+              hour: "$hour_of_day",
+              dayOfWeek: "$day_of_week",
+            },
+            avg_not_transmitting_percentage: {
+              $avg: "$network_breakdown.not_transmitting_percentage",
+            },
+            count: { $sum: 1 },
+          },
+        },
+        { $sort: { "_id.dayOfWeek": 1, "_id.hour": 1 } },
+      ];
+
+      return this.executeAggregation({ pipeline }, next);
+    } catch (error) {
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message }
+      );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
+    }
+  },
+
+  async getUptimeSummaryByNetwork({ filter = {}, network } = {}, next) {
+    try {
+      const pipeline = [
+        { $match: filter },
+        {
+          $unwind: {
+            path: "$network_breakdown",
+            preserveNullAndEmptyArrays: false,
+          },
+        },
+        { $match: { "network_breakdown.network": network.toLowerCase() } },
+        {
+          $group: {
+            _id: {
+              $dateToString: { format: "%Y-%m-%d", date: "$checked_at" },
+            },
+            avgOfflinePercentage: {
+              $avg: "$network_breakdown.not_transmitting_percentage",
+            },
+            maxOfflinePercentage: {
+              $max: "$network_breakdown.not_transmitting_percentage",
+            },
+            minOfflinePercentage: {
+              $min: "$network_breakdown.not_transmitting_percentage",
+            },
+            totalChecks: { $sum: 1 },
+            alertsTriggered: {
+              $sum: {
+                $cond: [
+                  { $gte: ["$network_breakdown.not_transmitting_percentage", 35] },
+                  1,
+                  0,
+                ],
+              },
+            },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ];
+
+      return this.executeAggregation({ pipeline }, next);
     } catch (error) {
       const httpError = new HttpError(
         "Internal Server Error",

--- a/src/device-registry/routes/v2/network-status.routes.js
+++ b/src/device-registry/routes/v2/network-status.routes.js
@@ -47,7 +47,7 @@ router.get(
 
 router.get(
   "/breakdown",
-  oneOf(networkStatusValidations.getNetworkBreakdown),
+  ...networkStatusValidations.getNetworkBreakdown,
   networkStatusController.getNetworkBreakdown
 );
 

--- a/src/device-registry/routes/v2/network-status.routes.js
+++ b/src/device-registry/routes/v2/network-status.routes.js
@@ -45,4 +45,10 @@ router.get(
   networkStatusController.getUptimeSummary
 );
 
+router.get(
+  "/breakdown",
+  oneOf(networkStatusValidations.getNetworkBreakdown),
+  networkStatusController.getNetworkBreakdown
+);
+
 module.exports = router;

--- a/src/device-registry/utils/network-status.util.js
+++ b/src/device-registry/utils/network-status.util.js
@@ -129,6 +129,7 @@ const networkStatusUtil = {
         end_date,
         status,
         threshold_exceeded,
+        network,
       } = query;
 
       const filter = {};
@@ -143,7 +144,14 @@ const networkStatusUtil = {
         filter.status = status;
       }
 
-      if (threshold_exceeded !== undefined) {
+      if (network) {
+        filter.network_breakdown = {
+          $elemMatch: {
+            network: network.toLowerCase(),
+            not_transmitting_percentage: { $gte: 35 },
+          },
+        };
+      } else if (threshold_exceeded !== undefined) {
         filter.threshold_exceeded = threshold_exceeded === "true";
       }
 
@@ -172,7 +180,7 @@ const networkStatusUtil = {
   getStatistics: async (request, next) => {
     try {
       const { query } = request;
-      const { tenant, start_date, end_date } = query;
+      const { tenant, start_date, end_date, network } = query;
 
       const filter = {};
 
@@ -180,6 +188,13 @@ const networkStatusUtil = {
         filter.checked_at = {};
         if (start_date) filter.checked_at.$gte = new Date(start_date);
         if (end_date) filter.checked_at.$lte = new Date(end_date);
+      }
+
+      if (network) {
+        const response = await NetworkStatusAlertModel(
+          tenant
+        ).getStatisticsByNetwork({ filter, network }, next);
+        return response;
       }
 
       const response = await NetworkStatusAlertModel(tenant).getStatistics(
@@ -203,7 +218,7 @@ const networkStatusUtil = {
   getHourlyTrends: async (request, next) => {
     try {
       const { query } = request;
-      const { tenant, start_date, end_date } = query;
+      const { tenant, start_date, end_date, network } = query;
 
       const filter = {};
 
@@ -211,6 +226,13 @@ const networkStatusUtil = {
         filter.checked_at = {};
         if (start_date) filter.checked_at.$gte = new Date(start_date);
         if (end_date) filter.checked_at.$lte = new Date(end_date);
+      }
+
+      if (network) {
+        const response = await NetworkStatusAlertModel(
+          tenant
+        ).getHourlyTrendsByNetwork({ filter, network }, next);
+        return response;
       }
 
       const response = await NetworkStatusAlertModel(tenant).getHourlyTrends(
@@ -234,14 +256,22 @@ const networkStatusUtil = {
   getRecentAlerts: async (request, next) => {
     try {
       const { query } = request;
-      const { tenant, hours = 24 } = query;
+      const { tenant, hours = 24, network } = query;
 
-      const filter = {
-        checked_at: {
-          $gte: new Date(Date.now() - hours * 60 * 60 * 1000),
-        },
-        threshold_exceeded: true,
-      };
+      const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
+
+      const filter = { checked_at: { $gte: cutoff } };
+
+      if (network) {
+        filter.network_breakdown = {
+          $elemMatch: {
+            network: network.toLowerCase(),
+            not_transmitting_percentage: { $gte: 35 },
+          },
+        };
+      } else {
+        filter.threshold_exceeded = true;
+      }
 
       const response = await NetworkStatusAlertModel(tenant).list(
         {
@@ -268,24 +298,28 @@ const networkStatusUtil = {
   getUptimeSummary: async (request, next) => {
     try {
       const { query } = request;
-      const { tenant, days = 7 } = query;
+      const { tenant, days = 7, network } = query;
 
       const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+      const filter = { checked_at: { $gte: startDate } };
+
+      if (network) {
+        const response = await NetworkStatusAlertModel(
+          tenant
+        ).getUptimeSummaryByNetwork({ filter, network }, next);
+        return response;
+      }
 
       const pipeline = [
-        {
-          $match: {
-            checked_at: { $gte: startDate },
-          },
-        },
+        { $match: filter },
         {
           $group: {
             _id: {
               $dateToString: { format: "%Y-%m-%d", date: "$checked_at" },
             },
-            avgOfflinePercentage: { $avg: "$offline_percentage" },
-            maxOfflinePercentage: { $max: "$offline_percentage" },
-            minOfflinePercentage: { $min: "$offline_percentage" },
+            avgOfflinePercentage: { $avg: "$not_transmitting_percentage" },
+            maxOfflinePercentage: { $max: "$not_transmitting_percentage" },
+            minOfflinePercentage: { $min: "$not_transmitting_percentage" },
             totalChecks: { $sum: 1 },
             alertsTriggered: {
               $sum: { $cond: ["$threshold_exceeded", 1, 0] },
@@ -299,6 +333,36 @@ const networkStatusUtil = {
         { pipeline },
         next
       );
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  getNetworkBreakdown: async (request, next) => {
+    try {
+      const { query } = request;
+      const { tenant, start_date, end_date } = query;
+
+      const filter = {};
+
+      if (start_date || end_date) {
+        filter.checked_at = {};
+        if (start_date) filter.checked_at.$gte = new Date(start_date);
+        if (end_date) filter.checked_at.$lte = new Date(end_date);
+      }
+
+      const response = await NetworkStatusAlertModel(
+        tenant
+      ).getStatisticsByNetwork({ filter }, next);
 
       return response;
     } catch (error) {

--- a/src/device-registry/utils/network-status.util.js
+++ b/src/device-registry/utils/network-status.util.js
@@ -146,12 +146,11 @@ const networkStatusUtil = {
 
       if (network) {
         filter.network_breakdown = {
-          $elemMatch: {
-            network: network.toLowerCase(),
-            not_transmitting_percentage: { $gte: 35 },
-          },
+          $elemMatch: { network: network.toLowerCase() },
         };
-      } else if (threshold_exceeded !== undefined) {
+      }
+
+      if (threshold_exceeded !== undefined) {
         filter.threshold_exceeded = threshold_exceeded === "true";
       }
 

--- a/src/device-registry/validators/network-status.validators.js
+++ b/src/device-registry/validators/network-status.validators.js
@@ -3,6 +3,7 @@ const constants = require("@config/constants");
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 const isEmpty = require("is-empty");
+const { validateNetwork } = require("@validators/common");
 
 const commonValidations = {
   tenant: [
@@ -23,9 +24,11 @@ const commonValidations = {
       .withMessage("network cannot be empty if provided")
       .bail()
       .trim()
-      .toLowerCase()
       .isString()
-      .withMessage("network must be a string"),
+      .withMessage("network must be a string")
+      .bail()
+      .toLowerCase()
+      .custom(validateNetwork),
   ],
   dateRange: [
     query("start_date")

--- a/src/device-registry/validators/network-status.validators.js
+++ b/src/device-registry/validators/network-status.validators.js
@@ -16,6 +16,36 @@ const commonValidations = {
       .isIn(constants.TENANTS)
       .withMessage("the tenant value is not among the expected ones"),
   ],
+  network: [
+    query("network")
+      .optional()
+      .notEmpty()
+      .withMessage("network cannot be empty if provided")
+      .bail()
+      .trim()
+      .toLowerCase()
+      .isString()
+      .withMessage("network must be a string"),
+  ],
+  dateRange: [
+    query("start_date")
+      .optional()
+      .isISO8601()
+      .withMessage("start_date must be a valid ISO 8601 date"),
+    query("end_date")
+      .optional()
+      .isISO8601()
+      .withMessage("end_date must be a valid ISO 8601 date")
+      .custom((value, { req }) => {
+        if (
+          req.query.start_date &&
+          new Date(value) <= new Date(req.query.start_date)
+        ) {
+          throw new Error("end_date must be after start_date");
+        }
+        return true;
+      }),
+  ],
 };
 
 const networkStatusValidations = {
@@ -89,23 +119,8 @@ const networkStatusValidations = {
 
   list: [
     ...commonValidations.tenant,
-    query("start_date")
-      .optional()
-      .isISO8601()
-      .withMessage("start_date must be a valid ISO 8601 date"),
-    query("end_date")
-      .optional()
-      .isISO8601()
-      .withMessage("end_date must be a valid ISO 8601 date")
-      .custom((value, { req }) => {
-        if (
-          req.query.start_date &&
-          new Date(value) <= new Date(req.query.start_date)
-        ) {
-          throw new Error("end_date must be after start_date");
-        }
-        return true;
-      }),
+    ...commonValidations.network,
+    ...commonValidations.dateRange,
     query("status")
       .optional()
       .isIn(["OK", "WARNING", "CRITICAL"])
@@ -118,62 +133,39 @@ const networkStatusValidations = {
 
   getStatistics: [
     ...commonValidations.tenant,
-    query("start_date")
-      .optional()
-      .isISO8601()
-      .withMessage("start_date must be a valid ISO 8601 date"),
-    query("end_date")
-      .optional()
-      .isISO8601()
-      .withMessage("end_date must be a valid ISO 8601 date")
-      .custom((value, { req }) => {
-        if (
-          req.query.start_date &&
-          new Date(value) <= new Date(req.query.start_date)
-        ) {
-          throw new Error("end_date must be after start_date");
-        }
-        return true;
-      }),
+    ...commonValidations.network,
+    ...commonValidations.dateRange,
   ],
 
   getHourlyTrends: [
     ...commonValidations.tenant,
-    query("start_date")
-      .optional()
-      .isISO8601()
-      .withMessage("start_date must be a valid ISO 8601 date"),
-    query("end_date")
-      .optional()
-      .isISO8601()
-      .withMessage("end_date must be a valid ISO 8601 date")
-      .custom((value, { req }) => {
-        if (
-          req.query.start_date &&
-          new Date(value) <= new Date(req.query.start_date)
-        ) {
-          throw new Error("end_date must be after start_date");
-        }
-        return true;
-      }),
+    ...commonValidations.network,
+    ...commonValidations.dateRange,
   ],
 
   getRecentAlerts: [
     ...commonValidations.tenant,
+    ...commonValidations.network,
     query("hours")
       .optional()
-      .isInt({ min: 1, max: 168 }) // Max 1 week
+      .isInt({ min: 1, max: 168 })
       .withMessage("hours must be between 1 and 168")
       .toInt(),
   ],
 
   getUptimeSummary: [
     ...commonValidations.tenant,
+    ...commonValidations.network,
     query("days")
       .optional()
-      .isInt({ min: 1, max: 90 }) // Max 3 months
+      .isInt({ min: 1, max: 90 })
       .withMessage("days must be between 1 and 90")
       .toInt(),
+  ],
+
+  getNetworkBreakdown: [
+    ...commonValidations.tenant,
+    ...commonValidations.dateRange,
   ],
 };
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds an optional `network` query parameter to all five existing network-status endpoints, enabling filtering by sensor manufacturer (e.g. `airqo`, `airgradient`, `kcca`, `metone`, `iqair`). Also introduces a new `GET /api/v2/devices/network-status/breakdown` endpoint that returns per-manufacturer statistics in a single call, powered by the `network_breakdown` array already stored on every check record.

Additionally fixes a silent aggregation bug in `getUptimeSummary` where the pipeline referenced a non-existent `$offline_percentage` field (correct field is `$not_transmitting_percentage`), causing the uptime trend chart on Beacon to fall back to client-side computation on every load.

**Changes by layer:**
- **Model** (`NetworkStatusAlert.js`): Added `getHourlyTrendsByNetwork` and `getUptimeSummaryByNetwork` static methods; updated `getStatisticsByNetwork` to accept an optional single-network filter; added `network_breakdown` to `toJSON()`.
- **Util** (`network-status.util.js`): All five util functions now extract `network` from the request query and branch to the per-network model methods when present. Fixed `$offline_percentage` → `$not_transmitting_percentage` in `getUptimeSummary`. Added `getNetworkBreakdown` util function.
- **Validators** (`network-status.validators.js`): Added optional `network` param to all query validators; extracted shared `commonValidations.dateRange` to DRY up repeated date range blocks; added `getNetworkBreakdown` validator.
- **Controller** (`network-status.controller.js`): Added `getNetworkBreakdown` handler.
- **Routes** (`routes/v2/network-status.routes.js`): Added `GET /breakdown` route.

### Why is this change needed?
The Beacon dashboard (`beacon.airqo.net/dashboard`) currently displays combined network status across all sensor manufacturers. Teams analysing a specific manufacturer fleet have no way to isolate their data via the existing API — a gap confirmed by the daily Slack summaries which already break down stats per network (AirQo, AirGradient, KCCA, MetOne, IQAir). The `network_breakdown` array has been stored on every `NetworkStatusAlert` check record since the model was created; this PR exposes it for querying without any schema migration. The new `/breakdown` endpoint provides a single call to power a planned per-manufacturer comparison view on the Beacon dashboard.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix (`getUptimeSummary` wrong field reference)
- [x] :sparkles: New feature (`GET /breakdown` endpoint)
- [x] :wrench: Enhancement/improvement (optional `network` param on all existing endpoints)
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — routes, validators, controller, util, model

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
All changes are backward compatible — the `network` parameter is optional on every endpoint, and omitting it leaves existing query paths identical to pre-PR behaviour. Verified against the five API calls made by the Beacon dashboard (`getStatistics`, `getHourlyTrends`, `getUptimeSummary`, `getRecentAlerts`, `getAlerts`): none send a `network` param, so all take the same code path as before. The `getUptimeSummary` field fix was confirmed safe: the Beacon frontend already detects the null-value bug via an explicit `avgOfflinePercentage === null` guard and falls back to client-side aggregation — the fix removes the need for that fallback without any frontend change.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All existing endpoint signatures and response shapes are preserved. The `network` param is strictly additive and optional. The `getUptimeSummary` bug fix changes values from `null` to real numbers, but the response field names are unchanged and the Beacon frontend handles this gracefully via its existing null guard.

---

## :memo: Additional Notes

- Network name values expected by the API are lowercase: `airqo`, `airgradient`, `kcca`, `metone`, `iqair`.
- The `/breakdown` endpoint is the recommended single call for driving a per-manufacturer grouped chart on Beacon — it unwinds and groups the `network_breakdown` sub-documents stored at check time, so no extra DB writes are needed.
- Frontend implementation guidance (network selector dropdown, URL state, heuristics notes) is documented in `src/device-registry/BEACON_NETWORK_FILTER_NOTES.md` (temporary, to be deleted after handoff to the Beacon frontend team).
- `getStatistics?network=<name>` returns a different response shape from the combined `getStatistics` (per-network fields vs. overall aggregate fields). Document this when updating the Beacon frontend service layer.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new network breakdown view and endpoint for network-status data.
  * Network-specific filtering is now available across status, trend, alert, and uptime views.
  * Date range filters are now supported consistently on relevant network-status queries.

* **Bug Fixes**
  * Network status summaries now use the correct percentage metrics for calculations.
  * Returned alert details now include network breakdown information for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->