### PR TITLE
Rename leftover AirQo Analytics/Platform references to AirQo Nexus

### DIFF
--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -167,7 +167,7 @@ The goal is to make every major AirQo digital product available as a **bootstrap
 
 ```bash
 # Example future developer experience
-npx create-airqo-platform my-iot-dashboard
+npx create-airqo-nexus my-iot-dashboard
 npx create-airqo-vertex my-device-console
 npx create-airqo-beacon my-fleet-manager
 npx create-airqo-ai my-intelligence-platform
@@ -180,7 +180,7 @@ A developer runs the command, answers a few configuration questions (sensor type
 
 | Template | What the developer inherits |
 |---|---|
-| `create-airqo-platform` | Multi-org analytics workspace, maps, charts, data export, auth |
+| `create-airqo-nexus` | Multi-org analytics workspace, maps, charts, data export, auth |
 | `create-airqo-vertex` | Device & site registry, grouping, admin console, API proxy layer |
 | `create-airqo-beacon` | Fleet health dashboard, OTA firmware, alerts, stock management |
 | `create-airqo-mobile` | Cross-platform mobile app with maps, forecasts, notifications, auth |
@@ -209,7 +209,7 @@ This vision has engineering implications for every roadmap. Concretely:
 
 | Product | Immediate IoT expansion | Template readiness |
 |---|---|---|
-| AirQo Nexus | Make sensor metric labels configurable | Extract to `create-airqo-platform`; document module boundaries |
+| AirQo Nexus | Make sensor metric labels configurable | Extract to `create-airqo-nexus`; document module boundaries |
 | Vertex | Generalise device schema beyond air quality sensors | `vertex-template` already exists; define and publish the contract |
 | Beacon | Make alert thresholds and metric types configurable per deployment | Extract core fleet management UI as template |
 | Mobile App | Enable metric type and health guidance content to be injected via config | Publish Flutter template with swappable data domain |

--- a/packages/airqo-icons/packages/flutter/README.md
+++ b/packages/airqo-icons/packages/flutter/README.md
@@ -390,7 +390,7 @@ We welcome contributions! Please see our [Contributing Guide](https://github.com
 
 ## 📄 License
 
-MIT © [AirQ0 Platform](https://analytics.airqo.net/account/login)
+MIT © [AirQo Nexus](https://nexus.airqo.net/account/login)
 
 ## 🔗 Links
 
@@ -398,4 +398,4 @@ MIT © [AirQ0 Platform](https://analytics.airqo.net/account/login)
 - [🌐 Icon Browser](https://aero-glyphs.vercel.app/)
 - [📱 React Package](https://www.npmjs.com/package/@airqo/icons-react)
 - [🐛 Report Issues](https://github.com/airqo-platform/airqo-libraries/issues)
-- [🌍 AirQo Platform](https://analytics.airqo.net/account/login)
+- [🌍 AirQo Nexus](https://nexus.airqo.net/account/login)

--- a/packages/airqo-icons/packages/flutter/README.md
+++ b/packages/airqo-icons/packages/flutter/README.md
@@ -390,7 +390,7 @@ We welcome contributions! Please see our [Contributing Guide](https://github.com
 
 ## 📄 License
 
-MIT © [AirQo Nexus](https://nexus.airqo.net/account/login)
+MIT © [AirQo Nexus](https://nexus.airqo.net/user/login)
 
 ## 🔗 Links
 
@@ -398,4 +398,4 @@ MIT © [AirQo Nexus](https://nexus.airqo.net/account/login)
 - [🌐 Icon Browser](https://aero-glyphs.vercel.app/)
 - [📱 React Package](https://www.npmjs.com/package/@airqo/icons-react)
 - [🐛 Report Issues](https://github.com/airqo-platform/airqo-libraries/issues)
-- [🌍 AirQo Nexus](https://nexus.airqo.net/account/login)
+- [🌍 AirQo Nexus](https://nexus.airqo.net/user/login)

--- a/packages/airqo-network-coverage/README.md
+++ b/packages/airqo-network-coverage/README.md
@@ -20,7 +20,7 @@ npm install @airqo-packages/network-coverage
 
 To call protected endpoints (registry write operations), you need an AirQo access token.
 
-1. Create an account at [analytics.airqo.net](https://analytics.airqo.net/user/login)
+1. Create an account at [nexus.airqo.net](https://nexus.airqo.net/user/login)
 2. Go to **Account Settings → API tab → Register a client**
 3. Generate an access token from the registered client
 4. Pass the token to the client constructor — it will be appended as `?token=` on every request automatically

--- a/packages/airqo-source-metadata/README.md
+++ b/packages/airqo-source-metadata/README.md
@@ -35,7 +35,7 @@ Pass a token directly or set `AIRQO_PLATFORM_TOKEN` or `AIRQO_API_TOKEN`.
 $env:AIRQO_API_TOKEN = "your-airqo-api-token"
 ```
 
