### PR TITLE
Fix opaque 500 on subscription cancel with pending Paddle change

### DIFF
--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -1022,6 +1022,19 @@ const transactions = {
         status: httpStatus.OK,
       };
     } catch (error) {
+      if (error.code === "subscription_locked_pending_changes") {
+        logger.warn(
+          `Cancellation blocked by pending scheduled change: user=${user._id} subscription=${subscriptionId}`,
+        );
+        return {
+          success: false,
+          message:
+            "You have a scheduled plan change pending. It will take effect on your next billing date, after which you can cancel.",
+          errors: { message: error.message },
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
       logger.error("Subscription cancellation failed", error);
       return {
         success: false,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Catches Paddle's `subscription_locked_pending_changes` error in `cancelSubscription` (utils/transaction.util.js) and returns a clear `400` response instead of a generic `500`.

### Why is this change needed?
When a user has a scheduled plan change (e.g. a downgrade) pending, Paddle rejects the cancel request. This previously surfaced to the client as an opaque `500 Failed to cancel subscription`, giving no indication of what actually went wrong or what the user should do next. This was found while reviewing staging error logs (`ApiError: cannot update subscription, pending scheduled changes`).

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** auth-service (Paddle subscription/transaction handling)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Targeted fix in the `cancelSubscription` catch block; verified against existing Paddle SDK error shape (`error.code`) used elsewhere in the file (e.g. `customer_already_exists` handling). No new automated test added yet — recommend adding one that mocks a `subscription_locked_pending_changes` error and asserts a `400` response.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
All other cancellation failures continue to return the original `500` behavior — only this specific, expected Paddle error code is now handled distinctly. Logged at `warn` level (not `error`) so it doesn't trigger the Slack `ops-alerts` channel for what is a normal, recoverable user scenario.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription cancellation errors when a plan change is already scheduled.
  * Users now receive a clear message explaining why cancellation cannot proceed, along with the relevant error details.
  * Other cancellation failures continue to use the existing error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->