### PR TITLE
Fix validation and logging bugs in auth-service

### DIFF
--- a/src/auth-service/docs/access-control/PERMISSIONS_GUIDE_FOR_FRONTEND.md
+++ b/src/auth-service/docs/access-control/PERMISSIONS_GUIDE_FOR_FRONTEND.md
@@ -184,7 +184,7 @@ The authoritative, up-to-date list is always available live via `GET /permission
 
 **The login response does not include permissions.** After login, call:
 
-```
+```http
 GET /profile/enhanced
 ```
 
@@ -194,8 +194,7 @@ Response (key fields under `data`):
 {
   "success": true,
   "data": {
-    "allPermissions": ["USER_CREATE", "GROUP_VIEW", "..."],
-    "systemPermissions": ["..."],
+    "systemPermissions": ["USER_CREATE", "..."],
     "groupPermissions": { "<groupId>": ["GROUP_VIEW", "..."] },
     "networkPermissions": { "<networkId>": ["..."] },
     "groupMemberships": ["..."],
@@ -211,18 +210,18 @@ Response (key fields under `data`):
 }
 ```
 
-Use `allPermissions` for a flat check, or `groupPermissions[groupId]` when the user is switching between organizations.
+There is no single flat array — build one client-side by unioning the per-context lists, e.g. `const all = [...new Set([...systemPermissions, ...Object.values(groupPermissions).flat(), ...Object.values(networkPermissions).flat()])]`. Use `groupPermissions[groupId]` directly when checking access for a specific organization.
 
 ## 5. Checking permissions for a specific group
 
-```
+```http
 GET /roles/me/groups/:group_id/permissions            // full detail + role info
 GET /roles/me/groups/:group_id/permissions/simplified  // lightweight version
 ```
 
 To check several groups/permissions at once:
 
-```
+```http
 POST /roles/me/permissions/bulk-check
 Body: { "group_ids": ["<id1>", "<id2>"], "permissions": ["GROUP_EDIT", "DEVICE_DEPLOY"] }
 ```
@@ -246,10 +245,10 @@ Response `data`:
 
 ## 6. Managing permissions & roles (for admin/settings screens)
 
-```
+```http
 GET    /permissions                       // list all permissions (paginated)
-POST   /permissions                       // create a custom permission: { permission, description, group_id? }
-PUT    /permissions/:permission_id        // update description only — name cannot be changed
+POST   /permissions                       // create a custom permission: { permission, description, group_id?, network_id? }
+PUT    /permissions/:permission_id        // update fields other than the permission code (e.g. description, network_id)
 DELETE /permissions/:permission_id
 
 GET    /roles                             // list roles with their permissions
@@ -265,4 +264,4 @@ POST   /roles/:role_id/users              // assign the role to user(s)
 - Permission names are globally unique and **cannot be renamed** after creation (only description changes).
 - `SYSTEM_ADMIN` / `SUPER_ADMIN` style permissions are platform-level only — they're never assigned on a group role.
 - Default/system roles cannot be deleted.
-- Always re-fetch `/profile/enhanced` when the user switches their active group, since permissions are per-group.
+- Re-fetch `/profile/enhanced` after a membership/role change (or on app refresh) — not on every group switch. It already returns `groupPermissions` for every group the user belongs to, so switching the active group just means reading `groupPermissions[groupId]` for the new group.

--- a/src/auth-service/docs/access-control/PERMISSIONS_GUIDE_FOR_FRONTEND.md
+++ b/src/auth-service/docs/access-control/PERMISSIONS_GUIDE_FOR_FRONTEND.md
@@ -1,0 +1,268 @@
+# Permissions Guide (AirQo Nexus API)
+
+Base URL:
+- Production: `https://api.airqo.net/api/v2/users` or `https://nexus.airqo.net/api/v2/users`
+- Staging: `https://nexus-staging.airqo.net/api/v2/users`
+
+All requests below require: `Authorization: JWT <token>`
+
+## 1. What is a permission?
+
+A permission is an uppercase string code in `SCOPE_ACTION` format, e.g. `USER_CREATE`, `DEVICE_DEPLOY`, `GROUP_VIEW`.
+
+## 2. Full list of permissions
+
+### System & Admin (platform-level only — never assigned on a group role)
+
+| Permission | What it's for |
+|---|---|
+| `SYSTEM_ADMIN` | System administration access |
+| `SUPER_ADMIN` | Super administrator access |
+| `DATABASE_ADMIN` | Database administration access |
+| `ADMIN_FULL_ACCESS` | Full administrative access |
+| `SYSTEM_CONFIGURE` | Configure system settings |
+| `SYSTEM_MONITOR` | Monitor system health and status |
+
+### Organization Management
+
+| Permission | What it's for |
+|---|---|
+| `ORG_CREATE` | Create new organizations |
+| `ORG_VIEW` | View organization details |
+| `ORG_UPDATE` | Update organization details |
+| `ORG_DELETE` | Delete organizations |
+| `ORG_APPROVE` | Approve organization requests |
+| `ORG_REJECT` | Reject organization requests |
+
+### Group Management
+
+| Permission | What it's for |
+|---|---|
+| `GROUP_VIEW` | View group information and basic details |
+| `GROUP_CREATE` | Create new groups |
+| `GROUP_EDIT` | Edit group settings and information |
+| `GROUP_DELETE` | Delete groups |
+| `GROUP_MANAGEMENT` | Full group management access |
+| `GROUP_SETTINGS` | Manage group-specific settings |
+
+### Network Management
+
+| Permission | What it's for |
+|---|---|
+| `NETWORK_VIEW` | View network information |
+| `NETWORK_CREATE` | Create new networks |
+| `NETWORK_EDIT` | Edit network settings |
+| `NETWORK_DELETE` | Delete networks |
+| `NETWORK_MANAGEMENT` | Full network management access |
+
+### User & Member Management
+
+| Permission | What it's for |
+|---|---|
+| `USER_VIEW` | View user information |
+| `USER_CREATE` | Create new users |
+| `USER_EDIT` | Edit user information |
+| `USER_DELETE` | Delete users |
+| `USER_MANAGEMENT` | Full user management access |
+| `USER_INVITE` | Invite new users |
+| `ORG_USER_ASSIGN` | Assign users to organizations (groups/networks) |
+| `MEMBER_VIEW` | View group members |
+| `MEMBER_INVITE` | Invite new members to group |
+| `MEMBER_REMOVE` | Remove members from group |
+| `MEMBER_EDIT` | Edit member information |
+| `MEMBER_SEARCH` | Search group members |
+| `MEMBER_EXPORT` | Export member data |
+
+### Role & Permission Management
+
+| Permission | What it's for |
+|---|---|
+| `ROLE_VIEW` | View roles and their permissions |
+| `ROLE_CREATE` | Create new roles |
+| `ROLE_EDIT` | Edit existing roles |
+| `ROLE_DELETE` | Delete roles |
+| `ROLE_ASSIGNMENT` | Assign roles to users |
+
+### Device Management
+
+| Permission | What it's for |
+|---|---|
+| `DEVICE_VIEW` | View devices |
+| `DEVICE_DEPLOY` | Deploy devices |
+| `DEVICE_RECALL` | Recall devices |
+| `DEVICE_MAINTAIN` | Maintain devices |
+| `DEVICE_UPDATE` | Update device information |
+| `DEVICE_DELETE` | Delete devices |
+| `DEVICE_CLAIM` | Claim and unclaim devices |
+
+### Site Management
+
+| Permission | What it's for |
+|---|---|
+| `SITE_VIEW` | View sites |
+| `SITE_CREATE` | Create new sites |
+| `SITE_UPDATE` | Update site information |
+| `SITE_DELETE` | Delete sites |
+
+### Dashboard & Analytics
+
+| Permission | What it's for |
+|---|---|
+| `DASHBOARD_VIEW` | View dashboard |
+| `ANALYTICS_VIEW` | View analytics and reports |
+| `ANALYTICS_EXPORT` | Export analytics data |
+| `DATA_VIEW` | View data |
+| `DATA_EXPORT` | Export data |
+| `DATA_COMPARE` | Compare data |
+| `DATA_CREATE` | Create data entries |
+| `DATA_UPDATE` | Update data entries |
+
+### User Profile
+
+| Permission | What it's for |
+|---|---|
+| `PROFILE_VIEW` | View own profile |
+| `PROFILE_UPDATE` | Update own profile |
+
+### Settings
+
+| Permission | What it's for |
+|---|---|
+| `SETTINGS_VIEW` | View system and group settings |
+| `SETTINGS_EDIT` | Edit system and group settings |
+
+### Content Management
+
+| Permission | What it's for |
+|---|---|
+| `CONTENT_VIEW` | View content |
+| `CONTENT_CREATE` | Create content |
+| `CONTENT_EDIT` | Edit content |
+| `CONTENT_DELETE` | Delete content |
+| `CONTENT_MODERATION` | Moderate content |
+
+### Audit & Reporting
+
+| Permission | What it's for |
+|---|---|
+| `ACTIVITY_VIEW` | View activity logs |
+| `AUDIT_VIEW` | View audit trails |
+| `AUDIT_EXPORT` | Export audit data |
+| `REPORT_GENERATE` | Generate reports |
+
+### API & Integration
+
+| Permission | What it's for |
+|---|---|
+| `API_ACCESS` | Access the API |
+| `TOKEN_GENERATE` | Generate API tokens |
+| `TOKEN_MANAGE` | Manage API tokens |
+| `TOKEN_ANALYZE` | Analyze token usage |
+
+### Shipping Management
+
+| Permission | What it's for |
+|---|---|
+| `SHIPPING_VIEW` | View shipping information |
+| `SHIPPING_CREATE` | Create shipping batches |
+| `SHIPPING_EDIT` | Edit shipping information |
+| `SHIPPING_DELETE` | Delete shipping records |
+
+> **Legacy permissions** such as `CREATE_UPDATE_AND_DELETE_NETWORK_DEVICES`, `VIEW_AIR_QUALITY_FOR_NETWORK`, `MANAGE_GROUP_SETTINGS`, `VIEW_GROUP_DASHBOARD`, `ACCESS_PLATFORM`, and similar `*_NETWORK_*` / `*_GROUP_*` combo permissions still exist on older roles but are being phased out — don't build new features against them; use the equivalent scoped permission above instead (e.g. `GROUP_SETTINGS` instead of `MANAGE_GROUP_SETTINGS`).
+
+The authoritative, up-to-date list is always available live via `GET /permissions`.
+
+## 3. How access is structured
+
+`User → Role (per Group) → Permissions`
+
+- A user is assigned a **Role** within a **Group** (organization). A role carries a fixed list of permissions.
+- The same user can hold different roles — and therefore different permissions — in different groups.
+- Users flagged `isSuperAdmin` implicitly have every permission everywhere.
+
+## 4. Getting the logged-in user's permissions
+
+**The login response does not include permissions.** After login, call:
+
+```
+GET /profile/enhanced
+```
+
+Response (key fields under `data`):
+
+```json
+{
+  "success": true,
+  "data": {
+    "allPermissions": ["USER_CREATE", "GROUP_VIEW", "..."],
+    "systemPermissions": ["..."],
+    "groupPermissions": { "<groupId>": ["GROUP_VIEW", "..."] },
+    "networkPermissions": { "<networkId>": ["..."] },
+    "groupMemberships": ["..."],
+    "networkMemberships": ["..."],
+    "isSuperAdmin": false,
+    "contextSummary": {
+      "totalPermissions": 12,
+      "groupMemberships": 2,
+      "networkMemberships": 0,
+      "isSuperAdmin": false
+    }
+  }
+}
+```
+
+Use `allPermissions` for a flat check, or `groupPermissions[groupId]` when the user is switching between organizations.
+
+## 5. Checking permissions for a specific group
+
+```
+GET /roles/me/groups/:group_id/permissions            // full detail + role info
+GET /roles/me/groups/:group_id/permissions/simplified  // lightweight version
+```
+
+To check several groups/permissions at once:
+
+```
+POST /roles/me/permissions/bulk-check
+Body: { "group_ids": ["<id1>", "<id2>"], "permissions": ["GROUP_EDIT", "DEVICE_DEPLOY"] }
+```
+
+Response `data`:
+
+```json
+{
+  "results": [
+    {
+      "group_id": "...",
+      "group_name": "...",
+      "role_name": "...",
+      "permission_checks": { "GROUP_EDIT": true, "DEVICE_DEPLOY": false },
+      "access_control": { "can_edit": true, "can_delete": false, "can_update": true }
+    }
+  ],
+  "summary": { "total_groups": 2, "groups_with_access": 2, "groups_with_errors": 0 }
+}
+```
+
+## 6. Managing permissions & roles (for admin/settings screens)
+
+```
+GET    /permissions                       // list all permissions (paginated)
+POST   /permissions                       // create a custom permission: { permission, description, group_id? }
+PUT    /permissions/:permission_id        // update description only — name cannot be changed
+DELETE /permissions/:permission_id
+
+GET    /roles                             // list roles with their permissions
+GET    /roles/:role_id/permissions        // permissions on a role
+GET    /roles/:role_id/available_permissions  // permissions not yet on a role
+POST   /roles/:role_id/permissions        // assign permission(s) to a role
+DELETE /roles/:role_id/permissions/:permission_id  // remove one permission from a role
+POST   /roles/:role_id/users              // assign the role to user(s)
+```
+
+## 7. Rules & gotchas
+
+- Permission names are globally unique and **cannot be renamed** after creation (only description changes).
+- `SYSTEM_ADMIN` / `SUPER_ADMIN` style permissions are platform-level only — they're never assigned on a group role.
+- Default/system roles cannot be deleted.
+- Always re-fetch `/profile/enhanced` when the user switches their active group, since permissions are per-group.

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -52,6 +52,13 @@ function validateProfilePicture(profilePicture) {
   }
   return true;
 }
