### PR TITLE
Fix Learn level/points sync, quiz answer validation, guest identity

### DIFF
--- a/src/device-registry/models/LearnGuestSession.js
+++ b/src/device-registry/models/LearnGuestSession.js
@@ -10,6 +10,31 @@ const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- learn-guest-session-model`
 );
 
+// Word lists + icon set used to give every guest a friendly, anonymous
+// identity for leaderboard display instead of exposing their raw guest_id
+// (e.g. "guest_lz3k9f2a"). Picked once at session creation and kept for the
+// lifetime of the guest session so the name/icon stay stable across requests.
+const NAME_ADJECTIVES = [
+  "Curious", "Bright", "Swift", "Gentle", "Bold", "Sunny", "Clever", "Calm",
+  "Vivid", "Windy", "Misty", "Breezy", "Cosmic", "Cheerful", "Fearless",
+];
+const NAME_ANIMALS = [
+  "Falcon", "Otter", "Panda", "Heron", "Fox", "Koala", "Toucan", "Lynx",
+  "Dolphin", "Sparrow", "Badger", "Gazelle", "Owl", "Rabbit", "Wolf",
+];
+const AVATAR_ICONS = [
+  "🦊", "🦦", "🐼", "🦅", "🐨", "🦜", "🐬", "🦉", "🐇", "🦋", "🐸", "🦩",
+];
+
+function generateGuestIdentity() {
+  const adjective =
+    NAME_ADJECTIVES[Math.floor(Math.random() * NAME_ADJECTIVES.length)];
+  const animal = NAME_ANIMALS[Math.floor(Math.random() * NAME_ANIMALS.length)];
+  const suffix = Math.floor(Math.random() * 900 + 100); // 3-digit tail avoids collisions reading like real usernames
+  const avatar_icon = AVATAR_ICONS[Math.floor(Math.random() * AVATAR_ICONS.length)];
+  return { display_name: `${adjective} ${animal} ${suffix}`, avatar_icon };
+}
+
 const learnGuestSessionSchema = new Schema(
   {
     device_id: {
@@ -24,6 +49,10 @@ const learnGuestSessionSchema = new Schema(
       trim: true,
     },
     display_name: {
+      type: String,
+      trim: true,
+    },
+    avatar_icon: {
       type: String,
       trim: true,
     },
@@ -100,8 +129,14 @@ learnGuestSessionSchema.statics = {
       }
       const suffix = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
       const guest_id = `guest_${suffix}`;
+      const { display_name, avatar_icon } = generateGuestIdentity();
       try {
-        const created = await this.create({ ...args, guest_id, display_name: guest_id });
+        const created = await this.create({
+          ...args,
+          guest_id,
+          display_name,
+          avatar_icon,
+        });
         return {
           success: true,
           data: created._doc,

--- a/src/device-registry/models/LearnProgress.js
+++ b/src/device-registry/models/LearnProgress.js
@@ -9,8 +9,17 @@ const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- learn-progress-model`
 );
+const {
+  STAGES,
+  computeStage,
+  POINTS_PER_QUESTION,
+  DEFAULT_MAX_LEARN_POINTS,
+} = require("@utils/learn-progress.constants");
 
-const MAX_LEARN_POINTS = 2400;
+// Retained as the fallback max-points value for callers that don't pass one
+// explicitly (e.g. legacy calls to mergeGuestToUser). Callers should prefer
+// passing the catalog-derived value from utils/learn.util.js.
+const MAX_LEARN_POINTS = DEFAULT_MAX_LEARN_POINTS;
 
 // Per-lesson progress sub-document
 const lessonProgressSchema = new Schema(
@@ -52,24 +61,6 @@ learnProgressSchema.index({ guest_id: 1 }, { sparse: true });
 learnProgressSchema.index({ user_id: 1 }, { sparse: true });
 learnProgressSchema.index({ device_id: 1 }, { unique: true });
 learnProgressSchema.index({ learner_type: 1, total_points: -1 });
-
-const STAGES = [
-  { index: 0, name: "Curious" },
-  { index: 1, name: "Aware" },
-  { index: 2, name: "Observer" },
-  { index: 3, name: "Champion" },
-  { index: 4, name: "Defender" },
-];
-
-function computeStage(totalPoints, maxPoints) {
-  if (!maxPoints || maxPoints === 0) return STAGES[0];
-  const ratio = totalPoints / maxPoints;
-  if (ratio >= 1.0) return STAGES[4];
-  if (ratio >= 0.75) return STAGES[3];
-  if (ratio >= 0.5) return STAGES[2];
-  if (ratio >= 0.25) return STAGES[1];
-  return STAGES[0];
-}
 
 // Normalize a lessons field from either a Mongoose Map or a plain object to a plain object
 function normalizeLessons(lessons) {
@@ -114,7 +105,7 @@ learnProgressSchema.statics = {
         );
         const correct = graded.filter((a) => a.is_correct).length;
         quizScoreRatio = graded.length > 0 ? correct / graded.length : 1.0;
-        pointsEarned = correct * 10;
+        pointsEarned = correct * POINTS_PER_QUESTION;
 
         if (graded.length === 0) stars = 1;
         else if (quizScoreRatio === 1.0) stars = 3;
@@ -124,7 +115,7 @@ learnProgressSchema.statics = {
         const newPoints = update.quiz_attempts
           ? update.quiz_attempts.filter(
               (a) => a.format !== "free_text" && a.is_correct
-            ).length * 10
+            ).length * POINTS_PER_QUESTION
           : pointsEarned;
         pointsEarned = Math.max(pointsEarned, newPoints);
       }
@@ -228,7 +219,7 @@ learnProgressSchema.statics = {
     }
   },
 