-Tokens can be generated from the API section of your AirQo Nexus account at <https://nexus.airqo.net/>.
+Log in to your AirQo Nexus account at <https://nexus.airqo.net/user/login>, then generate a token from **Account Settings → API tab → Register a client**.
 
 ## Quick start
 

--- a/packages/airqo-source-metadata/README.md
+++ b/packages/airqo-source-metadata/README.md
@@ -35,7 +35,7 @@ Pass a token directly or set `AIRQO_PLATFORM_TOKEN` or `AIRQO_API_TOKEN`.
 $env:AIRQO_API_TOKEN = "your-airqo-api-token"
 ```
 
-Tokens can be generated from the API section of your AirQo Analytics account at <https://analytics.airqo.net/>.
+Tokens can be generated from the API section of your AirQo Nexus account at <https://nexus.airqo.net/>.
 
 ## Quick start
 

--- a/src/analytics/api/views/README.md
+++ b/src/analytics/api/views/README.md
@@ -1,6 +1,6 @@
-# AirQo Analytics API Documentation
+# AirQo Nexus API Documentation
 
-This document provides comprehensive information about the AirQo Analytics API (versions 2 and 3), including endpoint descriptions, request formats, response structures, and usage examples.
+This document provides comprehensive information about the AirQo Nexus API (versions 2 and 3), including endpoint descriptions, request formats, response structures, and usage examples.
 
 ## Table of Contents
 
@@ -21,7 +21,7 @@ This document provides comprehensive information about the AirQo Analytics API (
 
 ## API Overview
 
-The AirQo Analytics API provides access to air quality data collected from AirQo's network of sensors. It allows users to:
+The AirQo Nexus API provides access to air quality data collected from AirQo's network of sensors. It allows users to:
 
 - Query raw measurements
 - Download processed data at different frequencies (hourly, daily, etc.)


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Cleans up remaining stale "AirQo Analytics" / "AirQo Platform" naming and old `analytics.airqo.net` domain links left over from the AirQo Nexus rebrand:
- `docs/PRODUCT_VISION.md` — renamed `create-airqo-platform` template references to `create-airqo-nexus`
- `src/analytics/api/views/README.md` — renamed "AirQo Analytics API" title/intro to "AirQo Nexus API"
- `packages/airqo-source-metadata/README.md` — updated account reference and login link to `nexus.airqo.net`
- `packages/airqo-network-coverage/README.md` — updated account creation link to `nexus.airqo.net`
- `packages/airqo-icons/packages/flutter/README.md` — updated license/footer links and labels ("AirQo Platform" → "AirQo Nexus", `analytics.airqo.net` → `nexus.airqo.net`), and standardized the login path to `/user/login` (was inconsistently `/account/login`)

### Why is this change needed?
A previous PR rebranded AirQo Analytics to AirQo Nexus, but several docs and package READMEs still referenced the old product name and the old `analytics.airqo.net` domain (confirmed stale — the live domain is now `nexus.airqo.net`, per `auth-service` environment docs).

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** N/A — documentation-only changes across `docs/`, `src/analytics/api/views/README.md`, and package READMEs (`airqo-source-metadata`, `airqo-network-coverage`, `airqo-icons`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Grepped the repo for remaining "AirQo Analytics" and `analytics.airqo.net` occurrences within the doc/README scope of this PR to confirm no stale references were left behind; verified generic "AirQo platform" (ecosystem) mentions were intentionally left untouched. Note: `analytics.airqo.net`/`ANALYTICS_PLATFORM_URL` still appear in `k8s/nginx/**/analytics-vs.yaml` (ingress hostnames) and `src/device-registry/utils/event.util.js` — these are infrastructure and backend code, not docs, and are intentionally out of scope for this PR.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
Follow-up to the initial AirQo Nexus rebrand PR — only markdown documentation was touched, no code or API changes.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review
