### PR TITLE
Add guest username, event scoping, and avatars to Learn leaderboard

### DIFF
--- a/src/device-registry/controllers/learn.controller.js
+++ b/src/device-registry/controllers/learn.controller.js
@@ -80,6 +80,10 @@ const learnController = {
           success: true,
           guest_id: result.data.guest_id,
           display_name: result.data.display_name,
+          avatar_icon: result.data.avatar_icon,
+          avatar_image_url: result.data.avatar_image_url,
+          username: result.data.username,
+          event_id: result.data.event_id,
           created_at: result.data.created_at,
         });
       }

--- a/src/device-registry/models/LearnGuestSession.js
+++ b/src/device-registry/models/LearnGuestSession.js
@@ -56,6 +56,25 @@ const learnGuestSessionSchema = new Schema(
       type: String,
       trim: true,
     },
+    // Client-chosen name that overrides display_name on the leaderboard once
+    // set (e.g. the in-person "stall" quiz flow, where a participant types
+    // their own name instead of keeping the random adjective+animal one).
+    username: {
+      type: String,
+      trim: true,
+      minlength: 3,
+      maxlength: 30,
+      default: null,
+    },
+    // Opaque scope id for one-off quiz events (e.g. a specific forum/stall).
+    // Username uniqueness is enforced per event_id, not globally, so the
+    // same chosen name can be reused across unrelated events.
+    event_id: {
+      type: String,
+      trim: true,
+      default: null,
+      index: true,
+    },
     app_version: {
       type: String,
       trim: true,
@@ -78,6 +97,13 @@ const learnGuestSessionSchema = new Schema(
 );
 
 learnGuestSessionSchema.index({ device_id: 1 }, { unique: true });
+// Scopes username uniqueness to a single event_id (docs without a username
+// are excluded via the partial filter so untouched guest sessions never
+// collide on this index).
+learnGuestSessionSchema.index(
+  { event_id: 1, username: 1 },
+  { unique: true, partialFilterExpression: { username: { $type: "string" } } }
+);
 
 learnGuestSessionSchema.statics = {
   async register(args, next) {
@@ -116,21 +142,73 @@ learnGuestSessionSchema.statics = {
     }
   },
 
+  async assertUsernameAvailable({ event_id = null, username, excludeId } = {}) {
+    if (typeof username !== "string") return;
+    const filter = { event_id: event_id || null, username };
+    if (excludeId) filter._id = { $ne: excludeId };
+    const clash = await this.findOne(filter).lean();
+    if (clash) {
+      const error = new Error("this username is already taken for this event");
+      error.isUsernameConflict = true;
+      throw error;
+    }
+  },
+
   async findOrCreate(args, next) {
     try {
-      const existing = await this.findOne({ device_id: args.device_id }).lean();
+      const { device_id, username, event_id } = args;
+      const existing = await this.findOne({ device_id }).lean();
+
       if (existing) {
-        return {
-          success: true,
-          data: existing,
-          message: "guest session retrieved",
-          status: httpStatus.OK,
-        };
+        const wantsUsernameChange =
+          typeof username === "string" && username !== existing.username;
+        if (!wantsUsernameChange) {
+          return {
+            success: true,
+            data: existing,
+            message: "guest session retrieved",
+            status: httpStatus.OK,
+          };
+        }
+
+        const scopeEventId = event_id !== undefined ? event_id : existing.event_id;
+        try {
+          await this.assertUsernameAvailable({
+            event_id: scopeEventId,
+            username,
+            excludeId: existing._id,
+          });
+          const updated = await this.findOneAndUpdate(
+            { _id: existing._id },
+            { username, ...(event_id !== undefined ? { event_id } : {}) },
+            { new: true }
+          ).lean();
+          return {
+            success: true,
+            data: updated,
+            message: "guest session updated",
+            status: httpStatus.OK,
+          };
+        } catch (updateError) {
+          if (updateError.isUsernameConflict || updateError.code === 11000) {
+            next(
+              new HttpError("Bad Request Error", httpStatus.CONFLICT, {
+                username: "this username is already taken for this event",
+              })
+            );
+            return;
+          }
+          throw updateError;
+        }
       }
+
       const suffix = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
       const guest_id = `guest_${suffix}`;
       const { display_name, avatar_icon } = generateGuestIdentity();
+
       try {
+        await this.assertUsernameAvailable({ event_id, username });
+
         const created = await this.create({
           ...args,
           guest_id,
@@ -144,9 +222,25 @@ learnGuestSessionSchema.statics = {
           status: httpStatus.CREATED,
         };
       } catch (createError) {
-        // Concurrent request won the race — re-fetch and return the winner's doc
+        if (createError.isUsernameConflict) {
+          next(
+            new HttpError("Bad Request Error", httpStatus.CONFLICT, {
+              username: "this username is already taken for this event",
+            })
+          );
+          return;
+        }
         if (createError.code === 11000) {
-          const race = await this.findOne({ device_id: args.device_id }).lean();
+          if (createError.keyPattern && createError.keyPattern.username) {
+            next(
+              new HttpError("Bad Request Error", httpStatus.CONFLICT, {
+                username: "this username is already taken for this event",
+              })
+            );
+            return;
+          }
+          // Concurrent request won the device_id race — re-fetch and return the winner's doc
+          const race = await this.findOne({ device_id }).lean();
           if (race) {
             return {
               success: true,
@@ -210,5 +304,7 @@ const LearnGuestSessionModel = (tenant) => {
     );
   }
 };
+
+LearnGuestSessionModel.AVATAR_ICONS = AVATAR_ICONS;
 
 module.exports = LearnGuestSessionModel;

--- a/src/device-registry/models/LearnGuestSession.js
+++ b/src/device-registry/models/LearnGuestSession.js
@@ -181,7 +181,7 @@ learnGuestSessionSchema.statics = {
           const updated = await this.findOneAndUpdate(
             { _id: existing._id },
             { username, ...(event_id !== undefined ? { event_id } : {}) },
-            { new: true }
+            { new: true, runValidators: true }
           ).lean();
           return {
             success: true,

--- a/src/device-registry/models/test/ut_learn-guest-session.model.js
+++ b/src/device-registry/models/test/ut_learn-guest-session.model.js
@@ -138,6 +138,111 @@ describe("LearnGuestSession Model", () => {
     });
   });
 
+  describe("Static method: findOrCreate — username + event scoping", () => {
+    it("should create a new session with a chosen username when it's available in that event", async () => {
+      sinon
+        .stub(Model, "findOne")
+        .onFirstCall().returns({ lean: sinon.stub().resolves(null) }) // no existing device_id session
+        .onSecondCall().returns({ lean: sinon.stub().resolves(null) }); // username available
+      const fakeCreated = {
+        _id: "new-id",
+        _doc: {
+          device_id: "dev-new",
+          guest_id: "guest_new",
+          username: "Thabo",
+          event_id: "pretoria-2026",
+        },
+      };
+      sinon.stub(Model, "create").resolves(fakeCreated);
+      const next = sinon.spy();
+
+      const result = await Model.findOrCreate(
+        { device_id: "dev-new", username: "Thabo", event_id: "pretoria-2026" },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.CREATED);
+      expect(next.called).to.be.false;
+    });
+
+    it("should reject creation via next(CONFLICT) when the username is already taken in that event", async () => {
+      sinon
+        .stub(Model, "findOne")
+        .onFirstCall().returns({ lean: sinon.stub().resolves(null) }) // no existing device_id session
+        .onSecondCall().returns({
+          lean: sinon.stub().resolves({ _id: "other-id", username: "Thabo" }),
+        }); // clash
+      const createStub = sinon.stub(Model, "create");
+      const next = sinon.spy();
+
+      const result = await Model.findOrCreate(
+        { device_id: "dev-new-2", username: "Thabo", event_id: "pretoria-2026" },
+        next
+      );
+
+      expect(result).to.be.undefined;
+      expect(next.calledOnce).to.be.true;
+      expect(next.firstCall.args[0].statusCode).to.equal(httpStatus.CONFLICT);
+      expect(createStub.called).to.be.false;
+    });
+
+    it("should update the username on an existing session when the new name is available", async () => {
+      const existingSession = {
+        _id: "session-1",
+        device_id: "dev-001",
+        guest_id: "guest_existing",
+        username: null,
+        event_id: "pretoria-2026",
+      };
+      sinon
+        .stub(Model, "findOne")
+        .onFirstCall().returns({ lean: sinon.stub().resolves(existingSession) })
+        .onSecondCall().returns({ lean: sinon.stub().resolves(null) }); // username available
+      sinon.stub(Model, "findOneAndUpdate").returns({
+        lean: sinon.stub().resolves({ ...existingSession, username: "Thabo" }),
+      });
+      const next = sinon.spy();
+
+      const result = await Model.findOrCreate(
+        { device_id: "dev-001", username: "Thabo" },
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.OK);
+      expect(result.data.username).to.equal("Thabo");
+    });
+
+    it("should reject an update via next(CONFLICT) when the new username is already taken in that event", async () => {
+      const existingSession = {
+        _id: "session-1",
+        device_id: "dev-001",
+        guest_id: "guest_existing",
+        username: null,
+        event_id: "pretoria-2026",
+      };
+      sinon
+        .stub(Model, "findOne")
+        .onFirstCall().returns({ lean: sinon.stub().resolves(existingSession) })
+        .onSecondCall().returns({
+          lean: sinon.stub().resolves({ _id: "other-id", username: "Thabo" }),
+        }); // clash
+      const updateStub = sinon.stub(Model, "findOneAndUpdate");
+      const next = sinon.spy();
+
+      const result = await Model.findOrCreate(
+        { device_id: "dev-001", username: "Thabo" },
+        next
+      );
+
+      expect(result).to.be.undefined;
+      expect(next.calledOnce).to.be.true;
+      expect(next.firstCall.args[0].statusCode).to.equal(httpStatus.CONFLICT);
+      expect(updateStub.called).to.be.false;
+    });
+  });
+
   describe("Static method: modify", () => {
     it("should return success when session is updated", async () => {
       const fakeUpdated = {

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -30,7 +30,7 @@ const AVATAR_FALLBACK_ICONS = LearnGuestSessionModel.AVATAR_ICONS || ["🙂"];
 // external service or upload step) from a stable seed (guest_id/user_id) so
 // every leaderboard entry has an image without requiring a photo upload.
 function buildAvatarImageUrl({ seed, icon }) {
-  const hash = crypto.createHash("md5").update(String(seed || "")).digest();
+  const hash = crypto.createHash("sha256").update(String(seed || "")).digest();
   const background = AVATAR_BACKGROUND_COLORS[hash[0] % AVATAR_BACKGROUND_COLORS.length];
   const resolvedIcon = icon || AVATAR_FALLBACK_ICONS[hash[1] % AVATAR_FALLBACK_ICONS.length];
   const svg =
@@ -1966,7 +1966,13 @@ const learn = {
 
       if (!currentUserInTop && hasIdentity) {
         const callerFilter = user_id ? { user_id } : { device_id };
-        const userProgress = await LearnProgress.findOne(callerFilter).lean();
+        // When scoped to an event, the caller's own doc must also satisfy the
+        // event's guest/user membership -- otherwise someone who never joined
+        // this event would still get back a rank computed against it.
+        const scopedCallerFilter = progressFilter.$or
+          ? { ...callerFilter, $or: progressFilter.$or }
+          : callerFilter;
+        const userProgress = await LearnProgress.findOne(scopedCallerFilter).lean();
         if (userProgress) {
           const ahead = await LearnProgress.countDocuments({
             ...progressFilter,

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -20,6 +20,27 @@ const {
   DEFAULT_MAX_LEARN_POINTS,
 } = require("@utils/learn-progress.constants");
 
+const AVATAR_BACKGROUND_COLORS = [
+  "#F97316", "#10B981", "#3B82F6", "#EF4444",
+  "#8B5CF6", "#EC4899", "#EAB308", "#14B8A6",
+];
+const AVATAR_FALLBACK_ICONS = LearnGuestSessionModel.AVATAR_ICONS || ["🙂"];
+
+// Builds a self-contained, deterministic avatar image (a data URI, no
+// external service or upload step) from a stable seed (guest_id/user_id) so
+// every leaderboard entry has an image without requiring a photo upload.
+function buildAvatarImageUrl({ seed, icon }) {
+  const hash = crypto.createHash("md5").update(String(seed || "")).digest();
+  const background = AVATAR_BACKGROUND_COLORS[hash[0] % AVATAR_BACKGROUND_COLORS.length];
+  const resolvedIcon = icon || AVATAR_FALLBACK_ICONS[hash[1] % AVATAR_FALLBACK_ICONS.length];
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128">` +
+    `<rect width="128" height="128" rx="64" fill="${background}"/>` +
+    `<text x="50%" y="54%" font-size="64" text-anchor="middle" dominant-baseline="middle">${resolvedIcon}</text>` +
+    `</svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
+}
+
 // Lesson ids belonging to published courses only — draft/unpublished course
 // content is invisible to learners and must not count toward max_points.
 async function getPublishedLessonIds(tenant, next) {
@@ -439,10 +460,10 @@ const learn = {
   createAnonymousSession: async (request, next) => {
     try {
       const tenant = getTenant(request);
-      const { device_id, app_version, platform } = request.body;
+      const { device_id, app_version, platform, username, event_id } = request.body;
 
       const result = await LearnGuestSessionModel(tenant).findOrCreate(
-        { device_id, app_version, platform },
+        { device_id, app_version, platform, username, event_id },
         next
       );
       if (!result?.success) return result;
@@ -452,8 +473,14 @@ const learn = {
         success: true,
         data: {
           guest_id: session.guest_id,
-          display_name: session.display_name,
+          display_name: session.username || session.display_name,
           avatar_icon: session.avatar_icon,
+          avatar_image_url: buildAvatarImageUrl({
+            seed: session.guest_id,
+            icon: session.avatar_icon,
+          }),
+          username: session.username || null,
+          event_id: session.event_id || null,
           created_at: session.createdAt,
         },
         message: result.message,
@@ -1858,6 +1885,7 @@ const learn = {
       const device_id = request.headers["x-device-id"];
       const user_id = request.user?.id || null;
       const hasIdentity = Boolean(user_id || device_id);
+      const event_id = request.query.event_id || null;
 
       // The leaderboard is public, read-only, aggregate data -- viewing it
       // never requires an identity. user_id/device_id are only used below
@@ -1867,12 +1895,39 @@ const learn = {
       const LearnProgress = LearnProgressModel(tenant);
       const maxPoints = await getMaxLearnPoints(tenant, next);
 
+      const progressFilter = { total_points: { $gt: 0 } };
+
+      // For a one-off quiz/event (e.g. an in-person stall), scope entries to
+      // only the guest sessions (and any accounts they later linked to) that
+      // joined under that event_id, instead of the global leaderboard.
+      if (event_id) {
+        const eventSessions = await LearnGuestSessionModel(tenant)
+          .find({ event_id })
+          .select("guest_id linked_user_id")
+          .lean();
+        const eventGuestIds = eventSessions.map((s) => s.guest_id);
+        const eventUserIds = eventSessions
+          .filter((s) => s.linked_user_id)
+          .map((s) => s.linked_user_id);
+
+        if (eventGuestIds.length === 0 && eventUserIds.length === 0) {
+          return {
+            success: true,
+            data: { scope: "event", event_id, entries: [], current_user_rank: null },
+            message: "successfully retrieved leaderboard",
+            status: httpStatus.OK,
+          };
+        }
+        progressFilter.$or = [
+          { guest_id: { $in: eventGuestIds } },
+          { user_id: { $in: eventUserIds } },
+        ];
+      }
+
       // Guests are ranked alongside registered users — they're identified by
       // a random display name/icon (see LearnGuestSession) rather than being
       // excluded outright.
-      const topLearners = await LearnProgress.find({
-        total_points: { $gt: 0 },
-      })
+      const topLearners = await LearnProgress.find(progressFilter)
         .sort({ total_points: -1 })
         .limit(limit)
         .select(
@@ -1894,7 +1949,7 @@ const learn = {
       if (guestIds.length > 0) {
         const guestSessions = await LearnGuestSessionModel(tenant)
           .find({ guest_id: { $in: guestIds } })
-          .select("guest_id display_name avatar_icon")
+          .select("guest_id display_name avatar_icon username")
           .lean();
         guestIdentityByGuestId = new Map(
           guestSessions.map((s) => [s.guest_id, s])
@@ -1914,6 +1969,7 @@ const learn = {
         const userProgress = await LearnProgress.findOne(callerFilter).lean();
         if (userProgress) {
           const ahead = await LearnProgress.countDocuments({
+            ...progressFilter,
             total_points: { $gt: userProgress.total_points },
           });
           currentUserRank = ahead + 1;
@@ -1923,17 +1979,29 @@ const learn = {
       return {
         success: true,
         data: {
-          scope: "global",
+          scope: event_id ? "event" : "global",
+          ...(event_id ? { event_id } : {}),
           entries: topLearners.map((l, i) => {
             const guestIdentity =
               l.learner_type === "guest"
                 ? guestIdentityByGuestId.get(l.guest_id)
                 : null;
+            // A guest's own chosen username (set via the anonymous-session
+            // endpoint) takes precedence over the auto-generated display name.
+            const resolvedName =
+              guestIdentity?.username || guestIdentity?.display_name || undefined;
+            const avatarIcon = guestIdentity?.avatar_icon || undefined;
             return {
               rank: i + 1,
               learner_type: l.learner_type,
-              display_name: guestIdentity?.display_name || undefined,
-              avatar_icon: guestIdentity?.avatar_icon || undefined,
+              display_name: resolvedName,
+              avatar_icon: avatarIcon,
+              // Auto-generated server-side so the leaderboard always has an
+              // image to show without requiring a photo upload from the learner.
+              avatar_image_url: buildAvatarImageUrl({
+                seed: l.guest_id || l.user_id || l.device_id,
+                icon: avatarIcon,
+              }),
               total_points: l.total_points,
               completed_lessons: l.completed_lessons,
               // Computed live so a leaderboard row can never disagree with

--- a/src/device-registry/utils/test/ut_learn.util.js
+++ b/src/device-registry/utils/test/ut_learn.util.js
@@ -961,6 +961,49 @@ describe("learnUtil", () => {
       expect(result.data.entries).to.deep.equal([]);
       expect(progressInstance.find.called).to.be.false;
     });
+
+    it("should not assign an event rank to a caller who has progress but never joined that event", async () => {
+      // Only guest_1 joined the "pretoria-2026" event.
+      guestSessionInstance.find = sinon.stub().returns({
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([{ guest_id: "guest_1", linked_user_id: null }]),
+      });
+      progressInstance.find = sinon.stub().returns({
+        sort: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([
+          {
+            guest_id: "guest_1",
+            learner_type: "guest",
+            total_points: 50,
+            completed_lessons: 5,
+          },
+        ]),
+      });
+      // Caller's own doc exists (they've played before) but under a device_id
+      // that isn't part of the event's guest/user id set.
+      progressInstance.findOne = sinon.stub().returns({
+        lean: sinon.stub().resolves(null),
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.getLeaderboard(
+        makeReq({
+          query: { tenant: "airqo", event_id: "pretoria-2026" },
+          headers: { "x-device-id": "dev-outsider" },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      // The outsider's own-progress lookup must have been scoped to the
+      // event's $or membership filter, not just their device_id.
+      expect(progressInstance.findOne).to.have.been.calledWith(
+        sinon.match({ device_id: "dev-outsider", $or: sinon.match.array })
+      );
+      expect(result.data.current_user_rank).to.be.null;
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/device-registry/utils/test/ut_learn.util.js
+++ b/src/device-registry/utils/test/ut_learn.util.js
@@ -235,6 +235,52 @@ describe("learnUtil", () => {
       expect(result.success).to.be.true;
       expect(result.data).to.have.property("guest_id", "guest_abc");
     });
+
+    it("should pass a chosen username/event_id through to the model and surface them plus a generated avatar_image_url", async () => {
+      guestSessionInstance.findOrCreate.resolves({
+        success: true,
+        data: {
+          guest_id: "guest_abc",
+          display_name: "Curious Falcon 482",
+          avatar_icon: "🦊",
+          username: "Thabo",
+          event_id: "pretoria-2026",
+          createdAt: new Date(),
+        },
+        message: "guest session created",
+        status: httpStatus.CREATED,
+      });
+      const next = sinon.spy();
+      const result = await learnUtil.createAnonymousSession(
+        makeReq({
+          body: { device_id: "dev-001", username: "Thabo", event_id: "pretoria-2026" },
+        }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(guestSessionInstance.findOrCreate).to.have.been.calledWith(
+        sinon.match({ device_id: "dev-001", username: "Thabo", event_id: "pretoria-2026" })
+      );
+      // The guest's own chosen username takes over the display_name shown back to the client.
+      expect(result.data.display_name).to.equal("Thabo");
+      expect(result.data.username).to.equal("Thabo");
+      expect(result.data.event_id).to.equal("pretoria-2026");
+      expect(result.data.avatar_image_url).to.match(/^data:image\/svg\+xml;base64,/);
+    });
+
+    it("should propagate a conflict (undefined result) when the model rejects a taken username", async () => {
+      guestSessionInstance.findOrCreate.resolves(undefined);
+      const next = sinon.spy();
+      const result = await learnUtil.createAnonymousSession(
+        makeReq({
+          body: { device_id: "dev-002", username: "Thabo", event_id: "pretoria-2026" },
+        }),
+        next
+      );
+
+      expect(result).to.be.undefined;
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -846,6 +892,74 @@ describe("learnUtil", () => {
 
       expect(result.success).to.be.true;
       expect(result.data.entries[0].current_stage.name).to.equal("Defender");
+    });
+
+    it("should scope entries to a single event_id and resolve a guest's custom username + avatar_image_url", async () => {
+      guestSessionInstance.find = sinon.stub().callsFake((filter) => {
+        if (filter && filter.event_id) {
+          return {
+            select: sinon.stub().returnsThis(),
+            lean: sinon.stub().resolves([{ guest_id: "guest_1", linked_user_id: null }]),
+          };
+        }
+        return {
+          select: sinon.stub().returnsThis(),
+          lean: sinon.stub().resolves([
+            {
+              guest_id: "guest_1",
+              display_name: "Curious Falcon 482",
+              avatar_icon: "🦊",
+              username: "Thabo",
+            },
+          ]),
+        };
+      });
+      progressInstance.find = sinon.stub().returns({
+        sort: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([
+          {
+            guest_id: "guest_1",
+            learner_type: "guest",
+            total_points: 50,
+            completed_lessons: 5,
+          },
+        ]),
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.getLeaderboard(
+        makeReq({ query: { tenant: "airqo", event_id: "pretoria-2026" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data.scope).to.equal("event");
+      expect(result.data.event_id).to.equal("pretoria-2026");
+      expect(result.data.entries[0].display_name).to.equal("Thabo");
+      expect(result.data.entries[0].avatar_image_url).to.match(
+        /^data:image\/svg\+xml;base64,/
+      );
+    });
+
+    it("should return an empty event-scoped leaderboard without querying progress when nobody joined that event", async () => {
+      guestSessionInstance.find = sinon.stub().returns({
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([]),
+      });
+      progressInstance.find = sinon.stub();
+
+      const next = sinon.spy();
+      const result = await learnUtil.getLeaderboard(
+        makeReq({ query: { tenant: "airqo", event_id: "no-participants" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data.scope).to.equal("event");
+      expect(result.data.entries).to.deep.equal([]);
+      expect(progressInstance.find.called).to.be.false;
     });
   });
 

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -75,6 +75,21 @@ const learnValidations = {
       .optional()
       .isIn(["android", "ios"])
       .withMessage("platform must be android or ios"),
+    body("username")
+      .optional()
+      .trim()
+      .isLength({ min: 3, max: 30 })
+      .withMessage("username must be between 3 and 30 characters")
+      .bail()
+      .matches(/^[A-Za-z0-9 _.-]+$/)
+      .withMessage(
+        "username may only contain letters, numbers, spaces, underscores, hyphens and periods"
+      ),
+    body("event_id")
+      .optional()
+      .trim()
+      .isLength({ min: 1, max: 100 })
+      .withMessage("event_id must be between 1 and 100 characters"),
     validate,
   ],
 
@@ -238,6 +253,11 @@ const learnValidations = {
       .optional()
       .isInt({ min: 1, max: 100 })
       .withMessage("limit must be an integer between 1 and 100"),
+    query("event_id")
+      .optional()
+      .trim()
+      .isLength({ min: 1, max: 100 })
+      .withMessage("event_id must be between 1 and 100 characters"),
     validate,
   ],
 

--- a/src/device-registry/validators/test/ut_learn.validators.js
+++ b/src/device-registry/validators/test/ut_learn.validators.js
@@ -129,6 +129,27 @@ describe("learnValidations", () => {
       await runMiddlewareChain(validations.createAnonymousSession, req);
       expect(validationResult(req).isEmpty()).to.be.true;
     });
+
+    it("should pass with a valid username and event_id", async () => {
+      const req = mockRequest(
+        {},
+        { ...validBody, username: "Thabo M.", event_id: "pretoria-2026" }
+      );
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
+    it("should fail when username is shorter than 3 characters", async () => {
+      const req = mockRequest({}, { ...validBody, username: "Th" });
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should fail when username contains disallowed characters", async () => {
+      const req = mockRequest({}, { ...validBody, username: "Thabo<script>" });
+      await runMiddlewareChain(validations.createAnonymousSession, req);
+      expect(validationResult(req).isEmpty()).to.be.false;
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -351,6 +372,12 @@ describe("learnValidations", () => {
       const req = mockRequest({ limit: "0" });
       await runMiddlewareChain(validations.getLeaderboard, req);
       expect(validationResult(req).isEmpty()).to.be.false;
+    });
+
+    it("should pass when a valid event_id is provided", async () => {
+      const req = mockRequest({ event_id: "pretoria-2026" });
+      await runMiddlewareChain(validations.getLeaderboard, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
     });
   });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds guest-identity support to the Learn (Quiz) leaderboard for one-off, in-person "stall" style events. Guests can now set a custom username on their anonymous session, the leaderboard resolves that username instead of only showing auto-generated guest names, every leaderboard entry now includes a server-generated `avatar_image_url`, and the leaderboard can be scoped to a single `event_id` so only that event's participants appear.

### Why is this change needed?
Product/community feedback on the Learn quiz stall flow asked for participants to see their own chosen name and an avatar on the shared leaderboard, scoped to just their event (e.g. a specific forum/stall), without adding a photo-upload step to the quiz flow.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` (Learn/Quiz guest sessions, progress, leaderboard)

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Added/updated unit tests across the Learn model, util, and validator suites:
- `LearnGuestSession` model: username creation/update, per-event uniqueness conflicts (`findOrCreate`).
- `learn.util`: `createAnonymousSession` passing through `username`/`event_id` and returning `avatar_image_url`; `getLeaderboard` event-scoping (including the empty-participants case) and username/avatar resolution.
- Validators: accepting valid `username`/`event_id`, rejecting short/invalid usernames.

Ran the full Learn suite (`models`, `utils`, `validators`, `controllers` test files) — all new and pre-existing tests pass, aside from one pre-existing, unrelated failure in `getCatalog` validator tests that predates this branch.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All new fields (`username`, `event_id`, `avatar_image_url`) are additive and optional; existing callers that omit them keep the current behavior (auto-generated display name, global leaderboard scope).

---

## :memo: Additional Notes

- `username` uniqueness is enforced per `event_id` (via a partial unique index), not globally, so the same name can be reused across unrelated events.
- `avatar_image_url` is a self-contained `data:image/svg+xml;base64,...` URI generated deterministically from the learner's id — no external service call, no storage, no upload step.
- Points/scoring/progress logic is unchanged — this only attaches and surfaces identity (username + avatar) on top of existing leaderboard data.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anonymous guest sessions can now include a custom username and event ID.
  * Leaderboards can be filtered by event and now show event-scoped results.
  * Guest entries now include generated avatar image URLs.

* **Bug Fixes**
  * Username conflicts are handled consistently, preventing duplicate names within the same event.
  * Existing guest sessions can update their username when the new name is available.

* **Tests**
  * Added coverage for username/event validation, session creation, conflict handling, and event-scoped leaderboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->