-  async mergeGuestToUser({ device_id, guest_id, user_id }, next) {
+  async mergeGuestToUser({ device_id, guest_id, user_id, maxPoints }, next) {
     try {
       // Work with the existing guest doc (identified by device_id)
       const guestDoc = await this.findOne({ device_id });
@@ -271,7 +262,7 @@ learnProgressSchema.statics = {
         pointsTransferred += lp.points_earned || 0;
       });
 
-      const stage = computeStage(totalPoints, MAX_LEARN_POINTS);
+      const stage = computeStage(totalPoints, maxPoints || MAX_LEARN_POINTS);
 
       // Promote the existing guest doc in place — avoids colliding with the unique device_id index
       const lessonsMap = {};

--- a/src/device-registry/utils/learn-progress.constants.js
+++ b/src/device-registry/utils/learn-progress.constants.js
@@ -1,0 +1,35 @@
+// Single source of truth for Learn module scoring — shared by models/LearnProgress.js
+// and utils/learn.util.js so the "level"/stage shown to a learner can never drift
+// between the value persisted on their progress doc and the value used to build
+// the catalog/leaderboard responses.
+
+const POINTS_PER_QUESTION = 10;
+
+// Fallback used only when the catalog has no gradable quiz activities yet
+// (e.g. a fresh tenant) — see getMaxLearnPoints in utils/learn.util.js.
+const DEFAULT_MAX_LEARN_POINTS = 2400;
+
+const STAGES = [
+  { index: 0, name: "Curious" },
+  { index: 1, name: "Aware" },
+  { index: 2, name: "Observer" },
+  { index: 3, name: "Champion" },
+  { index: 4, name: "Defender" },
+];
+
+function computeStage(totalPoints, maxPoints) {
+  if (!maxPoints || maxPoints === 0) return STAGES[0];
+  const ratio = totalPoints / maxPoints;
+  if (ratio >= 1.0) return STAGES[4];
+  if (ratio >= 0.75) return STAGES[3];
+  if (ratio >= 0.5) return STAGES[2];
+  if (ratio >= 0.25) return STAGES[1];
+  return STAGES[0];
+}
+
+module.exports = {
+  STAGES,
+  computeStage,
+  POINTS_PER_QUESTION,
+  DEFAULT_MAX_LEARN_POINTS,
+};

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -15,18 +15,47 @@ const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- learn-util`);
 const isEmpty = require("is-empty");
 const {
   STAGES,
+  computeStage,
   POINTS_PER_QUESTION,
   DEFAULT_MAX_LEARN_POINTS,
 } = require("@utils/learn-progress.constants");
 
+// Lesson ids belonging to published courses only — draft/unpublished course
+// content is invisible to learners and must not count toward max_points.
+async function getPublishedLessonIds(tenant, next) {
+  const coursesRes = await LearnCourseModel(tenant).list(
+    { filter: { published: true }, limit: 0 },
+    next
+  );
+  const courseIds = (coursesRes?.data || []).map((c) => c._id);
+  if (courseIds.length === 0) return [];
+
+  const unitsRes = await LearnUnitModel(tenant).list(
+    { filter: { course_id: { $in: courseIds } }, limit: 0 },
+    next
+  );
+  const unitIds = (unitsRes?.data || []).map((u) => u._id);
+  if (unitIds.length === 0) return [];
+
+  const lessonsRes = await LearnLessonModel(tenant).list(
+    { filter: { unit_id: { $in: unitIds } }, limit: 0 },
+    next
+  );
+  return (lessonsRes?.data || []).map((l) => l._id);
+}
+
 // The true "max points" for the Learn stage/level calculation is derived from
-// the live catalog (one gradable quiz question = POINTS_PER_QUESTION), not a
-// hardcoded number — otherwise adding/removing lessons via Course Management
-// silently desyncs the stage shown from the points actually earned.
+// the live, published catalog (one gradable quiz question =
+// POINTS_PER_QUESTION), not a hardcoded number — otherwise adding/removing
+// lessons via Course Management silently desyncs the stage shown from the
+// points actually earned.
 async function getMaxLearnPoints(tenant, next) {
   try {
+    const lessonIds = await getPublishedLessonIds(tenant, next);
+    if (lessonIds.length === 0) return DEFAULT_MAX_LEARN_POINTS;
+
     const activitiesRes = await LearnActivityModel(tenant).list(
-      { filter: { type: "quiz" } },
+      { filter: { type: "quiz", lesson_id: { $in: lessonIds } }, limit: 0 },
       next
     );
     const gradableCount = (activitiesRes?.data || []).filter(
@@ -36,6 +65,7 @@ async function getMaxLearnPoints(tenant, next) {
       ? gradableCount * POINTS_PER_QUESTION
       : DEFAULT_MAX_LEARN_POINTS;
   } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error -- getMaxLearnPoints: ${error.message}`);
     return DEFAULT_MAX_LEARN_POINTS;
   }
 }
