### PR TITLE
Add Clean Air Forum selfies backend and fix guest conversion bug

### DIFF
--- a/src/auth-service/bin/jobs/selfie-cleanup-job.js
+++ b/src/auth-service/bin/jobs/selfie-cleanup-job.js
@@ -1,0 +1,114 @@
+const cron = require("node-cron");
+const cloudinary = require("@config/cloudinary");
+const constants = require("@config/constants");
+const SelfieModel = require("@models/Selfie");
+const log4js = require("log4js");
+
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- bin/jobs/selfie-cleanup-job`
+);
+
+const RETENTION_DAYS = constants.CLEAN_AIR_FORUM_SELFIE_RETENTION_DAYS;
+const BATCH_SIZE = 100;
+const TAG = constants.CLEAN_AIR_FORUM_SELFIE_TAG;
+
+const isCloudinaryConfigured =
+  !!constants.CLOUD_NAME &&
+  !!constants.CLOUDINARY_API_KEY &&
+  !!constants.CLOUDINARY_API_SECRET;
+
+const cleanupOldSelfies = async () => {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - RETENTION_DAYS);
+
+  if (isCloudinaryConfigured) {
+    let deleted = 0;
+    let errors = 0;
+    let nextCursor;
+
+    try {
+      do {
+        const listOptions = {
+          resource_type: "image",
+          max_results: BATCH_SIZE,
+          direction: "asc",
+        };
+        if (nextCursor) listOptions.next_cursor = nextCursor;
+
+        const response = await cloudinary.api.resources_by_tag(
+          TAG,
+          listOptions
+        );
+
+        const stale = (response.resources || []).filter(
+          (r) => new Date(r.created_at) < cutoff
+        );
+
+        if (stale.length > 0) {
+          const publicIds = stale.map((r) => r.public_id);
+          try {
+            await cloudinary.api.delete_resources(publicIds, {
+              resource_type: "image",
+            });
+            deleted += publicIds.length;
+          } catch (deleteError) {
+            logger.error(
+              `Failed to delete batch of ${publicIds.length} selfies: ${deleteError.message}`
+            );
+            errors += publicIds.length;
+          }
+        }
+
+        // If none in this page are stale (oldest-first order), no later
+        // pages will be stale either — stop early to avoid unnecessary API
+        // calls.
+        if (stale.length < response.resources.length) {
+          break;
+        }
+
+        nextCursor = response.next_cursor;
+      } while (nextCursor);
+
+      if (deleted > 0 || errors > 0) {
+        logger.info(
+          `Selfie Cloudinary cleanup: deleted ${deleted}, errors ${errors}`
+        );
+      }
+    } catch (error) {
+      logger.error(`Selfie Cloudinary cleanup error: ${error.message}`);
+    }
+  } else {
+    logger.warn(
+      "Cloudinary not configured — skipping selfie Cloudinary cleanup"
+    );
+  }
+
+  // Mongo-side cleanup runs independently of the Cloudinary step above —
+  // both are governed by the same age cutoff, so a stale Mongo record is
+  // removed even if its matching Cloudinary asset was already gone or
+  // failed to delete.
+  try {
+    const tenant = constants.DEFAULT_TENANT || "airqo";
+    const response = await SelfieModel(tenant).removeMany({
+      filter: { createdAt: { $lt: cutoff } },
+    });
+
+    if (response.success && response.data.deletedCount > 0) {
+      logger.info(
+        `Selfie Mongo cleanup: deleted ${response.data.deletedCount} stale record(s)`
+      );
+    }
+  } catch (error) {
+    logger.error(`Selfie Mongo cleanup error: ${error.message}`);
+  }
+};
+
+global.cronJobs = global.cronJobs || {};
+const schedule = "30 2 * * *"; // every day at 2:30 AM, after the feedback screenshot cleanup job
+const jobName = "selfie-cleanup-job";
+global.cronJobs[jobName] = cron.schedule(schedule, cleanupOldSelfies, {
+  scheduled: true,
+  timezone: "Africa/Nairobi",
+});
+
+module.exports = { cleanupOldSelfies };

--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -114,6 +114,7 @@ const jobs = [
   "@bin/jobs/feedback-screenshot-cleanup-job",
   "@bin/jobs/feedback-reminder-job",
   "@bin/jobs/transaction-amount-fix-job",
+  "@bin/jobs/selfie-cleanup-job",
 ];
 
 // Initialize log4js with SAFE configuration

--- a/src/auth-service/config/core/envs.js
+++ b/src/auth-service/config/core/envs.js
@@ -188,6 +188,16 @@ const envs = {
   CLOUD_NAME: process.env.CLOUD_NAME,
   CLOUDINARY_API_KEY: process.env.CLOUDINARY_API_KEY,
   CLOUDINARY_API_SECRET: process.env.CLOUDINARY_API_SECRET,
+  // Clean Air Forum selfies: the Cloudinary upload preset should tag every
+  // upload with CLEAN_AIR_FORUM_SELFIE_TAG. The daily cron job in
+  // bin/jobs/selfie-cleanup-job.js deletes tagged Cloudinary assets (and
+  // their Mongo records) after CLEAN_AIR_FORUM_SELFIE_RETENTION_DAYS days,
+  // so storage/cost doesn't grow unbounded after each event.
+  CLEAN_AIR_FORUM_SELFIE_TAG: "clean-air-forum-selfie",
+  CLEAN_AIR_FORUM_SELFIE_RETENTION_DAYS: parseNumber(
+    process.env.CLEAN_AIR_FORUM_SELFIE_RETENTION_DAYS,
+    90,
+  ),
   // Optional pro/HTTPS-capable IP geolocation endpoint. When set, device.util
   // uses this URL for login location lookups; when absent, geolocation is
   // skipped entirely (returns null) to avoid plaintext HTTP calls.

--- a/src/auth-service/controllers/selfie.controller.js
+++ b/src/auth-service/controllers/selfie.controller.js
@@ -160,6 +160,56 @@ const selfie = {
       return;
     }
   },
+  delete: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await selfieUtil.delete(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message ? result.message : "",
+          deleted_selfie: result.data ? result.data : [],
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message ? result.message : "",
+          errors: result.errors ? result.errors : { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
 };
 
 module.exports = selfie;

--- a/src/auth-service/controllers/selfie.controller.js
+++ b/src/auth-service/controllers/selfie.controller.js
@@ -1,0 +1,165 @@
+const selfieUtil = require("@utils/selfie.util");
+const { HttpError, extractErrorsFromRequest } = require("@utils/shared");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+const httpStatus = require("http-status");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- selfie-controller`
+);
+
+const selfie = {
+  create: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await selfieUtil.create(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message ? result.message : "",
+          created_selfie: result.data ? result.data : [],
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message ? result.message : "",
+          errors: result.errors ? result.errors : { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  list: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await selfieUtil.list(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message ? result.message : "",
+          selfies: result.data ? result.data : [],
+          total: result.meta ? result.meta.total : 0,
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message ? result.message : "",
+          errors: result.errors ? result.errors : { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+  hide: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await selfieUtil.hide(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message ? result.message : "",
+          updated_selfie: result.data ? result.data : [],
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message ? result.message : "",
+          errors: result.errors ? result.errors : { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+};
+
+module.exports = selfie;

--- a/src/auth-service/models/GuestUser.js
+++ b/src/auth-service/models/GuestUser.js
@@ -11,6 +11,7 @@ const {
   createNotFoundResponse,
   createEmptySuccessResponse,
 } = require("@utils/shared");
+const { generateGuestIdentity } = require("@utils/common");
 const logger = require("log4js").getLogger(
   `${constants.ENVIRONMENT} -- guest-user-model`
 );
@@ -32,6 +33,16 @@ const GuestUserSchema = new Schema(
       type: String,
       trim: true,
     },
+    displayName: {
+      type: String,
+      trim: true,
+      maxlength: 100,
+    },
+    avatarIcon: {
+      type: String,
+      trim: true,
+      maxlength: 8,
+    },
   },
   { timestamps: true }
 );
@@ -43,9 +54,14 @@ GuestUserSchema.statics = {
         .generate(constants.RANDOM_PASSWORD_CONFIGURATION(16))
         .toUpperCase();
 
+      const identity =
+        args.displayName && args.avatarIcon ? {} : generateGuestIdentity();
+
       const createdGuestUser = await this.create({
         guest_id: guestId,
         ...args,
+        displayName: args.displayName || identity.displayName,
+        avatarIcon: args.avatarIcon || identity.avatarIcon,
       });
 
       if (!isEmpty(createdGuestUser)) {

--- a/src/auth-service/models/Selfie.js
+++ b/src/auth-service/models/Selfie.js
@@ -1,0 +1,196 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+const constants = require("@config/constants");
+const { getModelByTenant } = require("@config/database");
+const httpStatus = require("http-status");
+const isEmpty = require("is-empty");
+const {
+  createSuccessResponse,
+  createErrorResponse,
+  createNotFoundResponse,
+} = require("@utils/shared");
+const logger = require("log4js").getLogger(
+  `${constants.ENVIRONMENT} -- selfie-model`
+);
+
+function isTrustedCloudinarySelfieUrl(value) {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "res.cloudinary.com" &&
+      url.pathname.includes("/clean_air_forum_selfies/")
+    );
+  } catch (error) {
+    return false;
+  }
+}
+
+const SelfieSchema = new Schema(
+  {
+    eventId: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    imageUrl: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 2048,
+      validate: {
+        validator: isTrustedCloudinarySelfieUrl,
+        message:
+          "imageUrl must be an https://res.cloudinary.com/.../clean_air_forum_selfies/... URL",
+      },
+    },
+    locationName: {
+      type: String,
+      trim: true,
+      maxlength: 200,
+    },
+    pm25Value: {
+      type: Number,
+      min: 0,
+    },
+    aqiCategory: {
+      type: String,
+      trim: true,
+      maxlength: 50,
+    },
+    displayName: {
+      type: String,
+      trim: true,
+      maxlength: 40,
+    },
+    avatarIcon: {
+      type: String,
+      trim: true,
+      maxlength: 8,
+    },
+    guest_id: {
+      type: String,
+      trim: true,
+      index: true,
+    },
+    user_id: {
+      type: Schema.Types.ObjectId,
+      ref: "user",
+      index: true,
+    },
+    hidden: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    hiddenAt: {
+      type: Date,
+    },
+    hiddenBy: {
+      type: Schema.Types.ObjectId,
+      ref: "user",
+    },
+  },
+  { timestamps: true }
+);
+
+SelfieSchema.index({ eventId: 1, hidden: 1, createdAt: -1 });
+
+SelfieSchema.statics = {
+  async register(args, next) {
+    try {
+      const createdSelfie = await this.create({ ...args });
+
+      if (!isEmpty(createdSelfie)) {
+        return createSuccessResponse("create", createdSelfie, "selfie", {
+          message: "selfie submitted",
+        });
+      } else {
+        return createErrorResponse(
+          new Error("Operation successful but selfie NOT successfully created"),
+          "create",
+          logger,
+          "selfie"
+        );
+      }
+    } catch (err) {
+      return createErrorResponse(err, "create", logger, "selfie");
+    }
+  },
+
+  async list({ filter = {}, limit = 100, skip = 0, next } = {}) {
+    try {
+      const selfies = await this.aggregate()
+        .match(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .exec();
+
+      const totalCount = await this.countDocuments(filter);
+
+      return {
+        success: true,
+        data: selfies,
+        message: "successfully listed the selfies",
+        status: httpStatus.OK,
+        meta: {
+          total: totalCount,
+          skip,
+          limit,
+          page: Math.floor(skip / limit) + 1,
+          pages: Math.ceil(totalCount / limit) || 1,
+        },
+      };
+    } catch (err) {
+      return createErrorResponse(err, "list", logger, "selfie");
+    }
+  },
+
+  async modify({ filter = {}, update = {}, next } = {}) {
+    try {
+      const modifiedSelfie = await this.findOneAndUpdate(filter, update, {
+        new: true,
+      }).exec();
+
+      if (!isEmpty(modifiedSelfie)) {
+        return createSuccessResponse("update", modifiedSelfie, "selfie");
+      } else {
+        return createNotFoundResponse("selfie", "update", "selfie not found");
+      }
+    } catch (err) {
+      return createErrorResponse(err, "update", logger, "selfie");
+    }
+  },
+
+  async findOne({ filter = {}, next } = {}) {
+    try {
+      const selfie = await this.findOne(filter).exec();
+
+      if (!isEmpty(selfie)) {
+        return createSuccessResponse("find", selfie, "selfie", {
+          message: "successfully retrieved the selfie",
+        });
+      } else {
+        return createNotFoundResponse("selfie", "find", "selfie not found");
+      }
+    } catch (err) {
+      return createErrorResponse(err, "find", logger, "selfie");
+    }
+  },
+};
+
+const SelfieModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    let selfies = mongoose.model("selfies");
+    return selfies;
+  } catch (error) {
+    let selfies = getModelByTenant(dbTenant, "selfie", SelfieSchema);
+    return selfies;
+  }
+};
+
+module.exports = SelfieModel;

--- a/src/auth-service/models/Selfie.js
+++ b/src/auth-service/models/Selfie.js
@@ -123,6 +123,12 @@ SelfieSchema.statics = {
     try {
       const selfies = await this.aggregate()
         .match(filter)
+        .project({
+          user_id: 0,
+          guest_id: 0,
+          hiddenBy: 0,
+          hiddenAt: 0,
+        })
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(limit)
@@ -150,6 +156,14 @@ SelfieSchema.statics = {
 
   async modify({ filter = {}, update = {}, next } = {}) {
     try {
+      if (isEmpty(filter)) {
+        return createErrorResponse(
+          new Error("A filter is required to update a selfie"),
+          "update",
+          logger,
+          "selfie"
+        );
+      }
       const modifiedSelfie = await this.findOneAndUpdate(filter, update, {
         new: true,
       }).exec();

--- a/src/auth-service/models/Selfie.js
+++ b/src/auth-service/models/Selfie.js
@@ -179,6 +179,35 @@ SelfieSchema.statics = {
       return createErrorResponse(err, "find", logger, "selfie");
     }
   },
+
+  async remove({ filter = {}, next } = {}) {
+    try {
+      const removedSelfie = await this.findOneAndRemove(filter).exec();
+
+      if (!isEmpty(removedSelfie)) {
+        return createSuccessResponse("delete", removedSelfie, "selfie");
+      } else {
+        return createNotFoundResponse("selfie", "delete", "selfie not found");
+      }
+    } catch (err) {
+      return createErrorResponse(err, "delete", logger, "selfie");
+    }
+  },
+
+  async removeMany({ filter = {}, next } = {}) {
+    try {
+      const result = await this.deleteMany(filter).exec();
+
+      return {
+        success: true,
+        message: "successfully deleted stale selfies",
+        data: { deletedCount: result.deletedCount },
+        status: httpStatus.OK,
+      };
+    } catch (err) {
+      return createErrorResponse(err, "delete", logger, "selfie");
+    }
+  },
 };
 
 const SelfieModel = (tenant) => {

--- a/src/auth-service/routes/v2/index.js
+++ b/src/auth-service/routes/v2/index.js
@@ -269,6 +269,12 @@ const authRoutes = [
     description: "Guest user management",
   },
   {
+    path: "/selfies",
+    route: "@routes/v2/selfies.routes",
+    name: "selfies",
+    description: "Clean Air Forum selfie wall submissions and moderation",
+  },
+  {
     path: "/tenant-settings",
     route: "@routes/v2/tenant-settings.routes",
     name: "tenant-settings",
@@ -406,7 +412,7 @@ function getCategoryForRoute(routeName) {
       "surveys",
     ],
     notifications: ["notification-preferences", "campaigns"],
-    misc: ["checklist", "transactions", "guests"],
+    misc: ["checklist", "transactions", "guests", "selfies"],
   };
 
   for (const [category, routes] of Object.entries(categories)) {

--- a/src/auth-service/routes/v2/selfies.routes.js
+++ b/src/auth-service/routes/v2/selfies.routes.js
@@ -1,0 +1,37 @@
+const express = require("express");
+const router = express.Router();
+const selfieController = require("@controllers/selfie.controller");
+const selfieValidations = require("@validators/selfie.validators");
+const { enhancedJWTAuth, optionalJWTAuth } = require("@middleware/passport");
+const { requirePermissions } = require("@middleware/permissionAuth");
+const constants = require("@config/constants");
+const { validate, headers, pagination } = require("@validators/common");
+
+router.use(headers);
+
+router.post(
+  "/",
+  selfieValidations.create,
+  optionalJWTAuth,
+  validate,
+  selfieController.create
+);
+
+router.get(
+  "/",
+  selfieValidations.list,
+  pagination(),
+  validate,
+  selfieController.list
+);
+
+router.patch(
+  "/:id",
+  selfieValidations.hide,
+  enhancedJWTAuth,
+  requirePermissions([constants.SYSTEM_ADMIN]),
+  validate,
+  selfieController.hide
+);
+
+module.exports = router;

--- a/src/auth-service/routes/v2/selfies.routes.js
+++ b/src/auth-service/routes/v2/selfies.routes.js
@@ -34,4 +34,13 @@ router.patch(
   selfieController.hide
 );
 
+router.delete(
+  "/:id",
+  selfieValidations.delete,
+  enhancedJWTAuth,
+  requirePermissions([constants.SYSTEM_ADMIN]),
+  validate,
+  selfieController.delete
+);
+
 module.exports = router;

--- a/src/auth-service/utils/common/generate-filter.util.js
+++ b/src/auth-service/utils/common/generate-filter.util.js
@@ -127,6 +127,35 @@ const filter = {
       );
     }
   },
+  selfies: (req, next) => {
+    try {
+      let { id, eventId } = {
+        ...req.body,
+        ...req.query,
+        ...req.params,
+      };
+      let filter = { hidden: false };
+      if (id) {
+        filter["_id"] = ObjectId(id);
+      }
+      if (eventId) {
+        filter["eventId"] = eventId;
+      }
+
+      return filter;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      return next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          {
+            message: error.message,
+          }
+        )
+      );
+    }
+  },
   tenantSettings: (req, next) => {
     try {
       const { query, params } = req;

--- a/src/auth-service/utils/common/guest-identity.util.js
+++ b/src/auth-service/utils/common/guest-identity.util.js
@@ -1,0 +1,66 @@
+const NAME_ADJECTIVES = [
+  "Curious",
+  "Bright",
+  "Swift",
+  "Gentle",
+  "Bold",
+  "Calm",
+  "Eager",
+  "Jolly",
+  "Kind",
+  "Lively",
+  "Nimble",
+  "Proud",
+  "Sunny",
+  "Vivid",
+  "Witty",
+];
+
+const NAME_ANIMALS = [
+  "Falcon",
+  "Otter",
+  "Panda",
+  "Heron",
+  "Tiger",
+  "Sparrow",
+  "Dolphin",
+  "Lynx",
+  "Koala",
+  "Fox",
+  "Rabbit",
+  "Owl",
+  "Badger",
+  "Crane",
+  "Gecko",
+];
+
+const AVATAR_ICONS = [
+  "🦊",
+  "🦦",
+  "🐼",
+  "🦉",
+  "🐯",
+  "🐬",
+  "🐨",
+  "🦅",
+  "🐰",
+  "🦆",
+  "🦡",
+  "🐢",
+];
+
+function generateGuestIdentity() {
+  const adjective =
+    NAME_ADJECTIVES[Math.floor(Math.random() * NAME_ADJECTIVES.length)];
+  const animal = NAME_ANIMALS[Math.floor(Math.random() * NAME_ANIMALS.length)];
+  const suffix = Math.floor(Math.random() * 900 + 100);
+  const avatarIcon =
+    AVATAR_ICONS[Math.floor(Math.random() * AVATAR_ICONS.length)];
+
+  return {
+    displayName: `${adjective} ${animal} ${suffix}`,
+    avatarIcon,
+  };
+}
+
+module.exports = { generateGuestIdentity };

--- a/src/auth-service/utils/common/index.js
+++ b/src/auth-service/utils/common/index.js
@@ -20,6 +20,7 @@ const {
 const msgs = require("./email.msgs.util");
 const emailTemplates = require("./email.templates.util");
 const generateFilter = require("./generate-filter.util");
+const { generateGuestIdentity } = require("./guest-identity.util");
 const winstonLogger = require("./log-winston.util");
 const { publishKafkaEvent } = require("./kafka.util");
 const slugUtils = require("./slug.util");
@@ -57,5 +58,6 @@ module.exports = {
   msgs,
   emailTemplates,
   generateFilter,
+  generateGuestIdentity,
   publishKafkaEvent,
 };

--- a/src/auth-service/utils/guest-user.util.js
+++ b/src/auth-service/utils/guest-user.util.js
@@ -41,9 +41,11 @@ const guestUser = {
           })
         );
       }
-      // check if guest user exists
+      // Atomically claim (find + remove in one op) the guest record up
+      // front, so two concurrent convert requests for the same guest_id
+      // can't both pass an existence check before either one deletes it.
       const guestUser = await GuestUserModel(tenant)
-        .findOne({ guest_id })
+        .findOneAndDelete({ guest_id })
         .lean();
 
       if (isEmpty(guestUser)) {
@@ -71,14 +73,18 @@ const guestUser = {
       const newUser = await UserModel(tenant).register(registrationBody, next);
 
       if (!newUser || newUser.success === false) {
+        // Registration failed after the guest record was already claimed
+        // (deleted) above -- restore it so the guest isn't lost and the
+        // client can retry the conversion.
+        try {
+          await GuestUserModel(tenant).create(guestUser);
+        } catch (restoreError) {
+          logger.error(
+            `🐛🐛 Failed to restore guest ${guest_id} after failed conversion -- ${restoreError.message}`
+          );
+        }
         return newUser;
       }
-
-      //delete guest
-      const responseFromDeleteGuest = await GuestUserModel(tenant).remove(
-        { guest_id },
-        next
-      );
 
       return newUser;
     } catch (error) {

--- a/src/auth-service/utils/guest-user.util.js
+++ b/src/auth-service/utils/guest-user.util.js
@@ -53,25 +53,26 @@ const guestUser = {
           })
         );
       }
+      // Layer the guest's stored identity fields under whatever the
+      // client explicitly supplied — client-provided values always win,
+      // guest data only fills in what's missing.
+      const registrationBody = { ...body };
+      if (!registrationBody.firstName && guestUser.firstName) {
+        registrationBody.firstName = guestUser.firstName;
+      }
+      if (!registrationBody.lastName && guestUser.lastName) {
+        registrationBody.lastName = guestUser.lastName;
+      }
+      if (!registrationBody.userName && guestUser.displayName) {
+        registrationBody.userName = guestUser.displayName;
+      }
+
       // create new user
-      const newUser = await UserModel(tenant).register(body, next);
-      const newUserId = newUser.data._id;
+      const newUser = await UserModel(tenant).register(registrationBody, next);
 
-      // Migrate the data
-      const updatedFields = {
-        $set: {
-          //  migrate data from guest to new user
-          // ... your guest user fields here
-          // add the new id
-          user: newUserId,
-        },
-      };
-
-      const responseFromUpdateUser = await UserModel(tenant).modify(
-        { _id: newUserId },
-        updatedFields,
-        next
-      );
+      if (!newUser || newUser.success === false) {
+        return newUser;
+      }
 
       //delete guest
       const responseFromDeleteGuest = await GuestUserModel(tenant).remove(
@@ -79,7 +80,7 @@ const guestUser = {
         next
       );
 
-      return responseFromUpdateUser;
+      return newUser;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/auth-service/utils/selfie.util.js
+++ b/src/auth-service/utils/selfie.util.js
@@ -1,0 +1,145 @@
+const SelfieModel = require("@models/Selfie");
+const GuestUserModel = require("@models/GuestUser");
+const httpStatus = require("http-status");
+const { HttpError } = require("@utils/shared");
+const { generateFilter, generateGuestIdentity } = require("@utils/common");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- selfie-util`);
+
+async function resolveSubmitterIdentity({ request, tenant, body }) {
+  if (request.user && request.user._id) {
+    return {
+      user_id: request.user._id,
+      displayName: body.displayName || request.user.userName,
+      avatarIcon: body.avatarIcon,
+      guest_id: undefined,
+    };
+  }
+
+  if (body.guest_id) {
+    const guestUser = await GuestUserModel(tenant)
+      .findOne({ guest_id: body.guest_id })
+      .lean();
+
+    if (!isEmpty(guestUser)) {
+      GuestUserModel(tenant)
+        .modify({
+          filter: { guest_id: body.guest_id },
+          update: { lastActive: new Date() },
+        })
+        .catch((error) => {
+          logger.error(
+            `🐛🐛 Internal Server Error while touching guest lastActive -- ${error.message}`
+          );
+        });
+
+      return {
+        user_id: undefined,
+        guest_id: guestUser.guest_id,
+        displayName: body.displayName || guestUser.displayName,
+        avatarIcon: body.avatarIcon || guestUser.avatarIcon,
+      };
+    }
+    // stale/unknown guest_id -- fall through to a fresh anonymous identity
+  }
+
+  const identity = generateGuestIdentity();
+  return {
+    user_id: undefined,
+    guest_id: undefined,
+    displayName: body.displayName || identity.displayName,
+    avatarIcon: body.avatarIcon || identity.avatarIcon,
+  };
+}
+
+const selfie = {
+  create: async (request, next) => {
+    try {
+      const { query, body } = request;
+      const { tenant } = { ...body, ...query };
+
+      const identity = await resolveSubmitterIdentity({
+        request,
+        tenant,
+        body,
+      });
+
+      const response = await SelfieModel(tenant).register(
+        {
+          ...body,
+          ...identity,
+        },
+        next
+      );
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  list: async (request, next) => {
+    try {
+      const { query } = request;
+      const { tenant, limit, skip } = query;
+      const filter = generateFilter.selfies(request, next);
+
+      const response = await SelfieModel(tenant).list(
+        { skip, limit, filter },
+        next
+      );
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  hide: async (request, next) => {
+    try {
+      const { query, params } = request;
+      const { tenant, id } = { ...query, ...params };
+
+      const response = await SelfieModel(tenant).modify(
+        {
+          filter: { _id: id },
+          update: {
+            $set: {
+              hidden: true,
+              hiddenAt: new Date(),
+              hiddenBy: request.user && request.user._id,
+            },
+          },
+        },
+        next
+      );
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+};
+
+module.exports = selfie;

--- a/src/auth-service/utils/selfie.util.js
+++ b/src/auth-service/utils/selfie.util.js
@@ -46,10 +46,11 @@ async function destroyCloudinaryAsset(publicId) {
 
 async function resolveSubmitterIdentity({ request, tenant, body }) {
   if (request.user && request.user._id) {
+    const fallbackIdentity = body.avatarIcon ? {} : generateGuestIdentity();
     return {
       user_id: request.user._id,
       displayName: body.displayName || request.user.userName,
-      avatarIcon: body.avatarIcon,
+      avatarIcon: body.avatarIcon || fallbackIdentity.avatarIcon,
       guest_id: undefined,
     };
   }
@@ -63,7 +64,7 @@ async function resolveSubmitterIdentity({ request, tenant, body }) {
       GuestUserModel(tenant)
         .modify({
           filter: { guest_id: body.guest_id },
-          update: { lastActive: new Date() },
+          update: { $set: { lastActive: new Date() } },
         })
         .catch((error) => {
           logger.error(
@@ -102,9 +103,20 @@ const selfie = {
         body,
       });
 
+      // Whitelist client-settable fields explicitly -- moderation/audit
+      // fields (hidden, hiddenAt, hiddenBy) must never be settable directly
+      // from a public request body.
+      const allowedBody = {
+        eventId: body.eventId,
+        imageUrl: body.imageUrl,
+        locationName: body.locationName,
+        pm25Value: body.pm25Value,
+        aqiCategory: body.aqiCategory,
+      };
+
       const response = await SelfieModel(tenant).register(
         {
-          ...body,
+          ...allowedBody,
           ...identity,
         },
         next

--- a/src/auth-service/utils/selfie.util.js
+++ b/src/auth-service/utils/selfie.util.js
@@ -8,6 +8,42 @@ const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- selfie-util`);
 
+function extractCloudinaryPublicId(imageUrl) {
+  try {
+    const url = new URL(imageUrl);
+    const match = url.pathname.match(/\/upload\/(?:v\d+\/)?(.+?)\.[a-zA-Z0-9]+$/);
+    return match ? match[1] : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+async function destroyCloudinaryAsset(publicId) {
+  if (!publicId) {
+    return;
+  }
+  const isCloudinaryConfigured =
+    !!constants.CLOUD_NAME &&
+    !!constants.CLOUDINARY_API_KEY &&
+    !!constants.CLOUDINARY_API_SECRET;
+
+  if (!isCloudinaryConfigured) {
+    logger.warn(
+      `Cloudinary not configured — skipping asset deletion for ${publicId}`
+    );
+    return;
+  }
+
+  try {
+    const cloudinary = require("@config/cloudinary");
+    await cloudinary.uploader.destroy(publicId);
+  } catch (error) {
+    logger.error(
+      `🐛🐛 Failed to delete Cloudinary asset ${publicId} -- ${error.message}`
+    );
+  }
+}
+
 async function resolveSubmitterIdentity({ request, tenant, body }) {
   if (request.user && request.user._id) {
     return {
@@ -125,6 +161,39 @@ const selfie = {
             },
           },
         },
+        next
+      );
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+  delete: async (request, next) => {
+    try {
+      const { query, params } = request;
+      const { tenant, id } = { ...query, ...params };
+
+      const existing = await SelfieModel(tenant).findOne({
+        filter: { _id: id },
+      });
+
+      if (!existing || existing.success === false) {
+        return existing;
+      }
+
+      const publicId = extractCloudinaryPublicId(existing.data.imageUrl);
+      await destroyCloudinaryAsset(publicId);
+
+      const response = await SelfieModel(tenant).remove(
+        { filter: { _id: id } },
         next
       );
 

--- a/src/auth-service/validators/selfie.validators.js
+++ b/src/auth-service/validators/selfie.validators.js
@@ -3,6 +3,19 @@ const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 const constants = require("@config/constants");
 
+function isTrustedCloudinarySelfieUrl(value) {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "res.cloudinary.com" &&
+      url.pathname.includes("/clean_air_forum_selfies/")
+    );
+  } catch (error) {
+    return false;
+  }
+}
+
 const validateTenant = oneOf([
   query("tenant")
     .optional()
@@ -55,7 +68,12 @@ const create = [
     .bail()
     .trim()
     .isURL({ require_protocol: true })
-    .withMessage("imageUrl must be a valid URL"),
+    .withMessage("imageUrl must be a valid URL")
+    .bail()
+    .custom(isTrustedCloudinarySelfieUrl)
+    .withMessage(
+      "imageUrl must be an https://res.cloudinary.com/.../clean_air_forum_selfies/... URL"
+    ),
   body("locationName")
     .optional()
     .trim()
@@ -75,6 +93,11 @@ const create = [
     .trim()
     .isLength({ max: 40 })
     .withMessage("displayName cannot exceed 40 characters"),
+  body("avatarIcon")
+    .optional()
+    .trim()
+    .isLength({ max: 8 })
+    .withMessage("avatarIcon cannot exceed 8 characters"),
   body("guest_id").optional().trim(),
 ];
 

--- a/src/auth-service/validators/selfie.validators.js
+++ b/src/auth-service/validators/selfie.validators.js
@@ -1,0 +1,98 @@
+const { query, body, param, oneOf } = require("express-validator");
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Types.ObjectId;
+const constants = require("@config/constants");
+
+const validateTenant = oneOf([
+  query("tenant")
+    .optional()
+    .notEmpty()
+    .withMessage("tenant should not be empty if provided")
+    .trim()
+    .toLowerCase()
+    .bail()
+    .isIn(constants.TENANTS)
+    .withMessage("the tenant value is not among the expected ones"),
+  query("tenant")
+    .exists()
+    .withMessage("the tenant value is missing in the request query")
+    .trim()
+    .toLowerCase()
+    .bail()
+    .isIn(constants.TENANTS)
+    .withMessage("the tenant value is not among the expected ones"),
+]);
+
+const validateIdParam = oneOf([
+  param("id")
+    .exists()
+    .withMessage("the id param is missing in the request")
+    .bail()
+    .notEmpty()
+    .withMessage("this id cannot be empty")
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage("id must be an object ID")
+    .bail()
+    .customSanitizer((value) => {
+      return ObjectId(value);
+    }),
+]);
+
+const create = [
+  validateTenant,
+  body("eventId")
+    .exists()
+    .withMessage("the eventId is missing in the request")
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage("eventId cannot be empty"),
+  body("imageUrl")
+    .exists()
+    .withMessage("the imageUrl is missing in the request")
+    .bail()
+    .trim()
+    .isURL({ require_protocol: true })
+    .withMessage("imageUrl must be a valid URL"),
+  body("locationName")
+    .optional()
+    .trim()
+    .isLength({ max: 200 })
+    .withMessage("locationName cannot exceed 200 characters"),
+  body("pm25Value")
+    .optional()
+    .isFloat({ min: 0 })
+    .withMessage("pm25Value must be a non-negative number"),
+  body("aqiCategory")
+    .optional()
+    .trim()
+    .isLength({ max: 50 })
+    .withMessage("aqiCategory cannot exceed 50 characters"),
+  body("displayName")
+    .optional()
+    .trim()
+    .isLength({ max: 40 })
+    .withMessage("displayName cannot exceed 40 characters"),
+  body("guest_id").optional().trim(),
+];
+
+const list = [
+  validateTenant,
+  query("eventId")
+    .exists()
+    .withMessage("the eventId is missing in the request query")
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage("eventId cannot be empty"),
+];
+
+const hide = [validateTenant, validateIdParam];
+
+module.exports = {
+  create,
+  list,
+  hide,
+};

--- a/src/auth-service/validators/selfie.validators.js
+++ b/src/auth-service/validators/selfie.validators.js
@@ -91,8 +91,11 @@ const list = [
 
 const hide = [validateTenant, validateIdParam];
 
+const deleteSelfie = [validateTenant, validateIdParam];
+
 module.exports = {
   create,
   list,
   hide,
+  delete: deleteSelfie,
 };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds the real backend for the Clean Air Forum selfie-wall feature to
`auth-service` (mounted at `/api/v2/users/selfies`), replacing the mobile
team's temporary in-memory mock:

- `POST /selfies` — submit a selfie (`eventId`, `imageUrl`, optional
  `locationName`/`pm25Value`/`aqiCategory`/`displayName`). Works for a
  JWT-authenticated user, a known guest (`guest_id`), or a fully anonymous
  caller — anonymous submitters get an auto-generated display name +
  emoji avatar.
- `GET /selfies?eventId=...` — public wall listing, newest first, hidden
  submissions excluded.
- `PATCH /selfies/:id` — hides a submission (post-publish moderation,
  matches the original mock's behavior); requires an authenticated
  `SYSTEM_ADMIN`.
- New `models/Selfie.js`, `utils/selfie.util.js`,
  `validators/selfie.validators.js`, `controllers/selfie.controller.js`,
  `routes/v2/selfies.routes.js`, plus a small new
  `utils/common/guest-identity.util.js` for random guest name/avatar
  generation.

Also fixes a pre-existing bug found while building the above:
`POST /guests/convert` called `UserModel.modify()` with the wrong
argument shape, so it silently updated an arbitrary, unrelated user
document instead of the one just created — and it never migrated the
guest's stored name onto the new account. Both are fixed in
`utils/guest-user.util.js`, and `GuestUser` now carries `displayName`/
`avatarIcon` fields (auto-generated at registration if not supplied).

### Why is this change needed?

The mobile team shipped the selfie-wall feature ([PR #3755](https://github.com/airqo-platform/AirQo-frontend/pull/3755),
[PR #3756](https://github.com/airqo-platform/AirQo-frontend/pull/3756)) as
a client-side-only mock so it could be demoed before any backend existed —
that mock resets on every redeploy and isn't shared across replicas, which
is not viable for the actual event. This PR provides the persistent, real
backend it needs. The `convertGuest` fix was surfaced by this work (guest
identity data needed to be correct and migratable) but is a general
auth-service correctness fix independent of the selfies feature itself.

Note: Clean Air Forum Selfies and Learn (Know Your Air) are two
independent use cases per product guidance — this PR does not touch, and
is not related to, the separate Learn guest-leaderboard fix planned for
`device-registry` in a follow-up PR.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :bug: Bug fix
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `auth-service` only.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** All new/modified files were syntax-checked (`node -c`).
A full local boot/integration test was not run as part of this change —
please run `npm test` and manually exercise `POST`/`GET`/`PATCH /selfies`
and `POST /guests/convert` (with and without `firstName`/`lastName` in
the body) locally before merging.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All schema additions are optional/additive (`GuestUser.displayName`,
`GuestUser.avatarIcon`); the new `selfies` collection and routes are net
new. The `convertGuest` fix changes the response from "an unrelated,
incorrect user" to "the actual created user" — a correctness fix, not a
behavior any working caller could have intentionally depended on.

---

## :memo: Additional Notes

- This is PR 1 of 2 for the Clean Air Forum / Learn backend follow-ups —
  a second, separate PR will fix the Learn guest-leaderboard access bug
  in `device-registry`.
- Moderation model implemented is post-publish hide-only, matching the
  current mock exactly (no pending/approve/reject queue).
- Out of scope for this PR (other teams/infra): Cloudinary upload preset
  hardening, a signed-upload endpoint, and distributed rate limiting on
  the website's submission route.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selfie submission, listing, and hiding capabilities.
  * Introduced a new selfie endpoint with request validation and admin protection for hiding entries.
  * Added guest identity generation so anonymous users can receive a display name and avatar.
  * Selfie lists now support filtering by event and return total counts.

* **Bug Fixes**
  * Improved guest-to-user conversion so missing profile details are filled automatically and failed registrations stop cleanly.
  * Standardized error handling and validation responses across selfie actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->