### PR TITLE
Add cohort-based filtering to network-status endpoints

### DIFF
--- a/src/device-registry/bin/jobs/check-network-status-job.js
+++ b/src/device-registry/bin/jobs/check-network-status-job.js
@@ -27,6 +27,17 @@ const SUMMARY_JOB_LOG_TYPE = "network-status-summary";
 
 const logThrottleManager = new LogThrottleManager();
 
+// Runs a best-effort breakdown fetch, returning [] instead of throwing on failure
+const fetchBreakdownSafely = async (fetchFn, request, label) => {
+  try {
+    const result = await fetchFn(request);
+    return result && result.success ? result.data : [];
+  } catch (error) {
+    logger.warn(`Could not fetch ${label} breakdown: ${error.message}`);
+    return [];
+  }
+};
+
 const checkNetworkStatus = async () => {
   // Restrict job to run only in production
   if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") {
@@ -74,27 +85,12 @@ const checkNetworkStatus = async () => {
     const totalDeployedDevices = total_monitors;
     const notTransmittingDevicesCount = not_transmitting;
 
-    // Fetch per-network breakdown (non-blocking — failure doesn't affect main alert)
-    let networkBreakdown = [];
-    try {
-      const perNetworkResult = await deviceUtil.getDeviceCountSummaryByNetwork(request);
-      if (perNetworkResult && perNetworkResult.success) {
-        networkBreakdown = perNetworkResult.data;
-      }
-    } catch (networkBreakdownError) {
-      logger.warn(`Could not fetch per-network breakdown: ${networkBreakdownError.message}`);
-    }
-
-    // Fetch per-cohort breakdown (non-blocking — failure doesn't affect main alert)
-    let cohortBreakdown = [];
-    try {
-      const perCohortResult = await deviceUtil.getDeviceCountSummaryByCohort(request);
-      if (perCohortResult && perCohortResult.success) {
-        cohortBreakdown = perCohortResult.data;
-      }
-    } catch (cohortBreakdownError) {
-      logger.warn(`Could not fetch per-cohort breakdown: ${cohortBreakdownError.message}`);
-    }
+    // Fetch per-network and per-cohort breakdowns in parallel
+    // (non-blocking — failure of either doesn't affect the main alert)
+    const [networkBreakdown, cohortBreakdown] = await Promise.all([
+      fetchBreakdownSafely(deviceUtil.getDeviceCountSummaryByNetwork, request, "per-network"),
+      fetchBreakdownSafely(deviceUtil.getDeviceCountSummaryByCohort, request, "per-cohort"),
+    ]);
 
     if (totalDeployedDevices === 0) {
       logText("No deployed devices found");

--- a/src/device-registry/bin/jobs/check-network-status-job.js
+++ b/src/device-registry/bin/jobs/check-network-status-job.js
@@ -85,6 +85,17 @@ const checkNetworkStatus = async () => {
       logger.warn(`Could not fetch per-network breakdown: ${networkBreakdownError.message}`);
     }
 
+    // Fetch per-cohort breakdown (non-blocking — failure doesn't affect main alert)
+    let cohortBreakdown = [];
+    try {
+      const perCohortResult = await deviceUtil.getDeviceCountSummaryByCohort(request);
+      if (perCohortResult && perCohortResult.success) {
+        cohortBreakdown = perCohortResult.data;
+      }
+    } catch (cohortBreakdownError) {
+      logger.warn(`Could not fetch per-cohort breakdown: ${cohortBreakdownError.message}`);
+    }
+
     if (totalDeployedDevices === 0) {
       logText("No deployed devices found");
       logger.warn("🙀🙀 No deployed devices found.");
@@ -159,6 +170,7 @@ const checkNetworkStatus = async () => {
       threshold_exceeded: notTransmittingPercentage >= UPTIME_THRESHOLD,
       threshold_value: UPTIME_THRESHOLD,
       network_breakdown: networkBreakdown,
+      cohort_breakdown: cohortBreakdown,
     };
 
     const alertResult = await networkStatusUtil.createAlert({

--- a/src/device-registry/controllers/network-status.controller.js
+++ b/src/device-registry/controllers/network-status.controller.js
@@ -176,6 +176,16 @@ const networkStatusController = {
       "data"
     );
   },
+
+  getCohortBreakdown: async (req, res, next) => {
+    await handleControllerAction(
+      req,
+      res,
+      next,
+      networkStatusUtil.getCohortBreakdown,
+      "data"
+    );
+  },
 };
 
 module.exports = networkStatusController;

--- a/src/device-registry/controllers/test/ut_network-status.controller.js
+++ b/src/device-registry/controllers/test/ut_network-status.controller.js
@@ -37,6 +37,7 @@ describe("networkStatusController", () => {
       getRecentAlerts: sinon.stub(),
       getUptimeSummary: sinon.stub(),
       getNetworkBreakdown: sinon.stub(),
+      getCohortBreakdown: sinon.stub(),
     };
 
     sharedStub = {
@@ -265,6 +266,26 @@ describe("networkStatusController", () => {
       await controller.getNetworkBreakdown(req, res, next);
 
       expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.data).to.have.lengthOf(1);
+    });
+  });
+
+  describe("getCohortBreakdown", () => {
+    it("should return cohort breakdown data on success", async () => {
+      networkStatusUtilStub.getCohortBreakdown.resolves({
+        success: true,
+        data: [{ _id: "60f5a1b2c3d4e5f678901234", avg_not_transmitting_percentage: 10 }],
+        status: httpStatus.OK,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getCohortBreakdown(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      expect(networkStatusUtilStub.getCohortBreakdown.calledOnce).to.be.true;
       const jsonArgs = res.json.firstCall.args[0];
       expect(jsonArgs.data).to.have.lengthOf(1);
     });

--- a/src/device-registry/models/NetworkStatusAlert.js
+++ b/src/device-registry/models/NetworkStatusAlert.js
@@ -103,6 +103,24 @@ const networkStatusAlertSchema = new Schema(
         },
       },
     ],
+    // Per-cohort breakdown captured at check time
+    cohort_breakdown: [
+      {
+        cohort_id: { type: String },
+        cohort_name: { type: String },
+        total_monitors: { type: Number, default: 0, min: 0 },
+        operational_count: { type: Number, default: 0, min: 0 },
+        transmitting_count: { type: Number, default: 0, min: 0 },
+        data_available_count: { type: Number, default: 0, min: 0 },
+        not_transmitting_count: { type: Number, default: 0, min: 0 },
+        not_transmitting_percentage: {
+          type: Number,
+          default: 0,
+          min: 0,
+          max: 100,
+        },
+      },
+    ],
     // Additional metadata for future analysis
     day_of_week: {
       type: Number,
@@ -157,6 +175,7 @@ networkStatusAlertSchema.methods = {
       day_of_week: this.day_of_week,
       hour_of_day: this.hour_of_day,
       network_breakdown: this.network_breakdown,
+      cohort_breakdown: this.cohort_breakdown,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };
@@ -441,6 +460,144 @@ networkStatusAlertSchema.statics = {
               $sum: {
                 $cond: [
                   { $gte: ["$network_breakdown.not_transmitting_percentage", 35] },
+                  1,
+                  0,
+                ],
+              },
+            },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ];
+
+      return this.executeAggregation({ pipeline }, next);
+    } catch (error) {
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message }
+      );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
+    }
+  },
+
+  async getStatisticsByCohort({ filter = {}, cohort_id } = {}, next) {
+    try {
+      const pipeline = [
+        { $match: filter },
+        {
+          $unwind: {
+            path: "$cohort_breakdown",
+            preserveNullAndEmptyArrays: false,
+          },
+        },
+        ...(cohort_id
+          ? [{ $match: { "cohort_breakdown.cohort_id": cohort_id } }]
+          : []),
+        {
+          $group: {
+            _id: "$cohort_breakdown.cohort_id",
+            cohort_name: { $first: "$cohort_breakdown.cohort_name" },
+            totalChecks: { $sum: 1 },
+            avg_total_monitors: { $avg: "$cohort_breakdown.total_monitors" },
+            avg_operational_count: { $avg: "$cohort_breakdown.operational_count" },
+            avg_transmitting_count: { $avg: "$cohort_breakdown.transmitting_count" },
+            avg_data_available_count: { $avg: "$cohort_breakdown.data_available_count" },
+            avg_not_transmitting_percentage: { $avg: "$cohort_breakdown.not_transmitting_percentage" },
+            max_not_transmitting_percentage: { $max: "$cohort_breakdown.not_transmitting_percentage" },
+            min_not_transmitting_percentage: { $min: "$cohort_breakdown.not_transmitting_percentage" },
+          },
+        },
+        { $sort: { avg_not_transmitting_percentage: -1 } },
+      ];
+
+      return await this.executeAggregation({ pipeline }, next);
+    } catch (error) {
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message }
+      );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
+    }
+  },
+
+  async getHourlyTrendsByCohort({ filter = {}, cohort_id } = {}, next) {
+    try {
+      const pipeline = [
+        { $match: filter },
+        {
+          $unwind: {
+            path: "$cohort_breakdown",
+            preserveNullAndEmptyArrays: false,
+          },
+        },
+        { $match: { "cohort_breakdown.cohort_id": cohort_id } },
+        {
+          $group: {
+            _id: {
+              hour: "$hour_of_day",
+              dayOfWeek: "$day_of_week",
+            },
+            avg_not_transmitting_percentage: {
+              $avg: "$cohort_breakdown.not_transmitting_percentage",
+            },
+            count: { $sum: 1 },
+          },
+        },
+        { $sort: { "_id.dayOfWeek": 1, "_id.hour": 1 } },
+      ];
+
+      return this.executeAggregation({ pipeline }, next);
+    } catch (error) {
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message }
+      );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
+    }
+  },
+
+  async getUptimeSummaryByCohort({ filter = {}, cohort_id } = {}, next) {
+    try {
+      const pipeline = [
+        { $match: filter },
+        {
+          $unwind: {
+            path: "$cohort_breakdown",
+            preserveNullAndEmptyArrays: false,
+          },
+        },
+        { $match: { "cohort_breakdown.cohort_id": cohort_id } },
+        {
+          $group: {
+            _id: {
+              $dateToString: { format: "%Y-%m-%d", date: "$checked_at" },
+            },
+            avgOfflinePercentage: {
+              $avg: "$cohort_breakdown.not_transmitting_percentage",
+            },
+            maxOfflinePercentage: {
+              $max: "$cohort_breakdown.not_transmitting_percentage",
+            },
+            minOfflinePercentage: {
+              $min: "$cohort_breakdown.not_transmitting_percentage",
+            },
+            totalChecks: { $sum: 1 },
+            alertsTriggered: {
+              $sum: {
+                $cond: [
+                  { $gte: ["$cohort_breakdown.not_transmitting_percentage", 35] },
                   1,
                   0,
                 ],

--- a/src/device-registry/models/test/ut_network-status-alert.model.js
+++ b/src/device-registry/models/test/ut_network-status-alert.model.js
@@ -91,6 +91,12 @@ describe("NetworkStatusAlert Model", () => {
     it("should have timestamps enabled", () => {
       expect(Model.schema.options.timestamps).to.be.true;
     });
+
+    it("should define cohort_breakdown as an array field", () => {
+      const path = Model.schema.path("cohort_breakdown");
+      expect(path).to.exist;
+      expect(path.instance).to.equal("Array");
+    });
   });
 
   describe("Static method: register", () => {
@@ -210,6 +216,119 @@ describe("NetworkStatusAlert Model", () => {
       const next = sinon.spy();
 
       await Model.executeAggregation({ pipeline: [] }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: getStatisticsByCohort", () => {
+    it("should unwind cohort_breakdown, match cohort_id, and call executeAggregation", async () => {
+      const execStub = sinon
+        .stub(Model, "executeAggregation")
+        .resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await Model.getStatisticsByCohort(
+        { filter: {}, cohort_id: "60f5a1b2c3d4e5f678901234" },
+        next
+      );
+
+      expect(execStub.calledOnce).to.be.true;
+      const { pipeline } = execStub.firstCall.args[0];
+      expect(
+        pipeline.some(
+          (stage) => stage.$unwind && stage.$unwind.path === "$cohort_breakdown"
+        )
+      ).to.be.true;
+      expect(
+        pipeline.some(
+          (stage) =>
+            stage.$match &&
+            stage.$match["cohort_breakdown.cohort_id"] ===
+              "60f5a1b2c3d4e5f678901234"
+        )
+      ).to.be.true;
+    });
+
+    it("should call next when aggregation fails", async () => {
+      sinon.stub(Model, "aggregate").rejects(new Error("cohort agg error"));
+      const next = sinon.spy();
+
+      await Model.getStatisticsByCohort({ filter: {} }, next);
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: getHourlyTrendsByCohort", () => {
+    it("should match on cohort_id and call executeAggregation", async () => {
+      const execStub = sinon
+        .stub(Model, "executeAggregation")
+        .resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await Model.getHourlyTrendsByCohort(
+        { filter: {}, cohort_id: "60f5a1b2c3d4e5f678901234" },
+        next
+      );
+
+      expect(execStub.calledOnce).to.be.true;
+      const { pipeline } = execStub.firstCall.args[0];
+      expect(
+        pipeline.some(
+          (stage) =>
+            stage.$match &&
+            stage.$match["cohort_breakdown.cohort_id"] ===
+              "60f5a1b2c3d4e5f678901234"
+        )
+      ).to.be.true;
+    });
+
+    it("should call next when aggregation fails", async () => {
+      sinon.stub(Model, "aggregate").rejects(new Error("trend agg error"));
+      const next = sinon.spy();
+
+      await Model.getHourlyTrendsByCohort(
+        { filter: {}, cohort_id: "60f5a1b2c3d4e5f678901234" },
+        next
+      );
+
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe("Static method: getUptimeSummaryByCohort", () => {
+    it("should match on cohort_id and call executeAggregation", async () => {
+      const execStub = sinon
+        .stub(Model, "executeAggregation")
+        .resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await Model.getUptimeSummaryByCohort(
+        { filter: {}, cohort_id: "60f5a1b2c3d4e5f678901234" },
+        next
+      );
+
+      expect(execStub.calledOnce).to.be.true;
+      const { pipeline } = execStub.firstCall.args[0];
+      expect(
+        pipeline.some(
+          (stage) =>
+            stage.$match &&
+            stage.$match["cohort_breakdown.cohort_id"] ===
+              "60f5a1b2c3d4e5f678901234"
+        )
+      ).to.be.true;
+    });
+
+    it("should call next when aggregation fails", async () => {
+      sinon.stub(Model, "aggregate").rejects(new Error("uptime agg error"));
+      const next = sinon.spy();
+
+      await Model.getUptimeSummaryByCohort(
+        { filter: {}, cohort_id: "60f5a1b2c3d4e5f678901234" },
+        next
+      );
 
       expect(next.calledOnce).to.be.true;
     });

--- a/src/device-registry/routes/v2/network-status.routes.js
+++ b/src/device-registry/routes/v2/network-status.routes.js
@@ -51,4 +51,10 @@ router.get(
   networkStatusController.getNetworkBreakdown
 );
 
+router.get(
+  "/breakdown/cohorts",
+  ...networkStatusValidations.getCohortBreakdown,
+  networkStatusController.getCohortBreakdown
+);
+
 module.exports = router;

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -686,6 +686,105 @@ const deviceUtil = {
       throw httpError;
     }
   },
+  getDeviceCountSummaryByCohort: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const filter = generateFilter.devices(request, next);
+
+      const pipeline = [
+        { $match: filter },
+        { $unwind: { path: "$cohorts", preserveNullAndEmptyArrays: false } },
+        {
+          $group: {
+            _id: "$cohorts",
+            total: { $sum: 1 },
+            operational: {
+              $sum: {
+                $cond: [
+                  { $and: [{ $eq: ["$isOnline", true] }, { $eq: ["$rawOnlineStatus", true] }] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            transmitting: {
+              $sum: {
+                $cond: [
+                  { $and: [{ $eq: ["$isOnline", false] }, { $eq: ["$rawOnlineStatus", true] }] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            data_available: {
+              $sum: {
+                $cond: [
+                  { $and: [{ $eq: ["$isOnline", true] }, { $eq: ["$rawOnlineStatus", false] }] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            not_transmitting: {
+              $sum: {
+                $cond: [
+                  { $and: [{ $eq: ["$isOnline", false] }, { $eq: ["$rawOnlineStatus", false] }] },
+                  1,
+                  0,
+                ],
+              },
+            },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ];
+
+      const results = await DeviceModel(tenant)
+        .aggregate(pipeline)
+        .option({ maxTimeMS: 45000 })
+        .allowDiskUse(true);
+
+      const cohortIds = results.map((r) => r._id);
+      const cohorts = await CohortModel(tenant)
+        .find({ _id: { $in: cohortIds } })
+        .select("_id name")
+        .lean();
+      const cohortNameById = {};
+      cohorts.forEach((c) => {
+        cohortNameById[c._id.toString()] = c.name;
+      });
+
+      return {
+        success: true,
+        message: "Successfully retrieved per-cohort health summary.",
+        data: results.map((r) => ({
+          cohort_id: r._id.toString(),
+          cohort_name: cohortNameById[r._id.toString()] || "unknown",
+          total_monitors: r.total,
+          operational_count: r.operational,
+          transmitting_count: r.transmitting,
+          data_available_count: r.data_available,
+          not_transmitting_count: r.not_transmitting,
+          not_transmitting_percentage:
+            r.total > 0
+              ? parseFloat(((r.not_transmitting / r.total) * 100).toFixed(2))
+              : 0,
+        })),
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🪲🪲 Internal Server Error ${error.message}`);
+      const httpError = new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message },
+      );
+      if (typeof next === "function") {
+        return next(httpError);
+      }
+      throw httpError;
+    }
+  },
   getDeviceById: async (req, next) => {
     try {
       const { id } = req.params;

--- a/src/device-registry/utils/network-status.util.js
+++ b/src/device-registry/utils/network-status.util.js
@@ -130,6 +130,7 @@ const networkStatusUtil = {
         status,
         threshold_exceeded,
         network,
+        cohort_id,
       } = query;
 
       const filter = {};
@@ -147,6 +148,12 @@ const networkStatusUtil = {
       if (network) {
         filter.network_breakdown = {
           $elemMatch: { network: network.toLowerCase() },
+        };
+      }
+
+      if (cohort_id) {
+        filter.cohort_breakdown = {
+          $elemMatch: { cohort_id },
         };
       }
 
@@ -179,7 +186,7 @@ const networkStatusUtil = {
   getStatistics: async (request, next) => {
     try {
       const { query } = request;
-      const { tenant, start_date, end_date, network } = query;
+      const { tenant, start_date, end_date, network, cohort_id } = query;
 
       const filter = {};
 
@@ -193,6 +200,13 @@ const networkStatusUtil = {
         const response = await NetworkStatusAlertModel(
           tenant
         ).getStatisticsByNetwork({ filter, network }, next);
+        return response;
+      }
+
+      if (cohort_id) {
+        const response = await NetworkStatusAlertModel(
+          tenant
+        ).getStatisticsByCohort({ filter, cohort_id }, next);
         return response;
       }
 
@@ -217,7 +231,7 @@ const networkStatusUtil = {
   getHourlyTrends: async (request, next) => {
     try {
       const { query } = request;
-      const { tenant, start_date, end_date, network } = query;
+      const { tenant, start_date, end_date, network, cohort_id } = query;
 
       const filter = {};
 
@@ -231,6 +245,13 @@ const networkStatusUtil = {
         const response = await NetworkStatusAlertModel(
           tenant
         ).getHourlyTrendsByNetwork({ filter, network }, next);
+        return response;
+      }
+
+      if (cohort_id) {
+        const response = await NetworkStatusAlertModel(
+          tenant
+        ).getHourlyTrendsByCohort({ filter, cohort_id }, next);
         return response;
       }
 
@@ -255,7 +276,7 @@ const networkStatusUtil = {
   getRecentAlerts: async (request, next) => {
     try {
       const { query } = request;
-      const { tenant, hours = 24, network } = query;
+      const { tenant, hours = 24, network, cohort_id } = query;
 
       const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
 
@@ -265,6 +286,13 @@ const networkStatusUtil = {
         filter.network_breakdown = {
           $elemMatch: {
             network: network.toLowerCase(),
+            not_transmitting_percentage: { $gte: 35 },
+          },
+        };
+      } else if (cohort_id) {
+        filter.cohort_breakdown = {
+          $elemMatch: {
+            cohort_id,
             not_transmitting_percentage: { $gte: 35 },
           },
         };
@@ -297,7 +325,7 @@ const networkStatusUtil = {
   getUptimeSummary: async (request, next) => {
     try {
       const { query } = request;
-      const { tenant, days = 7, network } = query;
+      const { tenant, days = 7, network, cohort_id } = query;
 
       const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
       const filter = { checked_at: { $gte: startDate } };
@@ -306,6 +334,13 @@ const networkStatusUtil = {
         const response = await NetworkStatusAlertModel(
           tenant
         ).getUptimeSummaryByNetwork({ filter, network }, next);
+        return response;
+      }
+
+      if (cohort_id) {
+        const response = await NetworkStatusAlertModel(
+          tenant
+        ).getUptimeSummaryByCohort({ filter, cohort_id }, next);
         return response;
       }
 
@@ -362,6 +397,36 @@ const networkStatusUtil = {
       const response = await NetworkStatusAlertModel(
         tenant
       ).getStatisticsByNetwork({ filter }, next);
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  getCohortBreakdown: async (request, next) => {
+    try {
+      const { query } = request;
+      const { tenant, start_date, end_date } = query;
+
+      const filter = {};
+
+      if (start_date || end_date) {
+        filter.checked_at = {};
+        if (start_date) filter.checked_at.$gte = new Date(start_date);
+        if (end_date) filter.checked_at.$lte = new Date(end_date);
+      }
+
+      const response = await NetworkStatusAlertModel(
+        tenant
+      ).getStatisticsByCohort({ filter }, next);
 
       return response;
     } catch (error) {

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -297,6 +297,171 @@ describe("Device Util", () => {
       expect(thrown.message).to.equal("Internal Server Error");
     });
   });
+  describe("getDeviceCountSummaryByCohort", () => {
+    let sandbox;
+    let aggregateStub;
+    let generateFilterStub;
+    let cohortFindStub;
+
+    // Mirrors the real DeviceModel(tenant).aggregate(pipeline).option(...).allowDiskUse(true) chain
+    const createAggregateChain = (result, error) => ({
+      option: sinon.stub().returns({
+        allowDiskUse: sinon
+          .stub()
+          .returns(error ? Promise.reject(error) : Promise.resolve(result)),
+      }),
+    });
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      aggregateStub = sandbox.stub();
+      cohortFindStub = sandbox.stub();
+      const modelStub = sandbox.stub(mongoose, "model");
+      modelStub.withArgs("devices").returns({ aggregate: aggregateStub });
+      modelStub.withArgs("cohorts").returns({ find: cohortFindStub });
+      generateFilterStub = sandbox.stub(generateFilter, "devices");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should group results by cohort, look up cohort names, and compute percentages", async () => {
+      const cohortIdA = new mongoose.Types.ObjectId();
+      const cohortIdB = new mongoose.Types.ObjectId();
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+
+      aggregateStub.returns(
+        createAggregateChain([
+          {
+            _id: cohortIdA,
+            total: 100,
+            operational: 70,
+            transmitting: 15,
+            data_available: 5,
+            not_transmitting: 10,
+          },
+          {
+            _id: cohortIdB,
+            total: 50,
+            operational: 20,
+            transmitting: 5,
+            data_available: 0,
+            not_transmitting: 25,
+          },
+        ]),
+      );
+
+      cohortFindStub.returns({
+        select: sinon.stub().returns({
+          lean: sinon.stub().resolves([
+            { _id: cohortIdA, name: "Kampala Cohort" },
+            { _id: cohortIdB, name: "Jinja Cohort" },
+          ]),
+        }),
+      });
+
+      const result = await deviceUtil.getDeviceCountSummaryByCohort(request);
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.OK);
+      expect(result.data).to.deep.equal([
+        {
+          cohort_id: cohortIdA.toString(),
+          cohort_name: "Kampala Cohort",
+          total_monitors: 100,
+          operational_count: 70,
+          transmitting_count: 15,
+          data_available_count: 5,
+          not_transmitting_count: 10,
+          not_transmitting_percentage: 10,
+        },
+        {
+          cohort_id: cohortIdB.toString(),
+          cohort_name: "Jinja Cohort",
+          total_monitors: 50,
+          operational_count: 20,
+          transmitting_count: 5,
+          data_available_count: 0,
+          not_transmitting_count: 25,
+          not_transmitting_percentage: 50,
+        },
+      ]);
+    });
+
+    it("should unwind the cohorts array in the pipeline", async () => {
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+      aggregateStub.returns(createAggregateChain([]));
+      cohortFindStub.returns({
+        select: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+      });
+
+      await deviceUtil.getDeviceCountSummaryByCohort(request);
+
+      expect(aggregateStub.calledOnce).to.be.true;
+      const pipeline = aggregateStub.getCall(0).args[0];
+      const unwindStage = pipeline.find((stage) => stage.$unwind);
+      expect(unwindStage.$unwind.path).to.equal("$cohorts");
+      expect(unwindStage.$unwind.preserveNullAndEmptyArrays).to.be.false;
+    });
+
+    it("should default cohort_name to 'unknown' when the cohort can't be found", async () => {
+      const cohortId = new mongoose.Types.ObjectId();
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+      aggregateStub.returns(
+        createAggregateChain([
+          {
+            _id: cohortId,
+            total: 10,
+            operational: 5,
+            transmitting: 2,
+            data_available: 1,
+            not_transmitting: 2,
+          },
+        ]),
+      );
+      cohortFindStub.returns({
+        select: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+      });
+
+      const result = await deviceUtil.getDeviceCountSummaryByCohort(request);
+
+      expect(result.data[0].cohort_name).to.equal("unknown");
+    });
+
+    it("should return an empty array when no devices match the filter", async () => {
+      const request = { query: { tenant: "airqo" } };
+      generateFilterStub.returns({});
+      aggregateStub.returns(createAggregateChain([]));
+      cohortFindStub.returns({
+        select: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+      });
+
+      const result = await deviceUtil.getDeviceCountSummaryByCohort(request);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal([]);
+    });
+
+    it("should call next with an HttpError when aggregation fails", async () => {
+      const request = { query: { tenant: "airqo" } };
+      const next = sinon.spy();
+      generateFilterStub.returns({});
+      const dbError = new Error("Database connection failed");
+      aggregateStub.returns(createAggregateChain(null, dbError));
+
+      await deviceUtil.getDeviceCountSummaryByCohort(request, next);
+
+      expect(next.calledOnce).to.be.true;
+      const error = next.firstCall.args[0];
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error.statusCode).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+      expect(error.message).to.equal("Internal Server Error");
+    });
+  });
   describe("createOnPlatform", () => {
     let sandbox;
     let deviceRegisterStub,

--- a/src/device-registry/utils/test/ut_network-status.util.js
+++ b/src/device-registry/utils/test/ut_network-status.util.js
@@ -18,9 +18,12 @@ describe("networkStatusUtil", () => {
       list: sinon.stub(),
       getStatistics: sinon.stub(),
       getStatisticsByNetwork: sinon.stub(),
+      getStatisticsByCohort: sinon.stub(),
       getHourlyTrends: sinon.stub(),
       getHourlyTrendsByNetwork: sinon.stub(),
+      getHourlyTrendsByCohort: sinon.stub(),
       getUptimeSummaryByNetwork: sinon.stub(),
+      getUptimeSummaryByCohort: sinon.stub(),
       executeAggregation: sinon.stub(),
     };
 
@@ -222,6 +225,22 @@ describe("networkStatusUtil", () => {
       expect(passedArgs.filter).to.have.property("network_breakdown");
     });
 
+    it("should add cohort elemMatch filter when cohort_id query param is provided", async () => {
+      modelInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.list(
+        { query: { tenant: "airqo", cohort_id: "60f5a1b2c3d4e5f678901234" } },
+        next
+      );
+
+      const passedArgs = modelInstance.list.firstCall.args[0];
+      expect(passedArgs.filter).to.have.property("cohort_breakdown");
+      expect(passedArgs.filter.cohort_breakdown.$elemMatch).to.deep.equal({
+        cohort_id: "60f5a1b2c3d4e5f678901234",
+      });
+    });
+
     it("should call next on error", async () => {
       modelInstance.list.rejects(new Error("db error"));
       const next = sinon.spy();
@@ -253,6 +272,18 @@ describe("networkStatusUtil", () => {
 
       expect(modelInstance.getStatisticsByNetwork.calledOnce).to.be.true;
     });
+
+    it("should call getStatisticsByCohort when cohort_id query param is provided", async () => {
+      modelInstance.getStatisticsByCohort.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getStatistics(
+        { query: { tenant: "airqo", cohort_id: "60f5a1b2c3d4e5f678901234" } },
+        next
+      );
+
+      expect(modelInstance.getStatisticsByCohort.calledOnce).to.be.true;
+    });
   });
 
   describe("getHourlyTrends", () => {
@@ -275,6 +306,18 @@ describe("networkStatusUtil", () => {
       );
 
       expect(modelInstance.getHourlyTrendsByNetwork.calledOnce).to.be.true;
+    });
+
+    it("should call getHourlyTrendsByCohort when cohort_id is specified", async () => {
+      modelInstance.getHourlyTrendsByCohort.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getHourlyTrends(
+        { query: { tenant: "airqo", cohort_id: "60f5a1b2c3d4e5f678901234" } },
+        next
+      );
+
+      expect(modelInstance.getHourlyTrendsByCohort.calledOnce).to.be.true;
     });
   });
 
@@ -304,6 +347,19 @@ describe("networkStatusUtil", () => {
       const passedArgs = modelInstance.list.firstCall.args[0];
       expect(passedArgs.filter).to.have.property("network_breakdown");
     });
+
+    it("should add cohort breakdown elemMatch filter when cohort_id is provided", async () => {
+      modelInstance.list.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getRecentAlerts(
+        { query: { tenant: "airqo", cohort_id: "60f5a1b2c3d4e5f678901234" } },
+        next
+      );
+
+      const passedArgs = modelInstance.list.firstCall.args[0];
+      expect(passedArgs.filter).to.have.property("cohort_breakdown");
+    });
   });
 
   describe("getUptimeSummary", () => {
@@ -317,6 +373,18 @@ describe("networkStatusUtil", () => {
       );
 
       expect(modelInstance.getUptimeSummaryByNetwork.calledOnce).to.be.true;
+    });
+
+    it("should call getUptimeSummaryByCohort when cohort_id is provided", async () => {
+      modelInstance.getUptimeSummaryByCohort.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getUptimeSummary(
+        { query: { tenant: "airqo", days: "7", cohort_id: "60f5a1b2c3d4e5f678901234" } },
+        next
+      );
+
+      expect(modelInstance.getUptimeSummaryByCohort.calledOnce).to.be.true;
     });
 
     it("should call executeAggregation for global uptime when no network", async () => {
@@ -343,6 +411,22 @@ describe("networkStatusUtil", () => {
       );
 
       expect(modelInstance.getStatisticsByNetwork.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getCohortBreakdown", () => {
+    it("should call getStatisticsByCohort without a specific cohort_id", async () => {
+      modelInstance.getStatisticsByCohort.resolves({ success: true, data: [] });
+      const next = sinon.spy();
+
+      await networkStatusUtil.getCohortBreakdown(
+        { query: { tenant: "airqo" } },
+        next
+      );
+
+      expect(modelInstance.getStatisticsByCohort.calledOnce).to.be.true;
+      const passedArgs = modelInstance.getStatisticsByCohort.firstCall.args[0];
+      expect(passedArgs.cohort_id).to.be.undefined;
     });
   });
 });

--- a/src/device-registry/validators/network-status.validators.js
+++ b/src/device-registry/validators/network-status.validators.js
@@ -30,6 +30,16 @@ const commonValidations = {
       .toLowerCase()
       .custom(validateNetwork),
   ],
+  cohort_id: [
+    query("cohort_id")
+      .optional()
+      .notEmpty()
+      .withMessage("cohort_id cannot be empty if provided")
+      .bail()
+      .trim()
+      .isMongoId()
+      .withMessage("cohort_id must be a valid MongoDB ObjectId"),
+  ],
   dateRange: [
     query("start_date")
       .optional()
@@ -123,6 +133,7 @@ const networkStatusValidations = {
   list: [
     ...commonValidations.tenant,
     ...commonValidations.network,
+    ...commonValidations.cohort_id,
     ...commonValidations.dateRange,
     query("status")
       .optional()
@@ -137,18 +148,21 @@ const networkStatusValidations = {
   getStatistics: [
     ...commonValidations.tenant,
     ...commonValidations.network,
+    ...commonValidations.cohort_id,
     ...commonValidations.dateRange,
   ],
 
   getHourlyTrends: [
     ...commonValidations.tenant,
     ...commonValidations.network,
+    ...commonValidations.cohort_id,
     ...commonValidations.dateRange,
   ],
 
   getRecentAlerts: [
     ...commonValidations.tenant,
     ...commonValidations.network,
+    ...commonValidations.cohort_id,
     query("hours")
       .optional()
       .isInt({ min: 1, max: 168 })
@@ -159,6 +173,7 @@ const networkStatusValidations = {
   getUptimeSummary: [
     ...commonValidations.tenant,
     ...commonValidations.network,
+    ...commonValidations.cohort_id,
     query("days")
       .optional()
       .isInt({ min: 1, max: 90 })
@@ -167,6 +182,11 @@ const networkStatusValidations = {
   ],
 
   getNetworkBreakdown: [
+    ...commonValidations.tenant,
+    ...commonValidations.dateRange,
+  ],
+
+  getCohortBreakdown: [
     ...commonValidations.tenant,
     ...commonValidations.dateRange,
   ],

--- a/src/device-registry/validators/network-status.validators.js
+++ b/src/device-registry/validators/network-status.validators.js
@@ -37,8 +37,16 @@ const commonValidations = {
       .withMessage("cohort_id cannot be empty if provided")
       .bail()
       .trim()
+      .toLowerCase()
       .isMongoId()
-      .withMessage("cohort_id must be a valid MongoDB ObjectId"),
+      .withMessage("cohort_id must be a valid MongoDB ObjectId")
+      .bail()
+      .custom((value, { req }) => {
+        if (req.query.network) {
+          throw new Error("Provide either network or cohort_id, not both");
+        }
+        return true;
+      }),
   ],
   dateRange: [
     query("start_date")

--- a/src/device-registry/validators/test/ut_network-status.validators.js
+++ b/src/device-registry/validators/test/ut_network-status.validators.js
@@ -192,6 +192,31 @@ describe("networkStatusValidations", () => {
       await runMiddlewareChain(validations.list, req);
       expect(validationResult(req).isEmpty()).to.be.true;
     });
+
+    it("should pass with a valid cohort_id", async () => {
+      const req = mockRequest({ cohort_id: "60f5a1b2c3d4e5f678901234" });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail with an invalid cohort_id", async () => {
+      const req = mockRequest({ cohort_id: "not-an-object-id" });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when both network and cohort_id are provided", async () => {
+      const req = mockRequest({
+        network: "airqo",
+        cohort_id: "60f5a1b2c3d4e5f678901234",
+      });
+      await runMiddlewareChain(validations.list, req);
+      const errors = validationResult(req);
+      expect(errors.isEmpty()).to.be.false;
+      expect(
+        errors.array().some((e) => e.msg.includes("not both"))
+      ).to.be.true;
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -262,6 +287,18 @@ describe("networkStatusValidations", () => {
     it("should pass with no params", async () => {
       const req = mockRequest({});
       await runMiddlewareChain(validations.getNetworkBreakdown, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getCohortBreakdown
+  // ---------------------------------------------------------------------------
+
+  describe("getCohortBreakdown", () => {
+    it("should pass with no params", async () => {
+      const req = mockRequest({});
+      await runMiddlewareChain(validations.getCohortBreakdown, req);
       expect(validationResult(req).isEmpty()).to.be.true;
     });
   });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds cohort-based filtering to the Beacon network-status endpoints, mirroring the existing per-network (manufacturer) filtering. Devices, alerts, statistics, hourly trends, recent alerts, and uptime summaries can now be filtered by `cohort_id`, and a new `GET /breakdown/cohorts` endpoint returns a side-by-side breakdown across all cohorts.

### Why is this change needed?
The per-manufacturer breakdown shipped for Beacon, but the frontend team asked whether the same endpoints support filtering by cohort. Cohort filtering already existed for device-summary endpoints but was never extended to network-status alerts, so this closes that gap using the same pattern already validated for `network`.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** device-registry

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran the existing network-status unit test suite (model, util, validators, controller — 77 tests) to confirm no regressions. New cohort code paths mirror already-tested network code paths; syntax-checked all changed files. No new automated tests added yet for the cohort-specific branches.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- New optional `cohort_id` query param (validated as a MongoDB ObjectId) accepted on `GET /`, `/statistics`, `/trends/hourly`, `/recent`, and `/uptime-summary`.
- New `GET /breakdown/cohorts` endpoint returns per-cohort stats for all cohorts in one call, for comparison views.
- `cohort_breakdown` is now captured and stored on each network-status check record going forward — historical alerts won't have this data, same limitation the network breakdown already has.
- The per-network `network_breakdown` behavior is unchanged.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cohort-based network status views and breakdowns.
  * Introduced a new endpoint for retrieving cohort breakdown data.
  * Added cohort-level summaries and trends for network status reporting.

* **Bug Fixes**
  * Network status alerts now include cohort breakdown details when available.
  * Cohort data fetch failures no longer block alert generation; they now log a warning and continue.

* **Validation**
  * Added support for filtering network status requests by cohort ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->