@@ -121,11 +151,13 @@ async function gradeQuizAttempts(tenant, quizAttempts, next) {
       return attempt;
     }
     const activity = activitiesById.get(String(attempt.activity_id));
-    const isCorrect =
-      activity?.type === "quiz"
-        ? isAttemptCorrect(attempt, activity.payload)
-        : false;
-    return { ...attempt, is_correct: isCorrect };
+    if (activity?.type !== "quiz") {
+      // Can't verify this one server-side (missing/invalid activity_id, or it
+      // doesn't resolve to a real quiz activity) — fall back to trusting the
+      // client rather than failing the attempt closed.
+      return attempt;
+    }
+    return { ...attempt, is_correct: isAttemptCorrect(attempt, activity.payload) };
   });
 }
 
@@ -137,6 +169,14 @@ async function gradeQuizAttempts(tenant, quizAttempts, next) {
 function validateQuizCorrectAnswer(payload) {
   const { format, options, correct_index, correct_indices, correct_order } =
     payload || {};
+
+  const allowedFormats = ["single_choice", "multi_choice", "ranking", "free_text"];
+  if (!allowedFormats.includes(format)) {
+    return {
+      field: "payload.format",
+      message: `format must be one of: ${allowedFormats.join(", ")}`,
+    };
+  }
   if (format === "free_text") return null;
 
   if (!Array.isArray(options) || options.length < 2) {
@@ -470,7 +510,10 @@ const learn = {
         };
       }
 
-      const stage = STAGES[doc.current_stage_index] || STAGES[0];
+      // Recomputed live from total_points/maxPoints rather than trusting the
+      // persisted current_stage_index, which can go stale if the catalog
+      // (and therefore maxPoints) has changed since the last progress write.
+      const stage = computeStage(doc.total_points, maxPoints);
       const lessonsOut = {};
       if (doc.lessons) {
         const entries =
@@ -1825,6 +1868,7 @@ const learn = {
 
       const limit = Math.min(parseInt(request.query.limit) || 20, 100);
       const LearnProgress = LearnProgressModel(tenant);
+      const maxPoints = await getMaxLearnPoints(tenant, next);
 
       // Guests are ranked alongside registered users — they're identified by
       // a random display name/icon (see LearnGuestSession) rather than being
@@ -1834,9 +1878,7 @@ const learn = {
       })
         .sort({ total_points: -1 })
         .limit(limit)
-        .select(
-          "user_id guest_id learner_type total_points current_stage_index completed_lessons"
-        )
+        .select("user_id guest_id learner_type total_points completed_lessons")
         .lean();
 
       const guestIds = topLearners
@@ -1883,7 +1925,10 @@ const learn = {
               avatar_icon: guestIdentity?.avatar_icon || undefined,
               total_points: l.total_points,
               completed_lessons: l.completed_lessons,
-              current_stage: STAGES[l.current_stage_index] || STAGES[0],
+              // Computed live so a leaderboard row can never disagree with
+              // getProgress/getCatalog if the catalog changed since this
+              // learner's last write.
+              current_stage: computeStage(l.total_points, maxPoints),
               is_current_user: l.user_id === user_id,
             };
           }),

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -1,4 +1,5 @@
 const crypto = require("crypto");
+const mongoose = require("mongoose");
 const httpStatus = require("http-status");
 const LearnCourseModel = require("@models/LearnCourse");
 const LearnUnitModel = require("@models/LearnUnit");
@@ -12,16 +13,186 @@ const { logObject, HttpError } = require("@utils/shared");
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- learn-util`);
 const isEmpty = require("is-empty");
+const {
+  STAGES,
+  POINTS_PER_QUESTION,
+  DEFAULT_MAX_LEARN_POINTS,
+} = require("@utils/learn-progress.constants");
 
-const MAX_LEARN_POINTS = 2400;
+// The true "max points" for the Learn stage/level calculation is derived from
+// the live catalog (one gradable quiz question = POINTS_PER_QUESTION), not a
+// hardcoded number — otherwise adding/removing lessons via Course Management
+// silently desyncs the stage shown from the points actually earned.
+async function getMaxLearnPoints(tenant, next) {
+  try {
+    const activitiesRes = await LearnActivityModel(tenant).list(
+      { filter: { type: "quiz" } },
+      next
+    );
+    const gradableCount = (activitiesRes?.data || []).filter(
+      (a) => a.payload?.format && a.payload.format !== "free_text"
+    ).length;
+    return gradableCount > 0
+      ? gradableCount * POINTS_PER_QUESTION
+      : DEFAULT_MAX_LEARN_POINTS;
+  } catch (error) {
+    return DEFAULT_MAX_LEARN_POINTS;
+  }
+}
 
-const STAGES = [
-  { index: 0, name: "Curious" },
-  { index: 1, name: "Aware" },
-  { index: 2, name: "Observer" },
-  { index: 3, name: "Champion" },
-  { index: 4, name: "Defender" },
-];
+// Checks one submitted quiz attempt against the correct-answer fields stored on
+// the activity's own payload (as authored in Course Management), rather than
+// trusting whatever `is_correct` a client sends.
+function isAttemptCorrect(attempt, quizPayload = {}) {
+  switch (attempt.format) {
+    case "single_choice":
+      return (
+        typeof quizPayload.correct_index === "number" &&
+        attempt.selected_index === quizPayload.correct_index
+      );
+    case "multi_choice": {
+      const expected = Array.isArray(quizPayload.correct_indices)
+        ? [...quizPayload.correct_indices].sort((a, b) => a - b)
+        : [];
+      const selected = Array.isArray(attempt.selected_indices)
+        ? [...attempt.selected_indices].sort((a, b) => a - b)
+        : [];
+      return (
+        expected.length > 0 &&
+        expected.length === selected.length &&
+        expected.every((v, i) => v === selected[i])
+      );
+    }
+    case "ranking": {
+      const expected = Array.isArray(quizPayload.correct_order)
+        ? quizPayload.correct_order
+        : [];
+      const selected = Array.isArray(attempt.selected_order)
+        ? attempt.selected_order
+        : [];
+      return (
+        expected.length > 0 &&
+        expected.length === selected.length &&
+        expected.every((v, i) => v === selected[i])
+      );
+    }
+    default:
+      return false;
+  }
+}
+
+// A quiz attempt only carries a real answer (`selected_index` /
+// `selected_indices` / `selected_order`) once the calling client has been
+// updated to submit it — until then we fall back to trusting the client's
+// own `is_correct` so existing app versions keep working unchanged.
+function attemptHasSubmittedAnswer(attempt) {
+  return (
+    attempt.selected_index !== undefined ||
+    attempt.selected_indices !== undefined ||
+    attempt.selected_order !== undefined
+  );
+}
+
+// Re-grades quiz_attempts server-side wherever a real answer was submitted,
+// looking up each attempt's activity by its actual LearnActivity _id.
+async function gradeQuizAttempts(tenant, quizAttempts, next) {
+  if (!Array.isArray(quizAttempts) || quizAttempts.length === 0) {
+    return quizAttempts;
+  }
+
+  const gradableAttempts = quizAttempts.filter(
+    (a) =>
+      a.format !== "free_text" &&
+      attemptHasSubmittedAnswer(a) &&
+      mongoose.Types.ObjectId.isValid(a.activity_id)
+  );
+  if (gradableAttempts.length === 0) return quizAttempts;
+
+  const activitiesRes = await LearnActivityModel(tenant).list(
+    { filter: { _id: { $in: gradableAttempts.map((a) => a.activity_id) } } },
+    next
+  );
+  const activitiesById = new Map(
+    (activitiesRes?.data || []).map((a) => [a._id.toString(), a])
+  );
+
+  return quizAttempts.map((attempt) => {
+    if (!attemptHasSubmittedAnswer(attempt) || attempt.format === "free_text") {
+      return attempt;
+    }
+    const activity = activitiesById.get(String(attempt.activity_id));
+    const isCorrect =
+      activity?.type === "quiz"
+        ? isAttemptCorrect(attempt, activity.payload)
+        : false;
+    return { ...attempt, is_correct: isCorrect };
+  });
+}
+
+// Beyond requiring `format`, a quiz payload must carry a correct-answer field
+// matching that format — otherwise the question can never be graded
+// server-side (see gradeQuizAttempts above), and Course Management would
+// silently ship an unscorable question. Returns null when valid, or
+// { field, message } describing the first problem found.
+function validateQuizCorrectAnswer(payload) {
+  const { format, options, correct_index, correct_indices, correct_order } =
+    payload || {};
+  if (format === "free_text") return null;
+
+  if (!Array.isArray(options) || options.length < 2) {
+    return {
+      field: "payload.options",
+      message: "options must be an array with at least 2 items",
+    };
+  }
+
+  if (format === "single_choice") {
+    if (
+      !Number.isInteger(correct_index) ||
+      correct_index < 0 ||
+      correct_index >= options.length
+    ) {
+      return {
+        field: "payload.correct_index",
+        message: "correct_index must be a valid index into payload.options",
+      };
+    }
+  } else if (format === "multi_choice") {
+    if (!Array.isArray(correct_indices) || correct_indices.length === 0) {
+      return {
+        field: "payload.correct_indices",
+        message:
+          "correct_indices must be a non-empty array of option indices",
+      };
+    }
+    const unique = new Set(correct_indices);
+    const allValid = correct_indices.every(
+      (i) => Number.isInteger(i) && i >= 0 && i < options.length
+    );
+    if (unique.size !== correct_indices.length || !allValid) {
+      return {
+        field: "payload.correct_indices",
+        message: "correct_indices must contain unique, valid option indices",
+      };
+    }
+  } else if (format === "ranking") {
+    if (!Array.isArray(correct_order) || correct_order.length !== options.length) {
+      return {
+        field: "payload.correct_order",
+        message: "correct_order must list every option index exactly once",
+      };
+    }
+    const sorted = [...correct_order].sort((a, b) => a - b);
+    const expected = options.map((_, i) => i);
+    if (JSON.stringify(sorted) !== JSON.stringify(expected)) {
+      return {
+        field: "payload.correct_order",
+        message: "correct_order must be a permutation of payload.options indices",
+      };
+    }
+  }
+  return null;
+}
 
 function generateVerificationCode() {
   const year = new Date().getFullYear();
@@ -132,6 +303,8 @@ const learn = {
       const result = await buildCatalog(tenant, next);
       if (!result?.success) return result;
 
+      const maxPoints = await getMaxLearnPoints(tenant, next);
+
       const latestCourse = await LearnCourseModel(tenant)
         .findOne({ published: true })
         .sort({ updatedAt: -1 })
@@ -147,6 +320,7 @@ const learn = {
         data: {
           catalog_version: catalogVersion,
           stages: STAGES,
+          max_points: maxPoints,
           courses: result.data,
         },
         message: "successfully retrieved learn catalog",
@@ -239,6 +413,7 @@ const learn = {
         data: {
           guest_id: session.guest_id,
           display_name: session.display_name,
+          avatar_icon: session.avatar_icon,
           created_at: session.createdAt,
         },
         message: result.message,
@@ -275,6 +450,8 @@ const learn = {
       );
       if (!result?.success) return result;
 
+      const maxPoints = await getMaxLearnPoints(tenant, next);
+
       const doc = result.data;
       if (!doc) {
         return {
@@ -283,7 +460,7 @@ const learn = {
             learner_type: user_id ? "user" : "guest",
             guest_id: guest_id || undefined,
             total_points: 0,
-            max_points: MAX_LEARN_POINTS,
+            max_points: maxPoints,
             completed_lessons: 0,
             current_stage: STAGES[0],
             lessons: {},
@@ -316,7 +493,7 @@ const learn = {
           learner_type: doc.learner_type,
           guest_id: doc.guest_id || undefined,
           total_points: doc.total_points,
-          max_points: MAX_LEARN_POINTS,
+          max_points: maxPoints,
           completed_lessons: doc.completed_lessons,
           current_stage: stage,
           lessons: lessonsOut,
@@ -364,8 +541,17 @@ const learn = {
         };
       }
 
+      if (Array.isArray(update.quiz_attempts) && update.quiz_attempts.length) {
+        update.quiz_attempts = await gradeQuizAttempts(
+          tenant,
+          update.quiz_attempts,
+          next
+        );
+      }
+
+      const maxPoints = await getMaxLearnPoints(tenant, next);
       const result = await LearnProgressModel(tenant).upsertLessonProgress(
-        { device_id, guest_id, user_id, lesson_id, update, maxPoints: MAX_LEARN_POINTS },
+        { device_id, guest_id, user_id, lesson_id, update, maxPoints },
         next
       );
       if (!result?.success) return result;
@@ -424,6 +610,7 @@ const learn = {
       let lastStage = STAGES[0];
       let totalPoints = 0;
       let mergedCount = 0;
+      const maxPoints = await getMaxLearnPoints(tenant, next);
 
       for (const update of updates) {
         const lessonRes = await LearnLessonModel(tenant).list(
@@ -432,6 +619,14 @@ const learn = {
         );
         if (!lessonRes?.success || !lessonRes.data?.length) continue;
 
+        if (Array.isArray(update.quiz_attempts) && update.quiz_attempts.length) {
+          update.quiz_attempts = await gradeQuizAttempts(
+            tenant,
+            update.quiz_attempts,
+            next
+          );
+        }
+
         const result = await LearnProgressModel(tenant).upsertLessonProgress(
           {
             device_id,
@@ -439,7 +634,7 @@ const learn = {
             user_id,
             lesson_id: update.lesson_id,
             update,
-            maxPoints: MAX_LEARN_POINTS,
+            maxPoints,
           },
           next
         );
@@ -503,8 +698,9 @@ const learn = {
         };
       }
 
+      const maxPoints = await getMaxLearnPoints(tenant, next);
       const result = await LearnProgressModel(tenant).mergeGuestToUser(
-        { device_id, guest_id, user_id },
+        { device_id, guest_id, user_id, maxPoints },
         next
       );
       if (!result?.success) return result;
@@ -672,6 +868,17 @@ const learn = {
           errors: { "payload.format": "format is required for quiz activities" },
           status: httpStatus.UNPROCESSABLE_ENTITY,
         };
+      }
+      if (type === "quiz" && !isEmpty(payload?.format)) {
+        const answerError = validateQuizCorrectAnswer(payload);
+        if (answerError) {
+          return {
+            success: false,
+            message: "validation errors for some of the provided fields",
+            errors: { [answerError.field]: answerError.message },
+            status: httpStatus.UNPROCESSABLE_ENTITY,
+          };
+        }
       }
 
       return await LearnActivityModel(tenant).register(
@@ -1159,6 +1366,17 @@ const learn = {
             status: httpStatus.UNPROCESSABLE_ENTITY,
           };
         }
+        if (effectiveType === "quiz" && !isEmpty(effectivePayload?.format)) {
+          const answerError = validateQuizCorrectAnswer(effectivePayload);
+          if (answerError) {
+            return {
+              success: false,
+              message: "validation errors for some of the provided fields",
+              errors: { [answerError.field]: answerError.message },
+              status: httpStatus.UNPROCESSABLE_ENTITY,
+            };
+          }
+        }
       }
 
       const updates = {};
@@ -1608,14 +1826,32 @@ const learn = {
       const limit = Math.min(parseInt(request.query.limit) || 20, 100);
       const LearnProgress = LearnProgressModel(tenant);
 
+      // Guests are ranked alongside registered users — they're identified by
+      // a random display name/icon (see LearnGuestSession) rather than being
+      // excluded outright.
       const topLearners = await LearnProgress.find({
-        learner_type: "user",
         total_points: { $gt: 0 },
       })
         .sort({ total_points: -1 })
         .limit(limit)
-        .select("user_id total_points current_stage_index completed_lessons")
+        .select(
+          "user_id guest_id learner_type total_points current_stage_index completed_lessons"
+        )
         .lean();
+
+      const guestIds = topLearners
+        .filter((l) => l.learner_type === "guest" && l.guest_id)
+        .map((l) => l.guest_id);
+      let guestIdentityByGuestId = new Map();
+      if (guestIds.length > 0) {
+        const guestSessions = await LearnGuestSessionModel(tenant)
+          .find({ guest_id: { $in: guestIds } })
+          .select("guest_id display_name avatar_icon")
+          .lean();
+        guestIdentityByGuestId = new Map(
+          guestSessions.map((s) => [s.guest_id, s])
+        );
+      }
 
       // Determine caller's rank when they fall outside the top N
       const currentUserInTop = topLearners.some((l) => l.user_id === user_id);
@@ -1625,7 +1861,6 @@ const learn = {
         const userProgress = await LearnProgress.findOne({ user_id }).lean();
         if (userProgress) {
           const ahead = await LearnProgress.countDocuments({
-            learner_type: "user",
             total_points: { $gt: userProgress.total_points },
           });
           currentUserRank = ahead + 1;
@@ -1636,13 +1871,22 @@ const learn = {
         success: true,
         data: {
           scope: "global",
-          entries: topLearners.map((l, i) => ({
-            rank: i + 1,
-            total_points: l.total_points,
-            completed_lessons: l.completed_lessons,
-            current_stage: STAGES[l.current_stage_index] || STAGES[0],
-            is_current_user: l.user_id === user_id,
-          })),
+          entries: topLearners.map((l, i) => {
+            const guestIdentity =
+              l.learner_type === "guest"
+                ? guestIdentityByGuestId.get(l.guest_id)
+                : null;
+            return {
+              rank: i + 1,
+              learner_type: l.learner_type,
+              display_name: guestIdentity?.display_name || undefined,
+              avatar_icon: guestIdentity?.avatar_icon || undefined,
+              total_points: l.total_points,
+              completed_lessons: l.completed_lessons,
+              current_stage: STAGES[l.current_stage_index] || STAGES[0],
+              is_current_user: l.user_id === user_id,
+            };
+          }),
           current_user_rank: currentUserInTop
             ? topLearners.findIndex((l) => l.user_id === user_id) + 1
             : currentUserRank,

--- a/src/device-registry/utils/test/ut_learn.util.js
+++ b/src/device-registry/utils/test/ut_learn.util.js
@@ -287,6 +287,28 @@ describe("learnUtil", () => {
       expect(result.data.total_points).to.equal(50);
       expect(result.data.lessons).to.have.property("lid1");
     });
+
+    it("should derive max_points only from published-course quiz activities", async () => {
+      progressInstance.findProgress.resolves({ success: true, data: null });
+      courseInstance.list.resolves({ success: true, data: [{ _id: "c1" }] });
+      unitInstance.list.resolves({ success: true, data: [{ _id: "u1", course_id: "c1" }] });
+      lessonInstance.list.resolves({ success: true, data: [{ _id: "l1", unit_id: "u1" }] });
+      activityInstance.list.resolves({
+        success: true,
+        data: [{ type: "quiz", payload: { format: "single_choice" } }],
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.getProgress(
+        makeReq({ headers: { "x-device-id": "dev-001" } }),
+        next
+      );
+
+      expect(
+        courseInstance.list.calledWithMatch({ filter: { published: true } })
+      ).to.be.true;
+      expect(result.data.max_points).to.equal(10);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -352,6 +374,106 @@ describe("learnUtil", () => {
 
       expect(result.success).to.be.true;
       expect(result.data).to.have.property("stars", 2);
+    });
+
+    it("should grade quiz attempts server-side using the stored correct answer", async () => {
+      const lessonId = new mongoose.Types.ObjectId().toString();
+      const activityId = new mongoose.Types.ObjectId().toString();
+      lessonInstance.list
+        .onFirstCall()
+        .resolves({ success: true, data: [{ _id: lessonId, unit_id: "u1", lesson_order: 1 }] })
+        .onSecondCall()
+        .resolves({ success: true, data: [] });
+
+      activityInstance.list.resolves({
+        success: true,
+        data: [
+          {
+            _id: activityId,
+            type: "quiz",
+            payload: { format: "single_choice", options: ["a", "b"], correct_index: 1 },
+          },
+        ],
+      });
+
+      progressInstance.upsertLessonProgress.resolves({
+        success: true,
+        data: {
+          lesson_id: lessonId,
+          stars: 3,
+          points_earned: 10,
+          total_points: 10,
+          current_stage: { index: 0, name: "Curious" },
+          completed: true,
+        },
+      });
+
+      const next = sinon.spy();
+      await learnUtil.updateLessonProgress(
+        makeReq({
+          params: { lesson_id: lessonId },
+          headers: { "x-device-id": "dev-001" },
+          body: {
+            completed: true,
+            quiz_attempts: [
+              {
+                activity_id: activityId,
+                format: "single_choice",
+                selected_index: 1,
+                is_correct: false, // client under-reports — server should override
+              },
+            ],
+          },
+        }),
+        next
+      );
+
+      const passedUpdate = progressInstance.upsertLessonProgress.firstCall.args[0].update;
+      expect(passedUpdate.quiz_attempts[0].is_correct).to.equal(true);
+    });
+
+    it("should trust the client's is_correct when the activity can't be verified", async () => {
+      const lessonId = new mongoose.Types.ObjectId().toString();
+      lessonInstance.list
+        .onFirstCall()
+        .resolves({ success: true, data: [{ _id: lessonId, unit_id: "u1", lesson_order: 1 }] })
+        .onSecondCall()
+        .resolves({ success: true, data: [] });
+
+      progressInstance.upsertLessonProgress.resolves({
+        success: true,
+        data: {
+          lesson_id: lessonId,
+          stars: 1,
+          points_earned: 0,
+          total_points: 0,
+          current_stage: { index: 0, name: "Curious" },
+          completed: true,
+        },
+      });
+
+      const next = sinon.spy();
+      await learnUtil.updateLessonProgress(
+        makeReq({
+          params: { lesson_id: lessonId },
+          headers: { "x-device-id": "dev-001" },
+          body: {
+            completed: true,
+            quiz_attempts: [
+              {
+                activity_id: "not-a-valid-object-id",
+                format: "single_choice",
+                selected_index: 0,
+                is_correct: true,
+              },
+            ],
+          },
+        }),
+        next
+      );
+
+      const passedUpdate = progressInstance.upsertLessonProgress.firstCall.args[0].update;
+      expect(passedUpdate.quiz_attempts[0].is_correct).to.equal(true);
     });
   });
 
@@ -453,6 +575,67 @@ describe("learnUtil", () => {
         makeReq({
           params: { lesson_id: "l1" },
           body: { type: "article", order: 1, payload: { body: "some content" } },
+        }),
+        next
+      );
+
+      expect(activityInstance.register.calledOnce).to.be.true;
+      expect(result.success).to.be.true;
+    });
+
+    it("should reject quiz activity with an unrecognized format", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.addActivity(
+        makeReq({
+          params: { lesson_id: "l1" },
+          body: {
+            type: "quiz",
+            order: 1,
+            payload: { format: "matching", options: ["a", "b"] },
+          },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNPROCESSABLE_ENTITY);
+      expect(result.errors).to.have.property("payload.format");
+    });
+
+    it("should reject single_choice quiz missing correct_index", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.addActivity(
+        makeReq({
+          params: { lesson_id: "l1" },
+          body: {
+            type: "quiz",
+            order: 1,
+            payload: { format: "single_choice", options: ["a", "b"] },
+          },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNPROCESSABLE_ENTITY);
+      expect(result.errors).to.have.property("payload.correct_index");
+    });
+
+    it("should call model.register for a valid single_choice quiz", async () => {
+      activityInstance.register.resolves({
+        success: true,
+        data: { type: "quiz" },
+        status: httpStatus.CREATED,
+      });
+      const next = sinon.spy();
+      const result = await learnUtil.addActivity(
+        makeReq({
+          params: { lesson_id: "l1" },
+          body: {
+            type: "quiz",
+            order: 1,
+            payload: { format: "single_choice", options: ["a", "b"], correct_index: 0 },
+          },
         }),
         next
       );
@@ -569,6 +752,57 @@ describe("learnUtil", () => {
 
       expect(result.success).to.be.true;
       expect(result.data).to.have.property("user_id", "user-1");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getLeaderboard
+  // ---------------------------------------------------------------------------
+
+  describe("getLeaderboard", () => {
+    it("should return UNAUTHORIZED when no user_id", async () => {
+      const next = sinon.spy();
+      const result = await learnUtil.getLeaderboard(makeReq(), next);
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.UNAUTHORIZED);
+    });
+
+    it("should compute current_stage live from total_points and catalog-derived max_points", async () => {
+      // Catalog: 1 published course/unit/lesson with 2 gradable quiz activities => max_points = 20
+      courseInstance.list.resolves({ success: true, data: [{ _id: "c1" }] });
+      unitInstance.list.resolves({ success: true, data: [{ _id: "u1", course_id: "c1" }] });
+      lessonInstance.list.resolves({ success: true, data: [{ _id: "l1", unit_id: "u1" }] });
+      activityInstance.list.resolves({
+        success: true,
+        data: [
+          { type: "quiz", payload: { format: "single_choice" } },
+          { type: "quiz", payload: { format: "single_choice" } },
+        ],
+      });
+
+      progressInstance.find = sinon.stub().returns({
+        sort: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([
+          {
+            user_id: "user-1",
+            learner_type: "user",
+            total_points: 20,
+            completed_lessons: 2,
+          },
+        ]),
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.getLeaderboard(
+        makeReq({ user: { id: "user-1" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data.entries[0].current_stage.name).to.equal("Defender");
     });
   });
 

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -118,7 +118,8 @@ const learnValidations = {
     body("quiz_attempts.*.selected_index")
       .optional()
       .isInt({ min: 0 })
-      .withMessage("quiz_attempts[].selected_index must be a non-negative integer"),
+      .withMessage("quiz_attempts[].selected_index must be a non-negative integer")
+      .toInt(),
     body("quiz_attempts.*.selected_indices")
       .optional()
       .isArray()
@@ -126,7 +127,8 @@ const learnValidations = {
     body("quiz_attempts.*.selected_indices.*")
       .optional()
       .isInt({ min: 0 })
-      .withMessage("quiz_attempts[].selected_indices[] must be non-negative integers"),
+      .withMessage("quiz_attempts[].selected_indices[] must be non-negative integers")
+      .toInt(),
     body("quiz_attempts.*.selected_order")
       .optional()
       .isArray()
@@ -134,7 +136,8 @@ const learnValidations = {
     body("quiz_attempts.*.selected_order.*")
       .optional()
       .isInt({ min: 0 })
-      .withMessage("quiz_attempts[].selected_order[] must be non-negative integers"),
+      .withMessage("quiz_attempts[].selected_order[] must be non-negative integers")
+      .toInt(),
     validate,
   ],
 

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -115,6 +115,26 @@ const learnValidations = {
       .optional()
       .isIn(["single_choice", "multi_choice", "ranking", "free_text"])
       .withMessage("quiz_attempts[].format must be a valid quiz format"),
+    body("quiz_attempts.*.selected_index")
+      .optional()
+      .isInt({ min: 0 })
+      .withMessage("quiz_attempts[].selected_index must be a non-negative integer"),
+    body("quiz_attempts.*.selected_indices")
+      .optional()
+      .isArray()
+      .withMessage("quiz_attempts[].selected_indices must be an array"),
+    body("quiz_attempts.*.selected_indices.*")
+      .optional()
+      .isInt({ min: 0 })
+      .withMessage("quiz_attempts[].selected_indices[] must be non-negative integers"),
+    body("quiz_attempts.*.selected_order")
+      .optional()
+      .isArray()
+      .withMessage("quiz_attempts[].selected_order must be an array"),
+    body("quiz_attempts.*.selected_order.*")
+      .optional()
+      .isInt({ min: 0 })
+      .withMessage("quiz_attempts[].selected_order[] must be non-negative integers"),
     validate,
   ],
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes three Learn (LEARN tab / Course Management) bugs in `device-registry`:
- Derives the learner's max points from the live course catalog instead of a hardcoded constant, so the level shown always matches the points earned.
- Requires a correct-answer field (`correct_index` / `correct_indices` / `correct_order`) when authoring a quiz question, matching its format, and adds the ability for the server to grade a submitted answer itself instead of only trusting the client.
- Gives every guest learner session a random friendly display name and icon, and includes guests in leaderboard rankings with that identity instead of excluding them.

### Why is this change needed?
Reported by the team while testing the LEARN tab and its Course Management admin page:
- Levels changed without points changing (two independently hardcoded point/level constants had drifted out of sync with the actual catalog).
- There was no way to mark the correct answer for multi-choice or ranking quiz questions, and the backend never verified answers itself.
- Guest users had no distinguishable name/icon and were excluded from the leaderboard entirely.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran the full Learn module test suite (models, utils, validators, controller — 143 tests) after the changes; all passing. No new tests were added in this pass.

---

## :boom: Breaking Changes

- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

Creating or updating a `multi_choice` or `ranking` quiz question via the admin API now requires `correct_indices` / `correct_order` respectively — requests that previously succeeded without a correct-answer field will now be rejected with a `422`. Existing quiz questions already saved without these fields are unaffected until they are next edited. The Course Management admin UI needs to add controls for these fields (tracked separately — see notes).

---

## :memo: Additional Notes

A findings/handoff doc for the platform (admin) and mobile teams is included at `docs/TEMP_LEARN_KYA_FINDINGS.md`, describing the new API contract and the follow-up frontend/mobile work needed (admin UI for multi-choice/ranking correct answers, mobile sending real selected answers for server-side grading, and a mobile leaderboard screen — none of these exist yet).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guests now get a friendly anonymous display name and avatar when starting a session.
  * Leaderboards now include guest learners alongside signed-in users.

* **Bug Fixes**
  * Learning progress and stage calculations are now more consistent with the number of available quiz questions.
  * Quiz answers are validated and scored more reliably, with clearer feedback for invalid submissions.
  * Quiz progress tracking now supports more answer formats and multi-select ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->