### PR TITLE
Add admin bypass flags for token security detectors with expiry

### DIFF
--- a/src/auth-service/.mocharc.yml
+++ b/src/auth-service/.mocharc.yml
@@ -1,0 +1,31 @@
+# Mocha config. package.json's "test" script previously used an unquoted
+# ./**/test/ut_*.js glob, which the shell (not mocha) expanded — and plain
+# `sh` doesn't recurse `**`, so only single-level "test" directories ever
+# ran (~84 of 123 ut_*.js files). Quoting the glob here lets mocha's own
+# glob resolution (which does recurse) find all of them.
+spec: "./**/test/ut_*.js"
+exit: true
+
+# The following files throw at require-time (missing modules / wrong
+# module-alias paths — e.g. "@routes/tokens" instead of "@routes/v2/tokens.routes",
+# "@utils/email.msgs" instead of "@utils/common/email.msgs.util") and would
+# abort the entire mocha run before any test executes. They were never
+# reachable under the old non-recursive glob, so this is pre-existing rot,
+# not a regression from fixing the glob above. Ignored here so the rest of
+# the now-larger suite can actually run and report real pass/fail results;
+# not fixed, since that's a separate, larger cleanup.
+ignore:
+  - "./routes/v2/test/ut_clients.routes.js"
+  - "./routes/v2/test/ut_defaults.routes.js"
+  - "./routes/v2/test/ut_departments.routes.js"
+  - "./routes/v2/test/ut_index.js"
+  - "./routes/v2/test/ut_permissions.routes.js"
+  - "./routes/v2/test/ut_preferences.routes.js"
+  - "./routes/v2/test/ut_requests.routes.js"
+  - "./routes/v2/test/ut_roles.routes.js"
+  - "./routes/v2/test/ut_scopes.routes.js"
+  - "./routes/v2/test/ut_tokens.routes.js"
+  - "./utils/common/test/ut_email.templates.util.js"
+  - "./utils/common/test/ut_generate-filter.util.js"
+  - "./utils/common/test/ut_mailer.util.js"
+  - "./utils/test/ut_user.util.js"

