### PR TITLE
Temporarily disable selfie cleanup job to preserve recent photos

### DIFF
--- a/src/auth-service/bin/jobs/selfie-cleanup-job.js
+++ b/src/auth-service/bin/jobs/selfie-cleanup-job.js
@@ -107,7 +107,7 @@ global.cronJobs = global.cronJobs || {};
 const schedule = "30 2 * * *"; // every day at 2:30 AM, after the feedback screenshot cleanup job
 const jobName = "selfie-cleanup-job";
 global.cronJobs[jobName] = cron.schedule(schedule, cleanupOldSelfies, {
-  scheduled: true,
+  scheduled: false, // temporarily disabled — selfie feature is currently unused, no cost pressure to prune recent event photos
   timezone: "Africa/Nairobi",
 });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Temporarily disables the nightly selfie cleanup cron job in auth-service by setting `scheduled: false` on the node-cron task. The job remains registered but will no longer execute on its 2:30 AM schedule.

### Why is this change needed?
The job permanently deletes selfies (Cloudinary assets + MongoDB records) older than the configured retention period. The feature was mainly used during a recent event over a few days and isn't currently active, so there's no cost pressure requiring pruning right now. Disabling it prevents recent event selfies from being deleted while usage is low.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** auth-service (`bin/jobs/selfie-cleanup-job.js`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Verified the cron task config change locally; no functional test coverage needed since this only flips the job's `scheduled` flag off.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This is a temporary, easily reversible change — flip `scheduled` back to `true` in `bin/jobs/selfie-cleanup-job.js` to re-enable the job once retention/cost becomes a concern again.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled the automated cleanup of old selfie data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->