### PR TITLE
Fix isPrimaryInLocation validation rejecting empty mobile deploy values

### DIFF
--- a/src/device-registry/docs/DEVICE_ACTIVITIES_API.md
+++ b/src/device-registry/docs/DEVICE_ACTIVITIES_API.md
@@ -249,7 +249,7 @@ POST /api/v2/devices/activities/deploy/mobile?tenant=airqo&deviceName={deviceNam
 
 - `site_id` — must be absent; providing it will cause a validation error
 - `latitude` / `longitude` — the API derives position from the grid's center coordinates
-- `isPrimaryInLocation` — not applicable for mobile devices
+- `isPrimaryInLocation` — not applicable for mobile devices; omit the key entirely rather than sending it as an empty value
 
 **What happens server-side**
 

--- a/src/device-registry/validators/activities.validators.js
+++ b/src/device-registry/validators/activities.validators.js
@@ -384,7 +384,7 @@ const commonDeployValidations = {
     .custom(validateMountTypeConsistency),
 
   isPrimaryInLocation: body("isPrimaryInLocation")
-    .optional()
+    .optional({ checkFalsy: true })
     .isBoolean()
     .withMessage("isPrimaryInLocation must be a boolean")
     .toBoolean(),

--- a/src/device-registry/validators/activities.validators.js
+++ b/src/device-registry/validators/activities.validators.js
@@ -384,7 +384,10 @@ const commonDeployValidations = {
     .custom(validateMountTypeConsistency),
 
   isPrimaryInLocation: body("isPrimaryInLocation")
-    .optional({ checkFalsy: true })
+    .customSanitizer((value) =>
+      typeof value === "string" && value.trim() === "" ? undefined : value,
+    )
+    .optional()
     .isBoolean()
     .withMessage("isPrimaryInLocation must be a boolean")
     .toBoolean(),


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes the `isPrimaryInLocation` validator so that empty/falsy values (e.g. `""`) are treated the same as an omitted field, instead of failing boolean validation. Also updates the Device Activities API docs to advise the frontend to omit the field entirely for mobile deployments.

### Why is this change needed?

`isPrimaryInLocation` is optional and only meaningful for static deployments, but the mobile team reported that sending it as an empty value on `deploy/mobile` incorrectly returned a `400 Bad Request` ("isPrimaryInLocation must be a boolean"). The validator was missing a falsy-check guard that sibling optional fields (`site_id`, `grid_id`, `network`) already had, causing this asymmetry across `/deploy`, `/deploy/mobile`, and `/deploy/static`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** No automated tests added yet. Recommend manually verifying before merge: send `isPrimaryInLocation: ""` to `POST /api/v2/devices/activities/deploy/mobile` and confirm a `200` instead of the previous `400`; also confirm a valid boolean value (`true`/`false`) still validates correctly.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The validator fix is shared across `/deploy`, `/deploy/mobile`, and `/deploy/static` since they all reuse the same validation chain. Frontend (mobile) has been advised to omit `isPrimaryInLocation` from the request body entirely rather than relying on this fix.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile deployment validation so `isPrimaryInLocation` is treated as omitted when it’s empty or whitespace (avoids incorrect boolean validation failures).
  * Ensured `isPrimaryInLocation` behaves consistently as an optional field rather than accepting empty-string inputs.
* **Documentation**
  * Updated Mobile Deployment request guidance to clarify that `isPrimaryInLocation` must be omitted entirely for mobile devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->