### PR TITLE
Enforce max length on user name fields to prevent paragraph input

### DIFF
--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -234,11 +234,13 @@ const UserSchema = new Schema(
       type: String,
       required: [true, "FirstName is required!"],
       trim: true,
+      maxlength: [100, "FirstName cannot exceed 100 characters"],
     },
     lastName: {
       type: String,
       required: [true, "LastName is required"],
       trim: true,
+      maxlength: [100, "LastName cannot exceed 100 characters"],
     },
     userName: {
       type: String,

--- a/src/auth-service/routes/v2/guests.routes.js
+++ b/src/auth-service/routes/v2/guests.routes.js
@@ -15,6 +15,7 @@ router.post(
 );
 router.post(
   "/convert",
+  guestUserValidations.convertGuest,
   enhancedJWTAuth,
   validate,
   guestUserController.convertGuest

--- a/src/auth-service/validators/candidates.validators.js
+++ b/src/auth-service/validators/candidates.validators.js
@@ -178,12 +178,14 @@ const confirm = [
     body("firstName")
       .exists()
       .withMessage("the firstName should be provided")
+      .bail()
       .trim()
       .isLength({ max: 100 })
       .withMessage("the firstName cannot exceed 100 characters"),
     body("lastName")
       .exists()
       .withMessage("the lastName should be provided")
+      .bail()
       .trim()
       .isLength({ max: 100 })
       .withMessage("the lastName cannot exceed 100 characters"),

--- a/src/auth-service/validators/candidates.validators.js
+++ b/src/auth-service/validators/candidates.validators.js
@@ -44,7 +44,9 @@ const create = [
       .notEmpty()
       .withMessage("the firstName cannot be empty")
       .bail()
-      .trim(),
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("the firstName cannot exceed 100 characters"),
     body("lastName")
       .exists()
       .withMessage("the lastName should be provided")
@@ -52,7 +54,9 @@ const create = [
       .notEmpty()
       .withMessage("the lastName cannot be empty")
       .bail()
-      .trim(),
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("the lastName cannot exceed 100 characters"),
     body("country")
       .exists()
       .withMessage("the country should be provided")
@@ -174,11 +178,15 @@ const confirm = [
     body("firstName")
       .exists()
       .withMessage("the firstName should be provided")
-      .trim(),
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("the firstName cannot exceed 100 characters"),
     body("lastName")
       .exists()
       .withMessage("the lastName should be provided")
-      .trim(),
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("the lastName cannot exceed 100 characters"),
     body("category")
       .exists()
       .withMessage("the category should be provided")

--- a/src/auth-service/validators/guest-user.validators.js
+++ b/src/auth-service/validators/guest-user.validators.js
@@ -58,8 +58,16 @@ const getOne = [validateTenant, validateIdParam];
 const create = [
   validateTenant,
   oneOf([
-    body("firstName").optional().trim(),
-    body("lastName").optional().trim(),
+    body("firstName")
+      .optional()
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("firstName cannot exceed 100 characters"),
+    body("lastName")
+      .optional()
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("lastName cannot exceed 100 characters"),
   ]),
 ];
 const update = [validateTenant, validateIdParam];
@@ -80,8 +88,16 @@ const convertGuest = [
       .exists()
       .withMessage("the password is missing in your request")
       .trim(),
-    body("firstName").optional().trim(),
-    body("lastName").optional().trim(),
+    body("firstName")
+      .optional()
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("firstName cannot exceed 100 characters"),
+    body("lastName")
+      .optional()
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("lastName cannot exceed 100 characters"),
     body("userName").optional().trim(),
   ],
 ];

--- a/src/auth-service/validators/requests.validators.js
+++ b/src/auth-service/validators/requests.validators.js
@@ -102,13 +102,13 @@ const acceptInvitation = [
     body("firstName")
       .optional()
       .trim()
-      .isLength({ min: 1, max: 50 })
-      .withMessage("firstName must be between 1 and 50 characters"),
+      .isLength({ min: 1, max: 100 })
+      .withMessage("firstName must be between 1 and 100 characters"),
     body("lastName")
       .optional()
       .trim()
-      .isLength({ min: 1, max: 50 })
-      .withMessage("lastName must be between 1 and 50 characters"),
+      .isLength({ min: 1, max: 100 })
+      .withMessage("lastName must be between 1 and 100 characters"),
     body("password")
       .optional()
       .isLength({ min: 6 })

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -357,26 +357,28 @@ const firebaseSignup = oneOf([
     .withMessage("the phoneNumber must be valid"),
 ]);
 
-const syncAnalyticsAndMobile = oneOf([
-  body("firebase_uid")
-    .exists()
-    .withMessage(
-      "the firebase_uid is missing in body, consider using firebase_uid",
-    )
-    .bail()
-    .notEmpty()
-    .withMessage("the firebase_uid must not be empty")
-    .bail()
-    .trim(),
-  body("email")
-    .exists()
-    .withMessage("the email is missing in body, consider using email")
-    .bail()
-    .notEmpty()
-    .withMessage("the email is missing in body, consider using email")
-    .bail()
-    .isEmail()
-    .withMessage("this is not a valid email address"),
+const syncAnalyticsAndMobile = [
+  oneOf([
+    body("firebase_uid")
+      .exists()
+      .withMessage(
+        "the firebase_uid is missing in body, consider using firebase_uid",
+      )
+      .bail()
+      .notEmpty()
+      .withMessage("the firebase_uid must not be empty")
+      .bail()
+      .trim(),
+    body("email")
+      .exists()
+      .withMessage("the email is missing in body, consider using email")
+      .bail()
+      .notEmpty()
+      .withMessage("the email is missing in body, consider using email")
+      .bail()
+      .isEmail()
+      .withMessage("this is not a valid email address"),
+  ]),
   body("phoneNumber")
     .optional()
     .notEmpty()
@@ -394,7 +396,7 @@ const syncAnalyticsAndMobile = oneOf([
     .trim()
     .isLength({ max: 100 })
     .withMessage("lastName cannot exceed 100 characters"),
-]);
+];
 
 const emailReport = oneOf([
   body("senderEmail")

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -384,8 +384,16 @@ const syncAnalyticsAndMobile = oneOf([
     .bail()
     .isMobilePhone()
     .withMessage("the phoneNumber must be valid"),
-  body("firstName").optional().trim(),
-  body("lastName").optional().trim(),
+  body("firstName")
+    .optional()
+    .trim()
+    .isLength({ max: 100 })
+    .withMessage("firstName cannot exceed 100 characters"),
+  body("lastName")
+    .optional()
+    .trim()
+    .isLength({ max: 100 })
+    .withMessage("lastName cannot exceed 100 characters"),
 ]);
 
 const emailReport = oneOf([
@@ -508,12 +516,22 @@ const registerUser = [
       .exists()
       .withMessage("firstName is missing in your request")
       .bail()
-      .trim(),
+      .trim()
+      .notEmpty()
+      .withMessage("firstName should not be empty")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("firstName cannot exceed 100 characters"),
     body("lastName")
       .exists()
       .withMessage("lastName is missing in your request")
       .bail()
-      .trim(),
+      .trim()
+      .notEmpty()
+      .withMessage("lastName should not be empty")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("lastName cannot exceed 100 characters"),
     body("email")
       .exists()
       .withMessage("email is missing in your request")
@@ -550,12 +568,22 @@ const createUser = [
       .exists()
       .withMessage("firstName is missing in your request")
       .bail()
-      .trim(),
+      .trim()
+      .notEmpty()
+      .withMessage("firstName should not be empty")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("firstName cannot exceed 100 characters"),
     body("lastName")
       .exists()
       .withMessage("lastName is missing in your request")
       .bail()
-      .trim(),
+      .trim()
+      .notEmpty()
+      .withMessage("lastName should not be empty")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("lastName cannot exceed 100 characters"),
     body("category")
       .exists()
       .withMessage("category is missing in your request")
@@ -789,13 +817,17 @@ const newsletterSubscribe = [
       .notEmpty()
       .withMessage("the provided firstName should not be empty IF provided")
       .bail()
-      .trim(),
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("firstName cannot exceed 100 characters"),
     body("lastName")
       .optional()
       .notEmpty()
       .withMessage("the provided lastName should not be empty IF provided")
       .bail()
-      .trim(),
+      .trim()
+      .isLength({ max: 100 })
+      .withMessage("lastName cannot exceed 100 characters"),
     body("address")
       .optional()
       .notEmpty()
@@ -1128,12 +1160,22 @@ const registerViaOrgSlug = [
     .exists()
     .withMessage("firstName is missing in your request")
     .bail()
-    .trim(),
+    .trim()
+    .notEmpty()
+    .withMessage("firstName should not be empty")
+    .bail()
+    .isLength({ max: 100 })
+    .withMessage("firstName cannot exceed 100 characters"),
   body("lastName")
     .exists()
     .withMessage("lastName is missing in your request")
     .bail()
-    .trim(),
+    .trim()
+    .notEmpty()
+    .withMessage("lastName should not be empty")
+    .bail()
+    .isLength({ max: 100 })
+    .withMessage("lastName cannot exceed 100 characters"),
   body("email")
     .exists()
     .withMessage("email is missing in your request")


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a 100-character maximum length validation to the `firstName` and `lastName` fields across every auth-service endpoint that accepts them (registration, admin user creation, org-slug registration, guest users, candidates, newsletter signup), and adds a matching `maxlength` constraint to the Mongoose `User` schema as a backstop.

### Why is this change needed?
A user's paragraph-length text was accidentally saved as their first/last name and surfaced in the Analytics UI. Investigation showed that none of the `firstName`/`lastName` validators (or the Mongoose schema) enforced any length limit, so arbitrarily long input was accepted and persisted as-is.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- auth-service

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified all edited files pass `node --check` syntax validation. Manually traced every `firstName`/`lastName` validator in `users.validators.js`, `guest-user.validators.js`, and `candidates.validators.js` to confirm the new `isLength({ max: 100 })` rule is applied consistently, with matching error messages.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
Files changed:
- `validators/users.validators.js` — update-user, `registerUser`, `createUser`, `newsletterSubscribe`, `registerViaOrgSlug`
- `validators/guest-user.validators.js` — `create`, `convertGuest`
- `validators/candidates.validators.js` — candidate submission, `confirm`
- `models/User.js` — added `maxlength: 100` to `firstName`/`lastName` schema fields as defense-in-depth for any path that bypasses request validation

---

## :white_check_mark: Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 100-character maximum for first and last names across account registration, candidate creation/confirmation, guest conversion, and invitation acceptance flows.
  * Improved validation behavior and error messaging for missing/empty and over-length names.
  * Added missing request validation to the guest conversion endpoint to ensure the correct rules are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->