+function truncateProfilePicture(url) {
+  if (typeof url === "string" && url.length > maxLengthOfProfilePictures) {
+    return url.substring(0, maxLengthOfProfilePictures);
+  }
+  return url;
+}
+
 const passwordReg = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d@#?!$%^&*,.]{6,}$/;
 const networkRoleSchema = new Schema({
   network: {
@@ -499,6 +506,16 @@ const UserSchema = new Schema(
   { timestamps: true },
 );
 
+// Mongoose runs schema validation (including maxLength) before "save"
+// middleware, so any truncation must happen in a "validate" hook to take
+// effect before the check runs — doing it in pre("save") is too late.
+UserSchema.pre("validate", function (next) {
+  if (this.profilePicture) {
+    this.profilePicture = truncateProfilePicture(this.profilePicture);
+  }
+  next();
+});
+
 UserSchema.pre("save", async function (next) {
   try {
     if (this.isNew) {
@@ -523,24 +540,7 @@ UserSchema.pre("save", async function (next) {
         return next(new Error("userName is required!"));
       }
 
-      // 3. Profile picture validation
-      if (this.profilePicture && !validateProfilePicture(this.profilePicture)) {
-        if (this.profilePicture.length > maxLengthOfProfilePictures) {
-          this.profilePicture = this.profilePicture.substring(
-            0,
-            maxLengthOfProfilePictures,
-          );
-        }
-        if (!validateProfilePicture(this.profilePicture)) {
-          return next(
-            new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
-              message: "Invalid profile picture URL",
-            }),
-          );
-        }
-      }
-
-      // 4. Set default roles for new users ONLY
+      // 3. Set default roles for new users ONLY
       const tenant = this.tenant || constants.DEFAULT_TENANT || "airqo";
       const tenantSettings = await TenantSettingsModel(tenant)
         .findOne({ tenant })

--- a/src/auth-service/models/test/ut_user.model.js
+++ b/src/auth-service/models/test/ut_user.model.js
@@ -391,3 +391,27 @@ describe("UserSchema instance methods", () => {
     // Add more test cases to cover other scenarios
   });
 });
+
+describe("UserSchema hooks", () => {
+  describe("pre('validate') profilePicture truncation", () => {
+    it("should truncate an overlong profilePicture to 1024 characters before validation runs", async () => {
+      const overlongUrl = `https://example.com/${"a".repeat(2000)}`;
+      const user = new (UserModelFactory("airqo"))({
+        profilePicture: overlongUrl,
+      });
+
+      await expect(user.validate(["profilePicture"])).to.be.fulfilled;
+      expect(user.profilePicture.length).to.equal(1024);
+    });
+
+    it("should leave a profilePicture within the limit unchanged", async () => {
+      const shortUrl = "https://example.com/photo.jpg";
+      const user = new (UserModelFactory("airqo"))({
+        profilePicture: shortUrl,
+      });
+
+      await expect(user.validate(["profilePicture"])).to.be.fulfilled;
+      expect(user.profilePicture).to.equal(shortUrl);
+    });
+  });
+});

--- a/src/auth-service/utils/common/log-winston.util.js
+++ b/src/auth-service/utils/common/log-winston.util.js
@@ -78,4 +78,13 @@ const mongoTimeout = setTimeout(() => {
 }, 60000);
 mongoTimeout.unref();
 
+// Test-only hooks: production code never calls these directly — the poll
+// above drives addMongoTransport() once the driver connection is ready.
+// Tests use them to exercise the transport-wiring logic deterministically,
+// without waiting on real timers or a live DB connection.
+winstonLogger.__addMongoTransportForTesting = addMongoTransport;
+winstonLogger.__resetMongoTransportStateForTesting = () => {
+  mongoTransportAdded = false;
+};
+
 module.exports = winstonLogger;

--- a/src/auth-service/utils/common/log-winston.util.js
+++ b/src/auth-service/utils/common/log-winston.util.js
@@ -1,5 +1,6 @@
 const winston = require("winston");
 const mongoose = require("mongoose");
+const constants = require("@config/constants");
 
 // Console transport is live from the start so startup and outage logs are never
 // silently dropped. The MongoDB transport is added lazily once the driver
@@ -19,9 +20,17 @@ const addMongoTransport = () => {
     const { LogModel, LogDB, logSchema } = require("@models/log");
     const MongoDB = require("winston-mongodb").MongoDB;
 
+    // Pass the native MongoClient (via Mongoose's getClient()), not the
+    // Mongoose Connection itself — winston-mongodb only recognizes a
+    // connection string, a Promise<MongoClient>, or an object exposing
+    // .db() as a function. Anything else falls through to its deprecated
+    // "preconnected object" branch and logs a warning on every startup.
+    // dbName must be passed explicitly since the client isn't pre-scoped
+    // to the tenant db the way the Mongoose Connection was.
     winstonLogger.add(
       new MongoDB({
-        db: LogDB("airqo"),
+        db: LogDB("airqo").getClient(),
+        dbName: `${constants.DB_NAME}_airqo`,
         options: { useUnifiedTopology: true },
         collection: "logs",
         format: winston.format.combine(

--- a/src/auth-service/utils/common/test/ut_log-winston.util.js
+++ b/src/auth-service/utils/common/test/ut_log-winston.util.js
@@ -2,43 +2,73 @@ require("module-alias/register");
 const chai = require("chai");
 const sinon = require("sinon");
 const { expect } = chai;
-const winston = require("winston");
-const { MongoDB } = require("winston-mongodb");
+const winstonMongodbModule = require("winston-mongodb");
+const logModule = require("@models/log");
+const constants = require("@config/constants");
 const { winstonLogger } = require("@utils/common");
-const { LogDB, LogModel } = require("@models/log");
 
 describe("winstonLogger", () => {
+  beforeEach(() => {
+    winstonLogger.__resetMongoTransportStateForTesting();
+  });
+
   afterEach(() => {
     sinon.restore();
   });
 
-  it("should create the winston logger with the correct configurations", () => {
-    const createLoggerStub = sinon.stub(winston, "createLogger");
-    const mongoDBTransportStub = sinon.stub(winston.transports, "MongoDB");
+  it("adds the MongoDB transport with the expected configuration", () => {
+    const fakeClient = { fake: "mongoClient" };
+    const fakeConnection = { getClient: () => fakeClient };
+    const fakeModel = { modelName: "logs" };
 
-    const logger = winstonLogger;
+    sinon.stub(logModule, "LogDB").returns(fakeConnection);
+    sinon.stub(logModule, "LogModel").returns(fakeModel);
+    const addStub = sinon.stub(winstonLogger, "add");
+    const MongoDBStub = sinon
+      .stub(winstonMongodbModule, "MongoDB")
+      .returns({ on: () => {}, log: () => {} });
 
-    expect(createLoggerStub.calledOnce).to.be.true;
-    expect(mongoDBTransportStub.calledOnce).to.be.true;
+    winstonLogger.__addMongoTransportForTesting();
 
-    const transportOptions = mongoDBTransportStub.getCall(0).args[0];
+    expect(MongoDBStub.calledOnce).to.be.true;
+    const transportOptions = MongoDBStub.getCall(0).args[0];
 
-    // Ensure the MongoDB transport is created with the correct options
-    expect(transportOptions).to.deep.equal({
-      db: LogDB("airqo"),
-      options: { useNewUrlParser: true, useUnifiedTopology: true },
-      collection: "logs",
-      format: winston.format.combine(
-        winston.format.timestamp(),
-        winston.format.json(),
-        winston.format.metadata()
-      ),
-      metaKey: "metadata",
-      level: "info",
-      schema: LogSchema,
-      model: LogModel("airqo"),
+    // The transport must receive the native MongoClient (via getClient()),
+    // not the Mongoose Connection itself, plus an explicit dbName — passing
+    // the raw connection instead trips winston-mongodb's deprecated
+    // "preconnected object" path and logs a startup warning.
+    expect(transportOptions.db).to.equal(fakeClient);
+    expect(transportOptions.dbName).to.equal(`${constants.DB_NAME}_airqo`);
+    expect(transportOptions.options).to.deep.equal({
+      useUnifiedTopology: true,
     });
+    expect(transportOptions.collection).to.equal("logs");
+    expect(transportOptions.metaKey).to.equal("metadata");
+    expect(transportOptions.level).to.equal("info");
+    expect(transportOptions.model).to.equal(fakeModel);
+    expect(addStub.calledOnce).to.be.true;
+  });
+
+  it("does not add the transport a second time once already added", () => {
+    sinon.stub(logModule, "LogDB").returns({ getClient: () => ({}) });
+    sinon.stub(logModule, "LogModel").returns({});
+    const addStub = sinon.stub(winstonLogger, "add");
+    const MongoDBStub = sinon
+      .stub(winstonMongodbModule, "MongoDB")
+      .returns({ on: () => {}, log: () => {} });
+
+    winstonLogger.__addMongoTransportForTesting();
+    winstonLogger.__addMongoTransportForTesting();
+
+    expect(MongoDBStub.calledOnce).to.be.true;
+    expect(addStub.calledOnce).to.be.true;
+  });
+
+  it("falls back silently if the MongoDB transport cannot be constructed", () => {
+    sinon.stub(logModule, "LogDB").throws(new Error("DB not ready"));
+    const addStub = sinon.stub(winstonLogger, "add");
+
+    expect(() => winstonLogger.__addMongoTransportForTesting()).to.not.throw();
+    expect(addStub.called).to.be.false;
   });
 });
-
-// You can add more test cases to cover additional scenarios or edge cases.

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -1815,6 +1815,7 @@ const createUserModule = {
             {
               $set: updatedFields,
             },
+            { runValidators: true, context: "query" },
           );
           logObject("updatedUser", updatedUser);
           const responseFromDeleteCachedItem =

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -1804,19 +1804,27 @@ const createUserModule = {
 
         if (userExistsLocally) {
           const updatedFields = {};
-          if (firebaseUser.firstName !== null) {
-            updatedFields.firstName = firebaseUser.firstName;
+          if (
+            typeof firebaseUser.firstName === "string" &&
+            firebaseUser.firstName.trim()
+          ) {
+            updatedFields.firstName = firebaseUser.firstName.trim();
           }
-          if (firebaseUser.lastName !== null) {
-            updatedFields.lastName = firebaseUser.lastName;
+          if (
+            typeof firebaseUser.lastName === "string" &&
+            firebaseUser.lastName.trim()
+          ) {
+            updatedFields.lastName = firebaseUser.lastName.trim();
           }
-          const updatedUser = await UserModel(tenant).updateOne(
-            { _id: userExistsLocally._id },
-            {
-              $set: updatedFields,
-            },
-            { runValidators: true, context: "query" },
-          );
+          const updatedUser = isEmpty(updatedFields)
+            ? null
+            : await UserModel(tenant).updateOne(
+                { _id: userExistsLocally._id },
+                {
+                  $set: updatedFields,
+                },
+                { runValidators: true, context: "query" },
+              );
           logObject("updatedUser", updatedUser);
           const responseFromDeleteCachedItem =
             await createUserModule.deleteCachedItem(cacheID, next);

--- a/src/auth-service/validators/defaults.validators.js
+++ b/src/auth-service/validators/defaults.validators.js
@@ -131,6 +131,18 @@ const update = [
       .customSanitizer((value) => {
         return ObjectId(value);
       }),
+    body("network_id")
+      .optional()
+      .notEmpty()
+      .withMessage("the provided network_id should not be empty IF provided")
+      .bail()
+      .trim()
+      .isMongoId()
+      .withMessage("the network_id must be an object ID")
+      .bail()
+      .customSanitizer((value) => {
+        return ObjectId(value);
+      }),
     body("chartTitle")
       .optional()
       .notEmpty()
@@ -284,6 +296,18 @@ const create = [
       .trim()
       .isMongoId()
       .withMessage("the airqloud must be an object ID")
+      .bail()
+      .customSanitizer((value) => {
+        return ObjectId(value);
+      }),
+    body("network_id")
+      .optional()
+      .notEmpty()
+      .withMessage("the provided network_id should not be empty IF provided")
+      .bail()
+      .trim()
+      .isMongoId()
+      .withMessage("the network_id must be an object ID")
       .bail()
       .customSanitizer((value) => {
         return ObjectId(value);

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -711,6 +711,22 @@ const updateUser = [
       }),
   ],
   [
+    body("firstName")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("firstName should not be empty IF provided")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("firstName cannot exceed 100 characters"),
+    body("lastName")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("lastName should not be empty IF provided")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("lastName cannot exceed 100 characters"),
     body("networks")
       .optional()
       .custom((value) => {
@@ -744,6 +760,22 @@ const updateUserById = [
       }),
   ],
   [
+    body("firstName")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("firstName should not be empty IF provided")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("firstName cannot exceed 100 characters"),
+    body("lastName")
+      .optional()
+      .trim()
+      .notEmpty()
+      .withMessage("lastName should not be empty IF provided")
+      .bail()
+      .isLength({ max: 100 })
+      .withMessage("lastName cannot exceed 100 characters"),
     body("networks")
       .optional()
       .custom((value) => {

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -713,6 +713,9 @@ const updateUser = [
   [
     body("firstName")
       .optional()
+      .isString()
+      .withMessage("firstName must be a string")
+      .bail()
       .trim()
       .notEmpty()
       .withMessage("firstName should not be empty IF provided")
@@ -721,6 +724,9 @@ const updateUser = [
       .withMessage("firstName cannot exceed 100 characters"),
     body("lastName")
       .optional()
+      .isString()
+      .withMessage("lastName must be a string")
+      .bail()
       .trim()
       .notEmpty()
       .withMessage("lastName should not be empty IF provided")
@@ -762,6 +768,9 @@ const updateUserById = [
   [
     body("firstName")
       .optional()
+      .isString()
+      .withMessage("firstName must be a string")
+      .bail()
       .trim()
       .notEmpty()
       .withMessage("firstName should not be empty IF provided")
@@ -770,6 +779,9 @@ const updateUserById = [
       .withMessage("firstName cannot exceed 100 characters"),
     body("lastName")
       .optional()
+      .isString()
+      .withMessage("lastName must be a string")
+      .bail()
       .trim()
       .notEmpty()
       .withMessage("lastName should not be empty IF provided")


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes four issues surfaced by recent staging/production error logs:
1. Adds missing validation for a field on the Defaults API that was being sent as an empty value, causing internal server errors instead of a clear rejection.
2. Fixes a bug where signing in with a Google account could fail when the account's profile picture URL was unusually long — the length check was running at the wrong point in the save process, so a fix meant to shorten oversized URLs never actually took effect.
3. Closes a gap where a user's name fields could be saved with no length limit through one specific account-sync path, and adds the same length limit to the main profile-update endpoints as a backup safeguard.
4. Removes a recurring deprecation warning in the logs coming from how the logging system connects to its storage backend.

### Why is this change needed?
All four issues were actively appearing as repeated errors/warnings in the team's error-log channel, affecting account default settings, Google sign-ins, and data quality (e.g. a user's last name being saved as an entire paragraph). Fixing them removes a source of failed sign-ups and internal server errors, and prevents unbounded/malformed data from being stored.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** auth-service

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Changes were syntax-validated. Manual end-to-end testing (triggering each affected flow — Defaults creation, Google sign-in, profile update, and log output) and a full test suite run are still recommended before merge.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Validation is now stricter in a couple of spots (e.g. name fields and one identifier field are now length/format-checked where they weren't before), so requests that were previously silently accepted despite being invalid will now be rejected with a clear validation error instead.

---

## :memo: Additional Notes

These fixes were prompted by errors observed in the team's Slack error-log channel on 2026-07-22/23. Worth keeping an eye on the same log channel after deploy to confirm the errors stop recurring.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
