### PR TITLE
Add tiered 5-day and 2-day token expiry reminder emails

### DIFF
--- a/src/auth-service/bin/jobs/test/ut_token-expiration-job.js
+++ b/src/auth-service/bin/jobs/test/ut_token-expiration-job.js
@@ -1,118 +1,98 @@
 require("module-alias/register");
+const rewire = require("rewire");
+const mongoose = require("mongoose");
+
+// Bootstrap in-memory model registration so AccessTokenModel("airqo") resolves
+// via mongoose.model("access_tokens") instead of requiring a live DB connection.
+try {
+  const _schema = rewire("@models/AccessToken").__get__("AccessTokenSchema");
+  if (!mongoose.modelNames().includes("access_tokens")) {
+    mongoose.model("access_tokens", _schema);
+  }
+} catch (_) {}
+
 const sinon = require("sinon");
 const chai = require("chai");
-const expect = chai.expect;
 const sinonChai = require("sinon-chai");
+chai.use(sinonChai);
+const expect = chai.expect;
 
-describe("sendAlertsForExpiringTokens", () => {
-  let AccessTokenModel;
+const AccessTokenModel = require("@models/AccessToken");
+const { mailer } = require("@utils/common");
+const {
+  sendAlertsForExpiringTokens,
+  REMINDER_DAY_THRESHOLDS,
+} = require("../token-expiration-job");
+
+describe("token-expiration-job: sendAlertsForExpiringTokens", () => {
+  let getExpiringTokensStub;
+  let expiringTokenStub;
+
+  const tokenFor = (days, suffix) => ({
+    token: `tok_${suffix}`,
+    name: `token-${suffix}`,
+    expires: new Date(Date.now() + days * 24 * 60 * 60 * 1000),
+    user: { email: `user-${suffix}@example.com`, firstName: "Jane", lastName: "Doe" },
+  });
 
   beforeEach(() => {
-    // Set up mocks
-    AccessTokenModel = sinon.mock(AccessTokenModel);
-    sinon.stub(AccessTokenModel.prototype, "getExpiringTokens").returns(
-      Promise.resolve({
-        success: true,
-        data: [
-          {
-            user: {
-              email: "test@example.com",
-              firstName: "John",
-              lastName: "Doe",
-            },
-          },
-          {
-            user: {
-              email: "test2@example.com",
-              firstName: "Jane",
-              lastName: "Smith",
-            },
-          },
-        ],
-      })
+    getExpiringTokensStub = sinon.stub(
+      AccessTokenModel("airqo"),
+      "getExpiringTokens"
     );
+    // First page has one token, second page (skip=100) is empty — exercises
+    // the pagination loop in fetchTokensExpiringWithinDays.
+    getExpiringTokensStub.callsFake(async ({ skip, days }) => {
+      if (skip > 0) return { success: true, data: [] };
+      return { success: true, data: [tokenFor(days, days)] };
+    });
 
-    sinon.stub(console, "info");
+    expiringTokenStub = sinon
+      .stub(mailer, "expiringToken")
+      .resolves({ success: true });
+
     sinon.stub(console, "error");
   });
 
   afterEach(() => {
-    // Restore mocks
-    AccessTokenModel.restore();
-    console.info.restore();
+    getExpiringTokensStub.restore();
+    expiringTokenStub.restore();
     console.error.restore();
   });
 
-  describe("successful execution", () => {
-    it("should fetch expiring tokens and send emails", async () => {
-      await sendAlertsForExpiringTokens();
+  it("queries and emails once per configured day threshold", async () => {
+    await sendAlertsForExpiringTokens();
 
-      expect(AccessTokenModel.prototype.getExpiringTokens).to.have.been
-        .calledOnce;
-      expect(
-        AccessTokenModel.prototype.getExpiringTokens
-      ).to.have.been.calledWith({
-        skip: 0,
-        limit: 100,
-      });
+    expect(getExpiringTokensStub.callCount).to.equal(
+      REMINDER_DAY_THRESHOLDS.length * 2 // one call per threshold, plus the empty follow-up page
+    );
+    expect(expiringTokenStub.callCount).to.equal(REMINDER_DAY_THRESHOLDS.length);
 
-      const emailPromises = [
-        {
-          user: {
-            email: "test@example.com",
-            firstName: "John",
-            lastName: "Doe",
-          },
-        },
-        {
-          user: {
-            email: "test2@example.com",
-            firstName: "Jane",
-            lastName: "Smith",
-          },
-        },
-      ];
-
-      expect(mailer.expandingToken).to.have.been.calledTwice;
-      expect(mailer.expandingToken).to.have.been.calledWithMatch({
-        email: "test@example.com",
-        firstName: "John",
-        lastName: "Doe",
+    for (const days of REMINDER_DAY_THRESHOLDS) {
+      expect(expiringTokenStub).to.have.been.calledWithMatch({
+        email: `user-${days}@example.com`,
+        daysRemaining: days,
       });
-      expect(mailer.expandingToken).to.have.been.calledWithMatch({
-        email: "test2@example.com",
-        firstName: "Jane",
-        lastName: "Smith",
-      });
-    });
+    }
   });
 
-  describe("no expiring tokens found", () => {
-    it("should log info message when no tokens are found", async () => {
-      AccessTokenModel.mock().getExpiringTokens.resolves({
-        success: true,
-        data: [],
-      });
+  it("gives each threshold's reminder a distinct cooldownKey so they don't suppress each other", async () => {
+    await sendAlertsForExpiringTokens();
 
-      await sendAlertsForExpiringTokens();
+    const cooldownKeys = expiringTokenStub
+      .getCalls()
+      .map((call) => call.args[0].cooldownKey);
 
-      expect(console.info).to.have.been.calledWith(
-        "No expiring tokens found for this month."
-      );
-    });
+    expect(new Set(cooldownKeys).size).to.equal(cooldownKeys.length);
   });
 
-  describe("error handling", () => {
-    it("should log error when fetching tokens fails", async () => {
-      AccessTokenModel.mock().getExpiringTokens.rejects(
-        new Error("Test error")
-      );
+  it("continues to the next threshold when one lookup fails", async () => {
+    getExpiringTokensStub.restore();
+    getExpiringTokensStub = sinon
+      .stub(AccessTokenModel("airqo"), "getExpiringTokens")
+      .rejects(new Error("db unavailable"));
 
-      await sendAlertsForExpiringTokens();
-
-      expect(console.error).to.have.been.calledWith(
-        `🐛🐛 Internal Server Error -- Test error`
-      );
-    });
+    await sendAlertsForExpiringTokens(); // resolves cleanly even though every threshold's lookup rejects
+    expect(expiringTokenStub).to.not.have.been.called;
   });
 });

--- a/src/auth-service/bin/jobs/test/ut_token-expiration-job.js
+++ b/src/auth-service/bin/jobs/test/ut_token-expiration-job.js
@@ -29,6 +29,7 @@ describe("token-expiration-job: sendAlertsForExpiringTokens", () => {
   let expiringTokenStub;
 
   const tokenFor = (days, suffix) => ({
+    _id: `token-id-${suffix}`,
     token: `tok_${suffix}`,
     name: `token-${suffix}`,
     expires: new Date(Date.now() + days * 24 * 60 * 60 * 1000),
@@ -84,6 +85,45 @@ describe("token-expiration-job: sendAlertsForExpiringTokens", () => {
       .map((call) => call.args[0].cooldownKey);
 
     expect(new Set(cooldownKeys).size).to.equal(cooldownKeys.length);
+  });
+
+  it("bounds each threshold query with the next-smaller threshold as minDays", async () => {
+    await sendAlertsForExpiringTokens();
+
+    // REMINDER_DAY_THRESHOLDS is [5, 2]: the 5-day query should be floored at
+    // 2 days (band "2 to 5 days out") and the 2-day query floored at 0 (band
+    // "0 to 2 days out"), so together they partition the timeline with no gap
+    // and no overlap.
+    expect(getExpiringTokensStub).to.have.been.calledWithMatch({
+      days: 5,
+      minDays: 2,
+    });
+    expect(getExpiringTokensStub).to.have.been.calledWithMatch({
+      days: 2,
+      minDays: 0,
+    });
+  });
+
+  it("does not double-email a token that would match more than one threshold", async () => {
+    getExpiringTokensStub.callsFake(async ({ skip, days, minDays }) => {
+      if (skip > 0) return { success: true, data: [] };
+      // Mimic the model's real (minDays, days] band filtering: a token with
+      // 1 day left only ever satisfies the 2-day query (0 < 1 <= 2), never
+      // the 5-day query (2 < 1 is false), so it must only be emailed once.
+      const remaining = 1;
+      const matches = remaining > minDays && remaining <= days;
+      return {
+        success: true,
+        data: matches ? [tokenFor(remaining, "near-expiry")] : [],
+      };
+    });
+
+    await sendAlertsForExpiringTokens();
+
+    const recipientsEmailed = expiringTokenStub
+      .getCalls()
+      .map((call) => call.args[0].email);
+    expect(recipientsEmailed).to.deep.equal(["user-near-expiry@example.com"]);
   });
 
   it("continues to the next threshold when one lookup fails", async () => {

--- a/src/auth-service/bin/jobs/token-expiration-job.js
+++ b/src/auth-service/bin/jobs/token-expiration-job.js
@@ -8,10 +8,17 @@ const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/token-expiration-job -- ops-alerts`,
 );
 
-async function sendEmailsInBatches(tokens, batchSize = 100) {
+// Days-before-expiry at which a reminder email goes out, e.g. [5, 2] sends
+// one email when a token has 5 days left and a separate one at 2 days left.
+const REMINDER_DAY_THRESHOLDS = constants.TOKEN_EXPIRY_REMINDER_DAY_THRESHOLDS || [
+  5,
+  2,
+];
+
+async function sendEmailsInBatches(tokens, days, batchSize = 100) {
   for (let i = 0; i < tokens.length; i += batchSize) {
     const batch = tokens.slice(i, i + batchSize);
-    const emailPromises = batch.map((token) => {
+    const emailPromises = batch.map(async (token) => {
       logObject("the expiring token", token);
       const {
         user: { email, firstName, lastName },
@@ -20,22 +27,43 @@ async function sendEmailsInBatches(tokens, batchSize = 100) {
         expires,
       } = token;
 
-      logObject("the email to be used", email);
-      return mailer
-        .expiringToken({ email, firstName, lastName, token: tokenValue, tokenName, expires })
-        .then((response) => {
-          if (response && response.success === false) {
-            logger.error(
-              `🐛🐛 Error sending email to ${email}: ${stringify(response)}`,
-            );
-          }
+      // Scope the cooldown by token + expiry date + threshold so: (a) this
+      // reminder doesn't collide with the other threshold's reminder for the
+      // same token, (b) it doesn't collide with a different token's reminder
+      // for the same owner, and (c) a renewed/re-expiring token starts a
+      // fresh reminder cycle instead of being suppressed by a stale cooldown.
+      const expiryDay = new Date(expires).toISOString().slice(0, 10);
+      const cooldownKey = `${(tokenValue || "").slice(-4)}:${expiryDay}:${days}d`;
+
+      try {
+        const response = await mailer.expiringToken({
+          email,
+          firstName,
+          lastName,
+          token: tokenValue,
+          tokenName,
+          expires,
+          daysRemaining: days,
+          cooldownKey,
         });
+        if (response && response.success === false) {
+          logger.error(
+            `🐛🐛 Error sending ${days}-day expiry reminder to ${email}: ${stringify(
+              response,
+            )}`,
+          );
+        }
+      } catch (error) {
+        logger.error(
+          `🐛🐛 Error sending ${days}-day expiry reminder to ${email}: ${error.message}`,
+        );
+      }
     });
     await Promise.all(emailPromises);
   }
 }
 
-async function fetchAllExpiringTokens() {
+async function fetchTokensExpiringWithinDays(days) {
   let allTokens = [];
   let skip = 0;
   const limit = 100;
@@ -45,6 +73,7 @@ async function fetchAllExpiringTokens() {
     const tokensResponse = await AccessTokenModel("airqo").getExpiringTokens({
       skip,
       limit,
+      days,
     });
 
     if (tokensResponse.success && tokensResponse.data.length > 0) {
@@ -58,25 +87,37 @@ async function fetchAllExpiringTokens() {
 }
 
 const sendAlertsForExpiringTokens = async () => {
-  try {
-    const tokens = await fetchAllExpiringTokens();
-    if (tokens.length > 0) {
-      await sendEmailsInBatches(tokens);
-    } else {
-      logText("No expiring tokens found for this month.");
+  for (const days of REMINDER_DAY_THRESHOLDS) {
+    try {
+      const tokens = await fetchTokensExpiringWithinDays(days);
+      if (tokens.length > 0) {
+        await sendEmailsInBatches(tokens, days);
+      } else {
+        logText(`No tokens expiring within ${days} day(s) found today.`);
+      }
+    } catch (error) {
+      logger.error(
+        `🐛🐛 Internal Server Error -- ${days}-day expiry reminder sweep -- ${stringify(
+          error,
+        )}`,
+      );
     }
-  } catch (error) {
-    logger.error(`🐛🐛 Internal Server Error -- ${stringify(error)}`);
   }
 };
 
 global.cronJobs = global.cronJobs || {};
 const jobName = "token-expiration-job";
 global.cronJobs[jobName] = cron.schedule(
-  "0 0 5 * *", // every 5th day of the month at midnight
+  "0 8 * * *", // every day at 08:00
   sendAlertsForExpiringTokens,
   {
     scheduled: true,
     timezone: "Africa/Nairobi",
   },
 );
+
+module.exports = {
+  sendAlertsForExpiringTokens,
+  fetchTokensExpiringWithinDays,
+  REMINDER_DAY_THRESHOLDS,
+};

--- a/src/auth-service/bin/jobs/token-expiration-job.js
+++ b/src/auth-service/bin/jobs/token-expiration-job.js
@@ -14,6 +14,18 @@ const REMINDER_DAY_THRESHOLDS = constants.TOKEN_EXPIRY_REMINDER_DAY_THRESHOLDS |
   5,
   2,
 ];
+// Sorted descending so each threshold's query can be bounded below by the
+// next-smaller threshold, carving out non-overlapping bands (e.g. "2 to 5
+// days out", then "0 to 2 days out") — otherwise a token could match more
+// than one threshold's query in the same run and get two reminders at once.
+const SORTED_DESC_THRESHOLDS = [...REMINDER_DAY_THRESHOLDS].sort(
+  (a, b) => b - a,
+);
+const minDaysFor = (days) => {
+  const index = SORTED_DESC_THRESHOLDS.indexOf(days);
+  const nextSmaller = SORTED_DESC_THRESHOLDS[index + 1];
+  return nextSmaller !== undefined ? nextSmaller : 0;
+};
 
 async function sendEmailsInBatches(tokens, days, batchSize = 100) {
   for (let i = 0; i < tokens.length; i += batchSize) {
@@ -21,19 +33,22 @@ async function sendEmailsInBatches(tokens, days, batchSize = 100) {
     const emailPromises = batch.map(async (token) => {
       logObject("the expiring token", token);
       const {
+        _id,
         user: { email, firstName, lastName },
         token: tokenValue,
         name: tokenName,
         expires,
       } = token;
 
-      // Scope the cooldown by token + expiry date + threshold so: (a) this
+      // Scope the cooldown by token id + expiry date + threshold so: (a) this
       // reminder doesn't collide with the other threshold's reminder for the
       // same token, (b) it doesn't collide with a different token's reminder
       // for the same owner, and (c) a renewed/re-expiring token starts a
       // fresh reminder cycle instead of being suppressed by a stale cooldown.
+      // Uses the token document's _id rather than any fragment of the secret
+      // token value, so no part of the secret ever ends up in a log/cache key.
       const expiryDay = new Date(expires).toISOString().slice(0, 10);
-      const cooldownKey = `${(tokenValue || "").slice(-4)}:${expiryDay}:${days}d`;
+      const cooldownKey = `${_id}:${expiryDay}:${days}d`;
 
       try {
         const response = await mailer.expiringToken({
@@ -68,12 +83,14 @@ async function fetchTokensExpiringWithinDays(days) {
   let skip = 0;
   const limit = 100;
   let hasMoreTokens = true;
+  const minDays = minDaysFor(days);
 
   while (hasMoreTokens) {
     const tokensResponse = await AccessTokenModel("airqo").getExpiringTokens({
       skip,
       limit,
       days,
+      minDays,
     });
 
     if (tokensResponse.success && tokensResponse.data.length > 0) {

--- a/src/auth-service/config/core/numericals.js
+++ b/src/auth-service/config/core/numericals.js
@@ -56,6 +56,10 @@ const numericals = {
   // ── Security / notification thresholds ────────────────────────────────────
   COMPROMISED_TOKEN_COOLDOWN_DAYS: 30,
   EXPIRING_TOKEN_REMINDER_DAYS: 7,
+  // Days-before-expiry at which token-expiration-job sends a reminder email.
+  // Each value gets its own reminder (e.g. a 5-day-out email, then a
+  // separate 2-day-out email) — see token-expiration-job.js.
+  TOKEN_EXPIRY_REMINDER_DAY_THRESHOLDS: [5, 2],
   MAX_BOT_ALERTS_PER_DAY: 2,
 
   // ── Validation regex patterns ─────────────────────────────────────────────

--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -352,7 +352,7 @@ AccessTokenSchema.statics = {
   },
 
   async getExpiringTokens(
-    { skip = 0, limit = 100, filter = {}, days = 30 } = {},
+    { skip = 0, limit = 100, filter = {}, days = 30, minDays = 0 } = {},
     next
   ) {
     try {
@@ -368,10 +368,19 @@ AccessTokenSchema.statics = {
       // Preserve timezone-aware date calculations
       const currentDate = moment().tz(moment.tz.guess()).toDate();
       const cutoffDate = moment(currentDate).add(days, "days").toDate();
+      // minDays lets callers carve out a lower-bound band (e.g. "2 to 5 days
+      // out") so a single token isn't matched by more than one reminder
+      // threshold in the same job run. Defaults to 0, preserving the
+      // cumulative "expiring within the next N days" behavior for existing
+      // callers that don't pass it.
+      const floorDate =
+        minDays > 0
+          ? moment(currentDate).add(minDays, "days").toDate()
+          : currentDate;
 
       const response = await this.aggregate()
         .match({
-          expires: { $gt: currentDate, $lte: cutoffDate },
+          expires: { $gt: floorDate, $lte: cutoffDate },
           ...filter,
         })
         .lookup({

--- a/src/auth-service/models/AccessToken.js
+++ b/src/auth-service/models/AccessToken.js
@@ -351,7 +351,10 @@ AccessTokenSchema.statics = {
     }
   },
 
-  async getExpiringTokens({ skip = 0, limit = 100, filter = {} } = {}, next) {
+  async getExpiringTokens(
+    { skip = 0, limit = 100, filter = {}, days = 30 } = {},
+    next
+  ) {
     try {
       const inclusionProjection = constants.TOKENS_INCLUSION_PROJECTION;
       const exclusionProjection = constants.TOKENS_EXCLUSION_PROJECTION(
@@ -364,11 +367,11 @@ AccessTokenSchema.statics = {
 
       // Preserve timezone-aware date calculations
       const currentDate = moment().tz(moment.tz.guess()).toDate();
-      const oneMonthFromNow = moment(currentDate).add(1, "month").toDate();
+      const cutoffDate = moment(currentDate).add(days, "days").toDate();
 
       const response = await this.aggregate()
         .match({
-          expires: { $gt: currentDate, $lt: oneMonthFromNow },
+          expires: { $gt: currentDate, $lte: cutoffDate },
           ...filter,
         })
         .lookup({
@@ -391,8 +394,8 @@ AccessTokenSchema.statics = {
         .allowDiskUse(true);
 
       return createSuccessResponse("list", response, "expiring access token", {
-        message: "Successfully retrieved tokens expiring within the next month",
-        emptyMessage: "No tokens found expiring within the next month",
+        message: `Successfully retrieved tokens expiring within the next ${days} day(s)`,
+        emptyMessage: `No tokens found expiring within the next ${days} day(s)`,
       });
     } catch (error) {
       return createErrorResponse(

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -34,6 +34,7 @@ const buildTokenEmailSegment = ({
   tokenName = "",
   expires = null,
   expiredMode = false,
+  daysRemaining = null,
 } = {}) => {
   const maskedToken = escapeHtml(
     token && token.length > 12
@@ -45,6 +46,11 @@ const buildTokenEmailSegment = ({
     ? ` (<strong>${escapeHtml(tokenName)}</strong>)`
     : "";
 
+  const daysRemainingText =
+    Number.isFinite(daysRemaining) && daysRemaining >= 0
+      ? ` in <strong>${daysRemaining} day${daysRemaining === 1 ? "" : "s"}</strong>`
+      : "";
+
   let expiryLine = expiredMode
     ? ""
     : "<p>This token will expire in less than 1 month from today.</p>";
@@ -53,7 +59,7 @@ const buildTokenEmailSegment = ({
     if (!isNaN(expiryDate.getTime())) {
       expiryLine = expiredMode
         ? `<p>This token expired on <strong>${expiryDate.toDateString()}</strong>.</p>`
-        : `<p>This token will expire on <strong>${expiryDate.toDateString()}</strong>.</p>`;
+        : `<p>This token will expire${daysRemainingText} — on <strong>${expiryDate.toDateString()}</strong>.</p>`;
     }
   }
 
@@ -700,10 +706,17 @@ module.exports = {
     token = "",
     tokenName = "",
     expires = null,
+    daysRemaining = null,
   } = {}) => {
     const name = firstName + " " + lastName;
     const { maskedToken, tokenLabel, expiryLine, securityTip } =
-      buildTokenEmailSegment({ token, tokenName, expires, expiredMode: false });
+      buildTokenEmailSegment({
+        token,
+        tokenName,
+        expires,
+        expiredMode: false,
+        daysRemaining,
+      });
     const tokenCallout = `
       <div style="margin:16px 0; padding:12px 16px; background:#FFF8E7; border-left:4px solid #F5A623; border-radius:4px;">
         <span style="font-size:14px;"><strong>Token:</strong> <code>${maskedToken}</code>${tokenLabel}</span>

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -810,7 +810,9 @@ const getEmailSubject = (functionName, params) => {
     newDeviceLogin: "Security Alert: New Sign-In to Your AirQo Account",
     sendBotAlert: "🚨 Security Alert: Automated Bot Activity Detected",
     expiredToken: "Action Required: Your AirQo API Token Has Expired",
-    expiringToken: "Action Required: Your AirQo API Token Expires Soon — Regenerate Now",
+    expiringToken: params.daysRemaining
+      ? `Action Required: Your AirQo API Token Expires in ${params.daysRemaining} Day${params.daysRemaining === 1 ? "" : "s"} — Regenerate Now`
+      : "Action Required: Your AirQo API Token Expires Soon — Regenerate Now",
     autoSuspendedToken: "Security Alert: Your AirQo API Token Has Been Suspended",
     bypassExpiryReminder: "Action Required Soon: Your API Token's Security Exemption Is Expiring",
     bypassExpired: "Security Alert: Your API Token's Security Exemption Has Expired",
@@ -2497,6 +2499,7 @@ const mailer = {
         token: params.token,
         tokenName: params.tokenName,
         expires: params.expires,
+        daysRemaining: params.daysRemaining,
       }),
     {
       cooldownDays: constants.EXPIRING_TOKEN_REMINDER_DAYS,

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -810,9 +810,10 @@ const getEmailSubject = (functionName, params) => {
     newDeviceLogin: "Security Alert: New Sign-In to Your AirQo Account",
     sendBotAlert: "🚨 Security Alert: Automated Bot Activity Detected",
     expiredToken: "Action Required: Your AirQo API Token Has Expired",
-    expiringToken: params.daysRemaining
-      ? `Action Required: Your AirQo API Token Expires in ${params.daysRemaining} Day${params.daysRemaining === 1 ? "" : "s"} — Regenerate Now`
-      : "Action Required: Your AirQo API Token Expires Soon — Regenerate Now",
+    expiringToken:
+      Number.isFinite(params.daysRemaining) && params.daysRemaining >= 0
+        ? `Action Required: Your AirQo API Token Expires in ${params.daysRemaining} Day${params.daysRemaining === 1 ? "" : "s"} — Regenerate Now`
+        : "Action Required: Your AirQo API Token Expires Soon — Regenerate Now",
     autoSuspendedToken: "Security Alert: Your AirQo API Token Has Been Suspended",
     bypassExpiryReminder: "Action Required Soon: Your API Token's Security Exemption Is Expiring",
     bypassExpired: "Security Alert: Your API Token's Security Exemption Has Expired",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds tiered reminder emails for expiring AirQo API tokens. Previously, a single monthly job emailed owners of any token expiring within 30 days. This PR replaces that with a daily job that sends a dedicated reminder when a token has **5 days** left, and a second, separate reminder when it has **2 days** left — each with its own subject/body reflecting the exact days remaining.

### Why is this change needed?
The old monthly, 30-day-window reminder gave users little sense of urgency and could silently suppress reminders for a second token owned by the same user (the email cooldown was keyed by email address only, not by token). Precise 5-day/2-day reminders give users clearer, timelier notice to regenerate a token before it expires, and the new per-token cooldown key ensures every expiring token gets its own reminders.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Rewrote `bin/jobs/test/ut_token-expiration-job.js` (previously broken/non-functional) to cover: sending one email per configured day threshold, distinct cooldown keys per threshold so reminders don't suppress each other, and graceful continuation when one threshold's DB lookup fails. Ran the new job tests (3/3 passing), the `AccessToken` model tests (9/9 passing), and the existing mailer/email-message test suite before and after the change to confirm no regressions (83 passing / 10 pre-existing unrelated failures, identical on both baseline and branch).

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- `token-expiration-job` now runs daily at 08:00 (Africa/Nairobi) instead of monthly on the 5th.
- `AccessTokenModel.getExpiringTokens()` gained an optional `days` parameter (default `30`), so the existing admin "list expiring tokens" endpoint keeps its current behavior unchanged.
- Reminder day thresholds are configurable via `TOKEN_EXPIRY_REMINDER_DAY_THRESHOLDS` in `config/core/numericals.js`.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reminders for access tokens expiring in 5 and 2 days.
  * Updated reminder emails to display the exact remaining days and expiry date.
  * Added distinct reminder handling so each notification is delivered independently.

* **Bug Fixes**
  * Improved handling of email delivery failures without interrupting the reminder process.

* **Improvements**
  * Token expiry checks now run daily at 08:00 instead of monthly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->