### PR TITLE
Fix Learn leaderboard guest access in app logic and nginx gateway config

### DIFF
--- a/k8s/nginx/development/global-config.yaml
+++ b/k8s/nginx/development/global-config.yaml
@@ -152,6 +152,15 @@ data:
       if ($request_uri ~ '/api/(v1|v2)/devices/grids/summary') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/events/running') { return 200; }
       if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/catalog') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/lessons/') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/sessions/anonymous') { return 200; }
+      if ($request_uri ~ '^/api/(v1|v2)/devices/learn/progress($|[?])') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/lessons/') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/sync') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/courses') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/leaderboard') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/certificates/verify/') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }    
       if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # None API requests

--- a/k8s/nginx/development/global-config.yaml
+++ b/k8s/nginx/development/global-config.yaml
@@ -152,15 +152,15 @@ data:
       if ($request_uri ~ '/api/(v1|v2)/devices/grids/summary') { return 200; }
       if ($request_uri ~ '/api/(v1|v2)/devices/events/running') { return 200; }
       if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/catalog') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/lessons/') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/sessions/anonymous') { return 200; }
-      if ($request_uri ~ '^/api/(v1|v2)/devices/learn/progress($|[?])') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/lessons/') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/sync') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/courses') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/leaderboard') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/certificates/verify/') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/catalog$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/lessons/[^/]+$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/sessions/anonymous$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/lessons/[^/]+$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/sync$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/courses$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/leaderboard$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/certificates/verify/[^/]+$') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }    
       if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # None API requests

--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -167,6 +167,15 @@ data:
       if ($request_uri ~ '/api/(v1|v2)/devices/network-coverage(/export|/monitors|/countries)($|/|[?])') { return 200; }
       if ($request ~ '^(POST|DELETE) /api/(v1|v2)/devices/network-coverage/registry($|/|[?])') { return 200; }
       if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/catalog') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/lessons/') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/sessions/anonymous') { return 200; }
+      if ($request_uri ~ '^/api/(v1|v2)/devices/learn/progress($|[?])') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/lessons/') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/sync') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/courses') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/leaderboard') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/certificates/verify/') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }
       if ($request_uri ~ '/argocd') { return 200; }
       if ($request_uri !~ '/api/v') { return 200; } # None API requests

--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -167,15 +167,15 @@ data:
       if ($request_uri ~ '/api/(v1|v2)/devices/network-coverage(/export|/monitors|/countries)($|/|[?])') { return 200; }
       if ($request ~ '^(POST|DELETE) /api/(v1|v2)/devices/network-coverage/registry($|/|[?])') { return 200; }
       if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/catalog') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/lessons/') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/sessions/anonymous') { return 200; }
-      if ($request_uri ~ '^/api/(v1|v2)/devices/learn/progress($|[?])') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/lessons/') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/sync') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/courses') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/leaderboard') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/certificates/verify/') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/catalog$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/lessons/[^/]+$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/sessions/anonymous$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/lessons/[^/]+$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/sync$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/courses$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/leaderboard$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/certificates/verify/[^/]+$') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }
       if ($request_uri ~ '/argocd') { return 200; }
       if ($request_uri !~ '/api/v') { return 200; } # None API requests

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -166,15 +166,15 @@ data:
       if ($request_uri ~ '/api/(v1|v2)/devices/network-coverage(/export|/monitors|/countries)($|/|[?])') { return 200; }
       if ($request ~ '^(POST|DELETE) /api/(v1|v2)/devices/network-coverage/registry($|/|[?])') { return 200; }
       if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/catalog') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/lessons/') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/sessions/anonymous') { return 200; }
