### PR TITLE
Fix corrupted lastActive causing Invalid Date status

### DIFF
--- a/src/device-registry/bin/jobs/backups/backup-store-readings-job.js
+++ b/src/device-registry/bin/jobs/backups/backup-store-readings-job.js
@@ -18,6 +18,7 @@ const NodeCache = require("node-cache");
 // Constants
 const TIMEZONE = moment.tz.guess();
 const INACTIVE_THRESHOLD = 5 * 60 * 60 * 1000; // 5 hours in milliseconds
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes grace period for future timestamps
 
 const JOB_NAME = "store-readings-job";
 const JOB_SCHEDULE = "30 * * * *"; // At minute 30 of every hour
@@ -39,11 +40,26 @@ async function updateEntityStatus(Model, filter, time, entityType) {
   try {
     const entity = await Model.findOne(filter);
     if (entity) {
+      const measurementTime = moment(time).tz(TIMEZONE);
+      if (!measurementTime.isValid()) {
+        logger.warn(
+          `🙀🙀 Skipping ${entityType} status update: invalid timestamp for filter: ${stringify(
+            filter
+          )}`
+        );
+        return;
+      }
+      if (measurementTime.valueOf() - Date.now() > MAX_CLOCK_SKEW_MS) {
+        logger.warn(
+          `🙀🙀 Skipping ${entityType} status update: future timestamp (${measurementTime.toISOString()}) for filter: ${stringify(
+            filter
+          )}`
+        );
+        return;
+      }
       const isActive = isEntityActive(time);
       const updateData = {
-        lastActive: moment(time)
-          .tz(TIMEZONE)
-          .toDate(),
+        lastActive: measurementTime.toDate(),
         isOnline: isActive,
       };
       await Model.updateOne(filter, { $set: updateData });

--- a/src/device-registry/bin/jobs/beta/beta-store-readings-job.js
+++ b/src/device-registry/bin/jobs/beta/beta-store-readings-job.js
@@ -20,6 +20,7 @@ const NodeCache = require("node-cache");
 // Constants
 const TIMEZONE = moment.tz.guess();
 const INACTIVE_THRESHOLD = 5 * 60 * 60 * 1000; // 5 hours in milliseconds
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes grace period for future timestamps
 
 const JOB_NAME = "store-readings-job.beta";
 const JOB_SCHEDULE = "30 * * * *"; // At minute 30 of every hour
@@ -41,11 +42,26 @@ async function updateEntityStatus(Model, filter, time, entityType) {
   try {
     const entity = await Model.findOne(filter);
     if (entity) {
+      const measurementTime = moment(time).tz(TIMEZONE);
+      if (!measurementTime.isValid()) {
+        logger.warn(
+          `🙀🙀 Skipping ${entityType} status update: invalid timestamp for filter: ${stringify(
+            filter
+          )}`
+        );
+        return;
+      }
+      if (measurementTime.valueOf() - Date.now() > MAX_CLOCK_SKEW_MS) {
+        logger.warn(
+          `🙀🙀 Skipping ${entityType} status update: future timestamp (${measurementTime.toISOString()}) for filter: ${stringify(
+            filter
+          )}`
+        );
+        return;
+      }
       const isActive = isEntityActive(time);
       const updateData = {
-        lastActive: moment(time)
-          .tz(TIMEZONE)
-          .toDate(),
+        lastActive: measurementTime.toDate(),
         isOnline: isActive,
       };
       await Model.updateOne(filter, { $set: updateData });

--- a/src/device-registry/bin/jobs/fix-corrupted-last-active-job.js
+++ b/src/device-registry/bin/jobs/fix-corrupted-last-active-job.js
@@ -86,8 +86,21 @@ const fixCorruptedLastActive = async (tenant) => {
 
   try {
     const Device = DeviceModel(tenant);
+    // Catches both a future-dated lastActive (proper Date type, but beyond
+    // clock skew) and a lastActive stored as some other BSON type (string,
+    // etc.) from a write path that bypassed Mongoose casting — either one
+    // surfaces downstream as transmissionStatus "Invalid Date".
     const filter = {
-      lastActive: { $gt: new Date(Date.now() + MAX_CLOCK_SKEW_MS) },
+      lastActive: { $exists: true, $ne: null },
+      $or: [
+        {
+          lastActive: {
+            $type: "date",
+            $gt: new Date(Date.now() + MAX_CLOCK_SKEW_MS),
+          },
+        },
+        { lastActive: { $not: { $type: "date" } } },
+      ],
     };
 
     const total = await Device.countDocuments(filter);
@@ -126,11 +139,20 @@ const fixCorruptedLastActive = async (tenant) => {
         continue;
       }
 
-      await Device.collection.updateOne(
-        { _id: device._id },
+      // Conditional on the originally observed lastActive so a concurrent,
+      // legitimate write (e.g. from update-online-status-job) between the
+      // find() above and this update isn't clobbered by our stale snapshot.
+      const result = await Device.collection.updateOne(
+        { _id: device._id, lastActive: device.lastActive },
         { $set: { lastActive: new Date(fallback) } },
       );
-      fixed += 1;
+      if (result.modifiedCount > 0) {
+        fixed += 1;
+      } else {
+        logger.info(
+          `[${POD_ID}] ${JOB_NAME}: device ${device._id} lastActive changed concurrently, skipped.`,
+        );
+      }
     }
 
     logger.info(

--- a/src/device-registry/bin/jobs/fix-corrupted-last-active-job.js
+++ b/src/device-registry/bin/jobs/fix-corrupted-last-active-job.js
@@ -1,0 +1,146 @@
+const DeviceModel = require("@models/Device");
+const JobLockModel = require("@models/JobLock");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- fix-corrupted-last-active-job`,
+);
+const os = require("os");
+
+const JOB_NAME = "fix-corrupted-last-active";
+const LOCK_TTL_SECONDS = 15 * 60; // 15 minutes
+const POD_ID = process.env.HOSTNAME || os.hostname();
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+const acquireLock = async (tenant) => {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + LOCK_TTL_SECONDS * 1000);
+  try {
+    const result = await JobLockModel(tenant).findOneAndUpdate(
+      {
+        jobName: JOB_NAME,
+        $or: [
+          { jobName: { $exists: false } },
+          { expiresAt: { $lte: now } },
+          // Allow the same pod to reclaim its own lock after a restart within
+          // the TTL window — without this, the upsert hits a duplicate key and
+          // the pod can never re-acquire a lock it already held.
+          { acquiredBy: POD_ID },
+        ],
+      },
+      {
+        $set: {
+          acquiredBy: POD_ID,
+          acquiredAt: now,
+          expiresAt,
+        },
+        $setOnInsert: {
+          jobName: JOB_NAME,
+        },
+      },
+      { upsert: true, new: true, rawResult: false },
+    );
+    return result && result.acquiredBy === POD_ID;
+  } catch (error) {
+    if (error.code === 11000) return false;
+    logger.error(`[${POD_ID}] Lock acquisition error: ${error.message}`);
+    return false;
+  }
+};
+
+const releaseLock = async (tenant) => {
+  try {
+    await JobLockModel(tenant).findOneAndDelete({
+      jobName: JOB_NAME,
+      acquiredBy: POD_ID,
+    });
+  } catch (error) {
+    logger.error(`[${POD_ID}] Lock release error: ${error.message}`);
+  }
+};
+
+const isFutureOrInvalid = (value) => {
+  if (!value) return true;
+  const time = new Date(value).getTime();
+  return isNaN(time) || time > Date.now() + MAX_CLOCK_SKEW_MS;
+};
+
+/**
+ * One-time cleanup: corrects `lastActive` on devices left with a
+ * future/corrupted value by the (now-fixed) unvalidated write paths in
+ * beta-store-readings-job.js, backup-store-readings-job.js and
+ * update-raw-online-status-job.js. A bad lastActive surfaces downstream as
+ * transmissionStatus "Invalid Date".
+ *
+ * Safe to run on every startup: it first counts affected devices and returns
+ * immediately when none are found, so a clean fleet costs one query.
+ */
+const fixCorruptedLastActive = async (tenant) => {
+  const lockAcquired = await acquireLock(tenant);
+  if (!lockAcquired) {
+    logger.info(
+      `[${POD_ID}] Could not acquire lock for ${JOB_NAME} — another pod is running it.`,
+    );
+    return;
+  }
+
+  try {
+    const Device = DeviceModel(tenant);
+    const filter = {
+      lastActive: { $gt: new Date(Date.now() + MAX_CLOCK_SKEW_MS) },
+    };
+
+    const total = await Device.countDocuments(filter);
+
+    if (total === 0) {
+      logger.info(
+        `[${POD_ID}] ${JOB_NAME}: no devices with a future lastActive found — nothing to fix.`,
+      );
+      return;
+    }
+
+    logger.info(
+      `[${POD_ID}] ${JOB_NAME}: found ${total} device(s) with a corrupted lastActive. Fixing...`,
+    );
+
+    const devices = await Device.find(filter)
+      .select("_id lastActive lastRawData onlineStatusAccuracy.lastUpdate")
+      .lean();
+
+    let fixed = 0;
+    let manualReview = 0;
+
+    for (const device of devices) {
+      const fallback = [
+        device.lastRawData,
+        device.onlineStatusAccuracy?.lastUpdate,
+      ]
+        .filter((value) => !isFutureOrInvalid(value))
+        .sort((a, b) => new Date(b) - new Date(a))[0];
+
+      if (!fallback) {
+        manualReview += 1;
+        logger.warn(
+          `[${POD_ID}] ${JOB_NAME}: device ${device._id} has no valid fallback timestamp, needs manual review.`,
+        );
+        continue;
+      }
+
+      await Device.collection.updateOne(
+        { _id: device._id },
+        { $set: { lastActive: new Date(fallback) } },
+      );
+      fixed += 1;
+    }
+
+    logger.info(
+      `[${POD_ID}] ${JOB_NAME}: done. Fixed: ${fixed}, needs manual review: ${manualReview}.`,
+    );
+  } catch (error) {
+    logger.error(`[${POD_ID}] ${JOB_NAME} error: ${error.message}`);
+  } finally {
+    await releaseLock(tenant);
+  }
+};
+
+module.exports = fixCorruptedLastActive;

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -17,6 +17,7 @@ const { getUptimeAccuracyUpdateObject } = require("@utils/common");
 // Constants
 const TIMEZONE = moment.tz.guess();
 const RAW_INACTIVE_THRESHOLD = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes grace period for future feed timestamps
 const BATCH_SIZE = 50; // Reduced for better yielding
 const MAX_EXECUTION_TIME = 10 * 60 * 1000; // 10 minutes max execution
 const YIELD_INTERVAL = 5; // Yield every 5 operations
@@ -142,6 +143,20 @@ const isDeviceRawActive = (lastFeedTime) => {
   }
   const timeDiff = new Date().getTime() - new Date(lastFeedTime).getTime();
   return timeDiff < RAW_INACTIVE_THRESHOLD;
+};
+
+// Rejects unparseable timestamps and ones further in the future than clock
+// skew can explain, so a bad feed/device timestamp never gets persisted as
+// lastRawData/lastActive (surfaces downstream as transmissionStatus "Invalid Date").
+const isValidFeedTimestamp = (timestamp) => {
+  if (!timestamp) {
+    return false;
+  }
+  const parsed = new Date(timestamp).getTime();
+  if (isNaN(parsed)) {
+    return false;
+  }
+  return parsed - Date.now() <= MAX_CLOCK_SKEW_MS;
 };
 
 const isValidPM25 = (value) => {
@@ -445,9 +460,14 @@ const processIndividualDevice = async (
             data.ts ||
             null;
 
-          if (tsValue) {
+          if (tsValue && isValidFeedTimestamp(tsValue)) {
             lastFeedTime = tsValue;
             isRawOnline = isDeviceRawActive(tsValue);
+          } else if (tsValue) {
+            logger.warn(
+              `🙀🙀 Ignoring invalid/future feed timestamp (${tsValue}) for device ${device.name ||
+                device._id}`,
+            );
           } else {
             // No timestamp field — successful non-empty response means online
             isRawOnline = true;
@@ -679,7 +699,12 @@ const processIndividualDevice = async (
     let latestRawPm25 = null;
     let updateFields = {};
 
-    if (thingspeakData && thingspeakData.feeds && thingspeakData.feeds[0]) {
+    if (
+      thingspeakData &&
+      thingspeakData.feeds &&
+      thingspeakData.feeds[0] &&
+      isValidFeedTimestamp(thingspeakData.feeds[0].created_at)
+    ) {
       const lastFeed = thingspeakData.feeds[0];
       lastFeedTime = lastFeed.created_at;
       isRawOnline = isDeviceRawActive(lastFeedTime);
@@ -697,6 +722,18 @@ const processIndividualDevice = async (
         };
       }
     } else {
+      if (
+        thingspeakData &&
+        thingspeakData.feeds &&
+        thingspeakData.feeds[0] &&
+        !isValidFeedTimestamp(thingspeakData.feeds[0].created_at)
+      ) {
+        logger.warn(
+          `🙀🙀 Ignoring invalid/future ThingSpeak timestamp (${thingspeakData
+            .feeds[0].created_at}) for device ${device.name ||
+            device._id}, channel ${device.device_number}`,
+        );
+      }
       // ============================================================================
       // CRITICAL FIX: No new data from ThingSpeak
       // Use existing lastRawData to determine status

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -468,6 +468,9 @@ const processIndividualDevice = async (
               `🙀🙀 Ignoring invalid/future feed timestamp (${tsValue}) for device ${device.name ||
                 device._id}`,
             );
+            // Don't blindly mark offline on a bad timestamp — fall back to
+            // whether the device's existing lastRawData is still fresh.
+            isRawOnline = isDeviceRawActive(device.lastRawData);
           } else {
             // No timestamp field — successful non-empty response means online
             isRawOnline = true;
@@ -733,6 +736,11 @@ const processIndividualDevice = async (
             .feeds[0].created_at}) for device ${device.name ||
             device._id}, channel ${device.device_number}`,
         );
+        // Don't blindly mark offline on a bad timestamp — fall back to
+        // whether the device's existing lastRawData is still fresh. The
+        // shouldMarkOfflineFromStaleData check below can still override this
+        // to false if that fallback data is itself stale.
+        isRawOnline = isDeviceRawActive(device.lastRawData);
       }
       // ============================================================================
       // CRITICAL FIX: No new data from ThingSpeak

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -192,6 +192,16 @@ try {
   );
 }
 try {
+  const fixCorruptedLastActiveJob = require("@bin/jobs/fix-corrupted-last-active-job");
+  // Runs on every startup but self-skips immediately when no devices have a
+  // corrupted (future) lastActive value.
+  setTimeout(() => fixCorruptedLastActiveJob("airqo"), 10000);
+} catch (err) {
+  global.dedupLogger.error(
+    `fix-corrupted-last-active-job failed to start: ${err.message}`,
+  );
+}
+try {
   require("@bin/jobs/device-metadata-cleanup-job");
 } catch (err) {
   global.dedupLogger.error(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds timestamp validation to three device status update jobs (`beta-store-readings-job.js`, `backup-store-readings-job.js`, `update-raw-online-status-job.js`) so future/unparseable timestamps are rejected before being written to a device's `lastActive` field. Also adds a new startup job, `fix-corrupted-last-active-job.js`, that backfills any devices already left with a corrupted `lastActive` value, and wires it into `server.js` alongside the other startup jobs.

### Why is this change needed?
Devices with a corrupted `lastActive` value (set further in the future than clock skew can explain) were surfacing `transmissionStatus: "Invalid Date"` in the API response, which the Vertex dashboard then rendered as an "Invalid Date" status. The root cause was that several job paths wrote `lastActive` directly from a raw feed/reading timestamp with no validation, unlike `update-online-status-job.js` which already guards against this. This PR closes that gap and cleans up any devices already affected.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- device-registry

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified via `node --check` that all modified/new files are syntactically valid. Traced the root cause end-to-end using the device's actual API response (`transmissionStatus: "Invalid Date"`, `lastActive` dated 2028) to confirm the fix addresses the exact failure path.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
The new `fix-corrupted-last-active-job` runs once per pod on startup, uses a job lock to avoid duplicate runs across pods, and self-skips (single count query) when no devices have a future `lastActive` — so it's a no-op once the fleet is clean.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid or future-dated readings from incorrectly updating device activity and online status.
  * Added stricter timestamp validation with a configurable clock-skew limit to ignore overly-far-future data.
  * Automatically repaired devices with corrupted `lastActive` values at startup using a safe fallback when available.
  * Ensured the server remains running if the startup repair job fails to load or schedule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->