### PR TITLE
Fix distance ReferenceError and reduce rate-limit Slack alert spam

### DIFF
--- a/src/device-registry/utils/common/throttle.util.js
+++ b/src/device-registry/utils/common/throttle.util.js
@@ -4,7 +4,7 @@ const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- throttle-util`);
 
 const ANCIENT_QUERY_TTL = 3600;
-const BLOCK_LOG_TTL = 30;
+const BLOCK_LOG_TTL = 900; // matches the 15-minute BLOCK_DURATION in event.util.js, so a client gets one Slack alert per block instead of one every 30s
 const RATE_LIMIT_TTL = 360;
 
 const throttleUtil = {

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -24,6 +24,7 @@ const {
   stringify,
   ActivityLogger,
   throttleUtil,
+  distance,
 } = require("@utils/common");
 const isEmpty = require("is-empty");
 const cryptoJS = require("crypto-js");


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
<!-- Brief summary of the changes -->
Fixes a `ReferenceError: distance is not defined` crash in the nearest-readings/nearest-city lookup paths of `event.util.js`, and reduces excessive Slack ops-alerts spam from the emergency historical-query rate limiter.

### Why is this change needed?
<!-- Explain the motivation/problem this solves -->
Staging logs showed repeated `Internal Server Error distance is not defined` crashes because the `distance` helper was used in `getNearestReadings`/`findNearestCityReading` but never imported from `@utils/common`. Separately, production Slack ops-alerts were being flooded with a "RATE LIMITED" message roughly every 30 seconds for the full 15-minute duration of a client's block, since the dedup TTL (30s) didn't match the actual block duration (15 minutes), making the channel noisy and not actionable.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
<!-- List the affected services or mark N/A -->
- device-registry

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->
Verified `distance` is exported from `@utils/common` and correctly resolves at the two call sites (`getNearestReadings`, `findNearestCityReading`). Confirmed no local variable shadowing exists (existing `site.distance`/`distanceInKm`/`distanceToCenter` usages are unaffected). Syntax-checked both modified files with `node --check`.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)
<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
<!-- Any additional context, dependencies, or concerns -->
- `utils/event.util.js`: added missing `distance` to the `@utils/common` destructure import.
- `utils/common/throttle.util.js`: raised `BLOCK_LOG_TTL` from 30s to 900s to match the 15-minute `BLOCK_DURATION` used by the emergency rate limiter, so each block now produces one Slack alert instead of ~30.
- The initial "RATE LIMIT TRIGGERED" alert was left as-is since it already fires only once per fresh block.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved throttling for repeated block alerts and logs by aligning suppression timing with the 15-minute block duration.
  * Ensured nearest-reading calculations consistently use the shared distance utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->