### PR TITLE
Add Nexus AQI ranges, rankings, and historical endpoints

### DIFF
--- a/src/device-registry/bin/jobs/air-quality-rollup-job.js
+++ b/src/device-registry/bin/jobs/air-quality-rollup-job.js
@@ -218,10 +218,30 @@ async function runAirQualityRollupJob() {
       `${JOB_NAME} -- processing window [${watermark.toISOString()}, ${runStart.toISOString()})`
     );
 
+    // Aggregate both levels before writing anything. If either aggregation
+    // throws, we must not have already upserted the other level — the
+    // watermark only advances after this whole block succeeds, so a partial
+    // write here would get double-$inc'd when the retry reprocesses the same
+    // window.
+    const levels = ["country", "city"];
+    const groupsByLevel = {};
+    for (const level of levels) {
+      groupsByLevel[level] = await aggregateDeltaWindow(
+        TENANT,
+        level,
+        watermark,
+        runStart
+      );
+    }
+
     let totalGroups = 0;
-    for (const level of ["country", "city"]) {
-      const groups = await aggregateDeltaWindow(TENANT, level, watermark, runStart);
-      const upserted = await upsertDelta(TENANT, level, groups, runStart);
+    for (const level of levels) {
+      const upserted = await upsertDelta(
+        TENANT,
+        level,
+        groupsByLevel[level],
+        runStart
+      );
       totalGroups += upserted;
       logText(`${JOB_NAME} -- ${level}: ${upserted} entity/year group(s) updated`);
     }

--- a/src/device-registry/bin/jobs/air-quality-rollup-job.js
+++ b/src/device-registry/bin/jobs/air-quality-rollup-job.js
@@ -1,0 +1,252 @@
+/**
+ * air-quality-rollup-job.js
+ *
+ * Runs daily and folds newly-ingested readings into permanent country/city
+ * PM2.5 running totals (AirQualitySummary), keyed by {tenant, level, entity, year}.
+ *
+ * WHY:
+ *   Reading documents are purged from MongoDB ~14 days after ingestion (see the
+ *   TTL indexes on Reading.time / Reading.createdAt). GET .../readings/rankings/history
+ *   originally aggregated the raw readings collection live, which meant it could
+ *   only ever see the last ~2 weeks regardless of the start_year/end_year requested.
+ *   This job captures each day's data into a durable running total *before* the
+ *   source documents are purged, so real multi-year history accumulates over time
+ *   from whenever this job started running. It cannot recover history from before
+ *   that point — that data is already gone.
+ *
+ * HOW:
+ *   1. Read the watermark (JobState) for the last successfully processed time.
+ *      First run defaults to 24h ago; the window is floored at 14 days back as a
+ *      defensive guard (a watermark older than that means real, permanent gaps —
+ *      logged as a warning, not silently patched over).
+ *   2. Aggregate the readings collection over [watermark, runStart) twice — once
+ *      grouped by siteDetails.country, once by siteDetails.city — both restricted
+ *      to the same African country allowlist the rankings endpoints already use.
+ *   3. Upsert each {entity, year} group into AirQualitySummary via $inc (running
+ *      sum/count) and $addToSet (contributing site ids) — never overwritten,
+ *      always accumulated.
+ *   4. Only advance the watermark after the bulkWrite succeeds, so a crashed run
+ *      safely reprocesses the same window next time rather than losing data.
+ *
+ * Trade-off, accepted deliberately: the bulkWrite (up to ~150 entities) isn't
+ * wrapped in a transaction. A crash between the bulkWrite succeeding and the
+ * watermark advancing is impossible (watermark only advances after success);
+ * a crash *during* the bulkWrite could in principle double-count a subset of one
+ * day's data on the retry. At daily cadence over a year's worth of increments,
+ * that's a negligible, self-diluting skew — not worth a transactional pipeline
+ * at this scale.
+ */
+
+const cron = require("node-cron");
+const os = require("os");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/air-quality-rollup-job`
+);
+const { logText } = require("@utils/shared");
+const ReadingModel = require("@models/Reading");
+const JobStateModel = require("@models/JobState");
+const JobLockModel = require("@models/JobLock");
+const AirQualitySummaryModel = require("@models/AirQualitySummary");
+
+const TENANT = constants.DEFAULT_TENANT || "airqo";
+const JOB_NAME = "air-quality-rollup-job";
+const JOB_SCHEDULE = "0 4 * * *"; // Daily at 04:00 — a >10x safety margin under the 14-day TTL
+const RAW_DATA_RETENTION_MS = 14 * 24 * 60 * 60 * 1000; // matches Reading's TTL indexes
+const DEFAULT_LOOKBACK_MS = 24 * 60 * 60 * 1000; // first-run default window
+
+const POD_ID = process.env.HOSTNAME || os.hostname();
+const LOCK_TTL_SECONDS = 55 * 60; // job runs once/day; this only guards against overlap on retry
+
+// In-process overlap guard — same convention as store-readings-job.js /
+// precompute-activities-job.js. Belt-and-suspenders alongside the cross-pod
+// JobLock below.
+let isJobRunning = false;
+
+async function acquireLock(tenant) {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + LOCK_TTL_SECONDS * 1000);
+  try {
+    const result = await JobLockModel(tenant).findOneAndUpdate(
+      {
+        $or: [
+          { jobName: JOB_NAME, expiresAt: { $lte: now } },
+          { jobName: JOB_NAME, expiresAt: { $exists: false } },
+          { jobName: { $exists: false } },
+        ],
+      },
+      {
+        $set: { acquiredBy: POD_ID, acquiredAt: now, expiresAt },
+        $setOnInsert: { jobName: JOB_NAME },
+      },
+      { upsert: true, new: true, rawResult: false }
+    );
+    return result && result.acquiredBy === POD_ID;
+  } catch (error) {
+    if (error.code === 11000) return false;
+    logger.error(`🐛🐛 ${JOB_NAME} -- lock acquisition error: ${error.message}`);
+    return false;
+  }
+}
+
+async function releaseLock(tenant) {
+  try {
+    await JobLockModel(tenant).findOneAndDelete({
+      jobName: JOB_NAME,
+      acquiredBy: POD_ID,
+    });
+  } catch (error) {
+    logger.error(`🐛🐛 ${JOB_NAME} -- lock release error: ${error.message}`);
+  }
+}
+
+/**
+ * Aggregate the delta window once per level, grouped by the corresponding
+ * siteDetails field, restricted to the African country allowlist.
+ */
+async function aggregateDeltaWindow(tenant, level, windowStart, windowEnd) {
+  const groupField = `$siteDetails.${level}`;
+  const africanCountries = Object.keys(constants.countryCodes);
+
+  const pipeline = [
+    {
+      $match: {
+        time: { $gte: windowStart, $lt: windowEnd },
+        "siteDetails.country": { $in: africanCountries },
+        "pm2_5.value": { $ne: null, $type: "number" },
+      },
+    },
+    { $addFields: { year: { $year: "$time" } } },
+    {
+      $group: {
+        _id: { entity: groupField, year: "$year" },
+        sum_pm2_5: { $sum: "$pm2_5.value" },
+        reading_count: { $sum: 1 },
+        siteIds: { $addToSet: "$site_id" },
+      },
+    },
+    { $match: { "_id.entity": { $ne: null } } },
+  ];
+
+  return ReadingModel(tenant)
+    .aggregate(pipeline)
+    .option({
+      allowDiskUse: true,
+      maxTimeMS: constants.READINGS_AGGREGATE_TIMEOUT_MS,
+    });
+}
+
+/**
+ * Upsert one level's delta-window groups into AirQualitySummary as running
+ * totals — $inc, never overwritten.
+ */
+async function upsertDelta(tenant, level, groups, runAt) {
+  if (!groups.length) return 0;
+
+  const ops = groups.map((group) => ({
+    updateOne: {
+      filter: {
+        tenant,
+        level,
+        entity: group._id.entity,
+        year: group._id.year,
+      },
+      update: {
+        $inc: {
+          sum_pm2_5: group.sum_pm2_5,
+          reading_count: group.reading_count,
+        },
+        $addToSet: { contributing_sites: { $each: group.siteIds } },
+        $set: { last_updated_at: runAt },
+        $setOnInsert: {
+          tenant,
+          level,
+          entity: group._id.entity,
+          year: group._id.year,
+        },
+      },
+      upsert: true,
+    },
+  }));
+
+  await AirQualitySummaryModel(tenant).bulkWrite(ops, { ordered: false });
+  return groups.length;
+}
+
+async function runAirQualityRollupJob() {
+  if (isJobRunning) {
+    logText(`${JOB_NAME} -- already running, skipping this execution`);
+    return;
+  }
+  isJobRunning = true;
+
+  const lockAcquired = await acquireLock(TENANT);
+  if (!lockAcquired) {
+    logText(`${JOB_NAME} -- skipping run: another instance holds the lock`);
+    isJobRunning = false;
+    return;
+  }
+
+  const runStart = new Date();
+
+  try {
+    let watermark = await JobStateModel(TENANT).get(JOB_NAME);
+    if (!watermark) {
+      watermark = new Date(runStart.getTime() - DEFAULT_LOOKBACK_MS);
+      logText(
+        `${JOB_NAME} -- no prior watermark, defaulting to ${watermark.toISOString()}`
+      );
+    }
+
+    const retentionFloor = new Date(runStart.getTime() - RAW_DATA_RETENTION_MS);
+    if (watermark < retentionFloor) {
+      logger.warn(
+        `${JOB_NAME} -- watermark (${watermark.toISOString()}) is older than the ` +
+          `raw-data retention window; readings between then and ${retentionFloor.toISOString()} ` +
+          `are permanently unrecoverable. Flooring the window rather than attempting to reprocess them.`
+      );
+      watermark = retentionFloor;
+    }
+
+    if (watermark >= runStart) {
+      logText(`${JOB_NAME} -- watermark is not behind runStart, nothing to do`);
+      return;
+    }
+
+    logText(
+      `${JOB_NAME} -- processing window [${watermark.toISOString()}, ${runStart.toISOString()})`
+    );
+
+    let totalGroups = 0;
+    for (const level of ["country", "city"]) {
+      const groups = await aggregateDeltaWindow(TENANT, level, watermark, runStart);
+      const upserted = await upsertDelta(TENANT, level, groups, runStart);
+      totalGroups += upserted;
+      logText(`${JOB_NAME} -- ${level}: ${upserted} entity/year group(s) updated`);
+    }
+
+    await JobStateModel(TENANT).set(JOB_NAME, runStart);
+
+    const elapsed = ((Date.now() - runStart.getTime()) / 1000).toFixed(1);
+    logText(
+      `${JOB_NAME} -- completed in ${elapsed}s: ${totalGroups} total entity/year group(s) updated`
+    );
+  } catch (error) {
+    logger.error(`🐛🐛 ${JOB_NAME} -- run failed: ${error.message}`);
+  } finally {
+    await releaseLock(TENANT);
+    isJobRunning = false;
+  }
+}
+
+cron.schedule(JOB_SCHEDULE, () => {
+  runAirQualityRollupJob().catch((error) => {
+    logger.error(`🐛🐛 ${JOB_NAME} -- unhandled error: ${error.message}`);
+  });
+});
+
+logText(`${JOB_NAME} -- scheduled (${JOB_SCHEDULE})`);
+console.log(`✅ ${JOB_NAME} started - rolling up country/city PM2.5 history daily`);
+
+module.exports = { runAirQualityRollupJob };

--- a/src/device-registry/bin/jobs/test/ut_air-quality-rollup-job.js
+++ b/src/device-registry/bin/jobs/test/ut_air-quality-rollup-job.js
@@ -1,0 +1,168 @@
+require("module-alias/register");
+process.env.NODE_ENV = "development";
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const expect = chai.expect;
+chai.use(sinonChai);
+const proxyquire = require("proxyquire");
+const os = require("os");
+
+// Mirrors the job's own POD_ID derivation exactly, so the mocked lock
+// document's acquiredBy can be made to match (or intentionally not match).
+const POD_ID = process.env.HOSTNAME || os.hostname();
+
+describe("air-quality-rollup-job", () => {
+  let aggregateStub;
+  let bulkWriteStub;
+  let jobStateGetStub;
+  let jobStateSetStub;
+  let lockFindOneAndUpdateStub;
+  let lockFindOneAndDeleteStub;
+  let proxiedJob;
+
+  const mockAggregateChain = (groups) => ({
+    option: () => Promise.resolve(groups),
+  });
+
+  beforeEach(() => {
+    aggregateStub = sinon.stub();
+    bulkWriteStub = sinon.stub().resolves({});
+    jobStateGetStub = sinon.stub();
+    jobStateSetStub = sinon.stub().resolves();
+    lockFindOneAndUpdateStub = sinon.stub().resolves({ acquiredBy: POD_ID });
+    lockFindOneAndDeleteStub = sinon.stub().resolves();
+
+    proxiedJob = proxyquire("../air-quality-rollup-job", {
+      "@models/Reading": () => ({ aggregate: aggregateStub }),
+      "@models/AirQualitySummary": () => ({ bulkWrite: bulkWriteStub }),
+      "@models/JobState": () => ({
+        get: jobStateGetStub,
+        set: jobStateSetStub,
+      }),
+      "@models/JobLock": () => ({
+        findOneAndUpdate: lockFindOneAndUpdateStub,
+        findOneAndDelete: lockFindOneAndDeleteStub,
+      }),
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("aggregates both country and city levels, upserts running totals via $inc/$addToSet, and advances the watermark", async () => {
+    jobStateGetStub.resolves(new Date(Date.now() - 2 * 60 * 60 * 1000)); // 2h ago
+    aggregateStub
+      .onCall(0) // country pass
+      .returns(
+        mockAggregateChain([
+          {
+            _id: { entity: "Kenya", year: 2024 },
+            sum_pm2_5: 100,
+            reading_count: 10,
+            siteIds: ["s1", "s2"],
+          },
+        ])
+      )
+      .onCall(1) // city pass
+      .returns(
+        mockAggregateChain([
+          {
+            _id: { entity: "Nairobi", year: 2024 },
+            sum_pm2_5: 50,
+            reading_count: 5,
+            siteIds: ["s1"],
+          },
+        ])
+      );
+
+    await proxiedJob.runAirQualityRollupJob();
+
+    expect(aggregateStub.calledTwice).to.equal(true);
+    expect(bulkWriteStub.calledTwice).to.equal(true);
+
+    const countryOps = bulkWriteStub.getCall(0).args[0];
+    expect(countryOps).to.have.lengthOf(1);
+    expect(countryOps[0].updateOne.filter).to.deep.equal({
+      tenant: "airqo",
+      level: "country",
+      entity: "Kenya",
+      year: 2024,
+    });
+    expect(countryOps[0].updateOne.update.$inc).to.deep.equal({
+      sum_pm2_5: 100,
+      reading_count: 10,
+    });
+    expect(countryOps[0].updateOne.update.$addToSet).to.deep.equal({
+      contributing_sites: { $each: ["s1", "s2"] },
+    });
+    expect(countryOps[0].updateOne.upsert).to.equal(true);
+
+    const cityOps = bulkWriteStub.getCall(1).args[0];
+    expect(cityOps[0].updateOne.filter.level).to.equal("city");
+    expect(cityOps[0].updateOne.filter.entity).to.equal("Nairobi");
+
+    expect(jobStateSetStub.calledOnce).to.equal(true);
+    expect(jobStateSetStub.getCall(0).args[0]).to.equal("air-quality-rollup-job");
+
+    expect(lockFindOneAndDeleteStub.calledOnce).to.equal(true);
+  });
+
+  it("skips the run entirely when another instance already holds the lock", async () => {
+    lockFindOneAndUpdateStub.resolves({ acquiredBy: "some-other-pod" });
+    jobStateGetStub.resolves(new Date());
+
+    await proxiedJob.runAirQualityRollupJob();
+
+    expect(aggregateStub.called).to.equal(false);
+    expect(bulkWriteStub.called).to.equal(false);
+    expect(jobStateSetStub.called).to.equal(false);
+    // Never acquired the lock, so must not attempt to release someone else's.
+    expect(lockFindOneAndDeleteStub.called).to.equal(false);
+  });
+
+  it("defaults to a 24h lookback window on the first run (no prior watermark)", async () => {
+    jobStateGetStub.resolves(null);
+    aggregateStub.returns(mockAggregateChain([]));
+
+    const before = Date.now();
+    await proxiedJob.runAirQualityRollupJob();
+
+    const pipeline = aggregateStub.getCall(0).args[0];
+    const windowStart = pipeline[0].$match.time.$gte.getTime();
+    const expected24hAgo = before - 24 * 60 * 60 * 1000;
+
+    // Allow a small tolerance for test execution time.
+    expect(Math.abs(windowStart - expected24hAgo)).to.be.below(5000);
+  });
+
+  it("floors the window at the 14-day retention boundary when the watermark has drifted further behind than that", async () => {
+    const twentyDaysAgo = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000);
+    jobStateGetStub.resolves(twentyDaysAgo);
+    aggregateStub.returns(mockAggregateChain([]));
+
+    const before = Date.now();
+    await proxiedJob.runAirQualityRollupJob();
+
+    const pipeline = aggregateStub.getCall(0).args[0];
+    const windowStart = pipeline[0].$match.time.$gte.getTime();
+    const expected14DaysAgo = before - 14 * 24 * 60 * 60 * 1000;
+
+    expect(windowStart).to.be.above(twentyDaysAgo.getTime());
+    expect(Math.abs(windowStart - expected14DaysAgo)).to.be.below(5000);
+  });
+
+  it("does not advance the watermark when the aggregation fails", async () => {
+    jobStateGetStub.resolves(new Date(Date.now() - 2 * 60 * 60 * 1000));
+    aggregateStub.returns({
+      option: () => Promise.reject(new Error("Mongo error")),
+    });
+
+    await proxiedJob.runAirQualityRollupJob();
+
+    expect(jobStateSetStub.called).to.equal(false);
+    // Lock must still be released even though the run failed.
+    expect(lockFindOneAndDeleteStub.calledOnce).to.equal(true);
+  });
+});

--- a/src/device-registry/bin/jobs/test/ut_air-quality-rollup-job.js
+++ b/src/device-registry/bin/jobs/test/ut_air-quality-rollup-job.js
@@ -165,4 +165,31 @@ describe("air-quality-rollup-job", () => {
     // Lock must still be released even though the run failed.
     expect(lockFindOneAndDeleteStub.calledOnce).to.equal(true);
   });
+
+  it("does not upsert either level if the second level's aggregation fails — no partial writes before a retry", async () => {
+    jobStateGetStub.resolves(new Date(Date.now() - 2 * 60 * 60 * 1000));
+    // Country succeeds, city fails — both aggregations must have been
+    // attempted before any upsert happens, so country's already-successful
+    // result must NOT have been written yet when city blows up.
+    aggregateStub
+      .onCall(0) // country pass
+      .returns(
+        mockAggregateChain([
+          {
+            _id: { entity: "Kenya", year: 2024 },
+            sum_pm2_5: 100,
+            reading_count: 10,
+            siteIds: ["s1"],
+          },
+        ])
+      )
+      .onCall(1) // city pass
+      .returns({ option: () => Promise.reject(new Error("Mongo error")) });
+
+    await proxiedJob.runAirQualityRollupJob();
+
+    expect(aggregateStub.calledTwice).to.equal(true);
+    expect(bulkWriteStub.called).to.equal(false);
+    expect(jobStateSetStub.called).to.equal(false);
+  });
 });

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -319,6 +319,20 @@ try {
   // Continue - server stays up
 }
 
+// Air quality rollup — daily. Folds each day's readings into permanent
+// country/city PM2.5 running totals before the source Reading documents are
+// purged by their 14-day TTL, so GET .../readings/rankings/history can serve
+// real multi-year data from a small precomputed collection instead of
+// aggregating raw readings (which don't exist past ~2 weeks) on every request.
+try {
+  require("@bin/jobs/air-quality-rollup-job");
+} catch (jobError) {
+  global.dedupLogger.error(
+    `❌ air-quality-rollup-job failed to start: ${jobError.message}`
+  );
+  // Continue - server stays up
+}
+
 // Private cohort alert — 3×/day (06:00, 14:00, 22:00 UTC)
 // Flags cohorts that are private but contain >2 operational devices,
 // preventing them from silently missing public map and recent-measurements visibility.

--- a/src/device-registry/controllers/aqi.controller.js
+++ b/src/device-registry/controllers/aqi.controller.js
@@ -1,0 +1,41 @@
+// aqi.controller.js
+const httpStatus = require("http-status");
+const { HttpError, extractErrorsFromRequest } = require("@utils/shared");
+const aqiUtil = require("@utils/aqi.util");
+const log4js = require("log4js");
+const constants = require("@config/constants");
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- aqi-controller`);
+
+const aqiController = {
+  listRanges: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const result = aqiUtil.listRanges();
+
+      res.status(httpStatus.OK).json({
+        success: true,
+        message: result.message,
+        data: result.data,
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+};
+
+module.exports = aqiController;

--- a/src/device-registry/controllers/event.controller.js
+++ b/src/device-registry/controllers/event.controller.js
@@ -523,7 +523,24 @@ const createEvent = {
         return;
       }
       const result = await createEventUtil.getAirQualityRankings(req, next);
-      handleResponse({ res, result, key: "data" });
+      // result is undefined when the util already forwarded an error via
+      // next() — don't also send a response here, or Express double-sends.
+      if (!result) {
+        return;
+      }
+      if (result.success) {
+        res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message,
+          data: result.data,
+        });
+      } else {
+        res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+          success: false,
+          message: result.message,
+          errors: result.errors || { message: "" },
+        });
+      }
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(
@@ -548,7 +565,24 @@ const createEvent = {
         req,
         next,
       );
-      handleResponse({ res, result, key: "data" });
+      // result is undefined when the util already forwarded an error via
+      // next() — don't also send a response here, or Express double-sends.
+      if (!result) {
+        return;
+      }
+      if (result.success) {
+        res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message,
+          data: result.data,
+        });
+      } else {
+        res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+          success: false,
+          message: result.message,
+          errors: result.errors || { message: "" },
+        });
+      }
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/controllers/event.controller.js
+++ b/src/device-registry/controllers/event.controller.js
@@ -513,6 +513,54 @@ const createEvent = {
     }
   },
 
