### PR TITLE
Fix Learn progress read-back, replay scoring, and catalog gaps

### DIFF
--- a/src/device-registry/controllers/learn.controller.js
+++ b/src/device-registry/controllers/learn.controller.js
@@ -24,6 +24,7 @@ const learnController = {
           success: true,
           catalog_version: result.data.catalog_version,
           stages: result.data.stages,
+          max_points: result.data.max_points,
           courses: result.data.courses,
         });
       }

--- a/src/device-registry/controllers/test/ut_learn.controller.js
+++ b/src/device-registry/controllers/test/ut_learn.controller.js
@@ -101,6 +101,27 @@ describe("learnController", () => {
       expect(jsonArgs).to.have.property("courses");
     });
 
+    it("should include max_points from the util result", async () => {
+      learnUtilStub.getCatalog.resolves({
+        success: true,
+        data: {
+          catalog_version: "2025-01-01",
+          stages: [],
+          max_points: 2400,
+          courses: [],
+        },
+        status: httpStatus.OK,
+      });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.spy();
+
+      await controller.getCatalog(req, res, next);
+
+      const jsonArgs = res.json.firstCall.args[0];
+      expect(jsonArgs.max_points).to.equal(2400);
+    });
+
     it("should call next when validation fails", async () => {
       sharedStub.extractErrorsFromRequest.returns({ field: "error" });
       const req = makeReq();

--- a/src/device-registry/models/LearnProgress.js
+++ b/src/device-registry/models/LearnProgress.js
@@ -31,7 +31,7 @@ const lessonProgressSchema = new Schema(
     quiz_score_ratio: { type: Number, default: 0, min: 0, max: 1 },
     furthest_activity_index: { type: Number, default: 0, min: 0 },
     quiz_attempts: { type: Schema.Types.Mixed, default: [] },
-    free_text_response: { type: String, default: null },
+    free_text_response: { type: String, default: null, trim: true, maxlength: 2000 },
   },
   { _id: false }
 );
@@ -123,10 +123,15 @@ learnProgressSchema.statics = {
             : 1;
 
         // First completion always applies. On replay, only overwrite the stored
-        // result if it scores at least as well — stars, points, quiz_score_ratio
-        // and quiz_attempts move together so a replay can never leave points and
-        // stars reflecting two different attempts.
-        if (!currentLesson.completed || newPointsEarned >= pointsEarned) {
+        // result if it is not worse than the current best — stars, points,
+        // quiz_score_ratio and quiz_attempts move together so a replay can never
+        // leave points and stars reflecting two different attempts. Points alone
+        // can tie (e.g. 3/3 vs 3/6 both earn 30) while the ratio is worse, so a
+        // tie only overwrites when the ratio is at least as good too.
+        const isBetterOrEqual =
+          newPointsEarned > pointsEarned ||
+          (newPointsEarned === pointsEarned && newQuizScoreRatio >= quizScoreRatio);
+        if (!currentLesson.completed || isBetterOrEqual) {
           stars = newStars;
           pointsEarned = newPointsEarned;
           quizScoreRatio = newQuizScoreRatio;

--- a/src/device-registry/models/LearnProgress.js
+++ b/src/device-registry/models/LearnProgress.js
@@ -31,6 +31,7 @@ const lessonProgressSchema = new Schema(
     quiz_score_ratio: { type: Number, default: 0, min: 0, max: 1 },
     furthest_activity_index: { type: Number, default: 0, min: 0 },
     quiz_attempts: { type: Schema.Types.Mixed, default: [] },
+    free_text_response: { type: String, default: null },
   },
   { _id: false }
 );
@@ -95,29 +96,43 @@ learnProgressSchema.statics = {
       let stars = currentLesson.stars || 0;
       let pointsEarned = currentLesson.points_earned || 0;
       let quizScoreRatio = currentLesson.quiz_score_ratio || 0;
+      let quizAttempts = currentLesson.quiz_attempts || [];
       let completed = currentLesson.completed || false;
+      // Free text has no "better/worse" — the latest non-empty submission wins,
+      // independent of the quiz replay-scoring comparison below.
+      let freeTextResponse = currentLesson.free_text_response || null;
+      if (update.free_text_response) {
+        freeTextResponse = update.free_text_response;
+      }
 
-      if (update.completed && !currentLesson.completed) {
-        completed = true;
+      if (update.completed) {
         const attempts = update.quiz_attempts || [];
         const graded = attempts.filter(
           (a) => a.format !== "free_text" && a.is_correct !== undefined
         );
         const correct = graded.filter((a) => a.is_correct).length;
-        quizScoreRatio = graded.length > 0 ? correct / graded.length : 1.0;
-        pointsEarned = correct * POINTS_PER_QUESTION;
+        const newQuizScoreRatio = graded.length > 0 ? correct / graded.length : 1.0;
+        const newPointsEarned = correct * POINTS_PER_QUESTION;
+        const newStars =
+          graded.length === 0
+            ? 1
+            : newQuizScoreRatio === 1.0
+            ? 3
+            : newQuizScoreRatio >= 0.5
+            ? 2
+            : 1;
 
-        if (graded.length === 0) stars = 1;
-        else if (quizScoreRatio === 1.0) stars = 3;
-        else if (quizScoreRatio >= 0.5) stars = 2;
-        else stars = 1;
-      } else if (update.completed) {
-        const newPoints = update.quiz_attempts
-          ? update.quiz_attempts.filter(
-              (a) => a.format !== "free_text" && a.is_correct
-            ).length * POINTS_PER_QUESTION
-          : pointsEarned;
-        pointsEarned = Math.max(pointsEarned, newPoints);
+        // First completion always applies. On replay, only overwrite the stored
+        // result if it scores at least as well — stars, points, quiz_score_ratio
+        // and quiz_attempts move together so a replay can never leave points and
+        // stars reflecting two different attempts.
+        if (!currentLesson.completed || newPointsEarned >= pointsEarned) {
+          stars = newStars;
+          pointsEarned = newPointsEarned;
+          quizScoreRatio = newQuizScoreRatio;
+          quizAttempts = attempts;
+        }
+        completed = true;
       }
 
       const lessonUpdate = {
@@ -127,7 +142,8 @@ learnProgressSchema.statics = {
         points_earned: pointsEarned,
         quiz_score_ratio: quizScoreRatio,
         furthest_activity_index: furthest,
-        quiz_attempts: update.quiz_attempts || currentLesson.quiz_attempts || [],
+        quiz_attempts: quizAttempts,
+        free_text_response: freeTextResponse,
       };
 
       // Compute aggregate totals from existing lessons + updated lesson in one pass

--- a/src/device-registry/models/test/ut_learn-progress.model.js
+++ b/src/device-registry/models/test/ut_learn-progress.model.js
@@ -166,5 +166,159 @@ describe("LearnProgress Model", () => {
       expect(result.success).to.be.true;
       expect(result.data).to.have.property("lesson_id", "lesson-2");
     });
+
+    it("should overwrite stars/points/quiz_score_ratio on a replay that scores better", async () => {
+      const existingLessons = new Map([
+        [
+          "lesson-3",
+          {
+            completed: true,
+            stars: 1,
+            points_earned: 10,
+            quiz_score_ratio: 1 / 3,
+            furthest_activity_index: 4,
+            quiz_attempts: [
+              { activity_id: "a1", format: "single_choice", is_correct: true },
+            ],
+          },
+        ],
+      ]);
+      sinon.stub(Model, "findOne").resolves({ lessons: existingLessons });
+      sinon.stub(Model, "findOneAndUpdate").resolves({});
+      const next = sinon.spy();
+
+      const result = await Model.upsertLessonProgress(
+        {
+          device_id: "dev-003",
+          lesson_id: "lesson-3",
+          update: {
+            completed: true,
+            quiz_attempts: [
+              { activity_id: "a1", format: "single_choice", is_correct: true },
+              { activity_id: "a2", format: "single_choice", is_correct: true },
+              { activity_id: "a3", format: "single_choice", is_correct: true },
+            ],
+          },
+          maxPoints: 2400,
+        },
+        next
+      );
+
+      expect(result.data.stars).to.equal(3);
+      expect(result.data.points_earned).to.equal(30);
+    });
+
+    it("should keep the previous best result (stars, points, and quiz_attempts together) on a replay that scores worse", async () => {
+      const existingLessons = new Map([
+        [
+          "lesson-4",
+          {
+            completed: true,
+            stars: 3,
+            points_earned: 30,
+            quiz_score_ratio: 1,
+            furthest_activity_index: 4,
+            quiz_attempts: [
+              { activity_id: "a1", format: "single_choice", is_correct: true },
+              { activity_id: "a2", format: "single_choice", is_correct: true },
+              { activity_id: "a3", format: "single_choice", is_correct: true },
+            ],
+          },
+        ],
+      ]);
+      sinon.stub(Model, "findOne").resolves({ lessons: existingLessons });
+      const findOneAndUpdateStub = sinon
+        .stub(Model, "findOneAndUpdate")
+        .resolves({});
+      const next = sinon.spy();
+
+      const result = await Model.upsertLessonProgress(
+        {
+          device_id: "dev-004",
+          lesson_id: "lesson-4",
+          update: {
+            completed: true,
+            quiz_attempts: [
+              { activity_id: "a1", format: "single_choice", is_correct: false },
+              { activity_id: "a2", format: "single_choice", is_correct: false },
+              { activity_id: "a3", format: "single_choice", is_correct: true },
+            ],
+          },
+          maxPoints: 2400,
+        },
+        next
+      );
+
+      expect(result.data.stars).to.equal(3);
+      expect(result.data.points_earned).to.equal(30);
+
+      const setOp = findOneAndUpdateStub.firstCall.args[1].$set;
+      expect(setOp["lessons.lesson-4"].quiz_attempts).to.have.lengthOf(3);
+      expect(
+        setOp["lessons.lesson-4"].quiz_attempts.every((a) => a.is_correct)
+      ).to.be.true;
+    });
+
+    it("should persist free_text_response independent of quiz scoring", async () => {
+      sinon.stub(Model, "findOne").resolves(null);
+      const findOneAndUpdateStub = sinon
+        .stub(Model, "findOneAndUpdate")
+        .resolves({});
+      const next = sinon.spy();
+
+      await Model.upsertLessonProgress(
+        {
+          device_id: "dev-005",
+          lesson_id: "lesson-5",
+          update: {
+            completed: true,
+            free_text_response: "Because air pollution affects everyone.",
+          },
+          maxPoints: 2400,
+        },
+        next
+      );
+
+      const setOp = findOneAndUpdateStub.firstCall.args[1].$set;
+      expect(setOp["lessons.lesson-5"].free_text_response).to.equal(
+        "Because air pollution affects everyone."
+      );
+    });
+
+    it("should keep the previous free_text_response when a later update omits it", async () => {
+      const existingLessons = new Map([
+        [
+          "lesson-6",
+          {
+            completed: true,
+            stars: 1,
+            points_earned: 0,
+            quiz_score_ratio: 1,
+            furthest_activity_index: 2,
+            free_text_response: "My first answer.",
+          },
+        ],
+      ]);
+      sinon.stub(Model, "findOne").resolves({ lessons: existingLessons });
+      const findOneAndUpdateStub = sinon
+        .stub(Model, "findOneAndUpdate")
+        .resolves({});
+      const next = sinon.spy();
+
+      await Model.upsertLessonProgress(
+        {
+          device_id: "dev-006",
+          lesson_id: "lesson-6",
+          update: { completed: true, furthest_activity_index: 3 },
+          maxPoints: 2400,
+        },
+        next
+      );
+
+      const setOp = findOneAndUpdateStub.firstCall.args[1].$set;
+      expect(setOp["lessons.lesson-6"].free_text_response).to.equal(
+        "My first answer."
+      );
+    });
   });
 });

--- a/src/device-registry/models/test/ut_learn-progress.model.js
+++ b/src/device-registry/models/test/ut_learn-progress.model.js
@@ -208,6 +208,60 @@ describe("LearnProgress Model", () => {
       expect(result.data.points_earned).to.equal(30);
     });
 
+    it("should not downgrade stars/quiz_score_ratio on a replay that ties on points but has a worse ratio", async () => {
+      // Previous best: 3/3 correct = 30 points, ratio 1.0, 3 stars.
+      const existingLessons = new Map([
+        [
+          "lesson-3b",
+          {
+            completed: true,
+            stars: 3,
+            points_earned: 30,
+            quiz_score_ratio: 1,
+            furthest_activity_index: 3,
+            quiz_attempts: [
+              { activity_id: "a1", format: "single_choice", is_correct: true },
+              { activity_id: "a2", format: "single_choice", is_correct: true },
+              { activity_id: "a3", format: "single_choice", is_correct: true },
+            ],
+          },
+        ],
+      ]);
+      sinon.stub(Model, "findOne").resolves({ lessons: existingLessons });
+      const findOneAndUpdateStub = sinon
+        .stub(Model, "findOneAndUpdate")
+        .resolves({});
+      const next = sinon.spy();
+
+      // Replay: 3/6 correct — also 30 points, but a worse ratio (0.5) and stars (2).
+      const result = await Model.upsertLessonProgress(
+        {
+          device_id: "dev-003b",
+          lesson_id: "lesson-3b",
+          update: {
+            completed: true,
+            quiz_attempts: [
+              { activity_id: "a1", format: "single_choice", is_correct: true },
+              { activity_id: "a2", format: "single_choice", is_correct: true },
+              { activity_id: "a3", format: "single_choice", is_correct: true },
+              { activity_id: "a4", format: "single_choice", is_correct: false },
+              { activity_id: "a5", format: "single_choice", is_correct: false },
+              { activity_id: "a6", format: "single_choice", is_correct: false },
+            ],
+          },
+          maxPoints: 2400,
+        },
+        next
+      );
+
+      expect(result.data.stars).to.equal(3);
+      expect(result.data.points_earned).to.equal(30);
+
+      const setOp = findOneAndUpdateStub.firstCall.args[1].$set;
+      expect(setOp["lessons.lesson-3b"].quiz_score_ratio).to.equal(1);
+      expect(setOp["lessons.lesson-3b"].quiz_attempts).to.have.lengthOf(3);
+    });
+
     it("should keep the previous best result (stars, points, and quiz_attempts together) on a replay that scores worse", async () => {
       const existingLessons = new Map([
         [

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -553,7 +553,7 @@ const learn = {
             stars: lp.stars,
             points_earned: lp.points_earned,
             quiz_score_ratio: lp.quiz_score_ratio,
-            furthest_activity_index: lp.furthest_activity_index,
+            furthest_activity_index: lp.furthest_activity_index ?? 0,
             free_text_response: lp.free_text_response || null,
           };
         });

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -553,6 +553,8 @@ const learn = {
             stars: lp.stars,
             points_earned: lp.points_earned,
             quiz_score_ratio: lp.quiz_score_ratio,
+            furthest_activity_index: lp.furthest_activity_index,
+            free_text_response: lp.free_text_response || null,
           };
         });
       }

--- a/src/device-registry/utils/test/ut_learn.util.js
+++ b/src/device-registry/utils/test/ut_learn.util.js
@@ -319,7 +319,16 @@ describe("learnUtil", () => {
           completed_lessons: 1,
           current_stage_index: 0,
           lessons: new Map([
-            ["lid1", { completed: true, stars: 2, points_earned: 20, quiz_score_ratio: 0.8 }],
+            [
+              "lid1",
+              {
+                completed: true,
+                stars: 2,
+                points_earned: 20,
+                quiz_score_ratio: 0.8,
+                furthest_activity_index: 4,
+              },
+            ],
           ]),
         },
       });
@@ -332,6 +341,7 @@ describe("learnUtil", () => {
       expect(result.success).to.be.true;
       expect(result.data.total_points).to.equal(50);
       expect(result.data.lessons).to.have.property("lid1");
+      expect(result.data.lessons.lid1.furthest_activity_index).to.equal(4);
     });
 
     it("should derive max_points only from published-course quiz activities", async () => {

--- a/src/device-registry/utils/test/ut_learn.util.js
+++ b/src/device-registry/utils/test/ut_learn.util.js
@@ -342,6 +342,9 @@ describe("learnUtil", () => {
       expect(result.data.total_points).to.equal(50);
       expect(result.data.lessons).to.have.property("lid1");
       expect(result.data.lessons.lid1.furthest_activity_index).to.equal(4);
+      // lid1 has no free_text_response in the fixture — should fall back to null,
+      // not be omitted from the response.
+      expect(result.data.lessons.lid1.free_text_response).to.be.null;
     });
 
     it("should derive max_points only from published-course quiz activities", async () => {

--- a/src/device-registry/validators/learn.validators.js
+++ b/src/device-registry/validators/learn.validators.js
@@ -153,6 +153,11 @@ const learnValidations = {
       .isInt({ min: 0 })
       .withMessage("quiz_attempts[].selected_order[] must be non-negative integers")
       .toInt(),
+    body("free_text_response")
+      .optional()
+      .trim()
+      .isLength({ max: 2000 })
+      .withMessage("free_text_response must not exceed 2000 characters"),
     validate,
   ],
 
@@ -177,6 +182,11 @@ const learnValidations = {
       .bail()
       .trim()
       .notEmpty(),
+    body("updates.*.free_text_response")
+      .optional()
+      .trim()
+      .isLength({ max: 2000 })
+      .withMessage("updates[].free_text_response must not exceed 2000 characters"),
     validate,
   ],
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes several backend gaps in the Learn module's progress-tracking API
(`device-registry`):

- `GET /progress` now includes `furthest_activity_index` per lesson (was silently
  omitted, even though it's stored).
- Fixes a replay-scoring bug in `upsertLessonProgress`: when a lesson is completed more
  than once, `stars`, `points_earned`, `quiz_score_ratio`, and the stored `quiz_attempts`
  snapshot now move together as one "best result," instead of `points_earned` alone being
  maxed while `stars`/`quiz_score_ratio` stayed frozen from the first attempt.
- `free_text_response` is now validated, persisted per lesson, and returned by
  `GET /progress` — previously it was accepted by the app's request but silently dropped
  server-side despite the UI telling the learner "your response has been saved."
- `GET /catalog` now returns `max_points` in the response — it was already computed
  server-side but the controller never included it in the JSON payload.

### Why is this change needed?

A frontend engineer reported that a user who signs in on a new device starts from zero
even though their progress exists on the server (guest → account progress is already
linked on sign-in) — there was no endpoint response that gave back enough per-lesson state
to rehydrate the local UI. While closing that gap on `GET /progress`, we found the
underlying data being read back was itself unreliable: a replay-scoring bug could store
`stars` and `points_earned` reflecting two different attempts, and free-text answers were
silently discarded despite the app promising they were saved. Fixing those first avoids
shipping a "read progress back" capability on top of data that's already wrong.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

<!-- No tracked issue — raised directly from a frontend engineer's feedback thread. -->

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only (Learn module: `models/LearnProgress.js`,
`utils/learn.util.js`, `controllers/learn.controller.js`, `validators/learn.validators.js`).

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added/extended unit tests covering both replay-scoring branches (better
and worse replay), `free_text_response` persistence and retention across updates,
`furthest_activity_index` in the `GET /progress` response, and `max_points` in the
`GET /catalog` response. Full Learn-module suite: **141/141 passing**
(`models/test/ut_learn-progress.model.js`, `utils/test/ut_learn.util.js`,
`controllers/test/ut_learn.controller.js`, `validators/test/ut_learn.validators.js`).
No manual/integration testing was done against a running server for this change.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All changes are additive JSON fields on existing endpoint responses, or corrections to
scoring logic that only apply to writes made after this deploy — no request/response shape
was removed or renamed.

---

## :memo: Additional Notes

- **No data migration included.** The replay-scoring fix only corrects behaviour for
  lesson-completion writes made after this deploy. Any existing progress documents that
  already have inconsistent `stars`/`points_earned` from before this fix are not
  backfilled.
- `total_activities` (also sent by the mobile app) is intentionally left unhandled — nothing
  server-side needs it, and the value is already derivable from the catalog's activity
  count, so it wasn't worth adding schema/validator surface for.
- The root UX bug reported alongside this (quiz answers appearing pre-selected on the next
  question) is a **mobile-side** bug (missing `Key` causing Flutter to reuse quiz widget
  state across questions) and is out of scope for this PR. Related findings — the app never
  sending a real `activity_id`/`selected_index` for quiz attempts, which also blocks
  server-side quiz re-grading — are open and also require a mobile fix.
- One pre-existing, unrelated test failure appears when running the **full** repo test
  suite (`bin/jobs/test/ut_check-active-statuses.js` requires a live DB connection at
  import time) — not caused by or related to this change.
- Full investigation notes and a consolidated API doc for the Learn section are available in
  `src/device-registry/learn-courses-quiz-investigation.tmp.md` and
  `src/device-registry/learn-section-api-documentation.tmp.md` for reviewer context (temp
  files, not intended to be merged).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress responses now surface additional lesson details, including free-text responses and furthest activity tracking.
  * Lesson progress updates can now include free-text answers, with support for syncing them in bulk.

* **Bug Fixes**
  * Replay attempts now preserve the best recorded quiz results while still marking lessons complete.
  * Existing free-text responses remain intact unless explicitly updated.

* **Tests**
  * Added coverage for updated progress output, free-text persistence, and replay score behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->