### PR TITLE
Fix missing learner_type on guest progress breaking leaderboard displ…

### DIFF
--- a/src/device-registry/models/LearnProgress.js
+++ b/src/device-registry/models/LearnProgress.js
@@ -179,7 +179,17 @@ learnProgressSchema.statics = {
       if (!existing) {
         setOp.device_id = device_id;
         if (guest_id) setOp.guest_id = guest_id;
-        if (user_id) { setOp.user_id = user_id; setOp.learner_type = "user"; }
+        // findOneAndUpdate(..., { upsert: true }) does not apply schema
+        // defaults on insert, so learner_type must be set explicitly here for
+        // every new document — otherwise a guest's doc is created with no
+        // learner_type at all, which breaks any read path that matches on it
+        // (e.g. the leaderboard's guest-identity/display-name lookup).
+        if (user_id) {
+          setOp.user_id = user_id;
+          setOp.learner_type = "user";
+        } else {
+          setOp.learner_type = "guest";
+        }
       }
 
       // Single atomic write — no second findOneAndUpdate needed

--- a/src/device-registry/models/test/ut_learn-progress.model.js
+++ b/src/device-registry/models/test/ut_learn-progress.model.js
@@ -167,6 +167,31 @@ describe("LearnProgress Model", () => {
       expect(result.data).to.have.property("lesson_id", "lesson-2");
     });
 
+    it("should explicitly set learner_type on a brand-new guest document", async () => {
+      // findOneAndUpdate(upsert: true) doesn't apply schema defaults on insert,
+      // so learner_type must be written explicitly here or a new guest doc is
+      // created with no learner_type at all (the bug this test guards against).
+      sinon.stub(Model, "findOne").resolves(null);
+      const findOneAndUpdateStub = sinon
+        .stub(Model, "findOneAndUpdate")
+        .resolves({});
+      const next = sinon.spy();
+
+      await Model.upsertLessonProgress(
+        {
+          device_id: "dev-007",
+          guest_id: "guest-007",
+          lesson_id: "lesson-7",
+          update: { completed: false, furthest_activity_index: 1 },
+          maxPoints: 2400,
+        },
+        next
+      );
+
+      const setOp = findOneAndUpdateStub.firstCall.args[1].$set;
+      expect(setOp.learner_type).to.equal("guest");
+    });
+
     it("should overwrite stars/points/quiz_score_ratio on a replay that scores better", async () => {
       const existingLessons = new Map([
         [

--- a/src/device-registry/utils/learn.util.js
+++ b/src/device-registry/utils/learn.util.js
@@ -562,7 +562,8 @@ const learn = {
       return {
         success: true,
         data: {
-          learner_type: doc.learner_type,
+          // Fall back for documents predating explicit learner_type writes.
+          learner_type: doc.learner_type || (doc.user_id ? "user" : "guest"),
           guest_id: doc.guest_id || undefined,
           total_points: doc.total_points,
           max_points: maxPoints,
@@ -1944,8 +1945,13 @@ const learn = {
       const isCaller = (l) =>
         hasIdentity && (user_id ? l.user_id === user_id : l.device_id === device_id);
 
+      // Keyed off the absence of user_id rather than learner_type === "guest":
+      // documents created before learner_type was set explicitly on insert
+      // (findOneAndUpdate upsert doesn't apply schema defaults) can have it
+      // missing entirely, which would otherwise silently exclude a real guest
+      // from the display-name/avatar lookup below.
       const guestIds = topLearners
-        .filter((l) => l.learner_type === "guest" && l.guest_id)
+        .filter((l) => !l.user_id && l.guest_id)
         .map((l) => l.guest_id);
       let guestIdentityByGuestId = new Map();
       if (guestIds.length > 0) {
@@ -1990,10 +1996,9 @@ const learn = {
           scope: event_id ? "event" : "global",
           ...(event_id ? { event_id } : {}),
           entries: topLearners.map((l, i) => {
-            const guestIdentity =
-              l.learner_type === "guest"
-                ? guestIdentityByGuestId.get(l.guest_id)
-                : null;
+            const guestIdentity = !l.user_id
+              ? guestIdentityByGuestId.get(l.guest_id)
+              : null;
             // A guest's own chosen username (set via the anonymous-session
             // endpoint) takes precedence over the auto-generated display name.
             const resolvedName =
@@ -2001,7 +2006,8 @@ const learn = {
             const avatarIcon = guestIdentity?.avatar_icon || undefined;
             return {
               rank: i + 1,
-              learner_type: l.learner_type,
+              // Fall back for documents predating explicit learner_type writes.
+              learner_type: l.learner_type || (l.user_id ? "user" : "guest"),
               display_name: resolvedName,
               avatar_icon: avatarIcon,
               // Auto-generated server-side so the leaderboard always has an

--- a/src/device-registry/utils/test/ut_learn.util.js
+++ b/src/device-registry/utils/test/ut_learn.util.js
@@ -956,6 +956,48 @@ describe("learnUtil", () => {
       );
     });
 
+    it("should still resolve a guest's display_name/avatar when learner_type is missing on the progress doc (legacy data)", async () => {
+      // Reproduces a real production gap: documents created via the upsert
+      // write path before learner_type was explicitly set on insert have no
+      // learner_type field at all — not even the "guest" default — so the
+      // guest-identity lookup must not depend on it.
+      guestSessionInstance.find = sinon.stub().returns({
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([
+          {
+            guest_id: "guest_legacy",
+            display_name: "Curious Panda",
+            avatar_icon: "🐼",
+            username: null,
+          },
+        ]),
+      });
+      progressInstance.find = sinon.stub().returns({
+        sort: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().resolves([
+          {
+            device_id: "dev-legacy",
+            guest_id: "guest_legacy",
+            // learner_type intentionally omitted.
+            total_points: 40,
+            completed_lessons: 1,
+          },
+        ]),
+      });
+
+      const next = sinon.spy();
+      const result = await learnUtil.getLeaderboard(
+        makeReq({ query: { tenant: "airqo", event_id: "pretoria-2026" } }),
+        next
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.data.entries[0].display_name).to.equal("Curious Panda");
+      expect(result.data.entries[0].learner_type).to.equal("guest");
+    });
+
     it("should return an empty event-scoped leaderboard without querying progress when nobody joined that event", async () => {
       guestSessionInstance.find = sinon.stub().returns({
         select: sinon.stub().returnsThis(),


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes a data-integrity bug in the Learn module where a guest's progress document could be
created with no `learner_type` field at all, which silently broke the leaderboard's
guest-identity lookup (`display_name`, `avatar_icon`) for those entries:

- `models/LearnProgress.js` — `upsertLessonProgress` now explicitly sets
  `learner_type: "guest"` when creating a brand-new guest progress document (previously it
  was only set for the `user_id` case; `findOneAndUpdate(..., { upsert: true })` does not
  apply schema defaults on insert, so guest documents were created with the field entirely
  absent).
- `utils/learn.util.js` (`getLeaderboard`) — guest-identity matching now keys off `!user_id`
  instead of `learner_type === "guest"`, and the returned `learner_type` field falls back
  correctly. This makes **already-existing** guest leaderboard entries self-heal on read,
  with no data migration required.
- `utils/learn.util.js` (`getProgress`) — same defensive fallback applied for consistency,
  since it reads from the same underlying field.

### Why is this change needed?

A frontend engineer (Hassan) reported that `GET /leaderboard` entries were missing
`display_name` in the payload even though his UI code expects it. The payload he shared was
also missing `avatar_icon` and `learner_type` entirely (not just `display_name`), which traced
back to guest progress documents being written without `learner_type` set — the leaderboard's
guest-identity lookup depends on that field to find the matching display name/avatar. Fixing
the read path means existing affected entries (e.g. the `pretoria-2026` event leaderboard he
shared) correct themselves as soon as this deploys.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

<!-- No tracked issue — raised directly by a frontend engineer via Slack, referencing AirQo-frontend PR #3786. -->

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only (Learn module: `models/LearnProgress.js`,
`utils/learn.util.js`).

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added a test confirming a brand-new guest document gets `learner_type:
"guest"` explicitly written on insert, and a test reproducing the exact production scenario
(a guest progress doc with `learner_type` entirely missing) that confirms `GET /leaderboard`
now still resolves `display_name` and returns a correct `learner_type` in that case. Full
Learn-module suite: **144/144 passing** (`models/test/ut_learn-progress.model.js`,
`utils/test/ut_learn.util.js`, `controllers/test/ut_learn.controller.js`,
`validators/test/ut_learn.validators.js`). No manual/integration testing was done against a
running server for this change.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely additive/defensive: existing response shapes are unchanged, and the fix only makes
previously-missing fields (`display_name`, `avatar_icon`, `learner_type`) reliably present
going forward, for both new and pre-existing guest records.

---

## :memo: Additional Notes

- **No data migration required.** The read-path fix in `getLeaderboard`/`getProgress` means
  existing guest documents that already have a missing `learner_type` self-heal at read time
  — there's no need to backfill historical records.
- This was found while investigating a frontend-reported leaderboard payload
  (`AirQo-frontend` PR #3786) that was missing `display_name` for guest entries in an
  event-scoped leaderboard (`event_id=pretoria-2026`).
- Same underlying gap (`findOneAndUpdate` upsert not applying schema defaults) is the same
  category of issue fixed for `furthest_activity_index` in the earlier `learn-progress`
  branch/PR — worth keeping in mind if any other field is ever added to this schema and
  expected to have a default on insert.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lesson progress records so new guest and registered learner entries are classified correctly.
  * Improved compatibility with older progress records that lack learner classification data.
  * Corrected leaderboard results to consistently include guests and display their names and avatars.
  * Prevented missing classification information from affecting progress retrieval and leaderboard rankings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->