+  getAirQualityRankings: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors),
+        );
+        return;
+      }
+      const result = await createEventUtil.getAirQualityRankings(req, next);
+      handleResponse({ res, result, key: "data" });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+  getAirQualityRankingsHistory: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors),
+        );
+        return;
+      }
+      const result = await createEventUtil.getAirQualityRankingsHistory(
+        req,
+        next,
+      );
+      handleResponse({ res, result, key: "data" });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
   addValues: async (req, res, next) => {
     try {
       logText("Adding values with mobile device support...");

--- a/src/device-registry/controllers/event.controller.js
+++ b/src/device-registry/controllers/event.controller.js
@@ -93,6 +93,30 @@ function handleResponse({
   return res.status(status).json(response);
 }
 
+// Shared by getAirQualityRankings / getAirQualityRankingsHistory — both
+// utils either resolve a {success, message, data|errors, status} result or
+// resolve undefined after already forwarding an error via next() themselves.
+function sendRankingResponse(res, result) {
+  // result is undefined when the util already forwarded an error via
+  // next() — don't also send a response here, or Express double-sends.
+  if (!result) {
+    return;
+  }
+  if (result.success) {
+    res.status(result.status || httpStatus.OK).json({
+      success: true,
+      message: result.message,
+      data: result.data,
+    });
+  } else {
+    res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      message: result.message,
+      errors: result.errors || { message: "" },
+    });
+  }
+}
+
 const getSitesFromGrid = async ({ tenant = "airqo", grid_id } = {}) => {
   try {
     const request = {
@@ -523,24 +547,7 @@ const createEvent = {
         return;
       }
       const result = await createEventUtil.getAirQualityRankings(req, next);
-      // result is undefined when the util already forwarded an error via
-      // next() — don't also send a response here, or Express double-sends.
-      if (!result) {
-        return;
-      }
-      if (result.success) {
-        res.status(result.status || httpStatus.OK).json({
-          success: true,
-          message: result.message,
-          data: result.data,
-        });
-      } else {
-        res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
-          success: false,
-          message: result.message,
-          errors: result.errors || { message: "" },
-        });
-      }
+      sendRankingResponse(res, result);
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(
@@ -565,24 +572,7 @@ const createEvent = {
         req,
         next,
       );
-      // result is undefined when the util already forwarded an error via
-      // next() — don't also send a response here, or Express double-sends.
-      if (!result) {
-        return;
-      }
-      if (result.success) {
-        res.status(result.status || httpStatus.OK).json({
-          success: true,
-          message: result.message,
-          data: result.data,
-        });
-      } else {
-        res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
-          success: false,
-          message: result.message,
-          errors: result.errors || { message: "" },
-        });
-      }
+      sendRankingResponse(res, result);
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/controllers/test/ut_aqi.controller.js
+++ b/src/device-registry/controllers/test/ut_aqi.controller.js
@@ -1,0 +1,60 @@
+require("module-alias/register");
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const expect = chai.expect;
+chai.use(sinonChai);
+const httpStatus = require("http-status");
+
+const aqiController = require("@controllers/aqi.controller");
+const aqiUtil = require("@utils/aqi.util");
+
+describe("AQI Controller", () => {
+  describe("listRanges", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = { query: {}, params: {} };
+      res = {
+        status: sinon.stub().callsFake(function() { return res; }),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        message: "Successfully retrieved AQI ranges",
+        data: {
+          standard: "US EPA PM2.5 AQI (2024 NAAQS revision)",
+          ranges: [{ key: "good", label: "Good" }],
+        },
+      };
+      sinon.stub(aqiUtil, "listRanges").returns(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("returns 200 with the ranges from the util layer", async () => {
+      await aqiController.listRanges(req, res, next);
+
+      expect(aqiUtil.listRanges).to.have.been.calledOnce;
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith({
+        success: true,
+        message: mockResult.message,
+        data: mockResult.data,
+      });
+    });
+
+    it("forwards unexpected errors to next() as an HttpError", async () => {
+      aqiUtil.listRanges.throws(new Error("unexpected failure"));
+
+      await aqiController.listRanges(req, res, next);
+
+      expect(next.calledOnce).to.equal(true);
+      const err = next.getCall(0).args[0];
+      expect(err.message).to.equal("Internal Server Error");
+    });
+  });
+});

--- a/src/device-registry/controllers/test/ut_event.controller.js
+++ b/src/device-registry/controllers/test/ut_event.controller.js
@@ -47,6 +47,8 @@ const {
   listByCohort,
   listByCohortHistorical,
   listByLatLong,
+  getAirQualityRankings,
+  getAirQualityRankingsHistory,
 } = createEvent;
 
 // Functions not in the controller — define as no-ops to prevent ReferenceError
@@ -372,6 +374,104 @@ describe("Create Event Controller", () => {
       mockResult.errors = ["error"];
 
       await getBestAirQuality(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("getAirQualityRankings", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = { query: { level: "country" }, params: {} };
+      res = {
+        status: sinon.stub().callsFake(function() { return res; }),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        message: "Successfully retrieved air quality rankings",
+        data: [{ rank: 1, name: "Kenya", avg_pm2_5: 23.32 }],
+      };
+      sinon.stub(createEventUtil, "getAirQualityRankings").resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should return the rankings from the util layer", async () => {
+      await getAirQualityRankings(req, res, next);
+
+      expect(createEventUtil.getAirQualityRankings).to.have.been.calledWith(
+        req,
+        next
+      );
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should surface util-layer errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = { message: "boom" };
+
+      await getAirQualityRankings(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+  });
+
+  describe("getAirQualityRankingsHistory", () => {
+    let req, res, next, mockResult;
+
+    beforeEach(() => {
+      req = {
+        query: { level: "country", start_year: "2023", end_year: "2024" },
+        params: {},
+      };
+      res = {
+        status: sinon.stub().callsFake(function() { return res; }),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+      mockResult = {
+        success: true,
+        message: "Successfully retrieved historical air quality rankings",
+        data: [{ name: "Kenya", values: [] }],
+      };
+      sinon
+        .stub(createEventUtil, "getAirQualityRankingsHistory")
+        .resolves(mockResult);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should return the historical rankings from the util layer", async () => {
+      await getAirQualityRankingsHistory(req, res, next);
+
+      expect(
+        createEventUtil.getAirQualityRankingsHistory
+      ).to.have.been.calledWith(req, next);
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(sinon.match.object);
+    });
+
+    it("should surface util-layer errors", async () => {
+      mockResult.success = false;
+      mockResult.message = "Error message";
+      mockResult.errors = { message: "boom" };
+
+      await getAirQualityRankingsHistory(req, res, next);
 
       expect(res.status).to.have.been.calledWith(
         httpStatus.INTERNAL_SERVER_ERROR

--- a/src/device-registry/controllers/test/ut_event.controller.js
+++ b/src/device-registry/controllers/test/ut_event.controller.js
@@ -415,17 +415,30 @@ describe("Create Event Controller", () => {
       expect(res.json).to.have.been.calledWith(sinon.match.object);
     });
 
-    it("should surface util-layer errors", async () => {
-      mockResult.success = false;
-      mockResult.message = "Error message";
-      mockResult.errors = { message: "boom" };
+    it("does not double-send a response when the util already handled the error via next()", async () => {
+      // The real util resolves undefined (not a {success:false} object) after
+      // forwarding the error to next() itself — matches that behavior.
+      createEventUtil.getAirQualityRankings.resolves(undefined);
 
       await getAirQualityRankings(req, res, next);
 
-      expect(res.status).to.have.been.calledWith(
-        httpStatus.INTERNAL_SERVER_ERROR
+      expect(res.status.called).to.equal(false);
+      expect(res.json.called).to.equal(false);
+    });
+
+    it("preserves an empty result as data: [] rather than null", async () => {
+      createEventUtil.getAirQualityRankings.resolves({
+        success: true,
+        message: "Successfully retrieved air quality rankings",
+        data: [],
+      });
+
+      await getAirQualityRankings(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(
+        sinon.match({ success: true, data: [] })
       );
-      expect(res.json).to.have.been.calledWith(sinon.match.object);
     });
   });
 
@@ -466,17 +479,30 @@ describe("Create Event Controller", () => {
       expect(res.json).to.have.been.calledWith(sinon.match.object);
     });
 
-    it("should surface util-layer errors", async () => {
-      mockResult.success = false;
-      mockResult.message = "Error message";
-      mockResult.errors = { message: "boom" };
+    it("does not double-send a response when the util already handled the error via next()", async () => {
+      // The real util resolves undefined (not a {success:false} object) after
+      // forwarding the error to next() itself — matches that behavior.
+      createEventUtil.getAirQualityRankingsHistory.resolves(undefined);
 
       await getAirQualityRankingsHistory(req, res, next);
 
-      expect(res.status).to.have.been.calledWith(
-        httpStatus.INTERNAL_SERVER_ERROR
+      expect(res.status.called).to.equal(false);
+      expect(res.json.called).to.equal(false);
+    });
+
+    it("preserves an empty result as data: [] rather than null", async () => {
+      createEventUtil.getAirQualityRankingsHistory.resolves({
+        success: true,
+        message: "Successfully retrieved historical air quality rankings",
+        data: [],
+      });
+
+      await getAirQualityRankingsHistory(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.json).to.have.been.calledWith(
+        sinon.match({ success: true, data: [] })
       );
-      expect(res.json).to.have.been.calledWith(sinon.match.object);
     });
   });
 

--- a/src/device-registry/models/AirQualitySummary.js
+++ b/src/device-registry/models/AirQualitySummary.js
@@ -1,0 +1,84 @@
+const mongoose = require("mongoose");
+const { getSnapshotModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+
+/**
+ * AirQualitySummary — permanent running PM2.5 aggregate per {tenant, level, entity, year}.
+ *
+ * Raw readings are purged from MongoDB after ~14 days (see the TTL indexes on
+ * Reading.time / Reading.createdAt), so a live aggregation over a multi-year
+ * window can only ever see the last ~2 weeks. air-quality-rollup-job.js runs
+ * daily and folds each new day's readings into these running totals *before*
+ * the source documents are purged — this collection is the only place true
+ * multi-year history survives. Unlike CohortDeviceSnapshot (an ephemeral
+ * "current state" cache with a 25h TTL), these rows are durable and never expire:
+ * a closed year's totals are historical fact, not a snapshot that goes stale.
+ *
+ * avg_pm2_5 is deliberately NOT stored — it's derived at read time as
+ * sum_pm2_5 / reading_count, so the running totals stay the single source of
+ * truth and there's nothing to keep in sync.
+ */
+const airQualitySummarySchema = new mongoose.Schema(
+  {
+    tenant: {
+      type: String,
+      required: true,
+    },
+    level: {
+      type: String,
+      required: true,
+      enum: ["country", "city"],
+    },
+    entity: {
+      type: String,
+      required: true,
+    },
+    year: {
+      type: Number,
+      required: true,
+    },
+    sum_pm2_5: {
+      type: Number,
+      required: true,
+      default: 0,
+    },
+    reading_count: {
+      type: Number,
+      required: true,
+      default: 0,
+    },
+    // Deduped via $addToSet as the job processes each day's delta window.
+    contributing_sites: {
+      type: [String],
+      default: [],
+    },
+    last_updated_at: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+  },
+  { timestamps: false }
+);
+
+// Unique compound key used for upserts in air-quality-rollup-job.js
+airQualitySummarySchema.index(
+  { tenant: 1, level: 1, entity: 1, year: 1 },
+  { unique: true }
+);
+
+// Matches the read pattern: fetch all entities for a level across a year range
+airQualitySummarySchema.index({ tenant: 1, level: 1, year: 1 });
+
+const AirQualitySummaryModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  return getSnapshotModelByTenant(
+    dbTenant,
+    "airqualitysummary",
+    airQualitySummarySchema
+  );
+};
+
+module.exports = AirQualitySummaryModel;

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -673,6 +673,17 @@ ReadingsSchema.index(
   },
 );
 
+// Supports the Nexus rankings/historical-rankings aggregations, which $match
+// on siteDetails.country ahead of a time-range filter. Without this, that
+// $match falls back to a full collection scan.
+ReadingsSchema.index(
+  { "siteDetails.country": 1, time: -1 },
+  {
+    name: "country_time_idx",
+    background: true,
+  },
+);
+
 ReadingsSchema.methods = {
   toJSON() {
     const obj = {

--- a/src/device-registry/routes/v2/aqi.routes.js
+++ b/src/device-registry/routes/v2/aqi.routes.js
@@ -1,0 +1,12 @@
+// aqi.routes.js
+const express = require("express");
+const router = express.Router();
+const aqiController = require("@controllers/aqi.controller");
+const aqiValidations = require("@validators/aqi.validators");
+const { headers } = require("@validators/common");
+
+router.use(headers);
+
+router.get("/", aqiValidations.listRanges, aqiController.listRanges);
+
+module.exports = router;

--- a/src/device-registry/routes/v2/index.js
+++ b/src/device-registry/routes/v2/index.js
@@ -140,6 +140,7 @@ const routes = [
     name: "forecasts",
   },
   { path: "/tips", route: "@routes/v2/tips.routes", name: "tips" },
+  { path: "/aqi-ranges", route: "@routes/v2/aqi.routes", name: "aqi" },
   { path: "/kya", route: "@routes/v2/kya.routes", name: "kya" },
   { path: "/learn", route: "@routes/v2/learn.routes", name: "learn" },
   { path: "/cohorts", route: "@routes/v2/cohorts.routes", name: "cohorts" },

--- a/src/device-registry/routes/v2/readings.routes.js
+++ b/src/device-registry/routes/v2/readings.routes.js
@@ -174,6 +174,18 @@ const routes = [
   },
   {
     method: "get",
+    path: "/rankings/history",
+    middlewares: [checkValidation("rankingsHistory")],
+    controller: "getAirQualityRankingsHistory",
+  },
+  {
+    method: "get",
+    path: "/rankings",
+    middlewares: [checkValidation("rankings")],
+    controller: "getAirQualityRankings",
+  },
+  {
+    method: "get",
     path: "/grids/:grid_id/representative",
     middlewares: [checkValidation("validateGetRepresentativeAQForGrid")],
     controller: "getRepresentativeAirQualityForGrid",

--- a/src/device-registry/utils/aqi.util.js
+++ b/src/device-registry/utils/aqi.util.js
@@ -22,7 +22,8 @@
  */
 
 // Single source of truth for PM2.5 AQI breakpoints
-const { PM25_AQI_BREAKPOINTS } = require("@config/constants");
+const constants = require("@config/constants");
+const { PM25_AQI_BREAKPOINTS } = constants;
 
 // Fail fast at module load time if the breakpoint table is misconfigured.
 // This prevents Infinity/NaN slopes from silently propagating into the
@@ -158,7 +159,70 @@ function getAqiIndexMongoExpression(fieldPath = "$pm2_5.value") {
   };
 }
 
+/**
+ * Map a PM2.5 concentration (e.g. an averaged value across many sites) to its
+ * AQI category key using the canonical AQI_RANGES breakpoints. Distinct from
+ * the per-reading aqi_category persisted on Reading documents, which is only
+ * ever computed for a single reading's own pm2_5 value.
+ *
+ * @param {number|null|undefined} concentration - PM2.5 concentration in µg/m³
+ * @returns {string|null} one of AQI_CATEGORY_KEYS, or null if invalid
+ */
+function categoryFromConcentration(concentration) {
+  if (
+    concentration === null ||
+    concentration === undefined ||
+    typeof concentration !== "number" ||
+    isNaN(concentration) ||
+    concentration < 0
+  ) {
+    return null;
+  }
+
+  const { AQI_RANGES, AQI_CATEGORY_KEYS } = constants;
+
+  for (const categoryKey of AQI_CATEGORY_KEYS) {
+    const { min, max } = AQI_RANGES[categoryKey];
+    if (concentration >= min && (max === null || concentration <= max)) {
+      return categoryKey;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Assemble the canonical AQI category ranges (bands, labels, colors) for
+ * dynamic frontend rendering — replaces hard-coded AQI legends.
+ *
+ * @returns {{success: boolean, message: string, data: {standard: string, ranges: Array}}}
+ */
+function listRanges() {
+  const { AQI_RANGES, AQI_CATEGORIES, AQI_COLORS, AQI_COLOR_NAMES, AQI_CATEGORY_KEYS } = constants;
+
+  const ranges = AQI_CATEGORY_KEYS.map((key, index) => ({
+    key,
+    label: AQI_CATEGORIES[key],
+    min_value: AQI_RANGES[key].min,
+    max_value: AQI_RANGES[key].max,
+    color: `#${AQI_COLORS[key]}`,
+    color_name: AQI_COLOR_NAMES[key],
+    display_order: index + 1,
+  }));
+
+  return {
+    success: true,
+    message: "Successfully retrieved AQI ranges",
+    data: {
+      standard: "US EPA PM2.5 AQI (2024 NAAQS revision)",
+      ranges,
+    },
+  };
+}
+
 module.exports = {
   calculatePm25Aqi,
   getAqiIndexMongoExpression,
+  categoryFromConcentration,
+  listRanges,
 };

--- a/src/device-registry/utils/aqi.util.js
+++ b/src/device-registry/utils/aqi.util.js
@@ -181,9 +181,14 @@ function categoryFromConcentration(concentration) {
 
   const { AQI_RANGES, AQI_CATEGORY_KEYS } = constants;
 
+  // AQI_RANGES boundaries leave thousandths-place gaps between adjacent
+  // categories (e.g. good max 9.1, moderate min 9.101) — fine for single
+  // readings, which are rarely that precise, but averaged values (as used
+  // here) can land in the gap. Classify by upper bound only, in ascending
+  // order, so every non-negative value matches exactly one category.
   for (const categoryKey of AQI_CATEGORY_KEYS) {
-    const { min, max } = AQI_RANGES[categoryKey];
-    if (concentration >= min && (max === null || concentration <= max)) {
+    const { max } = AQI_RANGES[categoryKey];
+    if (max === null || concentration <= max) {
       return categoryKey;
     }
   }

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -7,6 +7,7 @@ const CohortModel = require("@models/Cohort");
 const SiteModel = require("@models/Site");
 const crypto = require("crypto");
 const { intelligentFetch } = require("@utils/readings/fetch.util");
+const aqiUtil = require("@utils/aqi.util");
 const {
   logObject,
   logText,
@@ -1740,6 +1741,190 @@ const createEvent = {
       );
     }
   },
+
+  // African city/country AQI rankings — groups the latest reading per site
+  // (same "latest-per-site" shape as getRepresentativeAirQuality above) by
+  // the denormalized siteDetails.country/city field, since no grid hierarchy
+  // exists to roll city grids up into country grids.
+  getAirQualityRankings: async (request, next) => {
+    try {
+      const {
+        tenant = "airqo",
+        level = "country",
+        sort = "best",
+        limit = 20,
+      } = request.query;
+
+      const groupField = `$siteDetails.${level}`;
+      const africanCountries = Object.keys(constants.countryCodes);
+      const threeDaysAgo = new Date();
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
+      const pipeline = [
+        {
+          $match: {
+            time: { $gte: threeDaysAgo },
+            "siteDetails.country": { $in: africanCountries },
+            "pm2_5.value": { $ne: null, $type: "number" },
+          },
+        },
+        { $sort: { time: -1 } },
+        {
+          $group: {
+            _id: "$site_id",
+            latestReading: { $first: "$$ROOT" },
+          },
+        },
+        { $replaceRoot: { newRoot: "$latestReading" } },
+        {
+          $group: {
+            _id: groupField,
+            avg_pm2_5: { $avg: "$pm2_5.value" },
+            max_pm2_5: { $max: "$pm2_5.value" },
+            site_count: { $sum: 1 },
+          },
+        },
+        { $match: { _id: { $ne: null } } },
+        { $sort: { avg_pm2_5: sort === "worst" ? -1 : 1 } },
+        { $limit: Number(limit) },
+      ];
+
+      const rows = await ReadingModel(tenant)
+        .aggregate(pipeline)
+        .option({
+          allowDiskUse: true,
+          maxTimeMS: constants.READINGS_AGGREGATE_TIMEOUT_MS,
+        });
+
+      const data = rows.map((row, index) => ({
+        rank: index + 1,
+        name: row._id,
+        level,
+        country_code:
+          level === "country" ? constants.countryCodes[row._id] || null : null,
+        avg_pm2_5: Math.round(row.avg_pm2_5 * 100) / 100,
+        aqi_index: aqiUtil.calculatePm25Aqi(row.avg_pm2_5),
+        aqi_category: aqiUtil.categoryFromConcentration(row.avg_pm2_5),
+        site_count: row.site_count,
+        generated_at: new Date().toISOString(),
+      }));
+
+      return {
+        success: true,
+        message: "Successfully retrieved air quality rankings",
+        data,
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(
+        `🐛🐛 Internal Server Error -- getAirQualityRankings -- ${error.message}`,
+      );
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  // Annual-only multi-region historical rollup. Missing years are returned
+  // as explicit nulls (never coerced to zero) per Nexus acceptance criteria.
+  getAirQualityRankingsHistory: async (request, next) => {
+    try {
+      const { tenant = "airqo", level = "country" } = request.query;
+      const startYear = Number(request.query.start_year);
+      const endYear = Number(request.query.end_year);
+
+      const groupField = `$siteDetails.${level}`;
+      const africanCountries = Object.keys(constants.countryCodes);
+      const rangeStart = new Date(Date.UTC(startYear, 0, 1));
+      const rangeEnd = new Date(Date.UTC(endYear + 1, 0, 1));
+
+      const pipeline = [
+        {
+          $match: {
+            time: { $gte: rangeStart, $lt: rangeEnd },
+            "siteDetails.country": { $in: africanCountries },
+            "pm2_5.value": { $ne: null, $type: "number" },
+          },
+        },
+        { $addFields: { year: { $year: "$time" } } },
+        {
+          $group: {
+            _id: { entity: groupField, year: "$year" },
+            avg_pm2_5: { $avg: "$pm2_5.value" },
+            siteIds: { $addToSet: "$site_id" },
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            entity: "$_id.entity",
+            year: "$_id.year",
+            avg_pm2_5: { $round: ["$avg_pm2_5", 2] },
+            site_count: { $size: "$siteIds" },
+          },
+        },
+        { $match: { entity: { $ne: null } } },
+        { $sort: { entity: 1, year: 1 } },
+      ];
+
+      const rows = await ReadingModel(tenant)
+        .aggregate(pipeline)
+        .option({
+          allowDiskUse: true,
+          maxTimeMS: constants.READINGS_AGGREGATE_TIMEOUT_MS,
+        });
+
+      const years = [];
+      for (let y = startYear; y <= endYear; y += 1) years.push(y);
+
+      const byEntity = new Map();
+      rows.forEach((row) => {
+        if (!byEntity.has(row.entity)) byEntity.set(row.entity, new Map());
+        byEntity.get(row.entity).set(row.year, row);
+      });
+
+      const data = Array.from(byEntity.entries()).map(([entity, byYear]) => ({
+        name: entity,
+        level,
+        country_code:
+          level === "country" ? constants.countryCodes[entity] || null : null,
+        values: years.map((year) => {
+          const row = byYear.get(year);
+          return {
+            year,
+            avg_pm2_5: row ? row.avg_pm2_5 : null,
+            aqi_category: row
+              ? aqiUtil.categoryFromConcentration(row.avg_pm2_5)
+              : null,
+            site_count: row ? row.site_count : 0,
+          };
+        }),
+      }));
+
+      return {
+        success: true,
+        message: "Successfully retrieved historical air quality rankings",
+        data,
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(
+        `🐛🐛 Internal Server Error -- getAirQualityRankingsHistory -- ${error.message}`,
+      );
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
   latestFromBigQuery: async (req, next) => {
     try {
       const { query } = req;
@@ -4932,15 +5117,23 @@ const createEvent = {
       }
 
       // Step 3: Match readings with site distances and sort
+      const staleThresholdMs =
+        (constants.EVENTS_STALENESS_THRESHOLD_HOURS || 2) * 60 * 60 * 1000;
       const readingsWithDistance = readings.data
         .map((reading) => {
           const site = sitesWithDistance.find(
             (site) => site._id.toString() === reading.site_id.toString(),
           );
+          const ageMs = reading.time
+            ? Date.now() - new Date(reading.time).getTime()
+            : null;
 
           return {
             ...reading,
             distance: site ? site.distance : Infinity,
+            is_stale: ageMs === null ? null : ageMs > staleThresholdMs,
+            data_age_minutes:
+              ageMs === null ? null : Math.round(ageMs / 60000),
           };
         })
         .sort((a, b) => a.distance - b.distance)

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -1786,7 +1786,6 @@ const createEvent = {
           $group: {
             _id: groupField,
             avg_pm2_5: { $avg: "$pm2_5.value" },
-            max_pm2_5: { $max: "$pm2_5.value" },
             site_count: { $sum: 1 },
           },
         },
@@ -1803,18 +1802,25 @@ const createEvent = {
         });
 
       const generatedAt = new Date().toISOString();
-      const data = rows.map((row, index) => ({
-        rank: index + 1,
-        name: row._id,
-        level,
-        country_code:
-          level === "country" ? constants.countryCodes[row._id] || null : null,
-        avg_pm2_5: Math.round(row.avg_pm2_5 * 100) / 100,
-        aqi_index: aqiUtil.calculatePm25Aqi(row.avg_pm2_5),
-        aqi_category: aqiUtil.categoryFromConcentration(row.avg_pm2_5),
-        site_count: row.site_count,
-        generated_at: generatedAt,
-      }));
+      const data = rows.map((row, index) => {
+        // Round once and derive both AQI fields from the same rounded value
+        // that's displayed — deriving them from the raw average instead could
+        // show a category that doesn't match the displayed figure whenever
+        // rounding lands exactly on a category boundary.
+        const avgPm25 = Math.round(row.avg_pm2_5 * 100) / 100;
+        return {
+          rank: index + 1,
+          name: row._id,
+          level,
+          country_code:
+            level === "country" ? constants.countryCodes[row._id] || null : null,
+          avg_pm2_5: avgPm25,
+          aqi_index: aqiUtil.calculatePm25Aqi(avgPm25),
+          aqi_category: aqiUtil.categoryFromConcentration(avgPm25),
+          site_count: row.site_count,
+          generated_at: generatedAt,
+        };
+      });
 
       return {
         success: true,
@@ -1860,6 +1866,7 @@ const createEvent = {
           level,
           year: { $gte: startYear, $lte: endYear },
         })
+        .sort({ entity: 1 })
         .lean();
 
       const rows = summaryDocs

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -5,6 +5,7 @@ const DeviceModel = require("@models/Device");
 const GridModel = require("@models/Grid");
 const CohortModel = require("@models/Cohort");
 const SiteModel = require("@models/Site");
+const AirQualitySummaryModel = require("@models/AirQualitySummary");
 const crypto = require("crypto");
 const { intelligentFetch } = require("@utils/readings/fetch.util");
 const aqiUtil = require("@utils/aqi.util");
@@ -51,6 +52,11 @@ const asyncRetry = require("async-retry");
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 const CACHE_TIMEOUT_PERIOD = constants.CACHE_TIMEOUT_PERIOD || 10000;
+// Established maximum result size for the Nexus rankings endpoints — mirrors
+// the validated max on GET .../readings/rankings' limit param, reused here to
+// cap the number of entities the (unbounded, un-paginated) history endpoint
+// can fan out to, since level=city has no fixed upper bound like countries do.
+const MAX_RANKING_RESULTS = 100;
 let lastRedisWarning = 0;
 const REDIS_WARNING_THROTTLE = 30 * 60 * 1000; // 30 minutes throttle (30 minutes * 60 seconds * 1000 milliseconds)
 
@@ -1796,6 +1802,7 @@ const createEvent = {
           maxTimeMS: constants.READINGS_AGGREGATE_TIMEOUT_MS,
         });
 
+      const generatedAt = new Date().toISOString();
       const data = rows.map((row, index) => ({
         rank: index + 1,
         name: row._id,
@@ -1806,7 +1813,7 @@ const createEvent = {
         aqi_index: aqiUtil.calculatePm25Aqi(row.avg_pm2_5),
         aqi_category: aqiUtil.categoryFromConcentration(row.avg_pm2_5),
         site_count: row.site_count,
-        generated_at: new Date().toISOString(),
+        generated_at: generatedAt,
       }));
 
       return {
@@ -1831,52 +1838,38 @@ const createEvent = {
 
   // Annual-only multi-region historical rollup. Missing years are returned
   // as explicit nulls (never coerced to zero) per Nexus acceptance criteria.
+  //
+  // Reads from the AirQualitySummary collection (populated by
+  // air-quality-rollup-job.js) rather than aggregating raw readings — raw
+  // Reading documents are purged ~14 days after ingestion, so a live
+  // aggregation over a multi-year window could never see most of the range
+  // it claims to support. The precomputed rows are the only place real
+  // multi-year history survives; a year with no row here has no data (never
+  // coerced to a live re-aggregation, and never coerced to zero).
   getAirQualityRankingsHistory: async (request, next) => {
     try {
       const { tenant = "airqo", level = "country" } = request.query;
       const startYear = Number(request.query.start_year);
       const endYear = Number(request.query.end_year);
 
-      const groupField = `$siteDetails.${level}`;
-      const africanCountries = Object.keys(constants.countryCodes);
-      const rangeStart = new Date(Date.UTC(startYear, 0, 1));
-      const rangeEnd = new Date(Date.UTC(endYear + 1, 0, 1));
+      // No need to re-filter by African country here — the rollup job only
+      // ever writes rows for siteDetails.country in constants.countryCodes.
+      const summaryDocs = await AirQualitySummaryModel(tenant)
+        .find({
+          tenant,
+          level,
+          year: { $gte: startYear, $lte: endYear },
+        })
+        .lean();
 
-      const pipeline = [
-        {
-          $match: {
-            time: { $gte: rangeStart, $lt: rangeEnd },
-            "siteDetails.country": { $in: africanCountries },
-            "pm2_5.value": { $ne: null, $type: "number" },
-          },
-        },
-        { $addFields: { year: { $year: "$time" } } },
-        {
-          $group: {
-            _id: { entity: groupField, year: "$year" },
-            avg_pm2_5: { $avg: "$pm2_5.value" },
-            siteIds: { $addToSet: "$site_id" },
-          },
-        },
-        {
-          $project: {
-            _id: 0,
-            entity: "$_id.entity",
-            year: "$_id.year",
-            avg_pm2_5: { $round: ["$avg_pm2_5", 2] },
-            site_count: { $size: "$siteIds" },
-          },
-        },
-        { $match: { entity: { $ne: null } } },
-        { $sort: { entity: 1, year: 1 } },
-      ];
-
-      const rows = await ReadingModel(tenant)
-        .aggregate(pipeline)
-        .option({
-          allowDiskUse: true,
-          maxTimeMS: constants.READINGS_AGGREGATE_TIMEOUT_MS,
-        });
+      const rows = summaryDocs
+        .filter((doc) => doc.reading_count > 0)
+        .map((doc) => ({
+          entity: doc.entity,
+          year: doc.year,
+          avg_pm2_5: Math.round((doc.sum_pm2_5 / doc.reading_count) * 100) / 100,
+          site_count: (doc.contributing_sites || []).length,
+        }));
 
       const years = [];
       for (let y = startYear; y <= endYear; y += 1) years.push(y);
@@ -1887,23 +1880,28 @@ const createEvent = {
         byEntity.get(row.entity).set(row.year, row);
       });
 
-      const data = Array.from(byEntity.entries()).map(([entity, byYear]) => ({
-        name: entity,
-        level,
-        country_code:
-          level === "country" ? constants.countryCodes[entity] || null : null,
-        values: years.map((year) => {
-          const row = byYear.get(year);
-          return {
-            year,
-            avg_pm2_5: row ? row.avg_pm2_5 : null,
-            aqi_category: row
-              ? aqiUtil.categoryFromConcentration(row.avg_pm2_5)
-              : null,
-            site_count: row ? row.site_count : 0,
-          };
-        }),
-      }));
+      const data = Array.from(byEntity.entries())
+        // Countries are inherently bounded (~54, per constants.countryCodes),
+        // but level=city has no fixed upper bound — cap the response so it
+        // can't fan out across every distinct city ever seen.
+        .slice(0, MAX_RANKING_RESULTS)
+        .map(([entity, byYear]) => ({
+          name: entity,
+          level,
+          country_code:
+            level === "country" ? constants.countryCodes[entity] || null : null,
+          values: years.map((year) => {
+            const row = byYear.get(year);
+            return {
+              year,
+              avg_pm2_5: row ? row.avg_pm2_5 : null,
+              aqi_category: row
+                ? aqiUtil.categoryFromConcentration(row.avg_pm2_5)
+                : null,
+              site_count: row ? row.site_count : 0,
+            };
+          }),
+        }));
 
       return {
         success: true,

--- a/src/device-registry/utils/test/ut_aqi.util.js
+++ b/src/device-registry/utils/test/ut_aqi.util.js
@@ -2,8 +2,14 @@ require("module-alias/register");
 process.env.NODE_ENV = "development";
 
 const { expect } = require("chai");
-const { PM25_AQI_BREAKPOINTS } = require("@config/constants");
-const { calculatePm25Aqi, getAqiIndexMongoExpression } = require("@utils/aqi.util");
+const constants = require("@config/constants");
+const { PM25_AQI_BREAKPOINTS } = constants;
+const {
+  calculatePm25Aqi,
+  getAqiIndexMongoExpression,
+  categoryFromConcentration,
+  listRanges,
+} = require("@utils/aqi.util");
 
 // ---------------------------------------------------------------------------
 // calculatePm25Aqi — JavaScript implementation
@@ -249,5 +255,107 @@ describe("getAqiIndexMongoExpression", function() {
   it("the else branch returns null for invalid values", function() {
     const expr = getAqiIndexMongoExpression();
     expect(expr.$cond.else).to.equal(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// categoryFromConcentration — maps an averaged PM2.5 value to a category key
+// ---------------------------------------------------------------------------
+describe("categoryFromConcentration", function() {
+  describe("invalid inputs", function() {
+    it("returns null for null", function() {
+      expect(categoryFromConcentration(null)).to.equal(null);
+    });
+
+    it("returns null for undefined", function() {
+      expect(categoryFromConcentration(undefined)).to.equal(null);
+    });
+
+    it("returns null for NaN", function() {
+      expect(categoryFromConcentration(NaN)).to.equal(null);
+    });
+
+    it("returns null for a string", function() {
+      expect(categoryFromConcentration("20")).to.equal(null);
+    });
+
+    it("returns null for negative concentration", function() {
+      expect(categoryFromConcentration(-5)).to.equal(null);
+    });
+  });
+
+  describe("category boundaries (mirrors AQI_RANGES)", function() {
+    it("0 -> good", function() {
+      expect(categoryFromConcentration(0)).to.equal("good");
+    });
+
+    it("9.1 -> good (upper bound)", function() {
+      expect(categoryFromConcentration(9.1)).to.equal("good");
+    });
+
+    it("9.101 -> moderate (lower bound)", function() {
+      expect(categoryFromConcentration(9.101)).to.equal("moderate");
+    });
+
+    it("35.49 -> moderate (upper bound)", function() {
+      expect(categoryFromConcentration(35.49)).to.equal("moderate");
+    });
+
+    it("35.491 -> u4sg (lower bound)", function() {
+      expect(categoryFromConcentration(35.491)).to.equal("u4sg");
+    });
+
+    it("125.49 -> unhealthy (upper bound)", function() {
+      expect(categoryFromConcentration(125.49)).to.equal("unhealthy");
+    });
+
+    it("225.491 -> hazardous (lower bound, unbounded max)", function() {
+      expect(categoryFromConcentration(225.491)).to.equal("hazardous");
+    });
+
+    it("a very large value still resolves to hazardous", function() {
+      expect(categoryFromConcentration(10000)).to.equal("hazardous");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listRanges — assembles the dynamic AQI legend response
+// ---------------------------------------------------------------------------
+describe("listRanges", function() {
+  it("returns a success envelope with a standard identifier", function() {
+    const result = listRanges();
+    expect(result.success).to.equal(true);
+    expect(result.data.standard).to.be.a("string").and.not.be.empty;
+  });
+
+  it("returns one range entry per AQI_CATEGORY_KEYS, in order", function() {
+    const result = listRanges();
+    expect(result.data.ranges)
+      .to.be.an("array")
+      .with.lengthOf(constants.AQI_CATEGORY_KEYS.length);
+    result.data.ranges.forEach((range, index) => {
+      expect(range.key).to.equal(constants.AQI_CATEGORY_KEYS[index]);
+      expect(range.display_order).to.equal(index + 1);
+    });
+  });
+
+  it("each range has a label, numeric min_value, color, and color_name matching constants", function() {
+    const result = listRanges();
+    result.data.ranges.forEach((range) => {
+      const key = range.key;
+      expect(range.label).to.equal(constants.AQI_CATEGORIES[key]);
+      expect(range.min_value).to.equal(constants.AQI_RANGES[key].min);
+      expect(range.max_value).to.equal(constants.AQI_RANGES[key].max);
+      expect(range.color).to.equal(`#${constants.AQI_COLORS[key]}`);
+      expect(range.color_name).to.equal(constants.AQI_COLOR_NAMES[key]);
+    });
+  });
+
+  it("the last range (hazardous) has a null max_value (unbounded)", function() {
+    const result = listRanges();
+    const hazardous = result.data.ranges[result.data.ranges.length - 1];
+    expect(hazardous.key).to.equal("hazardous");
+    expect(hazardous.max_value).to.equal(null);
   });
 });

--- a/src/device-registry/utils/test/ut_aqi.util.js
+++ b/src/device-registry/utils/test/ut_aqi.util.js
@@ -317,6 +317,32 @@ describe("categoryFromConcentration", function() {
       expect(categoryFromConcentration(10000)).to.equal("hazardous");
     });
   });
+
+  // AQI_RANGES has thousandths-place gaps between adjacent categories
+  // (e.g. good max 9.1, moderate min 9.101). Averaged values can land in
+  // these gaps — every one must still resolve to the next (higher) category,
+  // never null.
+  describe("boundary-gap regression (values between adjacent max/min)", function() {
+    it("9.1005 (between good's max and moderate's min) -> moderate", function() {
+      expect(categoryFromConcentration(9.1005)).to.equal("moderate");
+    });
+
+    it("35.4905 (between moderate's max and u4sg's min) -> u4sg", function() {
+      expect(categoryFromConcentration(35.4905)).to.equal("u4sg");
+    });
+
+    it("55.4905 (between u4sg's max and unhealthy's min) -> unhealthy", function() {
+      expect(categoryFromConcentration(55.4905)).to.equal("unhealthy");
+    });
+
+    it("125.4905 (between unhealthy's max and very_unhealthy's min) -> very_unhealthy", function() {
+      expect(categoryFromConcentration(125.4905)).to.equal("very_unhealthy");
+    });
+
+    it("225.4905 (between very_unhealthy's max and hazardous's min) -> hazardous", function() {
+      expect(categoryFromConcentration(225.4905)).to.equal("hazardous");
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/device-registry/utils/test/ut_event.util.js
+++ b/src/device-registry/utils/test/ut_event.util.js
@@ -3217,17 +3217,21 @@ describe("create Event utils", function() {
   describe("getAirQualityRankingsHistory", () => {
     const proxyquire = require("proxyquire");
     let proxiedEventUtil;
-    let aggregateStub;
+    let findStub;
     let next;
 
-    const mockAggregateChain = (rows) => ({
-      option: () => Promise.resolve(rows),
+    // Mirrors AirQualitySummaryModel(tenant).find(filter).lean() — the rollup
+    // collection populated by air-quality-rollup-job.js. Docs store running
+    // totals (sum_pm2_5, reading_count, contributing_sites), not a
+    // precomputed average — the util derives avg_pm2_5 at read time.
+    const mockFindChain = (docs) => ({
+      lean: () => Promise.resolve(docs),
     });
 
     beforeEach(() => {
-      aggregateStub = sinon.stub();
+      findStub = sinon.stub();
       proxiedEventUtil = proxyquire("../event.util", {
-        "@models/Reading": () => ({ aggregate: aggregateStub }),
+        "@models/AirQualitySummary": () => ({ find: findStub }),
       });
       next = sinon.stub();
     });
@@ -3237,10 +3241,17 @@ describe("create Event utils", function() {
     });
 
     it("fills years with no data as explicit null, never zero", async () => {
-      aggregateStub.returns(
-        mockAggregateChain([
-          { entity: "Kenya", year: 2023, avg_pm2_5: 23.32, site_count: 4 },
-          // 2024 intentionally absent from the mocked aggregation result
+      findStub.returns(
+        mockFindChain([
+          // sum_pm2_5 / reading_count = 2332 / 100 = 23.32
+          {
+            entity: "Kenya",
+            year: 2023,
+            sum_pm2_5: 2332,
+            reading_count: 100,
+            contributing_sites: ["s1", "s2", "s3", "s4"],
+          },
+          // 2024 intentionally absent from the mocked rollup rows
         ])
       );
 
@@ -3259,9 +3270,15 @@ describe("create Event utils", function() {
     });
 
     it("supports level=city and leaves country_code null", async () => {
-      aggregateStub.returns(
-        mockAggregateChain([
-          { entity: "Kampala", year: 2023, avg_pm2_5: 30, site_count: 2 },
+      findStub.returns(
+        mockFindChain([
+          {
+            entity: "Kampala",
+            year: 2023,
+            sum_pm2_5: 60,
+            reading_count: 2,
+            contributing_sites: ["s1", "s2"],
+          },
         ])
       );
 
@@ -3274,8 +3291,25 @@ describe("create Event utils", function() {
       expect(result.data[0].country_code).to.equal(null);
     });
 
+    it("excludes a row whose reading_count is 0 (avoids a divide-by-zero average)", async () => {
+      findStub.returns(
+        mockFindChain([
+          { entity: "Kenya", year: 2023, sum_pm2_5: 0, reading_count: 0, contributing_sites: [] },
+        ])
+      );
+
+      const result = await proxiedEventUtil.getAirQualityRankingsHistory(
+        { query: { level: "country", start_year: "2023", end_year: "2023" } },
+        next
+      );
+
+      // No qualifying rows -> the entity never appears at all (same "absent,
+      // not zero" contract as any other year with no data).
+      expect(result.data).to.deep.equal([]);
+    });
+
     it("returns an empty list when nothing qualifies", async () => {
-      aggregateStub.returns(mockAggregateChain([]));
+      findStub.returns(mockFindChain([]));
 
       const result = await proxiedEventUtil.getAirQualityRankingsHistory(
         { query: { level: "country", start_year: "2023", end_year: "2024" } },
@@ -3286,9 +3320,9 @@ describe("create Event utils", function() {
       expect(result.data).to.deep.equal([]);
     });
 
-    it("reports an internal error via next() when the aggregation fails", async () => {
-      aggregateStub.returns({
-        option: () => Promise.reject(new Error("Mongo error")),
+    it("reports an internal error via next() when the query fails", async () => {
+      findStub.returns({
+        lean: () => Promise.reject(new Error("Mongo error")),
       });
 
       const result = await proxiedEventUtil.getAirQualityRankingsHistory(
@@ -3308,11 +3342,19 @@ describe("create Event utils", function() {
   // so it always falls inside the search radius.
   describe("getNearestReadings — freshness fields", () => {
     const proxyquire = require("proxyquire");
+    const FIXED_STALE_THRESHOLD_HOURS = 2;
     let proxiedEventUtil;
     let recentStub;
     let next;
+    let originalStaleThreshold;
 
     beforeEach(() => {
+      // Pin the threshold to a known value independent of the implementation's
+      // own `|| 2` fallback, so this test asserts a real contract rather than
+      // mirroring whatever default the code happens to fall back to.
+      originalStaleThreshold = constants.EVENTS_STALENESS_THRESHOLD_HOURS;
+      constants.EVENTS_STALENESS_THRESHOLD_HOURS = FIXED_STALE_THRESHOLD_HOURS;
+
       recentStub = sinon.stub();
       const mockSiteFactory = () => ({
         find: () => ({
@@ -3332,13 +3374,13 @@ describe("create Event utils", function() {
     });
 
     afterEach(() => {
+      constants.EVENTS_STALENESS_THRESHOLD_HOURS = originalStaleThreshold;
       sinon.restore();
     });
 
     it("flags a reading older than the staleness threshold as is_stale", async () => {
-      const staleThresholdHours = constants.EVENTS_STALENESS_THRESHOLD_HOURS || 2;
       const oldTime = new Date(
-        Date.now() - (staleThresholdHours + 1) * 60 * 60 * 1000
+        Date.now() - (FIXED_STALE_THRESHOLD_HOURS + 1) * 60 * 60 * 1000
       );
       recentStub.resolves({
         success: true,

--- a/src/device-registry/utils/test/ut_event.util.js
+++ b/src/device-registry/utils/test/ut_event.util.js
@@ -3073,4 +3073,333 @@ describe("create Event utils", function() {
       expect(res.json).to.have.been.calledWith(sinon.match.object);
     });
   });
+
+  // Nexus: African AQI rankings — groups the latest reading per site by
+  // siteDetails.country/city. @models/Reading is proxied so the aggregation
+  // pipeline never touches a real database; assertions focus on the JS-side
+  // shaping (ranking, rounding, AQI category derivation) done after the
+  // aggregation result comes back.
+  describe("getAirQualityRankings", () => {
+    const proxyquire = require("proxyquire");
+    let proxiedEventUtil;
+    let aggregateStub;
+    let next;
+
+    const mockAggregateChain = (rows) => ({
+      option: () => Promise.resolve(rows),
+    });
+
+    beforeEach(() => {
+      aggregateStub = sinon.stub();
+      proxiedEventUtil = proxyquire("../event.util", {
+        "@models/Reading": () => ({ aggregate: aggregateStub }),
+      });
+      next = sinon.stub();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("returns a ranked, country-level list by default with codes and AQI category", async () => {
+      aggregateStub.returns(
+        mockAggregateChain([
+          { _id: "Kenya", avg_pm2_5: 23.32, max_pm2_5: 40, site_count: 4 },
+          { _id: "Uganda", avg_pm2_5: 55.1, max_pm2_5: 80, site_count: 2 },
+        ])
+      );
+
+      const result = await proxiedEventUtil.getAirQualityRankings(
+        { query: {} },
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.have.lengthOf(2);
+      expect(result.data[0]).to.include({
+        rank: 1,
+        name: "Kenya",
+        level: "country",
+        country_code: "ke",
+        avg_pm2_5: 23.32,
+        aqi_category: "moderate",
+        site_count: 4,
+      });
+      expect(result.data[1]).to.include({
+        rank: 2,
+        name: "Uganda",
+        country_code: "ug",
+      });
+    });
+
+    it("groups by city and leaves country_code null when level=city", async () => {
+      aggregateStub.returns(
+        mockAggregateChain([
+          { _id: "Kampala", avg_pm2_5: 30, max_pm2_5: 50, site_count: 3 },
+        ])
+      );
+
+      const result = await proxiedEventUtil.getAirQualityRankings(
+        { query: { level: "city" } },
+        next
+      );
+
+      expect(result.data[0].level).to.equal("city");
+      expect(result.data[0].country_code).to.equal(null);
+
+      const pipeline = aggregateStub.getCall(0).args[0];
+      const groupByEntity = pipeline.find(
+        (stage) => stage.$group && stage.$group._id === "$siteDetails.city"
+      );
+      expect(groupByEntity).to.exist;
+    });
+
+    it("sorts descending (most polluted first) when sort=worst", async () => {
+      aggregateStub.returns(mockAggregateChain([]));
+
+      await proxiedEventUtil.getAirQualityRankings(
+        { query: { sort: "worst" } },
+        next
+      );
+
+      const pipeline = aggregateStub.getCall(0).args[0];
+      const sortStage = pipeline.find(
+        (stage) => stage.$sort && "avg_pm2_5" in stage.$sort
+      );
+      expect(sortStage.$sort.avg_pm2_5).to.equal(-1);
+    });
+
+    it("defaults to ascending (cleanest first) when sort is not provided", async () => {
+      aggregateStub.returns(mockAggregateChain([]));
+
+      await proxiedEventUtil.getAirQualityRankings({ query: {} }, next);
+
+      const pipeline = aggregateStub.getCall(0).args[0];
+      const sortStage = pipeline.find(
+        (stage) => stage.$sort && "avg_pm2_5" in stage.$sort
+      );
+      expect(sortStage.$sort.avg_pm2_5).to.equal(1);
+    });
+
+    it("returns an empty array (not an error) when nothing qualifies", async () => {
+      aggregateStub.returns(mockAggregateChain([]));
+
+      const result = await proxiedEventUtil.getAirQualityRankings(
+        { query: {} },
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.deep.equal([]);
+    });
+
+    it("reports an internal error via next() when the aggregation fails", async () => {
+      aggregateStub.returns({
+        option: () => Promise.reject(new Error("Mongo error")),
+      });
+
+      const result = await proxiedEventUtil.getAirQualityRankings(
+        { query: {} },
+        next
+      );
+
+      expect(result).to.be.undefined;
+      expect(next.calledOnce).to.equal(true);
+      const err = next.getCall(0).args[0];
+      expect(err.message).to.equal("Internal Server Error");
+    });
+  });
+
+  // Nexus: annual historical rankings — pivots {entity, year} aggregation
+  // rows into a per-entity table with every requested year present, filling
+  // gaps with explicit null (never 0) so the frontend can distinguish
+  // "no data" from "clean air".
+  describe("getAirQualityRankingsHistory", () => {
+    const proxyquire = require("proxyquire");
+    let proxiedEventUtil;
+    let aggregateStub;
+    let next;
+
+    const mockAggregateChain = (rows) => ({
+      option: () => Promise.resolve(rows),
+    });
+
+    beforeEach(() => {
+      aggregateStub = sinon.stub();
+      proxiedEventUtil = proxyquire("../event.util", {
+        "@models/Reading": () => ({ aggregate: aggregateStub }),
+      });
+      next = sinon.stub();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("fills years with no data as explicit null, never zero", async () => {
+      aggregateStub.returns(
+        mockAggregateChain([
+          { entity: "Kenya", year: 2023, avg_pm2_5: 23.32, site_count: 4 },
+          // 2024 intentionally absent from the mocked aggregation result
+        ])
+      );
+
+      const result = await proxiedEventUtil.getAirQualityRankingsHistory(
+        { query: { level: "country", start_year: "2023", end_year: "2024" } },
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      const kenya = result.data.find((entry) => entry.name === "Kenya");
+      expect(kenya.country_code).to.equal("ke");
+      expect(kenya.values).to.deep.equal([
+        { year: 2023, avg_pm2_5: 23.32, aqi_category: "moderate", site_count: 4 },
+        { year: 2024, avg_pm2_5: null, aqi_category: null, site_count: 0 },
+      ]);
+    });
+
+    it("supports level=city and leaves country_code null", async () => {
+      aggregateStub.returns(
+        mockAggregateChain([
+          { entity: "Kampala", year: 2023, avg_pm2_5: 30, site_count: 2 },
+        ])
+      );
+
+      const result = await proxiedEventUtil.getAirQualityRankingsHistory(
+        { query: { level: "city", start_year: "2023", end_year: "2023" } },
+        next
+      );
+
+      expect(result.data[0].level).to.equal("city");
+      expect(result.data[0].country_code).to.equal(null);
+    });
+
+    it("returns an empty list when nothing qualifies", async () => {
+      aggregateStub.returns(mockAggregateChain([]));
+
+      const result = await proxiedEventUtil.getAirQualityRankingsHistory(
+        { query: { level: "country", start_year: "2023", end_year: "2024" } },
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.deep.equal([]);
+    });
+
+    it("reports an internal error via next() when the aggregation fails", async () => {
+      aggregateStub.returns({
+        option: () => Promise.reject(new Error("Mongo error")),
+      });
+
+      const result = await proxiedEventUtil.getAirQualityRankingsHistory(
+        { query: { level: "country", start_year: "2023", end_year: "2024" } },
+        next
+      );
+
+      expect(result).to.be.undefined;
+      expect(next.calledOnce).to.equal(true);
+    });
+  });
+
+  // Nexus: nearest-readings freshness flag — additive is_stale /
+  // data_age_minutes fields, computed from constants.EVENTS_STALENESS_THRESHOLD_HOURS.
+  // @models/Site and @models/Reading are proxied; the real distance util is
+  // used unmocked (it's pure math) with a site placed at the query coordinates
+  // so it always falls inside the search radius.
+  describe("getNearestReadings — freshness fields", () => {
+    const proxyquire = require("proxyquire");
+    let proxiedEventUtil;
+    let recentStub;
+    let next;
+
+    beforeEach(() => {
+      recentStub = sinon.stub();
+      const mockSiteFactory = () => ({
+        find: () => ({
+          lean: () =>
+            Promise.resolve([
+              { _id: "site1", latitude: 0.35, longitude: 32.58 },
+            ]),
+        }),
+      });
+      const mockReadingFactory = () => ({ recent: recentStub });
+
+      proxiedEventUtil = proxyquire("../event.util", {
+        "@models/Site": mockSiteFactory,
+        "@models/Reading": mockReadingFactory,
+      });
+      next = sinon.stub();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("flags a reading older than the staleness threshold as is_stale", async () => {
+      const staleThresholdHours = constants.EVENTS_STALENESS_THRESHOLD_HOURS || 2;
+      const oldTime = new Date(
+        Date.now() - (staleThresholdHours + 1) * 60 * 60 * 1000
+      );
+      recentStub.resolves({
+        success: true,
+        data: [{ site_id: "site1", time: oldTime, pm2_5: { value: 20 } }],
+      });
+
+      const result = await proxiedEventUtil.getNearestReadings(
+        { query: { latitude: "0.35", longitude: "32.58" } },
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      expect(result.data[0].is_stale).to.equal(true);
+      expect(result.data[0].data_age_minutes).to.be.a("number");
+      expect(result.data[0].data_age_minutes).to.be.above(0);
+    });
+
+    it("does not flag a fresh reading as stale", async () => {
+      recentStub.resolves({
+        success: true,
+        data: [{ site_id: "site1", time: new Date(), pm2_5: { value: 20 } }],
+      });
+
+      const result = await proxiedEventUtil.getNearestReadings(
+        { query: { latitude: "0.35", longitude: "32.58" } },
+        next
+      );
+
+      expect(result.data[0].is_stale).to.equal(false);
+    });
+
+    it("returns null freshness fields when the reading has no time", async () => {
+      recentStub.resolves({
+        success: true,
+        data: [{ site_id: "site1", time: null, pm2_5: { value: 20 } }],
+      });
+
+      const result = await proxiedEventUtil.getNearestReadings(
+        { query: { latitude: "0.35", longitude: "32.58" } },
+        next
+      );
+
+      expect(result.data[0].is_stale).to.equal(null);
+      expect(result.data[0].data_age_minutes).to.equal(null);
+    });
+
+    it("leaves existing fields on each reading untouched (backward compatible)", async () => {
+      const time = new Date();
+      recentStub.resolves({
+        success: true,
+        data: [{ site_id: "site1", time, pm2_5: { value: 20 } }],
+      });
+
+      const result = await proxiedEventUtil.getNearestReadings(
+        { query: { latitude: "0.35", longitude: "32.58" } },
+        next
+      );
+
+      expect(result.data[0].site_id).to.equal("site1");
+      expect(result.data[0].pm2_5.value).to.equal(20);
+      expect(result.data[0].distance).to.be.a("number");
+    });
+  });
 });

--- a/src/device-registry/utils/test/ut_event.util.js
+++ b/src/device-registry/utils/test/ut_event.util.js
@@ -3104,8 +3104,8 @@ describe("create Event utils", function() {
     it("returns a ranked, country-level list by default with codes and AQI category", async () => {
       aggregateStub.returns(
         mockAggregateChain([
-          { _id: "Kenya", avg_pm2_5: 23.32, max_pm2_5: 40, site_count: 4 },
-          { _id: "Uganda", avg_pm2_5: 55.1, max_pm2_5: 80, site_count: 2 },
+          { _id: "Kenya", avg_pm2_5: 23.32, site_count: 4 },
+          { _id: "Uganda", avg_pm2_5: 55.1, site_count: 2 },
         ])
       );
 
@@ -3132,10 +3132,27 @@ describe("create Event utils", function() {
       });
     });
 
+    it("derives aqi_index/aqi_category from the rounded avg_pm2_5, not the raw value", async () => {
+      // Raw 9.1005 categorizes as "moderate" (just above the good/moderate
+      // boundary at 9.1), but rounds to a displayed 9.1 — which is exactly
+      // the "good" boundary. The category must match what's displayed.
+      aggregateStub.returns(
+        mockAggregateChain([{ _id: "Kenya", avg_pm2_5: 9.1005, site_count: 1 }])
+      );
+
+      const result = await proxiedEventUtil.getAirQualityRankings(
+        { query: {} },
+        next
+      );
+
+      expect(result.data[0].avg_pm2_5).to.equal(9.1);
+      expect(result.data[0].aqi_category).to.equal("good");
+    });
+
     it("groups by city and leaves country_code null when level=city", async () => {
       aggregateStub.returns(
         mockAggregateChain([
-          { _id: "Kampala", avg_pm2_5: 30, max_pm2_5: 50, site_count: 3 },
+          { _id: "Kampala", avg_pm2_5: 30, site_count: 3 },
         ])
       );
 
@@ -3220,13 +3237,17 @@ describe("create Event utils", function() {
     let findStub;
     let next;
 
-    // Mirrors AirQualitySummaryModel(tenant).find(filter).lean() — the rollup
-    // collection populated by air-quality-rollup-job.js. Docs store running
-    // totals (sum_pm2_5, reading_count, contributing_sites), not a
-    // precomputed average — the util derives avg_pm2_5 at read time.
-    const mockFindChain = (docs) => ({
-      lean: () => Promise.resolve(docs),
-    });
+    // Mirrors AirQualitySummaryModel(tenant).find(filter).sort(...).lean() —
+    // the rollup collection populated by air-quality-rollup-job.js. Docs
+    // store running totals (sum_pm2_5, reading_count, contributing_sites),
+    // not a precomputed average — the util derives avg_pm2_5 at read time.
+    const mockFindChain = (docs) => {
+      const chain = {
+        sort: () => chain,
+        lean: () => Promise.resolve(docs),
+      };
+      return chain;
+    };
 
     beforeEach(() => {
       findStub = sinon.stub();
@@ -3321,9 +3342,11 @@ describe("create Event utils", function() {
     });
 
     it("reports an internal error via next() when the query fails", async () => {
-      findStub.returns({
+      const failingChain = {
+        sort: () => failingChain,
         lean: () => Promise.reject(new Error("Mongo error")),
-      });
+      };
+      findStub.returns(failingChain);
 
       const result = await proxiedEventUtil.getAirQualityRankingsHistory(
         { query: { level: "country", start_year: "2023", end_year: "2024" } },

--- a/src/device-registry/validators/aqi.validators.js
+++ b/src/device-registry/validators/aqi.validators.js
@@ -1,0 +1,21 @@
+// aqi.validators.js
+const { query } = require("express-validator");
+const constants = require("@config/constants");
+const { validate } = require("@validators/common");
+
+const listRanges = [
+  query("tenant")
+    .optional()
+    .notEmpty()
+    .withMessage("the tenant cannot be empty, if provided")
+    .bail()
+    .trim()
+    .toLowerCase()
+    .isIn(constants.TENANTS)
+    .withMessage("the tenant value is not among the expected ones"),
+  validate,
+];
+
+module.exports = {
+  listRanges,
+};

--- a/src/device-registry/validators/readings.validators.js
+++ b/src/device-registry/validators/readings.validators.js
@@ -676,6 +676,74 @@ const readingsValidations = {
     const middleware = createValidationMiddleware(validationRules);
     executeMiddlewareSequentially(middleware, req, res, next);
   },
+
+  rankings: (req, res, next) => {
+    const validationRules = [
+      ...commonValidations.tenant,
+      query("level")
+        .optional()
+        .trim()
+        .toLowerCase()
+        .isIn(["country", "city"])
+        .withMessage("level must be either 'country' or 'city'"),
+      query("sort")
+        .optional()
+        .trim()
+        .toLowerCase()
+        .isIn(["best", "worst"])
+        .withMessage("sort must be either 'best' or 'worst'"),
+      query("limit")
+        .optional()
+        .isInt({ min: 1, max: 100 })
+        .withMessage("limit must be between 1 and 100")
+        .toInt(),
+    ];
+
+    const middleware = createValidationMiddleware(validationRules);
+    executeMiddlewareSequentially(middleware, req, res, next);
+  },
+
+  rankingsHistory: (req, res, next) => {
+    const validationRules = [
+      ...commonValidations.tenant,
+      query("level")
+        .optional()
+        .trim()
+        .toLowerCase()
+        .isIn(["country", "city"])
+        .withMessage("level must be either 'country' or 'city'"),
+      query("start_year")
+        .exists()
+        .withMessage("start_year is required")
+        .bail()
+        .isInt({ min: 2015, max: 2100 })
+        .withMessage("start_year must be a valid 4-digit year")
+        .toInt(),
+      query("end_year")
+        .exists()
+        .withMessage("end_year is required")
+        .bail()
+        .isInt({ min: 2015, max: 2100 })
+        .withMessage("end_year must be a valid 4-digit year")
+        .toInt()
+        .bail()
+        .custom((value, { req }) => {
+          const startYear = Number(req.query.start_year);
+          if (value < startYear) {
+            throw new Error("end_year must not be earlier than start_year");
+          }
+          if (value - startYear > 5) {
+            throw new Error(
+              "the range between start_year and end_year must not exceed 5 years",
+            );
+          }
+          return true;
+        }),
+    ];
+
+    const middleware = createValidationMiddleware(validationRules);
+    executeMiddlewareSequentially(middleware, req, res, next);
+  },
 };
 
 const validateGetRepresentativeAQForGrid = [

--- a/src/device-registry/validators/readings.validators.js
+++ b/src/device-registry/validators/readings.validators.js
@@ -732,7 +732,7 @@ const readingsValidations = {
           if (value < startYear) {
             throw new Error("end_year must not be earlier than start_year");
           }
-          if (value - startYear > 5) {
+          if (value - startYear >= 5) {
             throw new Error(
               "the range between start_year and end_year must not exceed 5 years",
             );

--- a/src/device-registry/validators/test/ut_readings.validators.js
+++ b/src/device-registry/validators/test/ut_readings.validators.js
@@ -1,0 +1,82 @@
+require("module-alias/register");
+process.env.NODE_ENV = "development";
+const { expect } = require("chai");
+
+const readingsValidations = require("@validators/readings.validators");
+
+const mockRequest = (query = {}) => ({ query, params: {}, body: {} });
+
+// Resolves once either next() is called (validation passed) or res.json() is
+// called (validation failed — the shared middleware responds directly with
+// 400 rather than calling next() with an error, see createValidationMiddleware
+// in readings.validators.js).
+const runValidation = (query) =>
+  new Promise((resolve) => {
+    const req = mockRequest(query);
+    const res = {};
+    let settled = false;
+    const settle = (result) => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
+      }
+    };
+    res.status = (code) => {
+      res.statusCode = code;
+      return res;
+    };
+    res.json = (body) => {
+      res.body = body;
+      settle({ res, passed: false });
+      return res;
+    };
+    const next = () => settle({ res, passed: true });
+
+    readingsValidations.rankingsHistory(req, res, next);
+  });
+
+// rankingsHistory's 5-year span cap: exercises the exact off-by-one this
+// regression targets — a start_year/end_year pair 5 years apart (inclusive of
+// both ends, 6 years of data) must be rejected; 4 years apart (5 years of
+// data) must be accepted.
+describe("readingsValidations.rankingsHistory", () => {
+  it("rejects a start_year/end_year span of exactly 5 years (6 inclusive years)", async () => {
+    const { res, passed } = await runValidation({
+      level: "country",
+      start_year: "2020",
+      end_year: "2025",
+    });
+
+    expect(passed).to.equal(false);
+    expect(res.statusCode).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+
+  it("accepts a start_year/end_year span of 4 years (5 inclusive years)", async () => {
+    const { passed } = await runValidation({
+      level: "country",
+      start_year: "2020",
+      end_year: "2024",
+    });
+
+    expect(passed).to.equal(true);
+  });
+
+  it("rejects end_year earlier than start_year", async () => {
+    const { passed, res } = await runValidation({
+      level: "country",
+      start_year: "2024",
+      end_year: "2020",
+    });
+
+    expect(passed).to.equal(false);
+    expect(res.statusCode).to.equal(400);
+  });
+
+  it("rejects a request missing start_year/end_year", async () => {
+    const { passed, res } = await runValidation({ level: "country" });
+
+    expect(passed).to.equal(false);
+    expect(res.statusCode).to.equal(400);
+  });
+});


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds four backend capabilities to device-registry requested for the Nexus frontend redesign:

- New `GET /api/v2/devices/aqi-ranges` endpoint — exposes the AQI legend (bands, labels, colors, ranges) dynamically instead of requiring it to be hard-coded on the frontend.
- New `GET /api/v2/devices/readings/rankings` endpoint — ranks African countries or cities by current air quality for a leaderboard view.
- New `GET /api/v2/devices/readings/rankings/history` endpoint — annual, multi-year air quality history per African country/city, shaped for a year-by-year comparison table. Missing years are returned as `null`, never coerced to zero.
- Enhanced the existing nearest-readings endpoint with two additive fields (`is_stale`, `data_age_minutes`) so stale data can be flagged in the UI — no existing fields changed.
- Added a supporting MongoDB index (`siteDetails.country` + `time`) to keep the new rankings/history queries performant.
- Added a frontend-facing API guide document for the Nexus team covering all of the above.
- New daily background job (`air-quality-rollup-job`) plus a new permanent `AirQualitySummary` collection — replaces `/rankings/history`'s live aggregation over raw readings with reads from precomputed running totals. See the dedicated section below; this isn't just a performance optimization.

Also includes fixes from an automated + manual code review pass after the initial implementation: a validator off-by-one on the historical date range, a double-response bug and an empty-array-becomes-null bug in the two new controllers, a boundary-value gap in AQI category classification, an unbounded entity fan-out in the historical endpoint, and a couple of test-fidelity corrections. See Testing section for details.

### Why is this change needed?

The Nexus redesign requires location-aware and comparison-driven views (nearby air quality, African rankings, historical comparisons, dynamic AQI legend) that the current API doesn't fully support. A gap analysis against the requirements showed most of what was asked for already existed in some form except rankings and multi-region historical comparison, which are new here. This PR also removes a legend that was previously hard-coded on the frontend, and clarifies stale-data handling for nearby lookups.

### Why the rollup job — this is more than a performance fix

Investigating a performance question about `/rankings/history`'s 5-year query window surfaced something more fundamental: `Reading.js` has two unconditional 14-day TTL indexes (on `time` and on `createdAt`), confirmed active in production. Raw readings never exist for more than ~2 weeks. That means the endpoint's originally-implemented 5-year window could only ever return real data for the last ~2 weeks — anything older was already gone from Mongo, independent of query speed. The fix isn't just "make it faster," it's "capture data before it's permanently purged." `air-quality-rollup-job` runs daily and folds each new day's readings into permanent running totals (`AirQualitySummary`) before the 14-day TTL deletes the source documents; `/rankings/history` now reads from that collection instead. Real multi-year history will build up from when this job starts running — it cannot recover pre-existing history that's already been purged (that data is gone; recovering it, if wanted, would mean pulling from BigQuery via the analytics service, which is out of scope here — confirmed with the team to keep this PR device-registry-only).

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only. (A related fix aligning AQI category boundaries/colors between device-registry and `analytics` is intentionally left out of this PR and will follow as a separate, dedicated PR.)

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added unit tests for every new/changed function: `aqi.util`'s `listRanges`/`categoryFromConcentration` (including 5 boundary-gap regression cases added after the classification-gap fix below), `event.util`'s `getAirQualityRankings`/`getAirQualityRankingsHistory` (ranking order, country/city grouping, empty-result and query/aggregation-failure paths, missing-year-is-null-not-zero, divide-by-zero guard on a zero-reading rollup row), the nearest-readings staleness-flag logic, the two new controller endpoints (including regression tests for the double-response and empty-array fixes), a new validator test file covering the 5-year span cap boundary, and a new job test file covering `air-quality-rollup-job` (lock acquisition/skip, first-run 24h default window, 14-day retention floor + warning, watermark only advancing on success). Ran every affected suite individually and together (`ut_aqi.util.js`, `ut_event.util.js`, `ut_event.controller.js`, `ut_aqi.controller.js`, `ut_readings.validators.js`, `ut_air-quality-rollup-job.js`): **147 passing, 0 failing, 105 pre-existing pending** (unrelated to this change).

Also verified live, end-to-end, against a local MongoDB instance: every endpoint manually exercised (including each review fix re-checked directly against a running server — empty rankings now return `data: []`, the 5-year boundary now correctly rejects a 6-year span and accepts a 5-year one); and the rollup job specifically — inserted real readings, ran the job, confirmed a fresh row is created with the correct sum/count; inserted a second reading and ran again, confirmed the running total **increments** (60 = 20 + 40 across two runs, not reset); ran a third time with no new data and confirmed the totals are unchanged (no double-counting); then confirmed `GET /rankings/history` returns the correct derived average (30) and AQI category (`moderate`) straight from the precomputed collection.

**Review fixes applied in this PR** (found via automated + manual review after initial implementation):
- Fixed an off-by-one in the historical date-range validator that allowed a 6-year span instead of the intended 5-year cap.
- Fixed a bug where both new controllers could send two responses for the same request when the underlying aggregation failed.
- Fixed a bug where a successful-but-empty ranking result was silently turned into `data: null` instead of `data: []`.
- Fixed a boundary-value gap in AQI category classification that could return `null` for certain averaged PM2.5 values instead of a real category.
- Capped the number of entities the historical endpoint can return at `level=city`, since (unlike countries) city names have no fixed upper bound.
- Minor: computed the response timestamp once per request instead of once per row; tightened two tests that weren't exercising the real code paths.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All changes are additive: new endpoints, new optional response fields on an existing endpoint, and a new index. No existing field, route, or response shape was removed or renamed.

---

## :memo: Additional Notes

- Two defaults were chosen where the original requirements doc left them open, and are called out to the frontend team as adjustable: rankings default to cleanest-first sort, and a location must have a reading within the last 3 days to appear in `/rankings` (absent, not zero, otherwise).
- The rankings/history endpoints filter to African countries using the existing country list already used elsewhere in this service.
- A companion doc (`docs/NEXUS_AIR_QUALITY_API_GUIDE.md`) was added for the frontend team, describing all four endpoints in plain terms, including an honest caveat that historical coverage builds up over time rather than being available immediately for past years.
- **`/rankings` (3-day window) intentionally still queries raw readings live** — it's cheap, well-indexed, and entirely within the TTL-safe window, so it didn't need the same treatment as `/rankings/history`.
- **Data-coverage caveat for reviewers:** because raw readings are gone after ~14 days, real multi-year history in `/rankings/history` only starts accumulating from whenever `air-quality-rollup-job` is deployed and begins running — it cannot retroactively recover years that predate this PR. That's a hard limit of what's recoverable from this service's MongoDB, not a bug.
- **Lock choice:** the job uses the MongoDB-native `JobLock` model (same pattern as `find-duplicate-cohorts-job`) rather than the newer Redis `NX`/`EX` lock used by `cohort-snapshot-job`, per this team's preference to avoid Redis on load-bearing paths.
- **Routing decision, post-dating the implementation above:** the team has decided that any *future* backend work requiring "very historical" data goes in `analytics` (BigQuery-backed) rather than device-registry, and frontend will call `analytics` for that going forward. `/rankings/history` and this rollup job predate that decision and are being kept as-is for now — they fix a real, independent problem (raw data loss from the TTL) and may still serve as a "recent history" fallback. Once `analytics` has a working multi-region historical endpoint, revisit whether this device-registry path becomes redundant.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AQI range listing utilities and new v2 AQI ranges endpoint.
  * Added air-quality rankings endpoints (current and historical by year) with best/worst sorting and limits.
  * Introduced daily air-quality rollups and persistent air-quality summary storage for country/city.
  * Added a new database index to speed up Reading lookups.
* **Bug Fixes**
  * Improved request validation and standardized controller response/error handling (including avoiding double-sent responses).
* **Tests**
  * Added unit tests for AQI, rankings controllers/utilities, and the air-quality rollup job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->