--- a/src/auth-service/bin/jobs/bypass-expiry-job.js
+++ b/src/auth-service/bin/jobs/bypass-expiry-job.js
@@ -50,10 +50,19 @@ const revokeExpiredBypasses = async (tenant = "airqo") => {
 
     for (const doc of expired) {
       try {
-        await AccessTokenModel(tenant).updateOne(
-          { _id: doc._id },
+        // Re-assert the original match predicate ([field]: true, expired) in the
+        // update filter itself, not just the earlier find(). This makes the write
+        // atomic: if another pod's concurrent run already revoked this bypass
+        // between our find() and now, modifiedCount comes back 0 and we skip —
+        // preventing two overlapping cron runs from both emailing the owner.
+        const updateResult = await AccessTokenModel(tenant).updateOne(
+          { _id: doc._id, [field]: true, [expiresField]: { $lte: now } },
           { $set: { [field]: false }, $unset: { [expiresField]: "" } },
         );
+        const modified = updateResult.modifiedCount ?? updateResult.nModified ?? 0;
+        if (modified !== 1) {
+          continue;
+        }
         logger.info(
           `Bypass expired and cleared — token=...${(doc.token || "").slice(-4)} field=${field}`,
         );
@@ -67,6 +76,7 @@ const revokeExpiredBypasses = async (tenant = "airqo") => {
             token: doc.token,
             tokenName: doc.name || "",
             bypassLabel: BYPASS_LABELS[field] || field,
+            cooldownKey: `${(doc.token || "").slice(-4)}:${field}`,
           });
           if (result && result.success === false) {
             logger.error(
@@ -103,6 +113,10 @@ const sendUpcomingExpiryReminders = async (tenant = "airqo") => {
       try {
         const owner = await _getOwner(tenant, doc.client_id);
         if (!owner || !owner.email) continue;
+        // Include the expiry date in the cooldown key (not just token+field) so
+        // a renewal to a new future date starts a fresh reminder cycle instead
+        // of being silently suppressed by the cooldown from the previous cycle.
+        const expiryDay = new Date(doc[expiresField]).toISOString().slice(0, 10);
         const result = await mailer.bypassExpiryReminder({
           email: owner.email,
           firstName: owner.firstName || "",
@@ -111,6 +125,7 @@ const sendUpcomingExpiryReminders = async (tenant = "airqo") => {
           tokenName: doc.name || "",
           bypassLabel: BYPASS_LABELS[field] || field,
           expiresAt: doc[expiresField],
+          cooldownKey: `${(doc.token || "").slice(-4)}:${field}:${expiryDay}`,
         });
         if (result && result.success === false) {
           logger.error(

--- a/src/auth-service/bin/jobs/bypass-expiry-job.js
+++ b/src/auth-service/bin/jobs/bypass-expiry-job.js
@@ -1,0 +1,195 @@
+require("module-alias/register");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/bypass-expiry-job -- ops-alerts`,
+);
+const cron = require("node-cron");
+const AccessTokenModel = require("@models/AccessToken");
+const ClientModel = require("@models/Client");
+const UserModel = require("@models/User");
+const tokenUtil = require("@utils/token.util");
+const { mailer } = require("@utils/common");
+const { logText } = require("@utils/shared");
+
+const TIMEZONE = constants.TIMEZONE || "Africa/Kampala";
+const DAILY_SCHEDULE = "0 9 * * *"; // 9:00 AM every day
+const WEEKLY_SCHEDULE = "0 8 * * 1"; // 8:00 AM every Monday
+
+const BYPASS_LABELS = {
+  bypass_anomaly_detection: "Behavioural anomaly detection bypass",
+  bypass_compromise_detection: "High-compromise-activity auto-suspension bypass",
+  bypass_ip_blacklist: "IP-blacklist request-blocking bypass",
+};
+
+const _getOwner = async (tenant, clientId) => {
+  if (!clientId) return null;
+  const client = await ClientModel(tenant)
+    .findById(clientId)
+    .select("user_id")
+    .lean();
+  if (!client || !client.user_id) return null;
+  return UserModel(tenant)
+    .findById(client.user_id)
+    .select("email firstName lastName")
+    .lean();
+};
+
+// Auto-clears any bypass_* flag whose bypass_*_expires_at has passed, and
+// sends a one-time "bypassExpired" notice to the token owner so they aren't
+// surprised if normal detection kicks back in. Each expiry can only fire this
+// once — after the flag flips to false, the query below no longer matches it.
+const revokeExpiredBypasses = async (tenant = "airqo") => {
+  const now = new Date();
+  for (const field of tokenUtil.BYPASS_BOOLEAN_FIELDS) {
+    const expiresField = `${field}_expires_at`;
+    const expired = await AccessTokenModel(tenant)
+      .find({ [field]: true, [expiresField]: { $lte: now } })
+      .select(`name token client_id ${expiresField}`)
+      .lean();
+
+    for (const doc of expired) {
+      try {
+        await AccessTokenModel(tenant).updateOne(
+          { _id: doc._id },
+          { $set: { [field]: false }, $unset: { [expiresField]: "" } },
+        );
+        logger.info(
+          `Bypass expired and cleared — token=...${(doc.token || "").slice(-4)} field=${field}`,
+        );
+
+        const owner = await _getOwner(tenant, doc.client_id);
+        if (owner && owner.email) {
+          const result = await mailer.bypassExpired({
+            email: owner.email,
+            firstName: owner.firstName || "",
+            lastName: owner.lastName || "",
+            token: doc.token,
+            tokenName: doc.name || "",
+            bypassLabel: BYPASS_LABELS[field] || field,
+          });
+          if (result && result.success === false) {
+            logger.error(
+              `Failed to send bypassExpired email to ${owner.email}: ${result.message || "unknown error"}`,
+            );
+          }
+        }
+      } catch (error) {
+        logger.error(
+          `Failed to revoke expired bypass for token ...${(doc.token || "").slice(-4)}: ${error.message}`,
+        );
+      }
+    }
+  }
+};
+
+// Sends exactly one reminder per token+bypass per expiry cycle. The
+// mailer.bypassExpiryReminder cooldown (BYPASS_EXPIRY_REMINDER_LEAD_DAYS,
+// same window as the lookahead below) is what prevents the daily job run
+// from re-sending the same reminder every day inside the lead window.
+const sendUpcomingExpiryReminders = async (tenant = "airqo") => {
+  const now = new Date();
+  const leadDays = constants.BYPASS_EXPIRY_REMINDER_LEAD_DAYS;
+  const windowEnd = new Date(now.getTime() + leadDays * 24 * 60 * 60 * 1000);
+
+  for (const field of tokenUtil.BYPASS_BOOLEAN_FIELDS) {
+    const expiresField = `${field}_expires_at`;
+    const upcoming = await AccessTokenModel(tenant)
+      .find({ [field]: true, [expiresField]: { $gt: now, $lte: windowEnd } })
+      .select(`name token client_id ${expiresField}`)
+      .lean();
+
+    for (const doc of upcoming) {
+      try {
+        const owner = await _getOwner(tenant, doc.client_id);
+        if (!owner || !owner.email) continue;
+        const result = await mailer.bypassExpiryReminder({
+          email: owner.email,
+          firstName: owner.firstName || "",
+          lastName: owner.lastName || "",
+          token: doc.token,
+          tokenName: doc.name || "",
+          bypassLabel: BYPASS_LABELS[field] || field,
+          expiresAt: doc[expiresField],
+        });
+        if (result && result.success === false) {
+          logger.error(
+            `Failed to send bypassExpiryReminder email to ${owner.email}: ${result.message || "unknown error"}`,
+          );
+        }
+      } catch (error) {
+        logger.error(
+          `Failed to send bypass expiry reminder for token ...${(doc.token || "").slice(-4)}: ${error.message}`,
+        );
+      }
+    }
+  }
+};
+
+// Weekly, internal-only digest of every token with an active bypass right
+// now. Deliberately low cadence (weekly, not daily) and skipped entirely when
+// there is nothing to report, so admins are not nagged with empty summaries.
+const sendWeeklyBypassDigest = async (tenant = "airqo") => {
+  const bypasses = await tokenUtil.listActiveBypasses(tenant);
+  if (!bypasses || bypasses.length === 0) {
+    logText("No active security bypasses this week — skipping digest email.");
+    return;
+  }
+  const recipients = constants.SUPER_ADMIN_EMAIL_ALLOWLIST || [];
+  if (recipients.length === 0) {
+    logger.warn(
+      "SUPER_ADMIN_EMAIL_ALLOWLIST is empty — skipping weekly bypass digest.",
+    );
+    return;
+  }
+  const result = await mailer.bypassReportDigest({ recipients, bypasses });
+  if (result && result.success === false) {
+    logger.error(
+      `Failed to send weekly bypass digest: ${result.message || "unknown error"}`,
+    );
+  }
+};
+
+const runDailyBypassMaintenance = async (tenant = "airqo") => {
+  try {
+    if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") return;
+    await revokeExpiredBypasses(tenant);
+    await sendUpcomingExpiryReminders(tenant);
+  } catch (error) {
+    logger.error(`bypass-expiry-job daily run failed: ${error.message}`);
+  }
+};
+
+const runWeeklyBypassDigest = async (tenant = "airqo") => {
+  try {
+    if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") return;
+    await sendWeeklyBypassDigest(tenant);
+  } catch (error) {
+    logger.error(`bypass-expiry-job weekly digest failed: ${error.message}`);
+  }
+};
+
+const dailyJob = cron.schedule(
+  DAILY_SCHEDULE,
+  () => runDailyBypassMaintenance("airqo"),
+  { scheduled: true, timezone: TIMEZONE },
+);
+
+const weeklyJob = cron.schedule(
+  WEEKLY_SCHEDULE,
+  () => runWeeklyBypassDigest("airqo"),
+  { scheduled: true, timezone: TIMEZONE },
+);
+
+if (constants.ENVIRONMENT === "PRODUCTION ENVIRONMENT") {
+  dailyJob.start();
+  weeklyJob.start();
+}
+
+module.exports = {
+  revokeExpiredBypasses,
+  sendUpcomingExpiryReminders,
+  sendWeeklyBypassDigest,
+  runDailyBypassMaintenance,
+  runWeeklyBypassDigest,
+};

--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -110,6 +110,7 @@ const jobs = [
   "@bin/jobs/profile-picture-update-job",
   "@bin/jobs/role-cleanup-job",
   "@bin/jobs/daily-compromise-summary-job",
+  "@bin/jobs/bypass-expiry-job",
   "@bin/jobs/unknown-ip-cleanup-job",
   "@bin/jobs/feedback-screenshot-cleanup-job",
   "@bin/jobs/feedback-reminder-job",

--- a/src/auth-service/config/constants.js
+++ b/src/auth-service/config/constants.js
@@ -1,3 +1,10 @@
+// Populate process.env from .env.{NODE_ENV}.json before anything below reads
+// it. Previously this only happened if a specific test bootstrap file
+// (bin/test/ut_index.js) happened to load first — order that a correct,
+// fully-recursive test glob no longer guarantees. Idempotent: only fills
+// keys not already set, safe to call from multiple entry points.
+require("./env-loader").loadEnvironment();
+
 const coreConfig = require("./core");
 const { EnvOnlyValidator } = require("../utils/validation-reporter");
 
@@ -65,6 +72,13 @@ function envConfig(env) {
     COMPROMISE_SUSPEND_THRESHOLD: (() => {
       const v = parseInt(process.env.COMPROMISE_SUSPEND_THRESHOLD, 10);
       return Number.isFinite(v) && v > 0 ? v : 50;
+    })(),
+    // How many days before a bypass_*_expires_at date bypass-expiry-job starts
+    // sending a reminder email. Also used as the reminder email's cooldown so
+    // a token only gets reminded once per expiry cycle, not once per job run.
+    BYPASS_EXPIRY_REMINDER_LEAD_DAYS: (() => {
+      const v = parseInt(process.env.BYPASS_EXPIRY_REMINDER_LEAD_DAYS, 10);
+      return Number.isFinite(v) && v > 0 ? v : 3;
     })(),
     USE_REDIS_SESSIONS: parseBool(process.env.USE_REDIS_SESSIONS, false),
     ANALYTICS_PII_ENABLED: parseBool(process.env.ANALYTICS_PII_ENABLED, false),

--- a/src/auth-service/config/env-loader.js
+++ b/src/auth-service/config/env-loader.js
@@ -35,12 +35,23 @@ function applyToEnv(vars) {
   }
 }
 
+// Guards against repeat invocation: bin/index.js, config/check-environment.js,
+// and config/constants.js can all call loadEnvironment() (deliberately, so
+// population doesn't depend on which one happens to run first — see
+// constants.js). Without this flag, a missing .env.{NODE_ENV}.json in
+// staging/production — expected there, per the module doc above — would log
+// its warning once per caller instead of once per process.
+let loaded = false;
+
 /**
  * Load environment variables for the current NODE_ENV.
- * Must be called once, as early as possible in the process lifecycle,
- * before any config modules are required.
+ * Safe to call multiple times/from multiple entry points — only the first
+ * call in a process does any work.
  */
 function loadEnvironment() {
+  if (loaded) return;
+  loaded = true;
+
   const env = process.env.NODE_ENV || "development";
   const jsonPath = path.join(ROOT, `.env.${env}.json`);
 

--- a/src/auth-service/controllers/token.controller.js
+++ b/src/auth-service/controllers/token.controller.js
@@ -1867,9 +1867,13 @@ const createAccessToken = {
         return;
       }
       const request = req;
-      request.query.tenant = isEmpty(req.query.tenant)
-        ? constants.DEFAULT_TENANT || "airqo"
-        : req.query.tenant;
+      // This route is gated by validateAirqoTenantOnly, which only rejects an
+      // explicitly-passed non-"airqo" tenant — it does not enforce a value when
+      // the query param is omitted. Hardcode "airqo" here (not
+      // constants.DEFAULT_TENANT, which is env-controlled and not guaranteed to
+      // be "airqo") so this admin-only, airqo-only report can't silently read a
+      // different tenant's data if DEFAULT_TENANT is ever misconfigured.
+      request.query.tenant = isEmpty(req.query.tenant) ? "airqo" : req.query.tenant;
       const result = await tokenUtil.listBypassedTokens(request, next);
       if (isEmpty(result) || res.headersSent) return;
       if (result.success === true) {

--- a/src/auth-service/controllers/token.controller.js
+++ b/src/auth-service/controllers/token.controller.js
@@ -1854,6 +1854,40 @@ const createAccessToken = {
     }
   },
 
+  /**
+   * GET /tokens/bypasses — admin-only report of tokens with an active
+   * security-bypass flag (bypass_anomaly_detection / bypass_compromise_detection
+   * / bypass_ip_blacklist). Same data backs the weekly digest email.
+   */
+  listBypassedTokens: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = req;
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? constants.DEFAULT_TENANT || "airqo"
+        : req.query.tenant;
+      const result = await tokenUtil.listBypassedTokens(request, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success === true) {
+        return res.status(result.status || httpStatus.OK).json({
+          message: result.message || "",
+          bypassed_tokens: result.data || [],
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        message: result.message || "",
+        errors: result.errors || { message: "Internal Server Error" },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, { message: error.message }));
+    }
+  },
+
   resolveFlaggedToken: async (req, res, next) => {
     try {
       const errors = extractErrorsFromRequest(req);

--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -97,6 +97,28 @@ const AccessTokenSchema = new mongoose.Schema(
     // never auto-suspended by rate-spike or UA-change heuristics.
     // Honeypot traps, IP blocks, and manual suspension still apply.
     bypass_anomaly_detection: { type: Boolean, default: false },
+    // Optional expiry for bypass_anomaly_detection. When set and in the past,
+    // the bypass is treated as inactive at enforcement time even if the
+    // boolean itself is still true — bypass-expiry-job later clears the
+    // boolean and notifies the owner. Left unset, the bypass never expires.
+    bypass_anomaly_detection_expires_at: { type: Date },
+    // Admin-only flag. When true, the high-compromise-activity detector (many
+    // unique IPs hitting this token within 24h) never auto-suspends this token.
+    // For known multi-IP-by-design integrations (e.g. tokens fronted by a CDN,
+    // shared server pool, or third-party ingestion service) that legitimately
+    // get hit from many IPs. Honeypot traps, IP blocks, and manual suspension
+    // still apply.
+    bypass_compromise_detection: { type: Boolean, default: false },
+    bypass_compromise_detection_expires_at: { type: Date },
+    // Admin-only flag. When true, requests on this token are never rejected for
+    // originating from an IP already present in the BlacklistedIP collection
+    // (e.g. serverless/dynamic-egress integrations that legitimately rotate
+    // through IP ranges that get flagged). Distinct from bypass_compromise_detection,
+    // which only skips auto-suspension — this skips the per-request block itself.
+    // Admin-managed CIDR/ASN blocks, IP-prefix blocks, honeypot traps, and manual
+    // suspension are unaffected and still apply.
+    bypass_ip_blacklist: { type: Boolean, default: false },
+    bypass_ip_blacklist_expires_at: { type: Date },
   },
   { timestamps: true }
 );
@@ -475,6 +497,11 @@ AccessTokenSchema.methods = {
       request_pattern: this.request_pattern,
       allowed_origins: this.allowed_origins,
       bypass_anomaly_detection: this.bypass_anomaly_detection,
+      bypass_anomaly_detection_expires_at: this.bypass_anomaly_detection_expires_at,
+      bypass_compromise_detection: this.bypass_compromise_detection,
+      bypass_compromise_detection_expires_at: this.bypass_compromise_detection_expires_at,
+      bypass_ip_blacklist: this.bypass_ip_blacklist,
+      bypass_ip_blacklist_expires_at: this.bypass_ip_blacklist_expires_at,
     };
   },
 };

--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -496,12 +496,13 @@ AccessTokenSchema.methods = {
       last_user_agent: this.last_user_agent,
       request_pattern: this.request_pattern,
       allowed_origins: this.allowed_origins,
+      // bypass_anomaly_detection (pre-existing) is kept here; the newer
+      // bypass_compromise_detection/bypass_ip_blacklist flags and all
+      // *_expires_at companions are intentionally NOT exposed through this
+      // general-purpose serializer — they're admin-set/admin-facing detail,
+      // surfaced instead via the dedicated listActiveBypasses()/GET
+      // /tokens/bypasses admin report, not to every caller who can view a token.
       bypass_anomaly_detection: this.bypass_anomaly_detection,
-      bypass_anomaly_detection_expires_at: this.bypass_anomaly_detection_expires_at,
-      bypass_compromise_detection: this.bypass_compromise_detection,
-      bypass_compromise_detection_expires_at: this.bypass_compromise_detection_expires_at,
-      bypass_ip_blacklist: this.bypass_ip_blacklist,
-      bypass_ip_blacklist_expires_at: this.bypass_ip_blacklist_expires_at,
     };
   },
 };

--- a/src/auth-service/package.json
+++ b/src/auth-service/package.json
@@ -14,7 +14,7 @@
     "stage-pc": "set NODE_ENV=staging&&nodemon ./bin",
     "prod-pc": "set NODE_ENV=production&&nodemon ./bin",
     "create-env": "printenv > .env",
-    "test": "nyc --reporter=cobertura mocha ./**/test/ut_*.js --exit",
+    "test": "nyc --reporter=cobertura mocha",
     "kill-port": "node kill-app.js",
     "kill-port:force": "node kill-app.js --force",
     "kill-jobs": "node kill-jobs.js",

--- a/src/auth-service/routes/v2/tokens.routes.js
+++ b/src/auth-service/routes/v2/tokens.routes.js
@@ -381,6 +381,20 @@ router.put(
   createTokenController.resolveFlaggedToken,
 );
 
+/******************** Security-bypass reporting *****************************
+ * Admin-only report of tokens that currently have an active security-bypass
+ * flag (bypass_anomaly_detection / bypass_compromise_detection /
+ * bypass_ip_blacklist). Same data backs the weekly digest email sent by
+ * bin/jobs/bypass-expiry-job.js.
+ *************************************************************************/
+router.get(
+  "/bypasses",
+  validateAirqoTenantOnly,
+  enhancedJWTAuth,
+  requireAirQoSuperAdmin,
+  createTokenController.listBypassedTokens,
+);
+
 /******************** Cross-service honeypot flag endpoint **************
  * Called by downstream services (e.g. device-registry) to report a
  * honeypot hit for a token they cannot suspend themselves (token DB lives

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -819,6 +819,110 @@ module.exports = {
     return constants.EMAIL_BODY({ email, content, name });
   },
 
+  bypassExpiryReminder: ({
+    firstName = "",
+    lastName = "",
+    email = "",
+    token = "",
+    tokenName = "",
+    bypassLabel = "",
+    expiresAt = new Date(),
+  } = {}) => {
+    const name = `${firstName} ${lastName}`.trim() || "User";
+    const { maskedToken, tokenLabel } = buildTokenEmailSegment({ token, tokenName });
+    const expiryStr = expiresAt instanceof Date
+      ? expiresAt.toUTCString()
+      : new Date(expiresAt).toUTCString();
+    const content = `
+    <tr>
+      <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>A security exemption on one of your AirQo API tokens is expiring soon.</p>
+        <div style="margin:16px 0; padding:12px 16px; background:#F0F4FF; border-left:4px solid #4A6CF7; border-radius:4px;">
+          <p style="margin:0;"><strong>Token:</strong> <code>${maskedToken}</code>${tokenLabel}</p>
+          <p style="margin:4px 0 0;"><strong>Exemption:</strong> ${escapeHtml(bypassLabel)}</p>
+          <p style="margin:4px 0 0;"><strong>Expires at:</strong> ${expiryStr}</p>
+        </div>
+        <p>Once this exemption expires, normal automated security detection resumes for this token. If your integration's traffic pattern (e.g. dynamic/serverless egress IPs) still needs this exemption, please contact <a href="mailto:support@airqo.net">support@airqo.net</a> before the expiry date to request a renewal.</p>
+        <p>If this exemption is no longer needed, no action is required — it will lapse automatically.</p>
+      </td>
+    </tr>
+    `;
+    return constants.EMAIL_BODY({ email, content, name });
+  },
+
+  bypassExpired: ({
+    firstName = "",
+    lastName = "",
+    email = "",
+    token = "",
+    tokenName = "",
+    bypassLabel = "",
+  } = {}) => {
+    const name = `${firstName} ${lastName}`.trim() || "User";
+    const { maskedToken, tokenLabel } = buildTokenEmailSegment({ token, tokenName });
+    const content = `
+    <tr>
+      <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>A security exemption on one of your AirQo API tokens has expired and has been automatically removed.</p>
+        <div style="margin:16px 0; padding:12px 16px; background:#FFF3CD; border-left:4px solid #F59E0B; border-radius:4px;">
+          <p style="margin:0;"><strong>Token:</strong> <code>${maskedToken}</code>${tokenLabel}</p>
+          <p style="margin:4px 0 0;"><strong>Exemption removed:</strong> ${escapeHtml(bypassLabel)}</p>
+        </div>
+        <p>Normal automated security detection now applies to this token again. If your integration still relies on this exemption (for example, a serverless setup with rotating egress IPs) and you start seeing suspensions or blocked requests, please contact <a href="mailto:support@airqo.net">support@airqo.net</a> to discuss a renewal.</p>
+      </td>
+    </tr>
+    `;
+    return constants.EMAIL_BODY({ email, content, name });
+  },
+
+  bypassReportDigest: ({ recipients, bypasses = [] } = {}) => {
+    const today = new Date().toLocaleDateString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+
+    const rows = bypasses
+      .map((entry) => {
+        const bypassList = entry.bypasses
+          .map((b) => {
+            const expiry = b.expires_at
+              ? new Date(b.expires_at).toDateString()
+              : "no expiry set";
+            return `${escapeHtml(b.type)} (expires: ${expiry})`;
+          })
+          .join("; ");
+        return `
+    <li style="margin-bottom: 8px;">
+      Token ending in <strong>...${escapeHtml(entry.token_suffix || "XXXX")}</strong>
+      ${entry.token_name ? `(${escapeHtml(entry.token_name)}) ` : ""}
+      owned by <strong>${escapeHtml(entry.owner_email || "unknown user")}</strong>
+      — ${bypassList}
+    </li>`;
+      })
+      .join("");
+
+    const content = `
+    <tr>
+      <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <h3>Weekly Security-Bypass Report — ${today}</h3>
+        <p>
+          <strong>${bypasses.length}</strong> token(s) currently have at least one active
+          security-detection bypass (anomaly detection, high-compromise auto-suspension, or
+          IP-blacklist blocking). Review below and revoke any exemption that is no longer needed.
+        </p>
+        <ul>${rows}</ul>
+      </td>
+    </tr>
+    `;
+    return constants.EMAIL_BODY({
+      email: constants.SUPPORT_EMAIL,
+      content,
+      name: "Admin",
+    });
+  },
+
   existing_user: ({ firstName = "", lastName = "", email = "" } = {}) => {
     const name = firstName + " " + lastName;
     const FORGOT_PAGE = `${constants.ANALYTICS_BASE_URL}/user/forgotPwd`;

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -1024,7 +1024,14 @@ const createSecurityEmailFunction = (
     let otherParams = {};
     let tenant = "";
     try {
-      ({ email, tenant = "airqo", ...otherParams } = params);
+      let cooldownKey;
+      ({ email, tenant = "airqo", cooldownKey, ...otherParams } = params);
+      // Optional per-call cooldown scoping. Without it, the cooldown/dedup
+      // window is keyed only by (email, functionName) — fine for one-token
+      // alerts, but for per-token notifications (e.g. bypass expiry) that
+      // would let one token's email suppress another token's distinct alert
+      // to the same owner. Callers that don't pass cooldownKey are unaffected.
+      const emailType = cooldownKey ? `${functionName}:${cooldownKey}` : functionName;
 
       // ✅ STEP 1: Input validation
       if (!email) {
@@ -1060,7 +1067,7 @@ const createSecurityEmailFunction = (
           const EmailLog = EmailLogModel(tenant);
           const cooldownCheck = await EmailLog.canSendEmail({
             email,
-            emailType: functionName,
+            emailType,
             cooldownDays,
           });
 
@@ -1254,7 +1261,7 @@ const createSecurityEmailFunction = (
           const EmailLog = EmailLogModel(tenant);
           await EmailLog.logEmailSent({
             email,
-            emailType: functionName,
+            emailType,
             metadata: {
               messageId: emailResult.data.messageId,
               ...otherParams,

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -812,6 +812,9 @@ const getEmailSubject = (functionName, params) => {
     expiredToken: "Action Required: Your AirQo API Token Has Expired",
     expiringToken: "Action Required: Your AirQo API Token Expires Soon — Regenerate Now",
     autoSuspendedToken: "Security Alert: Your AirQo API Token Has Been Suspended",
+    bypassExpiryReminder: "Action Required Soon: Your API Token's Security Exemption Is Expiring",
+    bypassExpired: "Security Alert: Your API Token's Security Exemption Has Expired",
+    bypassReportDigest: "Weekly Security-Bypass Report",
 
     // ===== SENSOR MANUFACTURER (NETWORK) REQUEST FUNCTIONS =====
     notifyAdminOfSensorManufacturerRequest: `New Sensor Manufacturer Request: ${sanitizeEmailString(
@@ -948,6 +951,9 @@ const EMAIL_CATEGORIES = {
     "sendCompromiseSummary",
     "expiredToken",
     "expiringToken",
+    "bypassExpiryReminder",
+    "bypassExpired",
+    "bypassReportDigest",
     "onboardingAccountSetup",
     "notifyGroupStatusChanged",
   ],
@@ -2701,6 +2707,57 @@ const mailer = {
     {
       cooldownDays: 1, // Ensure only one summary per day
       enableCooldown: true,
+    },
+  ),
+  // Sent once per expiry cycle — the cooldown is set equal to the reminder
+  // lead window itself, so a daily job run only produces one email per
+  // token+bypass, not one per day the token sits inside the lead window.
+  bypassExpiryReminder: createSecurityEmailFunction(
+    "bypassExpiryReminder",
+    (params) =>
+      msgs.bypassExpiryReminder({
+        firstName: params.firstName,
+        lastName: params.lastName,
+        email: params.email,
+        token: params.token,
+        tokenName: params.tokenName,
+        bypassLabel: params.bypassLabel,
+        expiresAt: params.expiresAt,
+      }),
+    {
+      cooldownDays: constants.BYPASS_EXPIRY_REMINDER_LEAD_DAYS,
+      enableCooldown: true,
+    },
+  ),
+  // One-time notice sent by bypass-expiry-job right after it auto-clears an
+  // expired bypass flag — no repeat risk since the flag can only expire once
+  // per grant (renewing it resets bypass_*_expires_at to a new future date).
+  bypassExpired: createSecurityEmailFunction(
+    "bypassExpired",
+    (params) =>
+      msgs.bypassExpired({
+        firstName: params.firstName,
+        lastName: params.lastName,
+        email: params.email,
+        token: params.token,
+        tokenName: params.tokenName,
+        bypassLabel: params.bypassLabel,
+      }),
+    { cooldownDays: 1, enableCooldown: true },
+  ),
+  // Internal admin-only weekly digest of every token with an active bypass.
+  // Uses the admin-alert path (BCC, SUPPORT_EMAIL audit copy, daily rate cap)
+  // rather than createSecurityEmailFunction since this goes to a recipient
+  // list, not a single token owner.
+  bypassReportDigest: createAdminAlertFunction(
+    "bypassReportDigest",
+    (params) =>
+      msgs.bypassReportDigest({
+        recipients: params.recipients,
+        bypasses: params.bypasses,
+      }),
+    {
+      maxAlertsPerDay: 1,
     },
   ),
   clientActivationRequestAdmin: createMailerFunction(

--- a/src/auth-service/utils/common/test/ut_email.msgs.util.js
+++ b/src/auth-service/utils/common/test/ut_email.msgs.util.js
@@ -483,6 +483,105 @@ describe("email.msgs", () => {
     });
   });
 
+  describe("bypassExpiryReminder", () => {
+    const baseArgs = {
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "user@example.com",
+      token: "ABCDEFGH12345678WXYZ",
+      tokenName: "OpenAQ ingestion",
+      bypassLabel: "IP-blacklist request-blocking bypass",
+      expiresAt: new Date("2050-01-01T00:00:00Z"),
+    };
+
+    it("should return a string", () => {
+      expect(msgs.bypassExpiryReminder(baseArgs)).to.be.a("string");
+    });
+
+    it("should include the masked token and bypass label", () => {
+      const result = msgs.bypassExpiryReminder(baseArgs);
+      expect(result).to.include("ABCDEFGH");
+      expect(result).to.include("IP-blacklist request-blocking bypass");
+    });
+
+    it("should HTML-escape a bypass label containing special characters", () => {
+      const result = msgs.bypassExpiryReminder({
+        ...baseArgs,
+        bypassLabel: '<img src=x onerror="alert(1)">',
+      });
+      expect(result).to.include("&lt;img src=x");
+      expect(result).to.include("&quot;alert(1)&quot;");
+    });
+  });
+
+  describe("bypassExpired", () => {
+    const baseArgs = {
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "user@example.com",
+      token: "ABCDEFGH12345678WXYZ",
+      tokenName: "OpenAQ ingestion",
+      bypassLabel: "High-compromise-activity auto-suspension bypass",
+    };
+
+    it("should return a string", () => {
+      expect(msgs.bypassExpired(baseArgs)).to.be.a("string");
+    });
+
+    it("should include the masked token and bypass label", () => {
+      const result = msgs.bypassExpired(baseArgs);
+      expect(result).to.include("ABCDEFGH");
+      expect(result).to.include("High-compromise-activity auto-suspension bypass");
+    });
+  });
+
+  describe("bypassReportDigest", () => {
+    const baseArgs = {
+      recipients: ["admin@airqo.net"],
+      bypasses: [
+        {
+          token_suffix: "6NZN",
+          token_name: "OpenAQ ingestion",
+          owner_email: "owner@example.com",
+          bypasses: [
+            { type: "bypass_ip_blacklist", expires_at: "2050-01-01T00:00:00Z" },
+          ],
+        },
+      ],
+    };
+
+    it("should return a string", () => {
+      expect(msgs.bypassReportDigest(baseArgs)).to.be.a("string");
+    });
+
+    it("should include the token suffix and owner email", () => {
+      const result = msgs.bypassReportDigest(baseArgs);
+      expect(result).to.include("6NZN");
+      expect(result).to.include("owner@example.com");
+    });
+
+    it("should handle an empty bypasses array without throwing", () => {
+      const result = msgs.bypassReportDigest({ recipients: ["admin@airqo.net"], bypasses: [] });
+      expect(result).to.be.a("string");
+      expect(result).to.include("0");
+    });
+
+    it("should HTML-escape an owner email containing special characters", () => {
+      const result = msgs.bypassReportDigest({
+        recipients: ["admin@airqo.net"],
+        bypasses: [
+          {
+            token_suffix: "abcd",
+            token_name: "",
+            owner_email: '<script>alert(1)</script>',
+            bypasses: [{ type: "bypass_anomaly_detection", expires_at: null }],
+          },
+        ],
+      });
+      expect(result).to.include("&lt;script&gt;");
+    });
+  });
+
   // ── New feedback workflow templates ──────────────────────────────────────────
 
   describe("feedbackStatusUpdate", () => {

--- a/src/auth-service/utils/test/ut_token.util.js
+++ b/src/auth-service/utils/test/ut_token.util.js
@@ -16,7 +16,9 @@ describe("token util", () => {
     origWhitelistedIPModel,
     origBlockedDomainModel,
     origApiUsageCounterModel,
-    origGenerateFilter;
+    origGenerateFilter,
+    origClientModel,
+    origUserModel;
 
   beforeEach(() => {
     req = {
@@ -35,6 +37,8 @@ describe("token util", () => {
     origBlockedDomainModel = rewireToken.__get__("BlockedDomainModel");
     origApiUsageCounterModel = rewireToken.__get__("ApiUsageCounterModel");
     origGenerateFilter = rewireToken.__get__("generateFilter");
+    origClientModel = rewireToken.__get__("ClientModel");
+    origUserModel = rewireToken.__get__("UserModel");
   });
 
   afterEach(() => {
@@ -46,6 +50,8 @@ describe("token util", () => {
     rewireToken.__set__("BlockedDomainModel", origBlockedDomainModel);
     rewireToken.__set__("ApiUsageCounterModel", origApiUsageCounterModel);
     rewireToken.__set__("generateFilter", origGenerateFilter);
+    rewireToken.__set__("ClientModel", origClientModel);
+    rewireToken.__set__("UserModel", origUserModel);
     sinon.restore();
   });
 
@@ -428,6 +434,187 @@ describe("token util", () => {
 
       expect(result).to.not.equal(undefined);
       expect(result).to.have.property("success", true);
+    });
+  });
+
+  describe("updateAccessToken() - bypass field admin gating", () => {
+    it("strips bypass_* fields for a non-admin owner but keeps other fields", async () => {
+      req.body = {
+        name: "Updated Token",
+        bypass_compromise_detection: true,
+        bypass_ip_blacklist_expires_at: "2050-01-01T00:00:00Z",
+      };
+      req.params = { token: "tok123" };
+      req.user = { email: "owner@example.com", _id: "uid1" };
+
+      const tokenRecord = { _id: "tid1", token: "tok123", client_id: "cid1" };
+      const updatedToken = { _id: "tid1", name: "Updated Token" };
+      const origConstants = rewireToken.__get__("constants");
+
+      rewireToken.__set__("constants", {
+        ...origConstants,
+        SUPER_ADMIN_EMAIL_ALLOWLIST: ["admin@airqo.net"],
+      });
+      rewireToken.__set__("ClientModel", () => ({
+        findById: sinon.stub().returns({
+          select: sinon.stub().returns({
+            lean: sinon.stub().resolves({ user_id: "uid1" }),
+          }),
+        }),
+      }));
+
+      let capturedUpdate;
+      rewireToken.__set__("AccessTokenModel", () => ({
+        find: sinon.stub().returns({
+          lean: sinon.stub().resolves([tokenRecord]),
+        }),
+        findByIdAndUpdate: sinon.stub().callsFake((id, update) => {
+          capturedUpdate = update;
+          return { lean: sinon.stub().resolves(updatedToken) };
+        }),
+      }));
+
+      let result;
+      try {
+        result = await rewireToken.updateAccessToken(req, next);
+      } finally {
+        rewireToken.__set__("constants", origConstants);
+      }
+
+      expect(result).to.have.property("success", true);
+      expect(capturedUpdate).to.not.have.property("bypass_compromise_detection");
+      expect(capturedUpdate).to.not.have.property("bypass_ip_blacklist_expires_at");
+      expect(capturedUpdate).to.have.property("name", "Updated Token");
+    });
+
+    it("allows an admin to set bypass_* fields and their expiry", async () => {
+      req.body = {
+        bypass_ip_blacklist: true,
+        bypass_ip_blacklist_expires_at: "2050-01-01T00:00:00Z",
+      };
+      req.params = { token: "tok123" };
+      req.user = { email: "admin@airqo.net", _id: "uid1" };
+
+      const tokenRecord = { _id: "tid1", token: "tok123", client_id: "cid1" };
+      const updatedToken = {
+        _id: "tid1",
+        bypass_ip_blacklist: true,
+        bypass_ip_blacklist_expires_at: "2050-01-01T00:00:00Z",
+      };
+      const origConstants = rewireToken.__get__("constants");
+
+      rewireToken.__set__("constants", {
+        ...origConstants,
+        SUPER_ADMIN_EMAIL_ALLOWLIST: ["admin@airqo.net"],
+      });
+
+      let capturedUpdate;
+      rewireToken.__set__("AccessTokenModel", () => ({
+        find: sinon.stub().returns({
+          lean: sinon.stub().resolves([tokenRecord]),
+        }),
+        findByIdAndUpdate: sinon.stub().callsFake((id, update) => {
+          capturedUpdate = update;
+          return { lean: sinon.stub().resolves(updatedToken) };
+        }),
+      }));
+
+      let result;
+      try {
+        result = await rewireToken.updateAccessToken(req, next);
+      } finally {
+        rewireToken.__set__("constants", origConstants);
+      }
+
+      expect(result).to.have.property("success", true);
+      expect(capturedUpdate).to.have.property("bypass_ip_blacklist", true);
+      expect(capturedUpdate).to.have.property(
+        "bypass_ip_blacklist_expires_at",
+        "2050-01-01T00:00:00Z"
+      );
+    });
+  });
+
+  describe("_isBypassActive()", () => {
+    const isBypassActive = rewireToken.__get__("_isBypassActive");
+
+    it("returns false when the flag is false", () => {
+      expect(isBypassActive(false, null)).to.equal(false);
+    });
+
+    it("returns true when the flag is true and no expiry is set", () => {
+      expect(isBypassActive(true, null)).to.equal(true);
+    });
+
+    it("returns true when the flag is true and the expiry is in the future", () => {
+      const future = new Date(Date.now() + 60 * 60 * 1000);
+      expect(isBypassActive(true, future)).to.equal(true);
+    });
+
+    it("returns false when the flag is true but the expiry is in the past", () => {
+      const past = new Date(Date.now() - 60 * 60 * 1000);
+      expect(isBypassActive(true, past)).to.equal(false);
+    });
+  });
+
+  describe("listActiveBypasses()", () => {
+    it("returns an empty array when no tokens have an active bypass", async () => {
+      rewireToken.__set__("AccessTokenModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+        }),
+      }));
+
+      const result = await rewireToken.listActiveBypasses("airqo");
+      expect(result).to.deep.equal([]);
+    });
+
+    it("excludes bypasses whose expiry has already passed and resolves owner info", async () => {
+      const future = new Date(Date.now() + 60 * 60 * 1000);
+      const past = new Date(Date.now() - 60 * 60 * 1000);
+      const docs = [
+        {
+          _id: "t1",
+          name: "Tok One",
+          token: "abcd1234wxyzWXYZ",
+          client_id: "cid1",
+          bypass_anomaly_detection: true,
+          bypass_anomaly_detection_expires_at: future,
+          bypass_compromise_detection: true,
+          bypass_compromise_detection_expires_at: past,
+          bypass_ip_blacklist: false,
+          bypass_ip_blacklist_expires_at: null,
+        },
+      ];
+
+      rewireToken.__set__("AccessTokenModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({ lean: sinon.stub().resolves(docs) }),
+        }),
+      }));
+      rewireToken.__set__("ClientModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({
+            lean: sinon.stub().resolves([{ _id: "cid1", user_id: "uid1" }]),
+          }),
+        }),
+      }));
+      rewireToken.__set__("UserModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({
+            lean: sinon.stub().resolves([
+              { _id: "uid1", email: "owner@example.com", firstName: "O", lastName: "Wner" },
+            ]),
+          }),
+        }),
+      }));
+
+      const result = await rewireToken.listActiveBypasses("airqo");
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].owner_email).to.equal("owner@example.com");
+      expect(result[0].bypasses).to.have.lengthOf(1);
+      expect(result[0].bypasses[0].type).to.equal("bypass_anomaly_detection");
     });
   });
 

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -819,7 +819,7 @@ const isIPBlacklistedHelper = async (
       // meant to silence. Admin-managed CIDR/ASN and prefix blocks (checked
       // above) are unaffected.
       logger.info(
-        `IP-blacklist block bypassed via bypass_ip_blacklist -- TOKEN: ${token} -- TOKEN_DESCRIPTION: ${name} -- CLIENT_IP: ${ip}`,
+        `IP-blacklist block bypassed via bypass_ip_blacklist -- TOKEN_SUFFIX: ...${(token || "").slice(-4)} -- TOKEN_DESCRIPTION: ${name} -- CLIENT_IP: ${ip}`,
       );
       Promise.resolve().then(() =>
         postProcessing({ ip, token, name, client_id, endpoint, day }),
@@ -934,8 +934,20 @@ const isIPBlacklistedHelper = async (
               // Atomic update filtered on auto_suspended: {$ne: true} ensures exactly
               // one suspension + email even under concurrent requests — the DB write
               // itself acts as the dedup gate with no Redis or separate TTL document.
+              // The bypass_compromise_detection clause re-checks the exemption inside
+              // the same atomic write — closing the gap between the early bypass
+              // check above and this write, during which an admin could have granted
+              // the exemption (the fire-and-forget threshold computation in between
+              // awaits the aggregation above).
               const prevDoc = await AccessTokenModel("airqo").findOneAndUpdate(
-                { token, "request_pattern.auto_suspended": { $ne: true } },
+                {
+                  token,
+                  "request_pattern.auto_suspended": { $ne: true },
+                  $or: [
+                    { bypass_compromise_detection: { $ne: true } },
+                    { bypass_compromise_detection_expires_at: { $lte: new Date() } },
+                  ],
+                },
                 {
                   $set: {
                     "request_pattern.auto_suspended": true,
@@ -1130,8 +1142,19 @@ const _trackBehaviouralAnomaly = async ({ accessToken, token: rawToken, ip, user
       // transition false→true. Non-suspension updates use the plain filter so they
       // are never blocked on already-suspended tokens (which in practice never reach
       // here due to the line-1465 early-exit, but keeps the intent explicit).
+      // The bypass_anomaly_detection clause re-checks the exemption inside this
+      // same atomic write, closing the gap between the early bypass check at
+      // the top of this function and this write (several awaits — Redis
+      // incr/mget — happen in between, during which the exemption could change).
       const suspensionFilter = updates["request_pattern.auto_suspended"]
-        ? { token: rawToken, "request_pattern.auto_suspended": { $ne: true } }
+        ? {
+            token: rawToken,
+            "request_pattern.auto_suspended": { $ne: true },
+            $or: [
+              { bypass_anomaly_detection: { $ne: true } },
+              { bypass_anomaly_detection_expires_at: { $lte: new Date() } },
+            ],
+          }
         : { token: rawToken };
       prevDoc = await AccessTokenModel("airqo").findOneAndUpdate(
         suspensionFilter,

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -655,7 +655,7 @@ const isIPBlacklistedHelper = async (
       WhitelistedIPModel("airqo").findOne({ ip }),
       AccessTokenModel("airqo")
         .findOne(accessTokenFilter)
-        .select("name token client_id expiredEmailSent"),
+        .select("name token client_id expiredEmailSent bypass_ip_blacklist bypass_ip_blacklist_expires_at"),
       // Redis-first cache for the prefix list — avoids a full-collection scan
       // on every authenticated request. Falls through to MongoDB on cache miss
       // or Redis unavailability; both failure paths are non-fatal.
@@ -705,6 +705,8 @@ const isIPBlacklistedHelper = async (
       token = "",
       name = "",
       client_id = "",
+      bypass_ip_blacklist = false,
+      bypass_ip_blacklist_expires_at = null,
     } = (accessToken && accessToken._doc) || {};
 
     // Load CIDR-based ASN block list (Redis-cached, 10 min TTL, tenant-scoped).
@@ -808,6 +810,21 @@ const isIPBlacklistedHelper = async (
       return true;
     } else if (blacklistedIpPrefixes.includes(ipPrefix)) {
       return true;
+    } else if (blacklistedIP && _isBypassActive(bypass_ip_blacklist, bypass_ip_blacklist_expires_at)) {
+      // Token is admin-exempted from the IP-blacklist block itself (not just
+      // suspension) — e.g. serverless/dynamic-egress integrations that
+      // legitimately rotate through IP ranges that have been flagged.
+      // Skip blocking and skip logging this hit as a compromise event, since
+      // that log feeds the daily compromise-summary email this exemption is
+      // meant to silence. Admin-managed CIDR/ASN and prefix blocks (checked
+      // above) are unaffected.
+      logger.info(
+        `IP-blacklist block bypassed via bypass_ip_blacklist -- TOKEN: ${token} -- TOKEN_DESCRIPTION: ${name} -- CLIENT_IP: ${ip}`,
+      );
+      Promise.resolve().then(() =>
+        postProcessing({ ip, token, name, client_id, endpoint, day }),
+      );
+      return false;
     } else if (blacklistedIP) {
       logger.info(
         `🚨🚨 An AirQo API Access Token is compromised -- TOKEN: ${token} -- TOKEN_DESCRIPTION: ${name} -- CLIENT_IP: ${ip} `,
@@ -850,8 +867,29 @@ const isIPBlacklistedHelper = async (
           // at lower unique-IP volumes. The floor is 20 unique IPs per 24 hours.
           Promise.resolve().then(async () => {
             try {
+              // Fetch the exemption flag + tracking fields directly — the
+              // curated list() projection above (TOKENS_INCLUSION_PROJECTION)
+              // does not include request_pattern or bypass_compromise_detection.
+              const tokenFlags = await AccessTokenModel("airqo")
+                .findOne({ token })
+                .select("bypass_compromise_detection bypass_compromise_detection_expires_at request_pattern")
+                .lean();
+
+              if (
+                tokenFlags &&
+                _isBypassActive(
+                  tokenFlags.bypass_compromise_detection,
+                  tokenFlags.bypass_compromise_detection_expires_at
+                )
+              ) {
+                logger.info(
+                  `Compromise auto-suspension skipped — token exempted via bypass_compromise_detection (suffix=...${token.slice(-4)})`
+                );
+                return;
+              }
+
               const baseThreshold = constants.COMPROMISE_SUSPEND_THRESHOLD;
-              const requestPattern = listTokenResponse.data[0].request_pattern || {};
+              const requestPattern = (tokenFlags && tokenFlags.request_pattern) || {};
 
               // suspension_count is incremented on high-compromise auto-suspension. For tokens
               // suspended before this field was added, fall back to checking whether
@@ -1005,7 +1043,7 @@ const isIPBlacklisted = (...args) =>
 const _trackBehaviouralAnomaly = async ({ accessToken, token: rawToken, ip, userAgent }) => {
   // Service-account tokens opt out of behavioural scoring entirely.
   // Honeypot traps, IP blocks, and manual suspension still apply.
-  if (accessToken.bypass_anomaly_detection) {
+  if (_isBypassActive(accessToken.bypass_anomaly_detection, accessToken.bypass_anomaly_detection_expires_at)) {
     return;
   }
   const ANOMALY_SUSPEND_THRESHOLD = constants.ANOMALY_SUSPEND_THRESHOLD || 10;
@@ -1150,6 +1188,29 @@ const _trackBehaviouralAnomaly = async ({ accessToken, token: rawToken, ip, user
   } catch (err) {
     logger.error(`Non-critical: _trackBehaviouralAnomaly error: ${err.message}`);
   }
+};
+
+// The three admin-only security-bypass booleans and their matching optional
+// expiry fields. Shared by updateAccessToken (strip/audit) and the enforcement
+// helper below so the list only needs to be maintained in one place.
+const BYPASS_BOOLEAN_FIELDS = [
+  "bypass_anomaly_detection",
+  "bypass_compromise_detection",
+  "bypass_ip_blacklist",
+];
+const BYPASS_ADMIN_ONLY_FIELDS = BYPASS_BOOLEAN_FIELDS.reduce(
+  (acc, f) => acc.concat([f, `${f}_expires_at`]),
+  []
+);
+
+// A bypass flag is only "active" if it is true AND (no expiry is set OR the
+// expiry is still in the future). This is checked live at every enforcement
+// site rather than relying solely on the daily cleanup job, so there is never
+// a window where an expired bypass is still honoured.
+const _isBypassActive = (flag, expiresAt) => {
+  if (!flag) return false;
+  if (!expiresAt) return true;
+  return new Date(expiresAt).getTime() > Date.now();
 };
 
 const token = {
@@ -1350,11 +1411,14 @@ const token = {
         if (update._id) {
           delete update._id;
         }
-        // bypass_anomaly_detection is admin-only — non-super-admins cannot set it
-        // via the public PATCH endpoint even if the validator accepts the field.
-        if (update.bypass_anomaly_detection !== undefined) {
-          if (!isAdmin) {
-            delete update.bypass_anomaly_detection;
+        // The bypass_* booleans and their _expires_at companions are admin-only
+        // — non-super-admins cannot set any of them via the public PATCH
+        // endpoint even if the validator accepts the fields.
+        if (!isAdmin) {
+          for (const field of BYPASS_ADMIN_ONLY_FIELDS) {
+            if (update[field] !== undefined) {
+              delete update[field];
+            }
           }
         }
         // Expand request_pattern into dotted-path keys before passing to
@@ -1381,8 +1445,10 @@ const token = {
           if (update.request_pattern !== undefined) {
             auditFields.push(`request_pattern=${JSON.stringify(updatedToken.request_pattern)}`);
           }
-          if (update.bypass_anomaly_detection !== undefined) {
-            auditFields.push(`bypass_anomaly_detection=${updatedToken.bypass_anomaly_detection}`);
+          for (const field of BYPASS_ADMIN_ONLY_FIELDS) {
+            if (update[field] !== undefined) {
+              auditFields.push(`${field}=${updatedToken[field]}`);
+            }
           }
           if (auditFields.length > 0) {
             securityAuditLogger.info(
@@ -1493,7 +1559,7 @@ const token = {
         .select(
           "client_id token name tier scopes allowed_grids allowed_cohorts " +
           "access_schedule last_user_agent request_pattern allowed_origins " +
-          "bypass_anomaly_detection"
+          "bypass_anomaly_detection bypass_anomaly_detection_expires_at"
         );
 
       if (isEmpty(accessToken)) {
@@ -3725,6 +3791,96 @@ token.resolveFlaggedToken = async (request, next) => {
     const { note } = request.body;
     const filter = { _id: ObjectId(id) };
     return await FlaggedTokenModel(dbTenant).resolve({ filter, note: note || "" }, next);
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: error.message,
+      })
+    );
+  }
+};
+
+// Exposed so bin/jobs/bypass-expiry-job.js can iterate the same set of
+// bypass fields without duplicating the list.
+token.BYPASS_BOOLEAN_FIELDS = BYPASS_BOOLEAN_FIELDS;
+
+/**
+ * Admin-only report of tokens that currently have at least one security-bypass
+ * flag active (bypass_anomaly_detection / bypass_compromise_detection /
+ * bypass_ip_blacklist). Backs both the GET /tokens/bypasses endpoint and the
+ * weekly bypass-report digest email sent by bin/jobs/bypass-expiry-job.js.
+ * Only reports flags currently in force per _isBypassActive — a boolean left
+ * true past its own expires_at is not reported here (it will be cleared and
+ * reported as "expired" by the job on its next run instead).
+ */
+token.listActiveBypasses = async (tenant = "airqo") => {
+  const dbTenant = tenant || constants.DEFAULT_TENANT || "airqo";
+  const candidates = await AccessTokenModel(dbTenant)
+    .find({
+      $or: BYPASS_BOOLEAN_FIELDS.map((f) => ({ [f]: true })),
+    })
+    .select(
+      `name token client_id ${BYPASS_ADMIN_ONLY_FIELDS.join(" ")}`
+    )
+    .lean();
+
+  const active = candidates
+    .map((doc) => {
+      const bypasses = BYPASS_BOOLEAN_FIELDS.filter((f) =>
+        _isBypassActive(doc[f], doc[`${f}_expires_at`])
+      ).map((f) => ({
+        type: f,
+        expires_at: doc[`${f}_expires_at`] || null,
+      }));
+      return { doc, bypasses };
+    })
+    .filter((entry) => entry.bypasses.length > 0);
+
+  if (active.length === 0) return [];
+
+  const clientIds = [...new Set(active.map((e) => e.doc.client_id.toString()))];
+  const clients = await ClientModel(dbTenant)
+    .find({ _id: { $in: clientIds } })
+    .select("user_id")
+    .lean();
+  const clientOwnerMap = new Map(
+    clients.map((c) => [c._id.toString(), c.user_id])
+  );
+
+  const userIds = [...new Set([...clientOwnerMap.values()].filter(Boolean).map((id) => id.toString()))];
+  const users = await UserModel(dbTenant)
+    .find({ _id: { $in: userIds } })
+    .select("email firstName lastName")
+    .lean();
+  const userMap = new Map(users.map((u) => [u._id.toString(), u]));
+
+  return active.map(({ doc, bypasses }) => {
+    const ownerId = clientOwnerMap.get(doc.client_id.toString());
+    const owner = ownerId ? userMap.get(ownerId.toString()) : null;
+    return {
+      token_suffix: doc.token ? doc.token.slice(-4) : "",
+      token_name: doc.name || "",
+      client_id: doc.client_id,
+      owner_email: (owner && owner.email) || null,
+      owner_name: owner ? `${owner.firstName || ""} ${owner.lastName || ""}`.trim() : null,
+      bypasses,
+    };
+  });
+};
+
+token.listBypassedTokens = async (request, next) => {
+  try {
+    const { tenant } = { ...request.query };
+    const data = await token.listActiveBypasses(tenant);
+    return {
+      success: true,
+      message: isEmpty(data)
+        ? "No tokens currently have an active security bypass."
+        : "Successfully retrieved tokens with active security bypasses.",
+      data,
+      status: httpStatus.OK,
+    };
   } catch (error) {
     logger.error(`🐛🐛 Internal Server Error ${error.message}`);
     next(

--- a/src/auth-service/validators/test/ut_token.validators.js
+++ b/src/auth-service/validators/test/ut_token.validators.js
@@ -177,6 +177,114 @@ describe("Validation Functions", () => {
         .to.have.property("msg")
         .that.equals("bypass_anomaly_detection must be a boolean");
     });
+
+    ["bypass_compromise_detection", "bypass_ip_blacklist"].forEach((field) => {
+      it(`should accept ${field} true`, () => {
+        const result = validateTokenUpdate([{ [field]: true }]);
+        expect(result).to.be.undefined;
+      });
+
+      it(`should accept ${field} false`, () => {
+        const result = validateTokenUpdate([{ [field]: false }]);
+        expect(result).to.be.undefined;
+      });
+
+      it(`should reject non-boolean ${field}`, () => {
+        const result = validateTokenUpdate([{ [field]: "yes" }]);
+        expect(result)
+          .to.have.property("msg")
+          .that.equals(`${field} must be a boolean`);
+      });
+    });
+
+    [
+      "bypass_anomaly_detection_expires_at",
+      "bypass_compromise_detection_expires_at",
+      "bypass_ip_blacklist_expires_at",
+    ].forEach((field) => {
+      it(`should accept a future datetime for ${field}`, () => {
+        const result = validateTokenUpdate([{ [field]: "2050-01-01T00:00:00Z" }]);
+        expect(result).to.be.undefined;
+      });
+
+      it(`should accept null for ${field} to clear it`, () => {
+        const result = validateTokenUpdate([{ [field]: null }]);
+        expect(result).to.be.undefined;
+      });
+
+      it(`should reject a past datetime for ${field}`, () => {
+        const result = validateTokenUpdate([{ [field]: "2020-01-01T00:00:00Z" }]);
+        expect(result)
+          .to.have.property("msg")
+          .that.equals(`${field} must be in the future`);
+      });
+
+      it(`should reject an invalid datetime string for ${field}`, () => {
+        const result = validateTokenUpdate([{ [field]: "not-a-date" }]);
+        expect(result)
+          .to.have.property("msg")
+          .that.equals(`${field} must be a valid datetime, or null to clear it`);
+      });
+    });
+
+    describe("admin-only guard (middleware mode)", () => {
+      const buildReq = (user, body) => ({ user, body });
+
+      it("should reject setting bypass_compromise_detection with no req.user", () => {
+        const next = sinon.stub();
+        validateTokenUpdate(
+          buildReq(undefined, { bypass_compromise_detection: true }),
+          {},
+          next
+        );
+        expect(next).to.have.been.calledOnce;
+        const err = next.firstCall.args[0];
+        expect(err.errors[0].message).to.equal(
+          "bypass_compromise_detection can only be set by administrators"
+        );
+      });
+
+      it("should reject setting bypass_ip_blacklist_expires_at from a non-admin user", () => {
+        const next = sinon.stub();
+        validateTokenUpdate(
+          buildReq(
+            { email: "someone@example.com" },
+            { bypass_ip_blacklist_expires_at: "2050-01-01T00:00:00Z" }
+          ),
+          {},
+          next
+        );
+        expect(next).to.have.been.calledOnce;
+        const err = next.firstCall.args[0];
+        expect(err.errors[0].message).to.equal(
+          "bypass_ip_blacklist_expires_at can only be set by administrators"
+        );
+      });
+
+      it("should allow an admin user to set a bypass_* field", () => {
+        const origAllowlist = constants.SUPER_ADMIN_EMAIL_ALLOWLIST;
+        constants.SUPER_ADMIN_EMAIL_ALLOWLIST = ["admin@airqo.net"];
+        const next = sinon.stub();
+        try {
+          validateTokenUpdate(
+            buildReq({ email: "admin@airqo.net" }, { bypass_compromise_detection: true }),
+            {},
+            next
+          );
+        } finally {
+          constants.SUPER_ADMIN_EMAIL_ALLOWLIST = origAllowlist;
+        }
+        expect(next).to.have.been.calledOnce;
+        expect(next.firstCall.args[0]).to.be.undefined;
+      });
+
+      it("should not trigger the admin guard when no bypass_* field is touched", () => {
+        const next = sinon.stub();
+        validateTokenUpdate(buildReq(undefined, { name: "Updated" }), {}, next);
+        expect(next).to.have.been.calledOnce;
+        expect(next.firstCall.args[0]).to.be.undefined;
+      });
+    });
   });
 
   describe("validateSingleIp", () => {

--- a/src/auth-service/validators/token.validators.js
+++ b/src/auth-service/validators/token.validators.js
@@ -164,36 +164,71 @@ function _validateTokenUpdateItems(items) {
         return { msg: "bypass_anomaly_detection must be a boolean" };
       }
     }
+    if ("bypass_compromise_detection" in item) {
+      if (typeof item.bypass_compromise_detection !== "boolean") {
+        return { msg: "bypass_compromise_detection must be a boolean" };
+      }
+    }
+    if ("bypass_ip_blacklist" in item) {
+      if (typeof item.bypass_ip_blacklist !== "boolean") {
+        return { msg: "bypass_ip_blacklist must be a boolean" };
+      }
+    }
+    for (const field of BYPASS_EXPIRY_FIELDS) {
+      if (field in item) {
+        const v = item[field];
+        // null explicitly clears the expiry (bypass becomes open-ended again).
+        if (v !== null) {
+          if (!_isValidISO8601(v)) {
+            return { msg: `${field} must be a valid datetime, or null to clear it` };
+          }
+          if (!_isDateInFuture(v)) {
+            return { msg: `${field} must be in the future` };
+          }
+        }
+      }
+    }
   }
 }
+
+// The three admin-only bypass booleans plus their matching expiry fields.
+// Grouped so validateTokenUpdate can apply one identical admin-only guard to
+// all six instead of repeating the same check per field.
+const BYPASS_ADMIN_ONLY_FIELDS = [
+  "bypass_anomaly_detection",
+  "bypass_anomaly_detection_expires_at",
+  "bypass_compromise_detection",
+  "bypass_compromise_detection_expires_at",
+  "bypass_ip_blacklist",
+  "bypass_ip_blacklist_expires_at",
+];
+const BYPASS_EXPIRY_FIELDS = BYPASS_ADMIN_ONLY_FIELDS.filter((f) =>
+  f.endsWith("_expires_at")
+);
 
 const validateTokenUpdate = (itemsOrReq, res, next) => {
   if (Array.isArray(itemsOrReq)) {
     return _validateTokenUpdateItems(itemsOrReq);
   }
-  // middleware mode — check body fields + admin guard for bypass_anomaly_detection
+  // middleware mode — check body fields + admin guard for the bypass_* fields
   const req = itemsOrReq || {};
   const b = req.body || {};
   const items = Object.keys(b).map((k) => ({ [k]: b[k] }));
   const err = _validateTokenUpdateItems(items);
   if (err) return _mwError(next, err.msg);
 
-  // Admin check for bypass_anomaly_detection (middleware-only guard)
-  if ("bypass_anomaly_detection" in b) {
-    if (!req.user) {
-      return _mwError(
-        next,
-        "bypass_anomaly_detection can only be set by administrators"
+  const touchedBypassField = BYPASS_ADMIN_ONLY_FIELDS.find((f) => f in b);
+  if (touchedBypassField) {
+    const email = (req.user && req.user.email || "").toLowerCase();
+    const isAdmin =
+      !!req.user &&
+      (constants.SUPER_ADMIN_EMAIL_ALLOWLIST || []).some(
+        (e) => e.toLowerCase() === email
       );
-    }
-    const email = (req.user.email || "").toLowerCase();
-    const isAdmin = (constants.SUPER_ADMIN_EMAIL_ALLOWLIST || []).some(
-      (e) => e.toLowerCase() === email
-    );
     if (!isAdmin) {
       return _mwError(
         next,
-        "bypass_anomaly_detection can only be set by administrators"
+        `${touchedBypassField} can only be set by administrators`
       );
     }
   }


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds admin-only, time-limited exemption ("bypass") flags on individual API tokens for the three automated security detectors in auth-service:
- `bypass_anomaly_detection` — behavioural anomaly (UA-change / rate-spike) auto-suspension
- `bypass_compromise_detection` — high-compromise-activity (many unique IPs in 24h) auto-suspension
- `bypass_ip_blacklist` — per-request blocking when the source IP is already in the global blacklist

Each flag supports an optional `*_expires_at` date. A new daily/weekly job (`bin/jobs/bypass-expiry-job.js`) automatically revokes expired bypasses, emails the token owner a one-time reminder before expiry and a one-time notice on expiry, and sends a weekly digest to admins of all tokens with an active bypass (skipped entirely when there's nothing to report, to avoid notification fatigue). A new admin-only endpoint (`GET /tokens/bypasses`) exposes the same report on demand.

Also fixes the test runner: `npm test`'s glob was silently limited by the shell to ~84 of 123 test files (nested test directories two+ levels deep never ran). This is now fixed via `.mocharc.yml`, plus a fix to `config/constants.js` so environment-variable loading no longer depends on a specific test file loading first.

### Why is this change needed?
Automated security detection was flagging and suspending tokens used by legitimate serverless/dynamic-egress integrations (e.g. rotating cloud IPs), generating repeated false-positive suspension and compromise-summary emails. Admins needed a scoped, auditable, and non-permanent way to exempt a specific token from a specific detector without disabling detection service-wide or leaving the exemption in place indefinitely by default.

Separately, fixing the test-runner glob surfaced that roughly a third of this service's unit tests have never actually executed in CI, hiding both real test failures and several completely broken test files.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** auth-service

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Added ~48 new unit tests covering the bypass flags: field validation and admin-only guard (`validators/test/ut_token.validators.js`), enforcement helper + `updateAccessToken`/`listActiveBypasses` (`utils/test/ut_token.util.js`), and the new email templates (`utils/common/test/ut_email.msgs.util.js`) — all passing consistently. Manually verified the server boots cleanly, the new `GET /tokens/bypasses` route is reachable and correctly auth-gated, and the bypass-expiry job registers without error.

Fixing the test-runner glob surfaced ~120 pre-existing failures and 14 test files that throw at require-time (unrelated to this change — wrong module-alias paths, missing mock files, Jest assertions inside Mocha suites). The 14 crash-on-load files are quarantined via `.mocharc.yml`'s `ignore` list so the suite can run at all; the ~120 newly-surfaced failures are left as-is. **Both are intentionally deferred to a follow-up PR** and are not touched here — none are in files this PR modifies.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All new fields are optional, additive, and admin-only-settable. Existing tokens default to no bypass (current behavior unchanged).

---

## :memo: Additional Notes
- Follow-up PR will address the ~120 pre-existing test failures and the 14 quarantined broken test files surfaced by the test-runner fix.
- New env var: `BYPASS_EXPIRY_REMINDER_LEAD_DAYS` (default `3`) controls how many days before expiry the reminder email fires; also reused as that email's send cooldown so a token is only reminded once per expiry cycle.
- New endpoint: `GET /tokens/bypasses` (admin-only, `requireSystemAdmin`).

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time-limited security bypass controls for anomaly, compromise, and IP blacklist detection.
  * Added an admin-only view for tokens with active security bypasses.
  * Added automatic expiry handling, reminders, and weekly administrative digest emails.
* **Bug Fixes**
  * Expired bypasses are now automatically revoked, preventing indefinite security exemptions.
  * Improved validation ensures bypass expiry dates are valid and restricted to authorized administrators.
* **Tests**
  * Expanded coverage for bypass permissions, expiry behavior, reporting, and email notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->