-      if ($request_uri ~ '^/api/(v1|v2)/devices/learn/progress($|[?])') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/lessons/') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/sync') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/courses') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/leaderboard') { return 200; }
-      if ($request_uri ~ '/api/(v1|v2)/devices/learn/certificates/verify/') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/catalog$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/lessons/[^/]+$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/sessions/anonymous$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/lessons/[^/]+$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/sync$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/progress/courses$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/leaderboard$') { return 200; }
+      if ($uri ~ '^/api/(v1|v2)/devices/learn/certificates/verify/[^/]+$') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }
       if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # None API requests 

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -166,6 +166,15 @@ data:
       if ($request_uri ~ '/api/(v1|v2)/devices/network-coverage(/export|/monitors|/countries)($|/|[?])') { return 200; }
       if ($request ~ '^(POST|DELETE) /api/(v1|v2)/devices/network-coverage/registry($|/|[?])') { return 200; }
       if ($request ~ '^POST /api/(v1|v2)/devices/network-creation-requests($|[?]| )') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/catalog') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/lessons/') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/sessions/anonymous') { return 200; }
+      if ($request_uri ~ '^/api/(v1|v2)/devices/learn/progress($|[?])') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/lessons/') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/sync') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/progress/courses') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/leaderboard') { return 200; }
+      if ($request_uri ~ '/api/(v1|v2)/devices/learn/certificates/verify/') { return 200; }
       if ($request_uri ~ '/airflow/api/v') { return 200; }
       if ($request_uri ~ '/grafana/api') { return 200; }    
       if ($request_uri !~ '/api/v') { return 200; } # None API requests 

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -1855,17 +1855,14 @@ const learn = {
   getLeaderboard: async (request, next) => {
     try {
       const tenant = getTenant(request);
+      const device_id = request.headers["x-device-id"];
       const user_id = request.user?.id || null;
+      const hasIdentity = Boolean(user_id || device_id);
 
-      if (!user_id) {
-        return {
-          success: false,
-          message:
-            "authentication required — create an account to view the leaderboard",
-          status: httpStatus.UNAUTHORIZED,
-        };
-      }
-
+      // The leaderboard is public, read-only, aggregate data -- viewing it
+      // never requires an identity. user_id/device_id are only used below
+      // to personalize the response (is_current_user/current_user_rank)
+      // when the caller happens to be identifiable.
       const limit = Math.min(parseInt(request.query.limit) || 20, 100);
       const LearnProgress = LearnProgressModel(tenant);
       const maxPoints = await getMaxLearnPoints(tenant, next);
@@ -1878,8 +1875,17 @@ const learn = {
       })
         .sort({ total_points: -1 })
         .limit(limit)
-        .select("user_id guest_id learner_type total_points completed_lessons")
+        .select(
+          "user_id device_id guest_id learner_type total_points completed_lessons"
+        )
         .lean();
+
+      // Matches the caller against their own progress row -- user_id when
+      // JWT-authenticated, otherwise device_id (unique per LearnProgress
+      // doc, same convention used by getProgress/findProgress). Always
+      // false for a fully anonymous caller (no identity to match).
+      const isCaller = (l) =>
+        hasIdentity && (user_id ? l.user_id === user_id : l.device_id === device_id);
 
       const guestIds = topLearners
         .filter((l) => l.learner_type === "guest" && l.guest_id)
@@ -1895,12 +1901,17 @@ const learn = {
         );
       }
 
-      // Determine caller's rank when they fall outside the top N
-      const currentUserInTop = topLearners.some((l) => l.user_id === user_id);
+      // Determine caller's rank when they fall outside the top N -- skipped
+      // entirely for a fully anonymous caller (no identity to look up, and
+      // an unguarded { device_id: undefined } filter would otherwise be
+      // stripped by Mongoose into an unfiltered findOne({}), matching an
+      // arbitrary document).
+      const currentUserInTop = topLearners.some(isCaller);
       let currentUserRank = null;
 
-      if (!currentUserInTop) {
-        const userProgress = await LearnProgress.findOne({ user_id }).lean();
+      if (!currentUserInTop && hasIdentity) {
+        const callerFilter = user_id ? { user_id } : { device_id };
+        const userProgress = await LearnProgress.findOne(callerFilter).lean();
         if (userProgress) {
           const ahead = await LearnProgress.countDocuments({
             total_points: { $gt: userProgress.total_points },
@@ -1929,11 +1940,11 @@ const learn = {
               // getProgress/getCatalog if the catalog changed since this
               // learner's last write.
               current_stage: computeStage(l.total_points, maxPoints),
-              is_current_user: l.user_id === user_id,
+              is_current_user: isCaller(l),
             };
           }),
           current_user_rank: currentUserInTop
-            ? topLearners.findIndex((l) => l.user_id === user_id) + 1
+            ? topLearners.findIndex(isCaller) + 1
             : currentUserRank,
         },
         message: "successfully retrieved leaderboard",

--- a/src/device-registry/utils/test/ut_learn.util.js
+++ b/src/device-registry/utils/test/ut_learn.util.js
@@ -760,12 +760,55 @@ describe("learnUtil", () => {
   // ---------------------------------------------------------------------------
 
   describe("getLeaderboard", () => {
-    it("should return UNAUTHORIZED when no user_id", async () => {
+    it("should return the leaderboard for a fully anonymous caller (no device_id, no user_id), without personalization", async () => {
+      progressInstance.find = sinon.stub().returns({
+        sort: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([
+          {
+            device_id: "dev-001",
+            learner_type: "guest",
+            total_points: 30,
+            completed_lessons: 3,
+          },
+        ]),
+      });
+
       const next = sinon.spy();
       const result = await learnUtil.getLeaderboard(makeReq(), next);
 
-      expect(result.success).to.be.false;
-      expect(result.status).to.equal(httpStatus.UNAUTHORIZED);
+      expect(result.success).to.be.true;
+      expect(result.data.entries[0].is_current_user).to.be.false;
+      expect(result.data.current_user_rank).to.be.null;
+      // No identity was supplied, so no per-caller lookup should have run.
+      expect(progressInstance.findOne.called).to.be.false;
+    });
+
+    it("should allow a guest identified by X-Device-Id to view the leaderboard", async () => {
+      progressInstance.find = sinon.stub().returns({
+        sort: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([
+          {
+            device_id: "dev-001",
+            learner_type: "guest",
+            total_points: 30,
+            completed_lessons: 3,
+          },
+        ]),
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.getLeaderboard(
+        makeReq({ headers: { "x-device-id": "dev-001" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data.entries[0].is_current_user).to.be.true;
+      expect(result.data.current_user_rank).to.equal(1);
     });
 
     it("should compute current_stage live from total_points and catalog-derived max_points", async () => {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes `GET /leaderboard` (Learn / Know Your Air module) in `device-registry`
so it's genuinely public: any caller — no identity, a guest identified by
an `X-Device-Id` header, or a JWT-authenticated user — can view it, instead
of hard-rejecting whenever no JWT-authenticated user was present. Identity
(`user_id` or `device_id`) is now used only to *personalize* the response
(`is_current_user`/`current_user_rank`) when the caller happens to be
identifiable; viewing the list itself never requires one. Introduces a
single `isCaller` predicate reused across the "am I in the top N,"
`is_current_user`, and rank-lookup logic in `utils/learn.util.js` —
previously all three hardcoded `user_id`, which is what made guests
invisible to *themselves* even though they already appeared in the ranked
results for everyone else. The rank-lookup query is explicitly skipped for
a fully anonymous caller, since an unguarded `{ device_id: undefined }`
filter would otherwise be silently stripped by Mongoose into an
unfiltered `findOne({})`, matching an arbitrary document. No route/
controller/validator changes — endpoint URL and signature are unchanged.

Also updates the unit tests in `utils/test/ut_learn.util.js`: the
existing test asserting a rejection with no identity now asserts a fully
anonymous request succeeds without personalization, and a new test covers
the guest/`device_id` success path.

**Also adds the missing gateway-level exemptions** in
`k8s/nginx/{production,staging,development}/global-config.yaml`. This
turned out to be required, not optional — see "Why" below.

### Why is this change needed?

Guests are already ranked and displayed in the Learn leaderboard's
results (via `LearnGuestSession` `display_name`/`avatar_icon`), but
nothing let a guest caller past the auth gate to see it in the first
place. Application-level fix: the util layer required `request.user?.id`
with no fallback, making the leaderboard screen inaccessible in the
mobile app to anyone without an account, even though this is read-only,
aggregate, public-by-nature data where identity is only needed for
personalization, not for viewing the list itself.

**Gateway-level fix (the actual blocker):** `k8s/nginx/*/global-config.yaml`
injects `auth_request /auth;` into every nginx location globally. That
internal `/auth` location returns 200 (bypass) only for an explicit
allowlist of paths (e.g. `/api/(v1|v2)/users`, `grids/summary`,
`events/running`); everything else is proxied to auth-service's
`POST /verify`, which is gated by `enhancedJWTAuth` and 401s with no valid
JWT. **None of the Learn paths were on that allowlist**, so every request
to `/leaderboard`, `/catalog`, `/lessons`, `/sessions/anonymous`,
`/progress`, etc. was being rejected at the gateway before it ever reached
device-registry — regardless of what the application code does. The
application-level fix above is necessary but was not sufficient on its
own; this PR adds bypass rules for the guest/public Learn endpoints
(`catalog`, `lessons`, `sessions/anonymous`, `progress` (+`/lessons`,
`/sync`, `/courses`), `leaderboard`, `certificates/verify`) to all three
environments' `global-config.yaml`, matching the existing pattern. Routes
that should stay gated (`progress/link`, `certificates` list/issue,
`admin/courses*`) are deliberately left off the allowlist.

Note: this is a separate, independent PR from the recent auth-service
Clean Air Forum selfies work — Learn and Selfies are two independent use
cases per product guidance, and this PR does not touch or depend on that
work.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — application code (`utils/learn.util.js` + its test file).
- Shared infra: `k8s/nginx/production/global-config.yaml`,
  `k8s/nginx/staging/global-config.yaml`,
  `k8s/nginx/development/global-config.yaml` — this is the gateway config
  for **all** services behind it, not just device-registry, though the
  only changes made are additive bypass rules scoped to Learn's own paths.

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran `npx mocha utils/test/ut_learn.util.js` — 36/36
passing, including the updated and newly added `getLeaderboard` tests.
All three `global-config.yaml` files were validated as well-formed YAML
after editing. No manual/live end-to-end testing was performed in this
session (no running server, and nginx config changes can only really be
verified against a deployed gateway) — **strongly recommend verifying in
staging first**: confirm `GET /leaderboard` and the other newly-exempted
Learn paths are reachable without a JWT, and confirm `progress/link`,
`certificates` (list/issue), and `admin/courses*` still correctly require
one.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Response shape is unchanged. Only the rejection condition changed, and
strictly in a widening direction — requests that previously got rejected
(guest or fully anonymous) can now succeed; nothing that previously
succeeded (a JWT-authenticated caller) is affected. This restores the
already-intended behavior (guests were already meant to be visible in the
ranked results) rather than introducing a new access model.

---

## :memo: Additional Notes

- **Significant finding, deliberately out of scope here:** `request.user`
  is never assigned anywhere in this entire device-registry codebase — no
  JWT/passport middleware exists to populate it. Even once the gateway
  correctly proxies a request through, `progress/link`, `issueCertificate`,
  and `getCourseProgress`'s "JWT" paths have no way to actually populate
  `request.user` today. This is a separate, larger pre-existing gap and
  not something this PR attempts to fix — worth its own follow-up ticket.
- Route, controller, and validators are intentionally untouched; the
  application-level fix is isolated to `utils/learn.util.js` (plus its
  test file). The gateway-level fix is isolated to additive bypass rules
  in `global-config.yaml` — no existing rule was modified or removed.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded unauthenticated access for additional learning-related API routes (catalog, lessons, progress, leaderboard, and certificate verification).

* **Bug Fixes**
  * Updated leaderboard so anonymous and device-identified guests can load results without failing auth, with correct `is_current_user` labeling and `current_user_rank` only when applicable.

* **Tests**
  * Added/updated unit tests to cover anonymous and device-based guest leaderboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->