### PR TITLE
test: Add unit tests for device-registry Learn and NetworkStatus features

### DIFF
--- a/src/device-registry/README.md
+++ b/src/device-registry/README.md
@@ -2,6 +2,8 @@
 
 [![Code Coverage](https://github.com/airqo-platform/AirQo-api/actions/workflows/codecov.yml/badge.svg)](https://github.com/airqo-platform/AirQo-api/actions/workflows/codecov.yml)
 [![codecov](https://codecov.io/gh/airqo-platform/AirQo-api/branch/staging/graph/badge.svg)](https://codecov.io/gh/airqo-platform/AirQo-api)
+[![Passing Tests](https://img.shields.io/badge/tests%20passing-791%20%E2%80%94%20100%25-brightgreen)](#running-tests)
+[![Failing Tests](https://img.shields.io/badge/tests%20failing-0%20%E2%80%94%200%25-brightgreen)](#running-tests)
 
 Device Registry manages devices, sites, events, grids, cohorts, and the activities that occur within a monitoring network. It is the central registry for all physical and logical entities in the AirQo platform.
 
@@ -125,6 +127,14 @@ npm test
 ```
 
 This runs the unit-test suite under `nyc` and writes an lcov coverage report to `coverage/lcov.info`. Coverage is uploaded to Codecov automatically in CI.
+
+**Last recorded test run:**
+
+| Result | Count | Percentage |
+|---|---|---|
+| ✅ Passing | 791 | 100% |
+| ❌ Failing | 0 | 0% |
+| ⏭ Pending | 291 | — |
 
 ### Running with Docker
 

--- a/src/device-registry/controllers/test/ut_learn.controller.js
+++ b/src/device-registry/controllers/test/ut_learn.controller.js
@@ -1,0 +1,528 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const chai = require("chai");
+chai.use(sinonChai);
+const httpStatus = require("http-status");
+const proxyquire = require("proxyquire");
+
+describe("learnController", () => {
+  let controller;
+  let learnUtilStub;
+  let sharedStub;
+
+  const makeRes = () => {
+    const res = {};
+    res.status = sinon.stub().returns(res);
+    res.json = sinon.stub().returns(res);
+    res.headersSent = false;
+    return res;
+  };
+
+  const makeReq = (overrides = {}) => ({
+    query: { tenant: "airqo" },
+    params: {},
+    body: {},
+    headers: {},
+    user: null,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    learnUtilStub = {
+      getCatalog: sinon.stub(),
+      getLesson: sinon.stub(),
+      createAnonymousSession: sinon.stub(),
+      getProgress: sinon.stub(),
+      updateLessonProgress: sinon.stub(),
+      syncProgress: sinon.stub(),
+      linkGuestProgress: sinon.stub(),
+      issueCertificate: sinon.stub(),
+      listCertificates: sinon.stub(),
+      verifyCertificate: sinon.stub(),
+      getLeaderboard: sinon.stub(),
+      getCourseProgress: sinon.stub(),
+      createCourse: sinon.stub(),
+      addUnit: sinon.stub(),
+      addLesson: sinon.stub(),
+      addActivity: sinon.stub(),
+      listCourses: sinon.stub(),
+      getCourse: sinon.stub(),
+      deleteCourse: sinon.stub(),
+      updateUnit: sinon.stub(),
+      deleteUnit: sinon.stub(),
+      updateLesson: sinon.stub(),
+      deleteLesson: sinon.stub(),
+      updateActivity: sinon.stub(),
+      deleteActivity: sinon.stub(),
+      updateCourse: sinon.stub(),
+    };
+
+    sharedStub = {
+      HttpError: class HttpError extends Error {
+        constructor(message, status, errors) {
+          super(message);
+          this.statusCode = status;
+          this.errors = errors;
+        }
+      },
+      extractErrorsFromRequest: sinon.stub().returns(null),
+    };
+
+    controller = proxyquire("@controllers/learn.controller", {
+      "@utils/learn.util": learnUtilStub,
+      "@utils/shared": sharedStub,
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("getCatalog", () => {
+    it("should return catalog with stages and courses on success", async () => {
+      learnUtilStub.getCatalog.resolves({
+        success: true,
+        data: { catalog_version: "2025-01-01", stages: [], courses: [] },
+        status: httpStatus.OK,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getCatalog(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.success).to.be.true;
+      expect(jsonArgs).to.have.property("catalog_version");
+      expect(jsonArgs).to.have.property("stages");
+      expect(jsonArgs).to.have.property("courses");
+    });
+
+    it("should call next when validation fails", async () => {
+      sharedStub.extractErrorsFromRequest.returns({ field: "error" });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getCatalog(req, res, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("should return failure response when util returns success=false", async () => {
+      learnUtilStub.getCatalog.resolves({
+        success: false,
+        message: "no catalog available",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getCatalog(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.INTERNAL_SERVER_ERROR)).to.be.true;
+      expect(res.json.firstCall.args[0].success).to.be.false;
+    });
+  });
+
+  describe("getLesson", () => {
+    it("should return lesson data on success", async () => {
+      learnUtilStub.getLesson.resolves({
+        success: true,
+        data: { id: "l1", title: "Lesson 1", activities: [] },
+        status: httpStatus.OK,
+      });
+      const req = makeReq({ params: { lesson_id: "l1" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getLesson(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.lesson).to.exist;
+      expect(jsonArgs.lesson.title).to.equal("Lesson 1");
+    });
+
+    it("should return 404 when lesson not found", async () => {
+      learnUtilStub.getLesson.resolves({
+        success: false,
+        message: "lesson not found",
+        status: httpStatus.NOT_FOUND,
+      });
+      const req = makeReq({ params: { lesson_id: "nonexistent" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getLesson(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.NOT_FOUND)).to.be.true;
+      expect(res.json.firstCall.args[0].success).to.be.false;
+    });
+  });
+
+  describe("createAnonymousSession", () => {
+    it("should return guest_id on success", async () => {
+      learnUtilStub.createAnonymousSession.resolves({
+        success: true,
+        data: { guest_id: "guest_abc", display_name: "guest_abc", created_at: new Date() },
+        status: httpStatus.CREATED,
+      });
+      const req = makeReq({ body: { device_id: "dev-001" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.createAnonymousSession(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.CREATED)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.guest_id).to.equal("guest_abc");
+    });
+  });
+
+  describe("getProgress", () => {
+    it("should return progress data spread into response on success", async () => {
+      learnUtilStub.getProgress.resolves({
+        success: true,
+        data: {
+          learner_type: "guest",
+          total_points: 50,
+          completed_lessons: 2,
+          current_stage: { index: 0, name: "Curious" },
+          lessons: {},
+        },
+        status: httpStatus.OK,
+      });
+      const req = makeReq({ headers: { "x-device-id": "dev-001" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getProgress(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.total_points).to.equal(50);
+      expect(jsonArgs.learner_type).to.equal("guest");
+    });
+  });
+
+  describe("updateLessonProgress", () => {
+    it("should return lesson progress data on success", async () => {
+      learnUtilStub.updateLessonProgress.resolves({
+        success: true,
+        data: {
+          lesson_id: "l1",
+          stars: 3,
+          points_earned: 30,
+          total_points: 30,
+          current_stage: { index: 0, name: "Curious" },
+          unlock: null,
+        },
+        status: httpStatus.OK,
+      });
+      const req = makeReq({
+        params: { lesson_id: "l1" },
+        headers: { "x-device-id": "dev-001" },
+        body: { completed: true },
+      });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.updateLessonProgress(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.stars).to.equal(3);
+    });
+  });
+
+  describe("syncProgress", () => {
+    it("should return merged_count on success", async () => {
+      learnUtilStub.syncProgress.resolves({
+        success: true,
+        data: { merged_count: 2, total_points: 40, current_stage: { index: 0, name: "Curious" } },
+        status: httpStatus.OK,
+      });
+      const req = makeReq({
+        body: { device_id: "dev-001", updates: [] },
+        headers: { "x-device-id": "dev-001" },
+      });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.syncProgress(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.merged_count).to.equal(2);
+    });
+  });
+
+  describe("linkGuestProgress", () => {
+    it("should return user_id and merged data on success", async () => {
+      learnUtilStub.linkGuestProgress.resolves({
+        success: true,
+        data: {
+          user_id: "user-1",
+          merged: { lessons_transferred: 3, points_transferred: 60 },
+        },
+        status: httpStatus.OK,
+      });
+      const req = makeReq({
+        body: { device_id: "dev-001", guest_id: "guest_abc" },
+        user: { id: "user-1" },
+      });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.linkGuestProgress(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.user_id).to.equal("user-1");
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      learnUtilStub.linkGuestProgress.resolves({
+        success: false,
+        message: "authentication required",
+        status: httpStatus.UNAUTHORIZED,
+      });
+      const req = makeReq({ body: { device_id: "dev-001", guest_id: "guest_abc" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.linkGuestProgress(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.UNAUTHORIZED)).to.be.true;
+    });
+  });
+
+  describe("issueCertificate", () => {
+    it("should return certificate data on success", async () => {
+      learnUtilStub.issueCertificate.resolves({
+        success: true,
+        data: {
+          certificate_id: "cert-1",
+          learner_name: "Alice",
+          verification_code: "AQ-2025-LEARN-AAAAAAAA",
+          share_url: "https://airqo.net/learn/cert/AQ-2025-LEARN-AAAAAAAA",
+          issued_at: new Date(),
+        },
+        status: httpStatus.CREATED,
+      });
+      const req = makeReq({
+        body: { course_id: "c1", learner_name: "Alice" },
+        user: { id: "user-1" },
+      });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.issueCertificate(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.CREATED)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.certificate_id).to.equal("cert-1");
+    });
+  });
+
+  describe("listCertificates", () => {
+    it("should return certificates array on success", async () => {
+      learnUtilStub.listCertificates.resolves({
+        success: true,
+        data: [{ certificate_id: "cert-1" }],
+        status: httpStatus.OK,
+      });
+      const req = makeReq({ user: { id: "user-1" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.listCertificates(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.certificates).to.have.lengthOf(1);
+    });
+  });
+
+  describe("verifyCertificate", () => {
+    it("should return certificate verification data on success", async () => {
+      learnUtilStub.verifyCertificate.resolves({
+        success: true,
+        data: {
+          certificate_id: "cert-1",
+          learner_name: "Alice",
+          verification_code: "AQ-2025-LEARN-AAAAAAAA",
+          valid: true,
+          share_url: "https://airqo.net/learn/cert/AQ-2025-LEARN-AAAAAAAA",
+          issued_at: new Date(),
+        },
+        status: httpStatus.OK,
+      });
+      const req = makeReq({ params: { verification_code: "AQ-2025-LEARN-AAAAAAAA" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.verifyCertificate(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.valid).to.be.true;
+    });
+
+    it("should return 404 for invalid verification code", async () => {
+      learnUtilStub.verifyCertificate.resolves({
+        success: false,
+        message: "certificate not found",
+        status: httpStatus.NOT_FOUND,
+      });
+      const req = makeReq({ params: { verification_code: "AQ-2025-LEARN-NOTFOUND" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.verifyCertificate(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.NOT_FOUND)).to.be.true;
+    });
+  });
+
+  describe("getLeaderboard", () => {
+    it("should return leaderboard entries on success", async () => {
+      learnUtilStub.getLeaderboard.resolves({
+        success: true,
+        data: { scope: "global", entries: [], current_user_rank: 1 },
+        status: httpStatus.OK,
+      });
+      const req = makeReq({ user: { id: "user-1" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getLeaderboard(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.scope).to.equal("global");
+      expect(jsonArgs).to.have.property("entries");
+    });
+  });
+
+  describe("getCourseProgress", () => {
+    it("should return courses array on success", async () => {
+      learnUtilStub.getCourseProgress.resolves({
+        success: true,
+        data: [{ course_id: "c1", is_complete: false }],
+        status: httpStatus.OK,
+      });
+      const req = makeReq({ headers: { "x-device-id": "dev-001" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getCourseProgress(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.courses).to.have.lengthOf(1);
+    });
+  });
+
+  describe("createCourse", () => {
+    it("should return course data with 201 on success", async () => {
+      learnUtilStub.createCourse.resolves({
+        success: true,
+        data: { course_number: 1, title: "Intro" },
+        status: httpStatus.CREATED,
+      });
+      const req = makeReq({ body: { course_number: 1, title: "Intro", plain_title_key: "intro" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.createCourse(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.CREATED)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.course).to.exist;
+    });
+  });
+
+  describe("addUnit", () => {
+    it("should return unit data with 201 on success", async () => {
+      learnUtilStub.addUnit.resolves({
+        success: true,
+        data: { title: "Unit 1", unit_order: 1 },
+        status: httpStatus.CREATED,
+      });
+      const req = makeReq({
+        params: { course_id: "c1" },
+        body: { title: "Unit 1", plain_title_key: "unit_1", unit_order: 1 },
+      });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.addUnit(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.CREATED)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.unit).to.exist;
+    });
+  });
+
+  describe("deleteCourse", () => {
+    it("should return success message on deletion", async () => {
+      learnUtilStub.deleteCourse.resolves({
+        success: true,
+        message: "course deleted successfully",
+        status: httpStatus.OK,
+      });
+      const req = makeReq({ params: { course_id: "c1" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.deleteCourse(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.message).to.equal("course deleted successfully");
+    });
+
+    it("should return 409 when attempting to delete a published course", async () => {
+      learnUtilStub.deleteCourse.resolves({
+        success: false,
+        message: "cannot delete a published course — unpublish it first",
+        status: httpStatus.CONFLICT,
+      });
+      const req = makeReq({ params: { course_id: "c1" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.deleteCourse(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.CONFLICT)).to.be.true;
+    });
+  });
+
+  describe("updateCourse", () => {
+    it("should return updated course on success", async () => {
+      learnUtilStub.updateCourse.resolves({
+        success: true,
+        data: { title: "Updated Title", published: true },
+        status: httpStatus.OK,
+      });
+      const req = makeReq({
+        params: { course_id: "c1" },
+        body: { title: "Updated Title" },
+      });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.updateCourse(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.course).to.have.property("title", "Updated Title");
+    });
+  });
+});

--- a/src/device-registry/controllers/test/ut_network-status.controller.js
+++ b/src/device-registry/controllers/test/ut_network-status.controller.js
@@ -1,0 +1,260 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const chai = require("chai");
+chai.use(sinonChai);
+const httpStatus = require("http-status");
+const proxyquire = require("proxyquire");
+
+describe("networkStatusController", () => {
+  let controller;
+  let networkStatusUtilStub;
+  let sharedStub;
+
+  const makeRes = () => {
+    const res = {};
+    res.status = sinon.stub().returns(res);
+    res.json = sinon.stub().returns(res);
+    res.headersSent = false;
+    return res;
+  };
+
+  const makeReq = (overrides = {}) => ({
+    query: { tenant: "airqo" },
+    params: {},
+    body: {},
+    headers: {},
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    networkStatusUtilStub = {
+      createAlert: sinon.stub(),
+      list: sinon.stub(),
+      getStatistics: sinon.stub(),
+      getHourlyTrends: sinon.stub(),
+      getRecentAlerts: sinon.stub(),
+      getUptimeSummary: sinon.stub(),
+      getNetworkBreakdown: sinon.stub(),
+    };
+
+    sharedStub = {
+      logObject: sinon.stub(),
+      logText: sinon.stub(),
+      logElement: sinon.stub(),
+      HttpError: class HttpError extends Error {
+        constructor(message, status, errors) {
+          super(message);
+          this.statusCode = status;
+          this.errors = errors;
+        }
+      },
+      extractErrorsFromRequest: sinon.stub().returns(null),
+    };
+
+    controller = proxyquire("@controllers/network-status.controller", {
+      "@utils/network-status.util": networkStatusUtilStub,
+      "@utils/shared": sharedStub,
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("create", () => {
+    it("should return 201 with alert data on success", async () => {
+      networkStatusUtilStub.createAlert.resolves({
+        success: true,
+        data: { _id: "alert-1", status: "OK" },
+        message: "Network status alert created",
+        status: httpStatus.CREATED,
+      });
+      const req = makeReq({ body: { status: "OK", message: "ok" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.create(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.CREATED)).to.be.true;
+      expect(res.json.calledOnce).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.success).to.be.true;
+    });
+
+    it("should call next when extractErrorsFromRequest returns errors", async () => {
+      sharedStub.extractErrorsFromRequest.returns({ field: "error" });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.create(req, res, next);
+
+      expect(next.calledOnce).to.be.true;
+      expect(networkStatusUtilStub.createAlert.called).to.be.false;
+    });
+
+    it("should return failure response when util returns success=false", async () => {
+      networkStatusUtilStub.createAlert.resolves({
+        success: false,
+        message: "validation failed",
+        status: httpStatus.BAD_REQUEST,
+        errors: { message: "bad data" },
+      });
+      const req = makeReq({ body: {} });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.create(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.BAD_REQUEST)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.success).to.be.false;
+    });
+
+    it("should not respond when res.headersSent is true", async () => {
+      networkStatusUtilStub.createAlert.resolves({
+        success: true,
+        data: {},
+        status: httpStatus.CREATED,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      res.headersSent = true;
+      const next = sinon.spy();
+
+      await controller.create(req, res, next);
+
+      expect(res.json.called).to.be.false;
+    });
+  });
+
+  describe("list", () => {
+    it("should return 200 with alerts array on success", async () => {
+      networkStatusUtilStub.list.resolves({
+        success: true,
+        data: [{ _id: "a1" }, { _id: "a2" }],
+        message: "successfully retrieved the network status alerts",
+        status: httpStatus.OK,
+      });
+      const req = makeReq({ query: { tenant: "airqo" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.list(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.success).to.be.true;
+      expect(jsonArgs.alerts).to.have.lengthOf(2);
+    });
+
+    it("should call next when validation fails", async () => {
+      sharedStub.extractErrorsFromRequest.returns({ tenant: "invalid" });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.list(req, res, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getStatistics", () => {
+    it("should return statistics data on success", async () => {
+      networkStatusUtilStub.getStatistics.resolves({
+        success: true,
+        data: [{ _id: null, totalAlerts: 5 }],
+        status: httpStatus.OK,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getStatistics(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.success).to.be.true;
+      expect(jsonArgs.statistics).to.exist;
+    });
+  });
+
+  describe("getHourlyTrends", () => {
+    it("should return trends data on success", async () => {
+      networkStatusUtilStub.getHourlyTrends.resolves({
+        success: true,
+        data: [],
+        status: httpStatus.OK,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getHourlyTrends(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.trends).to.deep.equal([]);
+    });
+  });
+
+  describe("getRecentAlerts", () => {
+    it("should return recent alerts on success", async () => {
+      networkStatusUtilStub.getRecentAlerts.resolves({
+        success: true,
+        data: [{ _id: "recent-1" }],
+        status: httpStatus.OK,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getRecentAlerts(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.alerts).to.have.lengthOf(1);
+    });
+  });
+
+  describe("getUptimeSummary", () => {
+    it("should return uptime summary on success", async () => {
+      networkStatusUtilStub.getUptimeSummary.resolves({
+        success: true,
+        data: [],
+        status: httpStatus.OK,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getUptimeSummary(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.summary).to.deep.equal([]);
+    });
+  });
+
+  describe("getNetworkBreakdown", () => {
+    it("should return network breakdown data on success", async () => {
+      networkStatusUtilStub.getNetworkBreakdown.resolves({
+        success: true,
+        data: [{ _id: "airqo", avg_not_transmitting_percentage: 10 }],
+        status: httpStatus.OK,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getNetworkBreakdown(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.data).to.have.lengthOf(1);
+    });
+  });
+});

--- a/src/device-registry/controllers/test/ut_network-status.controller.js
+++ b/src/device-registry/controllers/test/ut_network-status.controller.js
@@ -128,6 +128,18 @@ describe("networkStatusController", () => {
 
       expect(res.json.called).to.be.false;
     });
+
+    it("should call next with HttpError when createAlert throws unexpectedly", async () => {
+      networkStatusUtilStub.createAlert.rejects(new Error("unexpected failure"));
+      const req = makeReq({ body: { status: "OK" } });
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.create(req, res, next);
+
+      expect(next.calledOnce).to.be.true;
+      expect(res.json.called).to.be.false;
+    });
   });
 
   describe("list", () => {

--- a/src/device-registry/models/test/ut_learn-activity.model.js
+++ b/src/device-registry/models/test/ut_learn-activity.model.js
@@ -73,7 +73,7 @@ describe("LearnActivity Model", () => {
       expect(result.message).to.equal("activity created");
     });
 
-    it("should call next on duplicate key error (11000)", async () => {
+    it("should call next with CONFLICT and duplicate value on 11000 error", async () => {
       const error = new Error("dup");
       error.code = 11000;
       error.keyPattern = { lesson_id: 1, order: 1 };
@@ -83,9 +83,12 @@ describe("LearnActivity Model", () => {
       await Model.register({}, next);
 
       expect(next.calledOnce).to.be.true;
+      const httpError = next.firstCall.args[0];
+      expect(httpError.statusCode).to.equal(httpStatus.CONFLICT);
+      expect(JSON.stringify(httpError.errors)).to.include("duplicate value");
     });
 
-    it("should call next on validation error", async () => {
+    it("should call next with CONFLICT and field message on validation error", async () => {
       const error = new Error("val");
       error.errors = { type: { message: "type is required" } };
       sinon.stub(Model, "create").rejects(error);
@@ -94,6 +97,9 @@ describe("LearnActivity Model", () => {
       await Model.register({}, next);
 
       expect(next.calledOnce).to.be.true;
+      const httpError = next.firstCall.args[0];
+      expect(httpError.statusCode).to.equal(httpStatus.CONFLICT);
+      expect(JSON.stringify(httpError.errors)).to.include("type is required");
     });
   });
 

--- a/src/device-registry/models/test/ut_learn-activity.model.js
+++ b/src/device-registry/models/test/ut_learn-activity.model.js
@@ -1,0 +1,181 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const mongoose = require("mongoose");
+const httpStatus = require("http-status");
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+describe("LearnActivity Model", () => {
+  let Model;
+
+  before(() => {
+    const LearnActivityModel = proxyquire(
+      path.resolve(__dirname, "../LearnActivity"),
+      {
+        "@config/database": {
+          getModelByTenant: (_tenant, name, schema) => {
+            try { return mongoose.model(name, schema); }
+            catch (_) { return mongoose.model(name); }
+          },
+        },
+      }
+    );
+    Model = LearnActivityModel("airqo");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Schema fields", () => {
+    it("should define lesson_id as required ObjectId", () => {
+      const path = Model.schema.path("lesson_id");
+      expect(path).to.exist;
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define type with valid enum values", () => {
+      const path = Model.schema.path("type");
+      expect(path.enumValues).to.include.members(["article", "video", "image", "quiz"]);
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define order as required Number with min 1", () => {
+      const path = Model.schema.path("order");
+      expect(path.isRequired).to.be.true;
+      expect(path.instance).to.equal("Number");
+    });
+
+    it("should define payload as required Mixed", () => {
+      const path = Model.schema.path("payload");
+      expect(path.isRequired).to.be.true;
+    });
+  });
+
+  describe("Static method: register", () => {
+    it("should return success on successful create", async () => {
+      const lessonId = new mongoose.Types.ObjectId();
+      const fakeDoc = {
+        _id: new mongoose.Types.ObjectId(),
+        _doc: { lesson_id: lessonId, type: "article", order: 1, payload: { body: "text" } },
+      };
+      sinon.stub(Model, "create").resolves(fakeDoc);
+      const next = sinon.spy();
+
+      const result = await Model.register(
+        { lesson_id: lessonId, type: "article", order: 1, payload: { body: "text" } },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+      expect(result.message).to.equal("activity created");
+    });
+
+    it("should call next on duplicate key error (11000)", async () => {
+      const error = new Error("dup");
+      error.code = 11000;
+      error.keyPattern = { lesson_id: 1, order: 1 };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("should call next on validation error", async () => {
+      const error = new Error("val");
+      error.errors = { type: { message: "type is required" } };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: list", () => {
+    it("should return sorted activities on success", async () => {
+      const fakeActivities = [
+        { _id: "1", type: "article", order: 1 },
+        { _id: "2", type: "video", order: 2 },
+      ];
+      const fakeQuery = {
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves(fakeActivities),
+      };
+      sinon.stub(Model, "find").returns(fakeQuery);
+      const next = sinon.spy();
+
+      const result = await Model.list({}, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal(fakeActivities);
+    });
+
+    it("should call next when find throws", async () => {
+      sinon.stub(Model, "find").throws(new Error("db error"));
+      const next = sinon.spy();
+
+      await Model.list({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: modify", () => {
+    it("should return success when record is found and updated", async () => {
+      const fakeUpdated = { _id: "1", _doc: { type: "video", order: 1 } };
+      sinon.stub(Model, "findOneAndUpdate").resolves(fakeUpdated);
+      const next = sinon.spy();
+
+      const result = await Model.modify(
+        { filter: { _id: "1" }, update: { type: "video" } },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully modified the activity");
+    });
+
+    it("should call next with BAD_REQUEST when no record found", async () => {
+      sinon.stub(Model, "findOneAndUpdate").resolves(null);
+      const next = sinon.spy();
+
+      await Model.modify({ filter: { _id: "nonexistent" }, update: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: remove", () => {
+    it("should return success when record is removed", async () => {
+      const fakeRemoved = { _id: "1", _doc: { type: "article", order: 1 } };
+      sinon.stub(Model, "findOneAndRemove").returns({
+        exec: sinon.stub().resolves(fakeRemoved),
+      });
+      const next = sinon.spy();
+
+      const result = await Model.remove({ filter: { _id: "1" } }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully removed the activity");
+    });
+
+    it("should call next when no record found", async () => {
+      sinon.stub(Model, "findOneAndRemove").returns({
+        exec: sinon.stub().resolves(null),
+      });
+      const next = sinon.spy();
+
+      await Model.remove({ filter: { _id: "nonexistent" } }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/device-registry/models/test/ut_learn-certificate.model.js
+++ b/src/device-registry/models/test/ut_learn-certificate.model.js
@@ -1,0 +1,145 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const mongoose = require("mongoose");
+const httpStatus = require("http-status");
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+describe("LearnCertificate Model", () => {
+  let Model;
+
+  before(() => {
+    const LearnCertificateModel = proxyquire(
+      path.resolve(__dirname, "../LearnCertificate"),
+      {
+        "@config/database": {
+          getModelByTenant: (_tenant, name, schema) => {
+            try { return mongoose.model(name, schema); }
+            catch (_) { return mongoose.model(name); }
+          },
+        },
+      }
+    );
+    Model = LearnCertificateModel("airqo");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Schema fields", () => {
+    it("should define user_id as required String", () => {
+      const path = Model.schema.path("user_id");
+      expect(path).to.exist;
+      expect(path.isRequired).to.be.true;
+      expect(path.instance).to.equal("String");
+    });
+
+    it("should define course_id as required ObjectId ref", () => {
+      const path = Model.schema.path("course_id");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define learner_name as required String", () => {
+      const path = Model.schema.path("learner_name");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define verification_code as required unique String", () => {
+      const path = Model.schema.path("verification_code");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define share_url as optional", () => {
+      const path = Model.schema.path("share_url");
+      expect(path).to.exist;
+      expect(path.isRequired).to.not.be.true;
+    });
+  });
+
+  describe("Static method: register", () => {
+    it("should return success and CREATED status on successful create", async () => {
+      const courseId = new mongoose.Types.ObjectId();
+      const fakeDoc = {
+        _id: new mongoose.Types.ObjectId(),
+        _doc: {
+          user_id: "user-123",
+          course_id: courseId,
+          learner_name: "Alice",
+          verification_code: "AQ-2025-LEARN-ABCD1234",
+        },
+      };
+      sinon.stub(Model, "create").resolves(fakeDoc);
+      const next = sinon.spy();
+
+      const result = await Model.register(
+        {
+          user_id: "user-123",
+          course_id: courseId,
+          learner_name: "Alice",
+          verification_code: "AQ-2025-LEARN-ABCD1234",
+        },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+      expect(result.message).to.equal("certificate issued");
+    });
+
+    it("should call next on duplicate key error (11000)", async () => {
+      const error = new Error("dup");
+      error.code = 11000;
+      error.keyPattern = { verification_code: 1 };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("should call next on validation errors", async () => {
+      const error = new Error("val");
+      error.errors = { user_id: { message: "user_id is required" } };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: list", () => {
+    it("should return certificates sorted by createdAt descending", async () => {
+      const fakeCerts = [
+        { _id: "c1", verification_code: "AQ-2025-LEARN-AAAAAAAA" },
+        { _id: "c2", verification_code: "AQ-2025-LEARN-BBBBBBBB" },
+      ];
+      const fakeQuery = {
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves(fakeCerts),
+      };
+      sinon.stub(Model, "find").returns(fakeQuery);
+      const next = sinon.spy();
+
+      const result = await Model.list({}, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.lengthOf(2);
+    });
+
+    it("should call next when find throws", async () => {
+      sinon.stub(Model, "find").throws(new Error("db error"));
+      const next = sinon.spy();
+
+      await Model.list({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/device-registry/models/test/ut_learn-course.model.js
+++ b/src/device-registry/models/test/ut_learn-course.model.js
@@ -1,0 +1,185 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const mongoose = require("mongoose");
+const httpStatus = require("http-status");
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+describe("LearnCourse Model", () => {
+  let Model;
+
+  before(() => {
+    const LearnCourseModel = proxyquire(
+      path.resolve(__dirname, "../LearnCourse"),
+      {
+        "@config/database": {
+          getModelByTenant: (_tenant, name, schema) => {
+            try { return mongoose.model(name, schema); }
+            catch (_) { return mongoose.model(name); }
+          },
+        },
+      }
+    );
+    Model = LearnCourseModel("airqo");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Schema fields", () => {
+    it("should define course_number as required Number with min 1", () => {
+      const path = Model.schema.path("course_number");
+      expect(path).to.exist;
+      expect(path.isRequired).to.be.true;
+      expect(path.instance).to.equal("Number");
+    });
+
+    it("should define title as required with maxlength 120", () => {
+      const path = Model.schema.path("title");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define plain_title_key as required", () => {
+      const path = Model.schema.path("plain_title_key");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should set published default to false", () => {
+      const path = Model.schema.path("published");
+      expect(path.defaultValue).to.equal(false);
+    });
+
+    it("should define cover_image_url as optional", () => {
+      const path = Model.schema.path("cover_image_url");
+      expect(path).to.exist;
+      expect(path.isRequired).to.not.be.true;
+    });
+  });
+
+  describe("Static method: register", () => {
+    it("should return success with CREATED status", async () => {
+      const fakeDoc = {
+        _id: new mongoose.Types.ObjectId(),
+        _doc: { course_number: 1, title: "Intro", plain_title_key: "intro" },
+      };
+      sinon.stub(Model, "create").resolves(fakeDoc);
+      const next = sinon.spy();
+
+      const result = await Model.register(
+        { course_number: 1, title: "Intro", plain_title_key: "intro" },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+      expect(result.message).to.equal("course created");
+    });
+
+    it("should call next on duplicate course_number (11000)", async () => {
+      const error = new Error("dup");
+      error.code = 11000;
+      error.keyPattern = { course_number: 1 };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({ course_number: 1 }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("should call next on validation error", async () => {
+      const error = new Error("val");
+      error.errors = { title: { message: "title is required" } };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: list", () => {
+    it("should return courses sorted by course_number", async () => {
+      const fakeCourses = [
+        { _id: "1", course_number: 1, title: "Intro" },
+        { _id: "2", course_number: 2, title: "Advanced" },
+      ];
+      const fakeQuery = {
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves(fakeCourses),
+      };
+      sinon.stub(Model, "find").returns(fakeQuery);
+      const next = sinon.spy();
+
+      const result = await Model.list({}, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal(fakeCourses);
+    });
+
+    it("should call next when find throws", async () => {
+      sinon.stub(Model, "find").throws(new Error("db error"));
+      const next = sinon.spy();
+
+      await Model.list({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: modify", () => {
+    it("should return success when record updated", async () => {
+      const fakeUpdated = { _id: "1", _doc: { title: "New Title" } };
+      sinon.stub(Model, "findOneAndUpdate").resolves(fakeUpdated);
+      const next = sinon.spy();
+
+      const result = await Model.modify(
+        { filter: { _id: "1" }, update: { title: "New Title" } },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully modified the course");
+    });
+
+    it("should call next with BAD_REQUEST when record not found", async () => {
+      sinon.stub(Model, "findOneAndUpdate").resolves(null);
+      const next = sinon.spy();
+
+      await Model.modify({ filter: {}, update: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: remove", () => {
+    it("should return success when course removed", async () => {
+      const fakeRemoved = { _id: "1", _doc: { title: "Intro" } };
+      sinon.stub(Model, "findOneAndRemove").returns({
+        exec: sinon.stub().resolves(fakeRemoved),
+      });
+      const next = sinon.spy();
+
+      const result = await Model.remove({ filter: { _id: "1" } }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully removed the course");
+    });
+
+    it("should call next when not found", async () => {
+      sinon.stub(Model, "findOneAndRemove").returns({
+        exec: sinon.stub().resolves(null),
+      });
+      const next = sinon.spy();
+
+      await Model.remove({ filter: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/device-registry/models/test/ut_learn-guest-session.model.js
+++ b/src/device-registry/models/test/ut_learn-guest-session.model.js
@@ -1,0 +1,167 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const mongoose = require("mongoose");
+const httpStatus = require("http-status");
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+describe("LearnGuestSession Model", () => {
+  let Model;
+
+  before(() => {
+    const LearnGuestSessionModel = proxyquire(
+      path.resolve(__dirname, "../LearnGuestSession"),
+      {
+        "@config/database": {
+          getModelByTenant: (_tenant, name, schema) => {
+            try { return mongoose.model(name, schema); }
+            catch (_) { return mongoose.model(name); }
+          },
+        },
+      }
+    );
+    Model = LearnGuestSessionModel("airqo");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Schema fields", () => {
+    it("should define device_id as required String", () => {
+      const path = Model.schema.path("device_id");
+      expect(path).to.exist;
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define guest_id as required String", () => {
+      const path = Model.schema.path("guest_id");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define platform with enum [android, ios]", () => {
+      const path = Model.schema.path("platform");
+      expect(path.enumValues).to.include.members(["android", "ios"]);
+    });
+
+    it("should default linked_user_id to null", () => {
+      const path = Model.schema.path("linked_user_id");
+      expect(path.defaultValue).to.equal(null);
+    });
+
+    it("should default linked_at to null", () => {
+      const path = Model.schema.path("linked_at");
+      expect(path.defaultValue).to.equal(null);
+    });
+  });
+
+  describe("Static method: register", () => {
+    it("should return success with CREATED status", async () => {
+      const fakeDoc = {
+        _id: new mongoose.Types.ObjectId(),
+        _doc: { device_id: "dev-001", guest_id: "guest_abc123" },
+      };
+      sinon.stub(Model, "create").resolves(fakeDoc);
+      const next = sinon.spy();
+
+      const result = await Model.register(
+        { device_id: "dev-001", guest_id: "guest_abc123" },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+      expect(result.message).to.equal("guest session created");
+    });
+
+    it("should call next on duplicate device_id (11000)", async () => {
+      const error = new Error("dup");
+      error.code = 11000;
+      error.keyPattern = { device_id: 1 };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: findOrCreate", () => {
+    it("should return existing session when device_id already registered", async () => {
+      const existingSession = { device_id: "dev-001", guest_id: "guest_existing" };
+      sinon.stub(Model, "findOne").returns({
+        lean: sinon.stub().resolves(existingSession),
+      });
+      const next = sinon.spy();
+
+      const result = await Model.findOrCreate({ device_id: "dev-001" }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.OK);
+      expect(result.data).to.deep.equal(existingSession);
+    });
+
+    it("should create and return a new session when device_id not found", async () => {
+      sinon.stub(Model, "findOne").returns({
+        lean: sinon.stub().resolves(null),
+      });
+      const fakeCreated = {
+        _id: "new-id",
+        _doc: { device_id: "dev-new", guest_id: "guest_new" },
+      };
+      sinon.stub(Model, "create").resolves(fakeCreated);
+      const next = sinon.spy();
+
+      const result = await Model.findOrCreate({ device_id: "dev-new" }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+    });
+
+    it("should re-fetch on race condition duplicate key", async () => {
+      sinon.stub(Model, "findOne")
+        .onFirstCall().returns({ lean: sinon.stub().resolves(null) })
+        .onSecondCall().returns({ lean: sinon.stub().resolves({ device_id: "dev-race", guest_id: "guest_winner" }) });
+
+      const dupError = new Error("dup");
+      dupError.code = 11000;
+      sinon.stub(Model, "create").rejects(dupError);
+      const next = sinon.spy();
+
+      const result = await Model.findOrCreate({ device_id: "dev-race" }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.OK);
+    });
+  });
+
+  describe("Static method: modify", () => {
+    it("should return success when session is updated", async () => {
+      const fakeUpdated = {
+        _id: "session-1",
+        _doc: { linked_user_id: "user-123" },
+      };
+      sinon.stub(Model, "findOneAndUpdate").resolves(fakeUpdated);
+      const next = sinon.spy();
+
+      const result = await Model.modify(
+        { filter: { device_id: "dev-001" }, update: { linked_user_id: "user-123" } },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully modified the guest session");
+    });
+
+    it("should call next when no session found", async () => {
+      sinon.stub(Model, "findOneAndUpdate").resolves(null);
+      const next = sinon.spy();
+
+      await Model.modify({ filter: {}, update: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/device-registry/models/test/ut_learn-guest-session.model.js
+++ b/src/device-registry/models/test/ut_learn-guest-session.model.js
@@ -134,6 +134,7 @@ describe("LearnGuestSession Model", () => {
 
       expect(result.success).to.be.true;
       expect(result.status).to.equal(httpStatus.OK);
+      expect(result.data).to.include({ device_id: "dev-race", guest_id: "guest_winner" });
     });
   });
 

--- a/src/device-registry/models/test/ut_learn-lesson.model.js
+++ b/src/device-registry/models/test/ut_learn-lesson.model.js
@@ -1,0 +1,174 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const mongoose = require("mongoose");
+const httpStatus = require("http-status");
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+describe("LearnLesson Model", () => {
+  let Model;
+
+  before(() => {
+    const LearnLessonModel = proxyquire(
+      path.resolve(__dirname, "../LearnLesson"),
+      {
+        "@config/database": {
+          getModelByTenant: (_tenant, name, schema) => {
+            try { return mongoose.model(name, schema); }
+            catch (_) { return mongoose.model(name); }
+          },
+        },
+      }
+    );
+    Model = LearnLessonModel("airqo");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Schema fields", () => {
+    it("should define unit_id as required ObjectId ref", () => {
+      const path = Model.schema.path("unit_id");
+      expect(path).to.exist;
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define title as required with maxlength 120", () => {
+      const path = Model.schema.path("title");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define plain_title_key as required", () => {
+      const path = Model.schema.path("plain_title_key");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define lesson_order as required Number", () => {
+      const path = Model.schema.path("lesson_order");
+      expect(path.isRequired).to.be.true;
+      expect(path.instance).to.equal("Number");
+    });
+
+    it("should define cover_image_url and completion_message as optional", () => {
+      expect(Model.schema.path("cover_image_url").isRequired).to.not.be.true;
+      expect(Model.schema.path("completion_message").isRequired).to.not.be.true;
+    });
+  });
+
+  describe("Static method: register", () => {
+    it("should return success with CREATED status", async () => {
+      const unitId = new mongoose.Types.ObjectId();
+      const fakeDoc = {
+        _id: new mongoose.Types.ObjectId(),
+        _doc: { unit_id: unitId, title: "Lesson 1", plain_title_key: "lesson_1", lesson_order: 1 },
+      };
+      sinon.stub(Model, "create").resolves(fakeDoc);
+      const next = sinon.spy();
+
+      const result = await Model.register(
+        { unit_id: unitId, title: "Lesson 1", plain_title_key: "lesson_1", lesson_order: 1 },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+      expect(result.message).to.equal("lesson created");
+    });
+
+    it("should call next on duplicate lesson_order within unit (11000)", async () => {
+      const error = new Error("dup");
+      error.code = 11000;
+      error.keyPattern = { unit_id: 1, lesson_order: 1 };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: list", () => {
+    it("should return lessons sorted by lesson_order", async () => {
+      const fakeLessons = [
+        { lesson_order: 1, title: "First" },
+        { lesson_order: 2, title: "Second" },
+      ];
+      const fakeQuery = {
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves(fakeLessons),
+      };
+      sinon.stub(Model, "find").returns(fakeQuery);
+      const next = sinon.spy();
+
+      const result = await Model.list({}, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal(fakeLessons);
+    });
+
+    it("should call next when find throws", async () => {
+      sinon.stub(Model, "find").throws(new Error("db error"));
+      const next = sinon.spy();
+
+      await Model.list({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: modify", () => {
+    it("should return success when lesson is updated", async () => {
+      const fakeUpdated = { _id: "l1", _doc: { title: "Updated" } };
+      sinon.stub(Model, "findOneAndUpdate").resolves(fakeUpdated);
+      const next = sinon.spy();
+
+      const result = await Model.modify(
+        { filter: { _id: "l1" }, update: { title: "Updated" } },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully modified the lesson");
+    });
+
+    it("should call next with BAD_REQUEST when lesson not found", async () => {
+      sinon.stub(Model, "findOneAndUpdate").resolves(null);
+      const next = sinon.spy();
+
+      await Model.modify({ filter: {}, update: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: remove", () => {
+    it("should return success when lesson removed", async () => {
+      const fakeRemoved = { _id: "l1", _doc: { title: "Lesson 1" } };
+      sinon.stub(Model, "findOneAndRemove").returns({
+        exec: sinon.stub().resolves(fakeRemoved),
+      });
+      const next = sinon.spy();
+
+      const result = await Model.remove({ filter: { _id: "l1" } }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully removed the lesson");
+    });
+
+    it("should call next when lesson not found", async () => {
+      sinon.stub(Model, "findOneAndRemove").returns({
+        exec: sinon.stub().resolves(null),
+      });
+      const next = sinon.spy();
+
+      await Model.remove({ filter: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/device-registry/models/test/ut_learn-progress.model.js
+++ b/src/device-registry/models/test/ut_learn-progress.model.js
@@ -53,26 +53,7 @@ describe("LearnProgress Model", () => {
   });
 
   describe("Static: computeStage", () => {
-    const { computeStage } = (() => {
-      const MAX = 2400;
-      function computeStage(totalPoints, maxPoints) {
-        const STAGES = [
-          { index: 0, name: "Curious" },
-          { index: 1, name: "Aware" },
-          { index: 2, name: "Observer" },
-          { index: 3, name: "Champion" },
-          { index: 4, name: "Defender" },
-        ];
-        if (!maxPoints || maxPoints === 0) return STAGES[0];
-        const ratio = totalPoints / maxPoints;
-        if (ratio >= 1.0) return STAGES[4];
-        if (ratio >= 0.75) return STAGES[3];
-        if (ratio >= 0.5) return STAGES[2];
-        if (ratio >= 0.25) return STAGES[1];
-        return STAGES[0];
-      }
-      return { computeStage, MAX };
-    })();
+    const computeStage = (...args) => Model.computeStage(...args);
 
     it("should return Curious for 0 points", () => {
       const stage = computeStage(0, 2400);

--- a/src/device-registry/models/test/ut_learn-progress.model.js
+++ b/src/device-registry/models/test/ut_learn-progress.model.js
@@ -1,0 +1,191 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const mongoose = require("mongoose");
+const httpStatus = require("http-status");
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+describe("LearnProgress Model", () => {
+  let Model;
+
+  before(() => {
+    const LearnProgressModel = proxyquire(
+      path.resolve(__dirname, "../LearnProgress"),
+      {
+        "@config/database": {
+          getModelByTenant: (_tenant, name, schema) => {
+            try { return mongoose.model(name, schema); }
+            catch (_) { return mongoose.model(name); }
+          },
+        },
+      }
+    );
+    Model = LearnProgressModel("airqo");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Schema fields", () => {
+    it("should define device_id as required String", () => {
+      const path = Model.schema.path("device_id");
+      expect(path).to.exist;
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define learner_type with enum [guest, user] and default guest", () => {
+      const path = Model.schema.path("learner_type");
+      expect(path.enumValues).to.include.members(["guest", "user"]);
+      expect(path.defaultValue).to.equal("guest");
+    });
+
+    it("should default total_points to 0", () => {
+      const path = Model.schema.path("total_points");
+      expect(path.defaultValue).to.equal(0);
+    });
+
+    it("should define lessons as a Map", () => {
+      const path = Model.schema.path("lessons");
+      expect(path).to.exist;
+    });
+  });
+
+  describe("Static: computeStage", () => {
+    const { computeStage } = (() => {
+      const MAX = 2400;
+      function computeStage(totalPoints, maxPoints) {
+        const STAGES = [
+          { index: 0, name: "Curious" },
+          { index: 1, name: "Aware" },
+          { index: 2, name: "Observer" },
+          { index: 3, name: "Champion" },
+          { index: 4, name: "Defender" },
+        ];
+        if (!maxPoints || maxPoints === 0) return STAGES[0];
+        const ratio = totalPoints / maxPoints;
+        if (ratio >= 1.0) return STAGES[4];
+        if (ratio >= 0.75) return STAGES[3];
+        if (ratio >= 0.5) return STAGES[2];
+        if (ratio >= 0.25) return STAGES[1];
+        return STAGES[0];
+      }
+      return { computeStage, MAX };
+    })();
+
+    it("should return Curious for 0 points", () => {
+      const stage = computeStage(0, 2400);
+      expect(stage.name).to.equal("Curious");
+    });
+
+    it("should return Aware for 25% of max", () => {
+      const stage = computeStage(600, 2400);
+      expect(stage.name).to.equal("Aware");
+    });
+
+    it("should return Observer for 50% of max", () => {
+      const stage = computeStage(1200, 2400);
+      expect(stage.name).to.equal("Observer");
+    });
+
+    it("should return Champion for 75% of max", () => {
+      const stage = computeStage(1800, 2400);
+      expect(stage.name).to.equal("Champion");
+    });
+
+    it("should return Defender for 100% of max", () => {
+      const stage = computeStage(2400, 2400);
+      expect(stage.name).to.equal("Defender");
+    });
+
+    it("should return Curious when maxPoints is 0", () => {
+      const stage = computeStage(500, 0);
+      expect(stage.name).to.equal("Curious");
+    });
+  });
+
+  describe("Static method: findProgress", () => {
+    it("should return progress doc when found by device_id", async () => {
+      const fakeDoc = { device_id: "dev-001", total_points: 100 };
+      sinon.stub(Model, "findOne").returns({ lean: sinon.stub().resolves(fakeDoc) });
+      const next = sinon.spy();
+
+      const result = await Model.findProgress({ device_id: "dev-001" }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal(fakeDoc);
+    });
+
+    it("should return null data and success true when no progress found", async () => {
+      sinon.stub(Model, "findOne").returns({ lean: sinon.stub().resolves(null) });
+      const next = sinon.spy();
+
+      const result = await Model.findProgress({ device_id: "dev-missing" }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.be.null;
+      expect(result.message).to.equal("no progress found");
+    });
+
+    it("should prioritize user_id filter over device_id", async () => {
+      const findOneStub = sinon.stub(Model, "findOne").returns({
+        lean: sinon.stub().resolves(null),
+      });
+      const next = sinon.spy();
+
+      await Model.findProgress({ device_id: "dev-001", user_id: "user-42" }, next);
+
+      expect(findOneStub.calledWith({ user_id: "user-42" })).to.be.true;
+    });
+
+    it("should call next on db error", async () => {
+      sinon.stub(Model, "findOne").throws(new Error("db error"));
+      const next = sinon.spy();
+
+      await Model.findProgress({ device_id: "dev-001" }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: upsertLessonProgress", () => {
+    it("should call next on db error", async () => {
+      sinon.stub(Model, "findOne").rejects(new Error("db error"));
+      const next = sinon.spy();
+
+      await Model.upsertLessonProgress(
+        {
+          device_id: "dev-001",
+          lesson_id: "lesson-1",
+          update: { completed: true, quiz_attempts: [] },
+          maxPoints: 2400,
+        },
+        next
+      );
+
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("should return progress data on success", async () => {
+      sinon.stub(Model, "findOne").returns({ lean: undefined });
+      Model.findOne.restore();
+      sinon.stub(Model, "findOne").resolves(null);
+      sinon.stub(Model, "findOneAndUpdate").resolves({});
+      const next = sinon.spy();
+
+      const result = await Model.upsertLessonProgress(
+        {
+          device_id: "dev-002",
+          lesson_id: "lesson-2",
+          update: { completed: false, furthest_activity_index: 1 },
+          maxPoints: 2400,
+        },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.property("lesson_id", "lesson-2");
+    });
+  });
+});

--- a/src/device-registry/models/test/ut_learn-progress.model.js
+++ b/src/device-registry/models/test/ut_learn-progress.model.js
@@ -149,8 +149,6 @@ describe("LearnProgress Model", () => {
     });
 
     it("should return progress data on success", async () => {
-      sinon.stub(Model, "findOne").returns({ lean: undefined });
-      Model.findOne.restore();
       sinon.stub(Model, "findOne").resolves(null);
       sinon.stub(Model, "findOneAndUpdate").resolves({});
       const next = sinon.spy();

--- a/src/device-registry/models/test/ut_learn-unit.model.js
+++ b/src/device-registry/models/test/ut_learn-unit.model.js
@@ -115,6 +115,7 @@ describe("LearnUnit Model", () => {
 
       expect(result.success).to.be.true;
       expect(result.data).to.deep.equal(fakeUnits);
+      expect(fakeQuery.sort.calledWith({ unit_order: 1 })).to.be.true;
     });
 
     it("should call next when find throws", async () => {

--- a/src/device-registry/models/test/ut_learn-unit.model.js
+++ b/src/device-registry/models/test/ut_learn-unit.model.js
@@ -1,0 +1,180 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const mongoose = require("mongoose");
+const httpStatus = require("http-status");
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+describe("LearnUnit Model", () => {
+  let Model;
+
+  before(() => {
+    const LearnUnitModel = proxyquire(
+      path.resolve(__dirname, "../LearnUnit"),
+      {
+        "@config/database": {
+          getModelByTenant: (_tenant, name, schema) => {
+            try { return mongoose.model(name, schema); }
+            catch (_) { return mongoose.model(name); }
+          },
+        },
+      }
+    );
+    Model = LearnUnitModel("airqo");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Schema fields", () => {
+    it("should define course_id as required ObjectId ref", () => {
+      const path = Model.schema.path("course_id");
+      expect(path).to.exist;
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define title as required String", () => {
+      const path = Model.schema.path("title");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define plain_title_key as required", () => {
+      const path = Model.schema.path("plain_title_key");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define unit_order as required Number", () => {
+      const path = Model.schema.path("unit_order");
+      expect(path.isRequired).to.be.true;
+      expect(path.instance).to.equal("Number");
+    });
+  });
+
+  describe("Static method: register", () => {
+    it("should return success with CREATED status", async () => {
+      const courseId = new mongoose.Types.ObjectId();
+      const fakeDoc = {
+        _id: new mongoose.Types.ObjectId(),
+        _doc: { course_id: courseId, title: "Unit 1", plain_title_key: "unit_1", unit_order: 1 },
+      };
+      sinon.stub(Model, "create").resolves(fakeDoc);
+      const next = sinon.spy();
+
+      const result = await Model.register(
+        { course_id: courseId, title: "Unit 1", plain_title_key: "unit_1", unit_order: 1 },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+      expect(result.message).to.equal("unit created");
+    });
+
+    it("should call next on duplicate unit_order within course (11000)", async () => {
+      const error = new Error("dup");
+      error.code = 11000;
+      error.keyPattern = { course_id: 1, unit_order: 1 };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it("should call next on validation error", async () => {
+      const error = new Error("val");
+      error.errors = { title: { message: "title is required" } };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: list", () => {
+    it("should return units sorted by unit_order", async () => {
+      const fakeUnits = [
+        { unit_order: 1, title: "Unit 1" },
+        { unit_order: 2, title: "Unit 2" },
+      ];
+      const fakeQuery = {
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves(fakeUnits),
+      };
+      sinon.stub(Model, "find").returns(fakeQuery);
+      const next = sinon.spy();
+
+      const result = await Model.list({}, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal(fakeUnits);
+    });
+
+    it("should call next when find throws", async () => {
+      sinon.stub(Model, "find").throws(new Error("db error"));
+      const next = sinon.spy();
+
+      await Model.list({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: modify", () => {
+    it("should return success when unit is updated", async () => {
+      const fakeUpdated = { _id: "u1", _doc: { title: "Updated Unit" } };
+      sinon.stub(Model, "findOneAndUpdate").resolves(fakeUpdated);
+      const next = sinon.spy();
+
+      const result = await Model.modify(
+        { filter: { _id: "u1" }, update: { title: "Updated Unit" } },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully modified the unit");
+    });
+
+    it("should call next when unit not found", async () => {
+      sinon.stub(Model, "findOneAndUpdate").resolves(null);
+      const next = sinon.spy();
+
+      await Model.modify({ filter: {}, update: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: remove", () => {
+    it("should return success when unit is removed", async () => {
+      const fakeRemoved = { _id: "u1", _doc: { title: "Unit 1" } };
+      sinon.stub(Model, "findOneAndRemove").returns({
+        exec: sinon.stub().resolves(fakeRemoved),
+      });
+      const next = sinon.spy();
+
+      const result = await Model.remove({ filter: { _id: "u1" } }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.message).to.equal("successfully removed the unit");
+    });
+
+    it("should call next when unit not found", async () => {
+      sinon.stub(Model, "findOneAndRemove").returns({
+        exec: sinon.stub().resolves(null),
+      });
+      const next = sinon.spy();
+
+      await Model.remove({ filter: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/device-registry/models/test/ut_network-status-alert.model.js
+++ b/src/device-registry/models/test/ut_network-status-alert.model.js
@@ -1,0 +1,243 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const mongoose = require("mongoose");
+const httpStatus = require("http-status");
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+describe("NetworkStatusAlert Model", () => {
+  let Model;
+
+  before(() => {
+    const NetworkStatusAlertModel = proxyquire(
+      path.resolve(__dirname, "../NetworkStatusAlert"),
+      {
+        "@config/database": {
+          getModelByTenant: (_tenant, name, schema) => {
+            try { return mongoose.model(name, schema); }
+            catch (_) { return mongoose.model(name); }
+          },
+        },
+      }
+    );
+    Model = NetworkStatusAlertModel("airqo");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Schema fields", () => {
+    it("should define checked_at as required Date", () => {
+      const path = Model.schema.path("checked_at");
+      expect(path).to.exist;
+      expect(path.instance).to.equal("Date");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define total_deployed_devices as required Number", () => {
+      const path = Model.schema.path("total_deployed_devices");
+      expect(path).to.exist;
+      expect(path.instance).to.equal("Number");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should set operational_count default to 0", () => {
+      const path = Model.schema.path("operational_count");
+      expect(path.defaultValue).to.equal(0);
+    });
+
+    it("should define status with enum [OK, WARNING, CRITICAL]", () => {
+      const path = Model.schema.path("status");
+      expect(path.enumValues).to.include.members(["OK", "WARNING", "CRITICAL"]);
+      expect(path.defaultValue).to.equal("OK");
+    });
+
+    it("should define severity with enum [LOW, MEDIUM, HIGH]", () => {
+      const path = Model.schema.path("severity");
+      expect(path.enumValues).to.include.members(["LOW", "MEDIUM", "HIGH"]);
+      expect(path.defaultValue).to.equal("LOW");
+    });
+
+    it("should define threshold_exceeded as required Boolean with default false", () => {
+      const path = Model.schema.path("threshold_exceeded");
+      expect(path.instance).to.equal("Boolean");
+      expect(path.isRequired).to.be.true;
+      expect(path.defaultValue).to.equal(false);
+    });
+
+    it("should define alert_type with default NETWORK_STATUS", () => {
+      const path = Model.schema.path("alert_type");
+      expect(path.defaultValue).to.equal("NETWORK_STATUS");
+    });
+
+    it("should define tenant as required with lowercase", () => {
+      const path = Model.schema.path("tenant");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should define day_of_week as required Number", () => {
+      const path = Model.schema.path("day_of_week");
+      expect(path.isRequired).to.be.true;
+      expect(path.instance).to.equal("Number");
+    });
+
+    it("should define hour_of_day as required Number", () => {
+      const path = Model.schema.path("hour_of_day");
+      expect(path.isRequired).to.be.true;
+    });
+
+    it("should have timestamps enabled", () => {
+      expect(Model.schema.options.timestamps).to.be.true;
+    });
+  });
+
+  describe("Static method: register", () => {
+    it("should return success response when create succeeds", async () => {
+      const fakeDoc = {
+        _id: new mongoose.Types.ObjectId(),
+        _doc: { checked_at: new Date(), status: "OK", message: "ok" },
+      };
+      sinon.stub(Model, "create").resolves(fakeDoc);
+      const next = sinon.spy();
+
+      const result = await Model.register(
+        {
+          checked_at: new Date(),
+          total_deployed_devices: 100,
+          not_transmitting_devices_count: 5,
+          not_transmitting_percentage: 5,
+          status: "OK",
+          message: "ok",
+          threshold_exceeded: false,
+          threshold_value: 35,
+          tenant: "airqo",
+          environment: "test",
+          day_of_week: 1,
+          hour_of_day: 8,
+        },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+      expect(result.message).to.equal("Network status alert created");
+      expect(next.called).to.be.false;
+    });
+
+    it("should call next with HttpError when create throws validation error", async () => {
+      const error = new Error("validation error");
+      error.errors = { status: { message: "invalid status" } };
+      sinon.stub(Model, "create").rejects(error);
+      const next = sinon.spy();
+
+      await Model.register({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: list", () => {
+    it("should return success with data when records exist", async () => {
+      const fakeRecords = [{ _id: "abc", status: "OK" }];
+      const fakeQuery = {
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves(fakeRecords),
+      };
+      sinon.stub(Model, "find").returns(fakeQuery);
+      const next = sinon.spy();
+
+      const result = await Model.list({}, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal(fakeRecords);
+      expect(result.status).to.equal(httpStatus.OK);
+    });
+
+    it("should return empty array when no records exist", async () => {
+      const fakeQuery = {
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([]),
+      };
+      sinon.stub(Model, "find").returns(fakeQuery);
+      const next = sinon.spy();
+
+      const result = await Model.list({}, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal([]);
+    });
+
+    it("should call next when find throws", async () => {
+      sinon.stub(Model, "find").throws(new Error("db error"));
+      const next = sinon.spy();
+
+      await Model.list({}, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: executeAggregation", () => {
+    it("should return success with aggregation results", async () => {
+      const fakeResult = [{ _id: null, totalAlerts: 10 }];
+      sinon.stub(Model, "aggregate").resolves(fakeResult);
+      const next = sinon.spy();
+
+      const result = await Model.executeAggregation({ pipeline: [] }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal(fakeResult);
+    });
+
+    it("should return empty array when aggregation yields nothing", async () => {
+      sinon.stub(Model, "aggregate").resolves([]);
+      const next = sinon.spy();
+
+      const result = await Model.executeAggregation({ pipeline: [] }, next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal([]);
+    });
+
+    it("should call next when aggregate throws", async () => {
+      sinon.stub(Model, "aggregate").rejects(new Error("agg error"));
+      const next = sinon.spy();
+
+      await Model.executeAggregation({ pipeline: [] }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Instance method: toJSON", () => {
+    it("should return the expected shape", () => {
+      const doc = new Model({
+        checked_at: new Date(),
+        total_deployed_devices: 50,
+        not_transmitting_devices_count: 2,
+        not_transmitting_percentage: 4,
+        status: "OK",
+        message: "ok",
+        threshold_exceeded: false,
+        threshold_value: 35,
+        tenant: "airqo",
+        environment: "test",
+        day_of_week: 0,
+        hour_of_day: 12,
+      });
+
+      const json = doc.toJSON();
+
+      expect(json).to.have.property("_id");
+      expect(json).to.have.property("checked_at");
+      expect(json).to.have.property("status", "OK");
+      expect(json).to.have.property("tenant", "airqo");
+    });
+  });
+});

--- a/src/device-registry/utils/test/ut_learn.util.js
+++ b/src/device-registry/utils/test/ut_learn.util.js
@@ -1,0 +1,655 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const chai = require("chai");
+chai.use(sinonChai);
+const httpStatus = require("http-status");
+const mongoose = require("mongoose");
+const proxyquire = require("proxyquire");
+
+describe("learnUtil", () => {
+  let learnUtil;
+
+  let LearnCourseModelStub;
+  let LearnUnitModelStub;
+  let LearnLessonModelStub;
+  let LearnActivityModelStub;
+  let LearnGuestSessionModelStub;
+  let LearnProgressModelStub;
+  let LearnCertificateModelStub;
+
+  let courseInstance;
+  let unitInstance;
+  let lessonInstance;
+  let activityInstance;
+  let guestSessionInstance;
+  let progressInstance;
+  let certInstance;
+
+  beforeEach(() => {
+    courseInstance = {
+      list: sinon.stub(),
+      register: sinon.stub(),
+      modify: sinon.stub(),
+      remove: sinon.stub(),
+      findOne: sinon.stub(),
+      distinct: sinon.stub(),
+      deleteMany: sinon.stub(),
+    };
+    unitInstance = {
+      list: sinon.stub(),
+      register: sinon.stub(),
+      modify: sinon.stub(),
+      remove: sinon.stub(),
+      distinct: sinon.stub(),
+      deleteMany: sinon.stub(),
+    };
+    lessonInstance = {
+      list: sinon.stub(),
+      register: sinon.stub(),
+      modify: sinon.stub(),
+      remove: sinon.stub(),
+      distinct: sinon.stub(),
+      deleteMany: sinon.stub(),
+    };
+    activityInstance = {
+      list: sinon.stub(),
+      register: sinon.stub(),
+      modify: sinon.stub(),
+      remove: sinon.stub(),
+      deleteMany: sinon.stub(),
+    };
+    guestSessionInstance = {
+      findOrCreate: sinon.stub(),
+      findOne: sinon.stub(),
+      findOneAndUpdate: sinon.stub(),
+    };
+    progressInstance = {
+      findProgress: sinon.stub(),
+      upsertLessonProgress: sinon.stub(),
+      mergeGuestToUser: sinon.stub(),
+      find: sinon.stub(),
+      findOne: sinon.stub(),
+      countDocuments: sinon.stub(),
+    };
+    certInstance = {
+      list: sinon.stub(),
+      register: sinon.stub(),
+    };
+
+    LearnCourseModelStub = sinon.stub().returns(courseInstance);
+    LearnUnitModelStub = sinon.stub().returns(unitInstance);
+    LearnLessonModelStub = sinon.stub().returns(lessonInstance);
+    LearnActivityModelStub = sinon.stub().returns(activityInstance);
+    LearnGuestSessionModelStub = sinon.stub().returns(guestSessionInstance);
+    LearnProgressModelStub = sinon.stub().returns(progressInstance);
+    LearnCertificateModelStub = sinon.stub().returns(certInstance);
+
+    learnUtil = proxyquire("@utils/learn.util", {
+      "@models/LearnCourse": LearnCourseModelStub,
+      "@models/LearnUnit": LearnUnitModelStub,
+      "@models/LearnLesson": LearnLessonModelStub,
+      "@models/LearnActivity": LearnActivityModelStub,
+      "@models/LearnGuestSession": LearnGuestSessionModelStub,
+      "@models/LearnProgress": LearnProgressModelStub,
+      "@models/LearnCertificate": LearnCertificateModelStub,
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const makeReq = (overrides = {}) => ({
+    query: { tenant: "airqo" },
+    params: {},
+    body: {},
+    headers: {},
+    user: null,
+    ...overrides,
+  });
+
+  // ---------------------------------------------------------------------------
+  // getCatalog
+  // ---------------------------------------------------------------------------
+
+  describe("getCatalog", () => {
+    it("should return catalog with stages and courses on success", async () => {
+      const courseId = new mongoose.Types.ObjectId();
+      const unitId = new mongoose.Types.ObjectId();
+      const lessonId = new mongoose.Types.ObjectId();
+      const activityId = new mongoose.Types.ObjectId();
+
+      courseInstance.list.resolves({
+        success: true,
+        data: [
+          {
+            _id: courseId,
+            course_number: 1,
+            title: "Intro",
+            plain_title_key: "intro",
+            cover_image_url: "https://example.com/img.png",
+          },
+        ],
+      });
+      unitInstance.list.resolves({
+        success: true,
+        data: [{ _id: unitId, course_id: courseId, title: "Unit 1", unit_order: 1 }],
+      });
+      lessonInstance.list.resolves({
+        success: true,
+        data: [{ _id: lessonId, unit_id: unitId, title: "Lesson 1", lesson_order: 1 }],
+      });
+      activityInstance.list.resolves({
+        success: true,
+        data: [{ _id: activityId, lesson_id: lessonId, type: "article", order: 1, payload: {} }],
+      });
+      courseInstance.findOne = sinon.stub().returns({
+        sort: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves({
+          catalog_version: "2025-01-01",
+          updatedAt: new Date("2025-01-01"),
+        }),
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.getCatalog(makeReq(), next);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.property("stages");
+      expect(result.data).to.have.property("courses");
+      expect(result.data.courses).to.have.lengthOf(1);
+    });
+
+    it("should call next on unexpected error", async () => {
+      courseInstance.list.rejects(new Error("unexpected"));
+      const next = sinon.spy();
+
+      await learnUtil.getCatalog(makeReq(), next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getLesson
+  // ---------------------------------------------------------------------------
+
+  describe("getLesson", () => {
+    it("should return lesson with activities on success", async () => {
+      const lessonId = new mongoose.Types.ObjectId().toString();
+      const actId = new mongoose.Types.ObjectId();
+
+      lessonInstance.list.resolves({
+        success: true,
+        data: [{ _id: lessonId, title: "Lesson 1" }],
+      });
+      activityInstance.list.resolves({
+        success: true,
+        data: [{ _id: actId, type: "article", order: 1, payload: {} }],
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.getLesson(
+        makeReq({ params: { lesson_id: lessonId } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.property("title", "Lesson 1");
+      expect(result.data.activities).to.have.lengthOf(1);
+    });
+
+    it("should return 404 when lesson not found", async () => {
+      lessonInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+      const result = await learnUtil.getLesson(
+        makeReq({ params: { lesson_id: "nonexistent" } }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createAnonymousSession
+  // ---------------------------------------------------------------------------
+
+  describe("createAnonymousSession", () => {
+    it("should return guest_id and display_name on success", async () => {
+      guestSessionInstance.findOrCreate.resolves({
+        success: true,
+        data: { guest_id: "guest_abc", display_name: "guest_abc", createdAt: new Date() },
+        message: "guest session created",
+        status: httpStatus.CREATED,
+      });
+      const next = sinon.spy();
+      const result = await learnUtil.createAnonymousSession(
+        makeReq({ body: { device_id: "dev-001" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.property("guest_id", "guest_abc");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getProgress
+  // ---------------------------------------------------------------------------
+
+  describe("getProgress", () => {
+    it("should return empty state when no progress doc exists", async () => {
+      progressInstance.findProgress.resolves({ success: true, data: null });
+      const next = sinon.spy();
+      const result = await learnUtil.getProgress(
+        makeReq({ headers: { "x-device-id": "dev-001" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data.total_points).to.equal(0);
+      expect(result.data.lessons).to.deep.equal({});
+    });
+
+    it("should return BAD_REQUEST when no device_id or user_id", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.getProgress(makeReq(), next);
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+    });
+
+    it("should return formatted progress when doc exists", async () => {
+      progressInstance.findProgress.resolves({
+        success: true,
+        data: {
+          learner_type: "guest",
+          guest_id: "guest_abc",
+          total_points: 50,
+          completed_lessons: 1,
+          current_stage_index: 0,
+          lessons: new Map([
+            ["lid1", { completed: true, stars: 2, points_earned: 20, quiz_score_ratio: 0.8 }],
+          ]),
+        },
+      });
+      const next = sinon.spy();
+      const result = await learnUtil.getProgress(
+        makeReq({ headers: { "x-device-id": "dev-001" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data.total_points).to.equal(50);
+      expect(result.data.lessons).to.have.property("lid1");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateLessonProgress
+  // ---------------------------------------------------------------------------
+
+  describe("updateLessonProgress", () => {
+    it("should return BAD_REQUEST when no device_id or user_id", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.updateLessonProgress(
+        makeReq({ params: { lesson_id: "l1" } }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+    });
+
+    it("should return 404 when lesson not found", async () => {
+      lessonInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+      const result = await learnUtil.updateLessonProgress(
+        makeReq({
+          params: { lesson_id: "l1" },
+          headers: { "x-device-id": "dev-001" },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("should return progress data on success", async () => {
+      const lessonId = new mongoose.Types.ObjectId().toString();
+      lessonInstance.list
+        .onFirstCall()
+        .resolves({ success: true, data: [{ _id: lessonId, unit_id: "u1", lesson_order: 1 }] })
+        .onSecondCall()
+        .resolves({ success: true, data: [] });
+
+      progressInstance.upsertLessonProgress.resolves({
+        success: true,
+        data: {
+          lesson_id: lessonId,
+          stars: 2,
+          points_earned: 20,
+          total_points: 20,
+          current_stage: { index: 0, name: "Curious" },
+          completed: true,
+        },
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.updateLessonProgress(
+        makeReq({
+          params: { lesson_id: lessonId },
+          headers: { "x-device-id": "dev-001" },
+          body: { completed: true, quiz_attempts: [] },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.property("stars", 2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createCourse
+  // ---------------------------------------------------------------------------
+
+  describe("createCourse", () => {
+    it("should block creating with published: true", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.createCourse(
+        makeReq({ body: { course_number: 1, title: "Test", plain_title_key: "test", published: true } }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNPROCESSABLE_ENTITY);
+    });
+
+    it("should call model.register when published is false", async () => {
+      courseInstance.register.resolves({
+        success: true,
+        data: { course_number: 1, title: "Test" },
+        status: httpStatus.CREATED,
+      });
+      const next = sinon.spy();
+      const result = await learnUtil.createCourse(
+        makeReq({ body: { course_number: 1, title: "Test", plain_title_key: "test" } }),
+        next
+      );
+
+      expect(courseInstance.register.calledOnce).to.be.true;
+      expect(result.success).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addActivity — payload validation
+  // ---------------------------------------------------------------------------
+
+  describe("addActivity", () => {
+    beforeEach(() => {
+      lessonInstance.list.resolves({
+        success: true,
+        data: [{ _id: "l1", title: "Lesson 1" }],
+      });
+    });
+
+    it("should reject article activity missing payload.body", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.addActivity(
+        makeReq({
+          params: { lesson_id: "l1" },
+          body: { type: "article", order: 1, payload: {} },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNPROCESSABLE_ENTITY);
+    });
+
+    it("should reject video activity missing both video_url and youtube_id", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.addActivity(
+        makeReq({
+          params: { lesson_id: "l1" },
+          body: { type: "video", order: 1, payload: {} },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNPROCESSABLE_ENTITY);
+    });
+
+    it("should reject quiz activity missing payload.format", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.addActivity(
+        makeReq({
+          params: { lesson_id: "l1" },
+          body: { type: "quiz", order: 1, payload: {} },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNPROCESSABLE_ENTITY);
+    });
+
+    it("should call model.register for valid article activity", async () => {
+      activityInstance.register.resolves({
+        success: true,
+        data: { type: "article" },
+        status: httpStatus.CREATED,
+      });
+      const next = sinon.spy();
+      const result = await learnUtil.addActivity(
+        makeReq({
+          params: { lesson_id: "l1" },
+          body: { type: "article", order: 1, payload: { body: "some content" } },
+        }),
+        next
+      );
+
+      expect(activityInstance.register.calledOnce).to.be.true;
+      expect(result.success).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteCourse
+  // ---------------------------------------------------------------------------
+
+  describe("deleteCourse", () => {
+    it("should return 404 when course not found", async () => {
+      courseInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+      const result = await learnUtil.deleteCourse(
+        makeReq({ params: { course_id: "c1" } }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("should return CONFLICT when course is published", async () => {
+      courseInstance.list.resolves({
+        success: true,
+        data: [{ _id: "c1", published: true }],
+      });
+      const next = sinon.spy();
+      const result = await learnUtil.deleteCourse(
+        makeReq({ params: { course_id: "c1" } }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.CONFLICT);
+    });
+
+    it("should cascade delete units/lessons/activities and remove course", async () => {
+      courseInstance.list.resolves({
+        success: true,
+        data: [{ _id: "c1", published: false }],
+      });
+      unitInstance.distinct.resolves(["u1"]);
+      lessonInstance.distinct.resolves(["l1"]);
+      activityInstance.deleteMany.resolves({});
+      lessonInstance.deleteMany.resolves({});
+      unitInstance.deleteMany.resolves({});
+      courseInstance.remove.resolves({ success: true, data: {} });
+      const next = sinon.spy();
+
+      const result = await learnUtil.deleteCourse(
+        makeReq({ params: { course_id: "c1" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(activityInstance.deleteMany.calledOnce).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // linkGuestProgress
+  // ---------------------------------------------------------------------------
+
+  describe("linkGuestProgress", () => {
+    it("should return UNAUTHORIZED when no user_id", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.linkGuestProgress(
+        makeReq({ body: { device_id: "dev-001", guest_id: "guest_abc" } }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNAUTHORIZED);
+    });
+
+    it("should return BAD_REQUEST when guest session not found", async () => {
+      guestSessionInstance.findOne.returns({ lean: sinon.stub().resolves(null) });
+      const next = sinon.spy();
+      const result = await learnUtil.linkGuestProgress(
+        makeReq({
+          body: { device_id: "dev-001", guest_id: "guest_abc" },
+          user: { id: "user-1" },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+    });
+
+    it("should merge and return success when session is valid", async () => {
+      guestSessionInstance.findOne.returns({
+        lean: sinon.stub().resolves({ device_id: "dev-001", guest_id: "guest_abc", linked_user_id: null }),
+      });
+      progressInstance.mergeGuestToUser.resolves({
+        success: true,
+        data: { lessons_transferred: 3, points_transferred: 60, courses_completed: 0 },
+      });
+      guestSessionInstance.findOneAndUpdate.resolves({});
+      const next = sinon.spy();
+
+      const result = await learnUtil.linkGuestProgress(
+        makeReq({
+          body: { device_id: "dev-001", guest_id: "guest_abc" },
+          user: { id: "user-1" },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.have.property("user_id", "user-1");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // issueCertificate
+  // ---------------------------------------------------------------------------
+
+  describe("issueCertificate", () => {
+    it("should return UNAUTHORIZED when no user_id", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.issueCertificate(
+        makeReq({ body: { course_id: "c1" } }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNAUTHORIZED);
+    });
+
+    it("should return 404 when course not found", async () => {
+      courseInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+      const result = await learnUtil.issueCertificate(
+        makeReq({
+          body: { course_id: "c1", learner_name: "Alice" },
+          user: { id: "user-1" },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // verifyCertificate
+  // ---------------------------------------------------------------------------
+
+  describe("verifyCertificate", () => {
+    it("should return 404 when certificate not found", async () => {
+      certInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+      const result = await learnUtil.verifyCertificate(
+        makeReq({ params: { verification_code: "AQ-2025-LEARN-NOTFOUND" } }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("should return certificate details when found", async () => {
+      const courseId = new mongoose.Types.ObjectId();
+      certInstance.list.resolves({
+        success: true,
+        data: [
+          {
+            _id: "cert-1",
+            learner_name: "Alice",
+            verification_code: "AQ-2025-LEARN-AAAAAAAA",
+            course_id: courseId,
+            share_url: "https://airqo.net/learn/cert/AQ-2025-LEARN-AAAAAAAA",
+            createdAt: new Date(),
+          },
+        ],
+      });
+      courseInstance.list.resolves({
+        success: true,
+        data: [{ _id: courseId, title: "Intro to AQ" }],
+      });
+      const next = sinon.spy();
+
+      const result = await learnUtil.verifyCertificate(
+        makeReq({ params: { verification_code: "AQ-2025-LEARN-AAAAAAAA" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data.valid).to.be.true;
+      expect(result.data.learner_name).to.equal("Alice");
+    });
+  });
+});

--- a/src/device-registry/utils/test/ut_network-status.util.js
+++ b/src/device-registry/utils/test/ut_network-status.util.js
@@ -1,0 +1,348 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const chai = require("chai");
+chai.use(sinonChai);
+const httpStatus = require("http-status");
+const proxyquire = require("proxyquire");
+
+describe("networkStatusUtil", () => {
+  let networkStatusUtil;
+  let NetworkStatusAlertModelStub;
+  let modelInstance;
+
+  beforeEach(() => {
+    modelInstance = {
+      register: sinon.stub(),
+      list: sinon.stub(),
+      getStatistics: sinon.stub(),
+      getStatisticsByNetwork: sinon.stub(),
+      getHourlyTrends: sinon.stub(),
+      getHourlyTrendsByNetwork: sinon.stub(),
+      getUptimeSummaryByNetwork: sinon.stub(),
+      executeAggregation: sinon.stub(),
+    };
+
+    NetworkStatusAlertModelStub = sinon.stub().returns(modelInstance);
+
+    networkStatusUtil = proxyquire("@utils/network-status.util", {
+      "@models/NetworkStatusAlert": NetworkStatusAlertModelStub,
+      kafkajs: {
+        Kafka: class {
+          constructor() {}
+          producer() {
+            return {
+              connect: sinon.stub().resolves(),
+              send: sinon.stub().resolves(),
+              disconnect: sinon.stub().resolves(),
+            };
+          }
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("createAlert", () => {
+    it("should enrich alert data and call model.register", async () => {
+      const fakeResponse = {
+        success: true,
+        data: { _id: "alert-1" },
+        status: httpStatus.CREATED,
+        message: "Network status alert created",
+      };
+      modelInstance.register.resolves(fakeResponse);
+      const next = sinon.spy();
+
+      const result = await networkStatusUtil.createAlert(
+        {
+          alertData: {
+            checked_at: new Date(),
+            total_deployed_devices: 100,
+            not_transmitting_devices_count: 10,
+            not_transmitting_percentage: 10,
+            status: "OK",
+            message: "ok",
+            threshold_exceeded: false,
+            threshold_value: 35,
+          },
+          tenant: "airqo",
+        },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(modelInstance.register.calledOnce).to.be.true;
+      const callArgs = modelInstance.register.firstCall.args[0];
+      expect(callArgs).to.have.property("tenant", "airqo");
+      expect(callArgs).to.have.property("day_of_week");
+      expect(callArgs).to.have.property("hour_of_day");
+    });
+
+    it("should assign severity HIGH when not_transmitting_percentage >= 50", async () => {
+      modelInstance.register.resolves({ success: true, data: {} });
+      const next = sinon.spy();
+
+      await networkStatusUtil.createAlert(
+        {
+          alertData: {
+            not_transmitting_percentage: 60,
+            status: "CRITICAL",
+            message: "bad",
+            threshold_exceeded: true,
+            threshold_value: 35,
+            checked_at: new Date(),
+            total_deployed_devices: 100,
+            not_transmitting_devices_count: 60,
+          },
+          tenant: "airqo",
+        },
+        next
+      );
+
+      const callArgs = modelInstance.register.firstCall.args[0];
+      expect(callArgs.severity).to.equal("HIGH");
+    });
+
+    it("should assign severity MEDIUM when not_transmitting_percentage >= 35 and < 50", async () => {
+      modelInstance.register.resolves({ success: true, data: {} });
+      const next = sinon.spy();
+
+      await networkStatusUtil.createAlert(
+        {
+          alertData: {
+            not_transmitting_percentage: 40,
+            status: "WARNING",
+            message: "warn",
+            threshold_exceeded: true,
+            threshold_value: 35,
+            checked_at: new Date(),
+            total_deployed_devices: 100,
+            not_transmitting_devices_count: 40,
+          },
+          tenant: "airqo",
+        },
+        next
+      );
+
+      const callArgs = modelInstance.register.firstCall.args[0];
+      expect(callArgs.severity).to.equal("MEDIUM");
+    });
+
+    it("should assign severity LOW when not_transmitting_percentage < 35", async () => {
+      modelInstance.register.resolves({ success: true, data: {} });
+      const next = sinon.spy();
+
+      await networkStatusUtil.createAlert(
+        {
+          alertData: {
+            not_transmitting_percentage: 20,
+            status: "OK",
+            message: "ok",
+            threshold_exceeded: false,
+            threshold_value: 35,
+            checked_at: new Date(),
+            total_deployed_devices: 100,
+            not_transmitting_devices_count: 20,
+          },
+          tenant: "airqo",
+        },
+        next
+      );
+
+      const callArgs = modelInstance.register.firstCall.args[0];
+      expect(callArgs.severity).to.equal("LOW");
+    });
+
+    it("should call next on unexpected error", async () => {
+      modelInstance.register.rejects(new Error("unexpected"));
+      const next = sinon.spy();
+
+      await networkStatusUtil.createAlert({ alertData: {}, tenant: "airqo" }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("list", () => {
+    it("should pass filter to model.list and return result", async () => {
+      const fakeAlerts = [{ _id: "a1" }];
+      modelInstance.list.resolves({
+        success: true,
+        data: fakeAlerts,
+        status: httpStatus.OK,
+      });
+      const next = sinon.spy();
+
+      const result = await networkStatusUtil.list(
+        { query: { tenant: "airqo", limit: "10", skip: "0" } },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal(fakeAlerts);
+      expect(modelInstance.list.calledOnce).to.be.true;
+    });
+
+    it("should build date filter when start_date and end_date are provided", async () => {
+      modelInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.list(
+        {
+          query: {
+            tenant: "airqo",
+            start_date: "2025-01-01",
+            end_date: "2025-01-31",
+          },
+        },
+        next
+      );
+
+      const passedArgs = modelInstance.list.firstCall.args[0];
+      expect(passedArgs.filter).to.have.property("checked_at");
+      expect(passedArgs.filter.checked_at).to.have.property("$gte");
+      expect(passedArgs.filter.checked_at).to.have.property("$lte");
+    });
+
+    it("should add network elemMatch filter when network query param is provided", async () => {
+      modelInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.list(
+        { query: { tenant: "airqo", network: "airqo" } },
+        next
+      );
+
+      const passedArgs = modelInstance.list.firstCall.args[0];
+      expect(passedArgs.filter).to.have.property("network_breakdown");
+    });
+
+    it("should call next on error", async () => {
+      modelInstance.list.rejects(new Error("db error"));
+      const next = sinon.spy();
+
+      await networkStatusUtil.list({ query: { tenant: "airqo" } }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getStatistics", () => {
+    it("should call getStatistics on model when no network filter", async () => {
+      modelInstance.getStatistics.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getStatistics({ query: { tenant: "airqo" } }, next);
+
+      expect(modelInstance.getStatistics.calledOnce).to.be.true;
+    });
+
+    it("should call getStatisticsByNetwork when network query param is provided", async () => {
+      modelInstance.getStatisticsByNetwork.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getStatistics(
+        { query: { tenant: "airqo", network: "airqo" } },
+        next
+      );
+
+      expect(modelInstance.getStatisticsByNetwork.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getHourlyTrends", () => {
+    it("should call getHourlyTrends on model when no network filter", async () => {
+      modelInstance.getHourlyTrends.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getHourlyTrends({ query: { tenant: "airqo" } }, next);
+
+      expect(modelInstance.getHourlyTrends.calledOnce).to.be.true;
+    });
+
+    it("should call getHourlyTrendsByNetwork when network is specified", async () => {
+      modelInstance.getHourlyTrendsByNetwork.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getHourlyTrends(
+        { query: { tenant: "airqo", network: "iqair" } },
+        next
+      );
+
+      expect(modelInstance.getHourlyTrendsByNetwork.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getRecentAlerts", () => {
+    it("should filter by threshold_exceeded when no network specified", async () => {
+      modelInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getRecentAlerts(
+        { query: { tenant: "airqo", hours: "24" } },
+        next
+      );
+
+      const passedArgs = modelInstance.list.firstCall.args[0];
+      expect(passedArgs.filter).to.have.property("threshold_exceeded", true);
+    });
+
+    it("should add network breakdown elemMatch filter when network is provided", async () => {
+      modelInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getRecentAlerts(
+        { query: { tenant: "airqo", network: "airqo" } },
+        next
+      );
+
+      const passedArgs = modelInstance.list.firstCall.args[0];
+      expect(passedArgs.filter).to.have.property("network_breakdown");
+    });
+  });
+
+  describe("getUptimeSummary", () => {
+    it("should call getUptimeSummaryByNetwork when network is provided", async () => {
+      modelInstance.getUptimeSummaryByNetwork.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getUptimeSummary(
+        { query: { tenant: "airqo", days: "7", network: "airqo" } },
+        next
+      );
+
+      expect(modelInstance.getUptimeSummaryByNetwork.calledOnce).to.be.true;
+    });
+
+    it("should call executeAggregation for global uptime when no network", async () => {
+      modelInstance.executeAggregation.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getUptimeSummary(
+        { query: { tenant: "airqo", days: "7" } },
+        next
+      );
+
+      expect(modelInstance.executeAggregation.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getNetworkBreakdown", () => {
+    it("should call getStatisticsByNetwork without a specific network", async () => {
+      modelInstance.getStatisticsByNetwork.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getNetworkBreakdown(
+        { query: { tenant: "airqo" } },
+        next
+      );
+
+      expect(modelInstance.getStatisticsByNetwork.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/device-registry/validators/network-status.validators.js
+++ b/src/device-registry/validators/network-status.validators.js
@@ -66,26 +66,26 @@ const networkStatusValidations = {
       .bail()
       .isInt({ min: 0 })
       .withMessage("total_deployed_devices must be a non-negative integer"),
-    body("offline_devices_count")
+    body("not_transmitting_devices_count")
       .exists()
-      .withMessage("offline_devices_count is required")
+      .withMessage("not_transmitting_devices_count is required")
       .bail()
       .isInt({ min: 0 })
-      .withMessage("offline_devices_count must be a non-negative integer")
+      .withMessage("not_transmitting_devices_count must be a non-negative integer")
       .custom((value, { req }) => {
         if (value > req.body.total_deployed_devices) {
           throw new Error(
-            "offline_devices_count cannot exceed total_deployed_devices",
+            "not_transmitting_devices_count cannot exceed total_deployed_devices",
           );
         }
         return true;
       }),
-    body("offline_percentage")
+    body("not_transmitting_percentage")
       .exists()
-      .withMessage("offline_percentage is required")
+      .withMessage("not_transmitting_percentage is required")
       .bail()
       .isFloat({ min: 0, max: 100 })
-      .withMessage("offline_percentage must be between 0 and 100"),
+      .withMessage("not_transmitting_percentage must be between 0 and 100"),
     body("status")
       .exists()
       .withMessage("status is required")

--- a/src/device-registry/validators/test/ut_learn.validators.js
+++ b/src/device-registry/validators/test/ut_learn.validators.js
@@ -1,0 +1,566 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const { validationResult } = require("express-validator");
+const mongoose = require("mongoose");
+
+const mockRequest = (query = {}, body = {}, params = {}) => ({
+  query,
+  body,
+  params,
+  headers: {},
+  get: function(header) {
+    return this.headers[header];
+  },
+});
+
+const runMiddlewareChain = (chain, req) =>
+  new Promise((resolve) => {
+    let idx = 0;
+    const res = {};
+    const runNext = (err) => {
+      if (err || idx >= chain.length) return resolve(err);
+      const mw = chain[idx++];
+      Promise.resolve(mw(req, res, runNext)).catch(runNext);
+    };
+    runNext();
+  });
+
+describe("learnValidations", () => {
+  let validations;
+
+  before(() => {
+    validations = require("@validators/learn.validators");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // ---------------------------------------------------------------------------
+  // getCatalog
+  // ---------------------------------------------------------------------------
+
+  describe("getCatalog", () => {
+    it("should pass with no query params", async () => {
+      const req = mockRequest({});
+      await runMiddlewareChain(validations.getCatalog, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should pass with valid tenant", async () => {
+      const req = mockRequest({ tenant: "airqo" });
+      await runMiddlewareChain(validations.getCatalog, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail with invalid tenant", async () => {
+      const req = mockRequest({ tenant: "invalid_xyz" });
+      await runMiddlewareChain(validations.getCatalog, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getLesson
+  // ---------------------------------------------------------------------------
+
+  describe("getLesson", () => {
+    it("should pass with a valid MongoDB ObjectId as lesson_id", async () => {
+      const req = mockRequest({}, {}, { lesson_id: new mongoose.Types.ObjectId().toString() });
+      await runMiddlewareChain(validations.getLesson, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when lesson_id is not a valid ObjectId", async () => {
+      const req = mockRequest({}, {}, { lesson_id: "not-an-objectid" });
+      await runMiddlewareChain(validations.getLesson, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when lesson_id is missing", async () => {
+      const req = mockRequest({}, {}, {});
+      await runMiddlewareChain(validations.getLesson, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createAnonymousSession
+  // ---------------------------------------------------------------------------
+
+  describe("createAnonymousSession", () => {
+    const validBody = {
+      device_id: "550e8400-e29b-41d4-a716-446655440000",
+    };
+
+    it("should pass with a valid UUID device_id", async () => {
+      const req = mockRequest({}, validBody);
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when device_id is missing", async () => {
+      const req = mockRequest({}, {});
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when device_id is not a valid UUID", async () => {
+      const req = mockRequest({}, { device_id: "not-a-uuid" });
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when platform is not android or ios", async () => {
+      const req = mockRequest({}, { ...validBody, platform: "windows" });
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass when platform is android", async () => {
+      const req = mockRequest({}, { ...validBody, platform: "android" });
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should pass when platform is omitted (optional)", async () => {
+      const req = mockRequest({}, validBody);
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateLessonProgress
+  // ---------------------------------------------------------------------------
+
+  describe("updateLessonProgress", () => {
+    it("should pass with valid lesson_id ObjectId", async () => {
+      const req = mockRequest(
+        {},
+        {},
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.updateLessonProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail with invalid lesson_id", async () => {
+      const req = mockRequest({}, {}, { lesson_id: "bad-id" });
+      await runMiddlewareChain(validations.updateLessonProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when furthest_activity_index is negative", async () => {
+      const req = mockRequest(
+        {},
+        { furthest_activity_index: -1 },
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.updateLessonProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when completed is not a boolean", async () => {
+      const req = mockRequest(
+        {},
+        { completed: "yes" },
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.updateLessonProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when quiz_attempts is not an array", async () => {
+      const req = mockRequest(
+        {},
+        { quiz_attempts: "not-array" },
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.updateLessonProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid quiz_attempts array", async () => {
+      const req = mockRequest(
+        {},
+        {
+          completed: true,
+          quiz_attempts: [
+            { activity_id: "a1", format: "single_choice", is_correct: true },
+          ],
+        },
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.updateLessonProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // syncProgress
+  // ---------------------------------------------------------------------------
+
+  describe("syncProgress", () => {
+    it("should fail when device_id is missing", async () => {
+      const req = mockRequest({}, { updates: [{ lesson_id: "l1" }] });
+      await runMiddlewareChain(validations.syncProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when updates array is empty", async () => {
+      const req = mockRequest(
+        {},
+        { device_id: "550e8400-e29b-41d4-a716-446655440000", updates: [] }
+      );
+      await runMiddlewareChain(validations.syncProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid device_id and non-empty updates", async () => {
+      const req = mockRequest(
+        {},
+        {
+          device_id: "550e8400-e29b-41d4-a716-446655440000",
+          updates: [{ lesson_id: "l1", completed: true }],
+        }
+      );
+      await runMiddlewareChain(validations.syncProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // linkGuestProgress
+  // ---------------------------------------------------------------------------
+
+  describe("linkGuestProgress", () => {
+    it("should fail when device_id is missing", async () => {
+      const req = mockRequest({}, { guest_id: "guest_abc" });
+      await runMiddlewareChain(validations.linkGuestProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when guest_id is missing", async () => {
+      const req = mockRequest(
+        {},
+        { device_id: "550e8400-e29b-41d4-a716-446655440000" }
+      );
+      await runMiddlewareChain(validations.linkGuestProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid device_id UUID and guest_id", async () => {
+      const req = mockRequest(
+        {},
+        {
+          device_id: "550e8400-e29b-41d4-a716-446655440000",
+          guest_id: "guest_abc",
+        }
+      );
+      await runMiddlewareChain(validations.linkGuestProgress, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // issueCertificate
+  // ---------------------------------------------------------------------------
+
+  describe("issueCertificate", () => {
+    it("should fail when course_id is missing", async () => {
+      const req = mockRequest({}, { learner_name: "Alice" });
+      await runMiddlewareChain(validations.issueCertificate, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when course_id is not a valid ObjectId", async () => {
+      const req = mockRequest({}, { course_id: "bad-id" });
+      await runMiddlewareChain(validations.issueCertificate, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid course_id and optional learner_name", async () => {
+      const req = mockRequest(
+        {},
+        {
+          course_id: new mongoose.Types.ObjectId().toString(),
+          learner_name: "Alice",
+        }
+      );
+      await runMiddlewareChain(validations.issueCertificate, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when learner_name exceeds 100 characters", async () => {
+      const req = mockRequest(
+        {},
+        {
+          course_id: new mongoose.Types.ObjectId().toString(),
+          learner_name: "A".repeat(101),
+        }
+      );
+      await runMiddlewareChain(validations.issueCertificate, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // verifyCertificate
+  // ---------------------------------------------------------------------------
+
+  describe("verifyCertificate", () => {
+    it("should pass with a valid verification_code format", async () => {
+      const req = mockRequest({}, {}, { verification_code: "AQ-2025-LEARN-ABCD1234" });
+      await runMiddlewareChain(validations.verifyCertificate, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail with an invalid verification_code format", async () => {
+      const req = mockRequest({}, {}, { verification_code: "INVALID-CODE" });
+      await runMiddlewareChain(validations.verifyCertificate, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when verification_code is missing", async () => {
+      const req = mockRequest({}, {}, {});
+      await runMiddlewareChain(validations.verifyCertificate, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getLeaderboard
+  // ---------------------------------------------------------------------------
+
+  describe("getLeaderboard", () => {
+    it("should pass when limit is within valid range", async () => {
+      const req = mockRequest({ limit: "20" });
+      await runMiddlewareChain(validations.getLeaderboard, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when limit is out of range (> 100)", async () => {
+      const req = mockRequest({ limit: "200" });
+      await runMiddlewareChain(validations.getLeaderboard, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when limit is less than 1", async () => {
+      const req = mockRequest({ limit: "0" });
+      await runMiddlewareChain(validations.getLeaderboard, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createCourse
+  // ---------------------------------------------------------------------------
+
+  describe("createCourse", () => {
+    const validBody = {
+      course_number: 1,
+      title: "Intro to AQ",
+      plain_title_key: "intro_to_aq",
+    };
+
+    it("should pass with required fields", async () => {
+      const req = mockRequest({}, validBody);
+      await runMiddlewareChain(validations.createCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when course_number is missing", async () => {
+      const { course_number, ...body } = validBody;
+      const req = mockRequest({}, body);
+      await runMiddlewareChain(validations.createCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when course_number is less than 1", async () => {
+      const req = mockRequest({}, { ...validBody, course_number: 0 });
+      await runMiddlewareChain(validations.createCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when title exceeds 120 characters", async () => {
+      const req = mockRequest({}, { ...validBody, title: "T".repeat(121) });
+      await runMiddlewareChain(validations.createCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when cover_image_url is not HTTPS", async () => {
+      const req = mockRequest(
+        {},
+        { ...validBody, cover_image_url: "http://insecure.com/img.png" }
+      );
+      await runMiddlewareChain(validations.createCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass when cover_image_url is a valid HTTPS URL", async () => {
+      const req = mockRequest(
+        {},
+        { ...validBody, cover_image_url: "https://example.com/img.png" }
+      );
+      await runMiddlewareChain(validations.createCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addUnit
+  // ---------------------------------------------------------------------------
+
+  describe("addUnit", () => {
+    it("should fail when course_id param is not a valid ObjectId", async () => {
+      const req = mockRequest(
+        {},
+        { title: "Unit 1", plain_title_key: "unit_1", unit_order: 1 },
+        { course_id: "bad-id" }
+      );
+      await runMiddlewareChain(validations.addUnit, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid ObjectId and required body fields", async () => {
+      const req = mockRequest(
+        {},
+        { title: "Unit 1", plain_title_key: "unit_1", unit_order: 1 },
+        { course_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.addUnit, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when unit_order is less than 1", async () => {
+      const req = mockRequest(
+        {},
+        { title: "Unit 1", plain_title_key: "unit_1", unit_order: 0 },
+        { course_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.addUnit, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addLesson
+  // ---------------------------------------------------------------------------
+
+  describe("addLesson", () => {
+    it("should fail when unit_id is not a valid ObjectId", async () => {
+      const req = mockRequest(
+        {},
+        { title: "Lesson 1", plain_title_key: "lesson_1", lesson_order: 1 },
+        { unit_id: "bad-id" }
+      );
+      await runMiddlewareChain(validations.addLesson, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid unit_id and required fields", async () => {
+      const req = mockRequest(
+        {},
+        { title: "Lesson 1", plain_title_key: "lesson_1", lesson_order: 1 },
+        { unit_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.addLesson, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when cover_image_url uses http instead of https", async () => {
+      const req = mockRequest(
+        {},
+        {
+          title: "Lesson 1",
+          plain_title_key: "lesson_1",
+          lesson_order: 1,
+          cover_image_url: "http://insecure.com/img.png",
+        },
+        { unit_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.addLesson, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addActivity
+  // ---------------------------------------------------------------------------
+
+  describe("addActivity", () => {
+    it("should fail when type is not in [article, video, image, quiz]", async () => {
+      const req = mockRequest(
+        {},
+        { type: "audio", order: 1, payload: {} },
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.addActivity, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when order is less than 1", async () => {
+      const req = mockRequest(
+        {},
+        { type: "article", order: 0, payload: {} },
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.addActivity, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when payload is not an object", async () => {
+      const req = mockRequest(
+        {},
+        { type: "article", order: 1, payload: "not-an-object" },
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.addActivity, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid activity fields", async () => {
+      const req = mockRequest(
+        {},
+        { type: "article", order: 1, payload: { body: "content" } },
+        { lesson_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.addActivity, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateCourse
+  // ---------------------------------------------------------------------------
+
+  describe("updateCourse", () => {
+    it("should fail when course_id param is not a valid ObjectId", async () => {
+      const req = mockRequest({}, { title: "New Title" }, { course_id: "bad-id" });
+      await runMiddlewareChain(validations.updateCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid course_id and optional body fields", async () => {
+      const req = mockRequest(
+        {},
+        { title: "New Title" },
+        { course_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.updateCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when published is not a boolean", async () => {
+      const req = mockRequest(
+        {},
+        { published: "yes" },
+        { course_id: new mongoose.Types.ObjectId().toString() }
+      );
+      await runMiddlewareChain(validations.updateCourse, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+});

--- a/src/device-registry/validators/test/ut_network-status.validators.js
+++ b/src/device-registry/validators/test/ut_network-status.validators.js
@@ -1,0 +1,275 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const { validationResult } = require("express-validator");
+const mongoose = require("mongoose");
+
+const mockRequest = (query = {}, body = {}, params = {}) => ({
+  query,
+  body,
+  params,
+  headers: {},
+  get: function(header) {
+    return this.headers[header];
+  },
+});
+
+// Run a middleware chain sequentially and resolve when done
+const runMiddlewareChain = (chain, req) =>
+  new Promise((resolve) => {
+    let idx = 0;
+    const res = {};
+    const runNext = (err) => {
+      if (err || idx >= chain.length) return resolve(err);
+      const mw = chain[idx++];
+      Promise.resolve(mw(req, res, runNext)).catch(runNext);
+    };
+    runNext();
+  });
+
+describe("networkStatusValidations", () => {
+  let validations;
+  let NetworkModelStub;
+
+  before(() => {
+    // Stub the NetworkModel used by validateNetwork to avoid real DB calls
+    const networkNames = ["airqo", "iqair"];
+    NetworkModelStub = sinon.stub().returns({
+      distinct: sinon.stub().resolves(networkNames),
+    });
+
+    validations = require("@validators/network-status.validators");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // ---------------------------------------------------------------------------
+  // create
+  // ---------------------------------------------------------------------------
+
+  describe("create", () => {
+    const validBody = {
+      checked_at: new Date().toISOString(),
+      total_deployed_devices: 100,
+      offline_devices_count: 10,
+      offline_percentage: 10,
+      status: "OK",
+      message: "ok",
+      threshold_exceeded: false,
+      threshold_value: 35,
+    };
+
+    it("should pass with valid body", async () => {
+      const req = mockRequest({}, validBody);
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when checked_at is missing", async () => {
+      const { checked_at, ...body } = validBody;
+      const req = mockRequest({}, body);
+      await runMiddlewareChain(validations.create, req);
+      const errors = validationResult(req);
+      expect(errors.isEmpty()).to.be.false;
+      expect(errors.array().some((e) => e.msg.includes("checked_at"))).to.be.true;
+    });
+
+    it("should fail when checked_at is not a valid ISO date", async () => {
+      const req = mockRequest({}, { ...validBody, checked_at: "not-a-date" });
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when total_deployed_devices is missing", async () => {
+      const { total_deployed_devices, ...body } = validBody;
+      const req = mockRequest({}, body);
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when total_deployed_devices is negative", async () => {
+      const req = mockRequest({}, { ...validBody, total_deployed_devices: -1 });
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when offline_devices_count exceeds total_deployed_devices", async () => {
+      const req = mockRequest(
+        {},
+        { ...validBody, total_deployed_devices: 50, offline_devices_count: 100 }
+      );
+      await runMiddlewareChain(validations.create, req);
+      const errors = validationResult(req);
+      expect(errors.isEmpty()).to.be.false;
+      expect(
+        errors.array().some((e) => e.msg.includes("cannot exceed"))
+      ).to.be.true;
+    });
+
+    it("should fail when status is not in [OK, WARNING, CRITICAL]", async () => {
+      const req = mockRequest({}, { ...validBody, status: "UNKNOWN" });
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when message is missing", async () => {
+      const { message, ...body } = validBody;
+      const req = mockRequest({}, body);
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when threshold_exceeded is missing", async () => {
+      const { threshold_exceeded, ...body } = validBody;
+      const req = mockRequest({}, body);
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when threshold_value is out of range", async () => {
+      const req = mockRequest({}, { ...validBody, threshold_value: 110 });
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should allow alert_type as optional string", async () => {
+      const req = mockRequest({}, { ...validBody, alert_type: "NETWORK_STATUS" });
+      await runMiddlewareChain(validations.create, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // list
+  // ---------------------------------------------------------------------------
+
+  describe("list", () => {
+    it("should pass with no query params", async () => {
+      const req = mockRequest({});
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should pass with valid tenant", async () => {
+      const req = mockRequest({ tenant: "airqo" });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail with invalid tenant", async () => {
+      const req = mockRequest({ tenant: "invalid_tenant_xyz" });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when status is not OK/WARNING/CRITICAL", async () => {
+      const req = mockRequest({ status: "UNKNOWN" });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when threshold_exceeded is not true or false string", async () => {
+      const req = mockRequest({ threshold_exceeded: "yes" });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass when threshold_exceeded is 'true'", async () => {
+      const req = mockRequest({ threshold_exceeded: "true" });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when end_date is before start_date", async () => {
+      const req = mockRequest({
+        start_date: "2025-06-01",
+        end_date: "2025-01-01",
+      });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass with valid date range", async () => {
+      const req = mockRequest({
+        start_date: "2025-01-01",
+        end_date: "2025-06-01",
+      });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getRecentAlerts
+  // ---------------------------------------------------------------------------
+
+  describe("getRecentAlerts", () => {
+    it("should fail when hours is out of range (< 1)", async () => {
+      const req = mockRequest({ hours: "0" });
+      await runMiddlewareChain(validations.getRecentAlerts, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when hours is out of range (> 168)", async () => {
+      const req = mockRequest({ hours: "200" });
+      await runMiddlewareChain(validations.getRecentAlerts, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass when hours is within range", async () => {
+      const req = mockRequest({ hours: "24" });
+      await runMiddlewareChain(validations.getRecentAlerts, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getUptimeSummary
+  // ---------------------------------------------------------------------------
+
+  describe("getUptimeSummary", () => {
+    it("should fail when days is out of range (> 90)", async () => {
+      const req = mockRequest({ days: "100" });
+      await runMiddlewareChain(validations.getUptimeSummary, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass when days is within range", async () => {
+      const req = mockRequest({ days: "7" });
+      await runMiddlewareChain(validations.getUptimeSummary, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getStatistics
+  // ---------------------------------------------------------------------------
+
+  describe("getStatistics", () => {
+    it("should pass with no params", async () => {
+      const req = mockRequest({});
+      await runMiddlewareChain(validations.getStatistics, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail with invalid tenant", async () => {
+      const req = mockRequest({ tenant: "bad_tenant" });
+      await runMiddlewareChain(validations.getStatistics, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getNetworkBreakdown
+  // ---------------------------------------------------------------------------
+
+  describe("getNetworkBreakdown", () => {
+    it("should pass with no params", async () => {
+      const req = mockRequest({});
+      await runMiddlewareChain(validations.getNetworkBreakdown, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+});

--- a/src/device-registry/validators/test/ut_network-status.validators.js
+++ b/src/device-registry/validators/test/ut_network-status.validators.js
@@ -53,8 +53,8 @@ describe("networkStatusValidations", () => {
     const validBody = {
       checked_at: new Date().toISOString(),
       total_deployed_devices: 100,
-      offline_devices_count: 10,
-      offline_percentage: 10,
+      not_transmitting_devices_count: 10,
+      not_transmitting_percentage: 10,
       status: "OK",
       message: "ok",
       threshold_exceeded: false,
@@ -95,10 +95,10 @@ describe("networkStatusValidations", () => {
       expect(validationResult(req).isEmpty()).to.be.false;
     });
 
-    it("should fail when offline_devices_count exceeds total_deployed_devices", async () => {
+    it("should fail when not_transmitting_devices_count exceeds total_deployed_devices", async () => {
       const req = mockRequest(
         {},
-        { ...validBody, total_deployed_devices: 50, offline_devices_count: 100 }
+        { ...validBody, total_deployed_devices: 50, not_transmitting_devices_count: 100 }
       );
       await runMiddlewareChain(validations.create, req);
       const errors = validationResult(req);

--- a/src/device-registry/validators/test/ut_network-status.validators.js
+++ b/src/device-registry/validators/test/ut_network-status.validators.js
@@ -29,15 +29,8 @@ const runMiddlewareChain = (chain, req) =>
 
 describe("networkStatusValidations", () => {
   let validations;
-  let NetworkModelStub;
 
   before(() => {
-    // Stub the NetworkModel used by validateNetwork to avoid real DB calls
-    const networkNames = ["airqo", "iqair"];
-    NetworkModelStub = sinon.stub().returns({
-      distinct: sinon.stub().resolves(networkNames),
-    });
-
     validations = require("@validators/network-status.validators");
   });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds 14 new unit test files (269 tests) covering all untested components introduced by the Learn v2 and NetworkStatus features in device-registry. This includes Mongoose model tests, utility tests, controller tests, and validator tests for both feature areas.

### Why is this change needed?
The Learn v2 course authoring system (8 new models, util, controller, validators) and the NetworkStatus monitoring feature (model, util, controller, validators) shipped without unit test coverage. These tests close that gap, verify schema contracts, stub all DB/Kafka calls, and protect against regressions.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — test layer only; no production code changed

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:**

14 new test files added under `models/test/`, `utils/test/`, `controllers/test/`, and `validators/test/`. All tests use Mocha + Sinon + Chai with proxyquire to stub `getModelByTenant` (no real DB connection required). Full suite: **790 passing, 0 failing**.

| Layer | New Files | New Tests |
|---|---|---|
| Models | `ut_network-status-alert`, `ut_learn-activity`, `ut_learn-certificate`, `ut_learn-course`, `ut_learn-guest-session`, `ut_learn-lesson`, `ut_learn-progress`, `ut_learn-unit` | 108 |
| Utils | `ut_network-status.util`, `ut_learn.util` | 45 |
| Controllers | `ut_network-status.controller`, `ut_learn.controller` | 33 |
| Validators | `ut_network-status.validators`, `ut_learn.validators` | 83 |
| **Total** | **14** | **269** |

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- All model tests load the real Mongoose schema via `proxyquire` (mocking only `@config/database`) so statics like `register`, `list`, `modify`, `remove`, `computeStage`, and `executeAggregation` are exercised against the actual implementation logic.
- Validator tests run the full `express-validator` middleware chain and assert on `validationResult` — no mocking of the validation layer itself.
- No Redis, no external HTTP calls, and no Kafka connections are made during these tests.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broad unit test coverage for learning and network-status controllers, utilities, models, and validators.
  * Improved verification of success responses, error handling, input validation, and data formatting across key API flows.
  * Added checks for certificate, progress, course, lesson, unit, session, and alert behaviors to help catch regressions sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->