### PR TITLE
Make AQI ranges admin-editable via API instead of code + redeploy

### DIFF
--- a/src/device-registry/controllers/aqi.controller.js
+++ b/src/device-registry/controllers/aqi.controller.js
@@ -2,9 +2,16 @@
 const httpStatus = require("http-status");
 const { HttpError, extractErrorsFromRequest } = require("@utils/shared");
 const aqiUtil = require("@utils/aqi.util");
-const log4js = require("log4js");
+const SystemConfigModel = require("@models/SystemConfig");
 const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- aqi-controller`);
+
+const resolveTenant = (req) => {
+  const tenant = req.query.tenant;
+  return isEmpty(tenant) ? constants.DEFAULT_TENANT || "airqo" : tenant;
+};
 
 const aqiController = {
   listRanges: async (req, res, next) => {
@@ -17,7 +24,9 @@ const aqiController = {
         return;
       }
 
-      const result = aqiUtil.listRanges();
+      const tenant = resolveTenant(req);
+      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
+      const result = aqiUtil.listRanges(resolved);
 
       res.status(httpStatus.OK).json({
         success: true,
@@ -36,6 +45,106 @@ const aqiController = {
       return;
     }
   },
+
+  updateRanges: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const tenant = resolveTenant(req);
+      const value = { ranges: buildRangesWithDerivedMin(req.body.ranges) };
+
+      await SystemConfigModel(tenant).upsert(
+        aqiUtil.AQI_RANGES_CONFIG_KEY,
+        value,
+        req.body.updated_by || null
+      );
+      // Invalidate after the write succeeds, not before, so a concurrent
+      // read can't be caught between an invalidated cache and the new value
+      // actually landing in Mongo.
+      aqiUtil.invalidateAqiRangesCache(tenant);
+
+      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
+      const result = aqiUtil.listRanges(resolved);
+
+      res.status(httpStatus.OK).json({
+        success: true,
+        message: "Successfully updated AQI ranges",
+        data: result.data,
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
+
+  deleteRanges: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const tenant = resolveTenant(req);
+      await SystemConfigModel(tenant).deleteOne({
+        key: aqiUtil.AQI_RANGES_CONFIG_KEY,
+      });
+      aqiUtil.invalidateAqiRangesCache(tenant);
+
+      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
+      const result = aqiUtil.listRanges(resolved);
+
+      res.status(httpStatus.OK).json({
+        success: true,
+        message: "Successfully reverted AQI ranges to defaults",
+        data: result.data,
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+      return;
+    }
+  },
 };
+
+// good.min_value is always 0; every other category's min_value is the
+// previous category's max_value. Derived server-side rather than accepted
+// from the caller — see the "min_value not accepted" note in aqi.validators.js.
+function buildRangesWithDerivedMin(ranges) {
+  let prevMax = 0;
+  return ranges.map((range, index) => {
+    const min_value = index === 0 ? 0 : prevMax;
+    prevMax = range.max_value;
+    return {
+      key: range.key,
+      label: range.label,
+      min_value,
+      max_value: range.max_value,
+      color: range.color.replace(/^#/, ""), // stored bare, listRanges() re-adds the #
+      color_name: range.color_name || null,
+    };
+  });
+}
 
 module.exports = aqiController;

--- a/src/device-registry/controllers/test/ut_aqi.controller.js
+++ b/src/device-registry/controllers/test/ut_aqi.controller.js
@@ -5,6 +5,7 @@ const sinonChai = require("sinon-chai");
 const expect = chai.expect;
 chai.use(sinonChai);
 const httpStatus = require("http-status");
+const proxyquire = require("proxyquire");
 
 const aqiController = require("@controllers/aqi.controller");
 const aqiUtil = require("@utils/aqi.util");
@@ -25,9 +26,11 @@ describe("AQI Controller", () => {
         message: "Successfully retrieved AQI ranges",
         data: {
           standard: "US EPA PM2.5 AQI (2024 NAAQS revision)",
+          source: "default",
           ranges: [{ key: "good", label: "Good" }],
         },
       };
+      sinon.stub(aqiUtil, "resolveActiveAqiRanges").resolves(null);
       sinon.stub(aqiUtil, "listRanges").returns(mockResult);
     });
 
@@ -38,6 +41,7 @@ describe("AQI Controller", () => {
     it("returns 200 with the ranges from the util layer", async () => {
       await aqiController.listRanges(req, res, next);
 
+      expect(aqiUtil.resolveActiveAqiRanges).to.have.been.calledOnce;
       expect(aqiUtil.listRanges).to.have.been.calledOnce;
       expect(res.status).to.have.been.calledWith(httpStatus.OK);
       expect(res.json).to.have.been.calledWith({
@@ -55,6 +59,105 @@ describe("AQI Controller", () => {
       expect(next.calledOnce).to.equal(true);
       const err = next.getCall(0).args[0];
       expect(err.message).to.equal("Internal Server Error");
+    });
+  });
+
+  describe("updateRanges / deleteRanges", () => {
+    let req, res, next, upsertStub, deleteOneStub, proxiedController;
+
+    const validRanges = () =>
+      require("@config/constants").AQI_CATEGORY_KEYS.map((key, i, arr) => ({
+        key,
+        label: "Custom " + key,
+        max_value: i === arr.length - 1 ? null : (i + 1) * 10,
+        color: "#ABCDEF",
+      }));
+
+    beforeEach(() => {
+      res = {
+        status: sinon.stub().callsFake(function() { return res; }),
+        json: sinon.spy(),
+      };
+      next = sinon.spy();
+
+      upsertStub = sinon.stub().resolves({});
+      deleteOneStub = sinon.stub().resolves({});
+      proxiedController = proxyquire("../aqi.controller", {
+        "@models/SystemConfig": () => ({
+          upsert: upsertStub,
+          deleteOne: deleteOneStub,
+        }),
+      });
+
+      sinon.stub(aqiUtil, "resolveActiveAqiRanges").resolves(null);
+      sinon.stub(aqiUtil, "invalidateAqiRangesCache");
+      sinon.stub(aqiUtil, "listRanges").returns({
+        success: true,
+        message: "ok",
+        data: { standard: "...", source: "custom", ranges: [] },
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("updateRanges upserts, invalidates the cache, and returns the freshly-resolved config", async () => {
+      req = { query: {}, params: {}, body: { ranges: validRanges(), admin_secret: "x" } };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      expect(upsertStub.calledOnce).to.equal(true);
+      expect(upsertStub.getCall(0).args[0]).to.equal(aqiUtil.AQI_RANGES_CONFIG_KEY);
+      expect(aqiUtil.invalidateAqiRangesCache.calledOnce).to.equal(true);
+      // Cache must be invalidated only after the write succeeds.
+      expect(aqiUtil.invalidateAqiRangesCache.calledAfter(upsertStub)).to.equal(true);
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+    });
+
+    it("updateRanges derives min_value server-side rather than trusting the caller", async () => {
+      req = { query: {}, params: {}, body: { ranges: validRanges(), admin_secret: "x" } };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      const storedValue = upsertStub.getCall(0).args[1];
+      expect(storedValue.ranges[0].min_value).to.equal(0);
+      expect(storedValue.ranges[1].min_value).to.equal(storedValue.ranges[0].max_value);
+    });
+
+    it("updateRanges strips the leading # before persisting the color", async () => {
+      req = { query: {}, params: {}, body: { ranges: validRanges(), admin_secret: "x" } };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      const storedValue = upsertStub.getCall(0).args[1];
+      expect(storedValue.ranges[0].color).to.equal("ABCDEF");
+    });
+
+    it("deleteRanges removes the override, invalidates the cache, and returns the default config", async () => {
+      req = { query: {}, params: {}, body: {} };
+
+      await proxiedController.deleteRanges(req, res, next);
+
+      expect(deleteOneStub.calledOnce).to.equal(true);
+      expect(deleteOneStub.getCall(0).args[0]).to.deep.equal({
+        key: aqiUtil.AQI_RANGES_CONFIG_KEY,
+      });
+      expect(aqiUtil.invalidateAqiRangesCache.calledOnce).to.equal(true);
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+    });
+
+    it("forwards a Mongo write failure to next() as an HttpError", async () => {
+      upsertStub.rejects(new Error("Mongo write failed"));
+      req = { query: {}, params: {}, body: { ranges: validRanges(), admin_secret: "x" } };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      expect(next.calledOnce).to.equal(true);
+      const err = next.getCall(0).args[0];
+      expect(err.message).to.equal("Internal Server Error");
+      // A failed write must not invalidate the cache — nothing changed.
+      expect(aqiUtil.invalidateAqiRangesCache.called).to.equal(false);
     });
   });
 });

--- a/src/device-registry/models/SystemConfig.js
+++ b/src/device-registry/models/SystemConfig.js
@@ -1,0 +1,61 @@
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+
+/**
+ * SystemConfig — durable, admin-editable key/value configuration store.
+ *
+ * Distinct from ComputedCache (which has a mandatory TTL and is explicitly
+ * an ephemeral cache for expensive computed results): documents here persist
+ * indefinitely until explicitly deleted. First consumer is the "aqi_ranges"
+ * key (see utils/aqi.util.js's resolveActiveAqiRanges), letting AQI category
+ * boundaries/colors be changed via API instead of a code change + redeploy.
+ *
+ * `updated_by` is free text, not a verified identity — device-registry has
+ * no real per-user auth (write access is gated by a shared admin secret, see
+ * requireAdminSecret in validators/aqi.validators.js), so this can only ever
+ * record what the caller optionally claims, not a confirmed identity.
+ */
+const systemConfigSchema = new mongoose.Schema(
+  {
+    key: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    value: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true,
+    },
+    version: {
+      type: Number,
+      default: 1,
+    },
+    updated_by: {
+      type: String,
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+systemConfigSchema.statics.upsert = async function(key, value, updated_by) {
+  return this.findOneAndUpdate(
+    { key },
+    { $set: { value, updated_by }, $inc: { version: 1 } },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+};
+
+const SystemConfigModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("systemconfigs");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "systemconfig", systemConfigSchema);
+  }
+};
+
+module.exports = SystemConfigModel;

--- a/src/device-registry/models/SystemConfig.js
+++ b/src/device-registry/models/SystemConfig.js
@@ -51,11 +51,11 @@ systemConfigSchema.statics.upsert = async function(key, value, updated_by) {
 const SystemConfigModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
-  try {
-    return mongoose.model("systemconfigs");
-  } catch (error) {
-    return getModelByTenant(dbTenant, "systemconfig", systemConfigSchema);
-  }
+  // getModelByTenant registers models on a tenant-specific connection (via
+  // connection.model(), not the global mongoose.model() registry), so a
+  // preceding `mongoose.model("systemconfigs")` lookup here would never
+  // succeed and always fall through — it's dead code, not a real cache.
+  return getModelByTenant(dbTenant, "systemconfig", systemConfigSchema);
 };
 
 module.exports = SystemConfigModel;

--- a/src/device-registry/routes/v2/aqi.routes.js
+++ b/src/device-registry/routes/v2/aqi.routes.js
@@ -8,5 +8,7 @@ const { headers } = require("@validators/common");
 router.use(headers);
 
 router.get("/", aqiValidations.listRanges, aqiController.listRanges);
+router.put("/", aqiValidations.updateRanges, aqiController.updateRanges);
+router.delete("/", aqiValidations.deleteRanges, aqiController.deleteRanges);
 
 module.exports = router;

--- a/src/device-registry/utils/aqi.util.js
+++ b/src/device-registry/utils/aqi.util.js
@@ -251,40 +251,79 @@ function listRanges(resolved = null) {
 }
 
 /**
- * Validate that a stored/candidate AQI ranges value has the exact shape
- * categoryFromConcentration/listRanges require: all AQI_CATEGORY_KEYS present
- * in order, max_value strictly increasing with the last one null, colors
- * valid 6-hex-digit codes. Used both to defensively re-check a doc that may
- * have been hand-edited outside the API, and to validate a PUT body.
+ * Validate an AQI ranges array against the shared contract: all
+ * AQI_CATEGORY_KEYS present in order, max_value strictly increasing with the
+ * last one null, colors valid 6-hex-digit codes (with or without a leading
+ * "#", per hexHasPrefix), labels non-empty strings, and color_name (when
+ * present) a non-empty string. Single source of truth for both the PUT body
+ * validator (validators/aqi.validators.js, hexHasPrefix: true — the wire
+ * format is #RRGGBB) and isValidAqiRangesShape below (hexHasPrefix: false —
+ * the stored/normalized form, already stripped of its leading "#" by
+ * buildRangesWithDerivedMin in aqi.controller.js) — kept as one function so
+ * the two can't silently drift apart the way isValidAqiRangesShape and the
+ * validator's own color_name check already had before this was consolidated.
+ *
+ * @returns {string|null} the first validation error message, or null if valid
+ */
+function validateAqiRangesArray(ranges, { hexHasPrefix = false } = {}) {
+  const { AQI_CATEGORY_KEYS } = constants;
+  if (!Array.isArray(ranges) || ranges.length !== AQI_CATEGORY_KEYS.length) {
+    return `ranges must contain exactly ${AQI_CATEGORY_KEYS.length} categories`;
+  }
+
+  const keys = ranges.map((range) => range && range.key);
+  if (keys.join(",") !== AQI_CATEGORY_KEYS.join(",")) {
+    return `ranges must contain exactly these keys in order: ${AQI_CATEGORY_KEYS.join(", ")}`;
+  }
+
+  const colorRegex = hexHasPrefix ? /^#[0-9A-Fa-f]{6}$/ : /^[0-9A-Fa-f]{6}$/;
+  let prevMax = -Infinity;
+  for (let i = 0; i < ranges.length; i += 1) {
+    const range = ranges[i];
+    const isLast = i === ranges.length - 1;
+
+    if (isLast) {
+      if (range.max_value !== null) {
+        return `${range.key}.max_value must be null (unbounded)`;
+      }
+    } else {
+      if (typeof range.max_value !== "number" || !(range.max_value > prevMax)) {
+        return `${range.key}.max_value must be a number strictly greater than the previous category's max_value`;
+      }
+      prevMax = range.max_value;
+    }
+
+    if (!colorRegex.test(range.color || "")) {
+      return `${range.key}.color must be a 6-hex-digit code${hexHasPrefix ? ", e.g. #34C759" : ""}`;
+    }
+    if (typeof range.label !== "string" || !range.label.trim()) {
+      return `${range.key}.label must be a non-empty string`;
+    }
+    if (
+      range.color_name !== undefined &&
+      range.color_name !== null &&
+      (typeof range.color_name !== "string" || !range.color_name.trim())
+    ) {
+      return `${range.key}.color_name must be a non-empty string when provided`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate that a stored/candidate AQI ranges value (the normalized form
+ * already persisted in SystemConfig — bare hex colors, no leading "#") has
+ * the exact shape categoryFromConcentration/listRanges require. Used to
+ * defensively re-check a doc that may have been hand-edited outside the API
+ * before trusting it — NOT used to validate a raw incoming PUT body, which
+ * uses #-prefixed colors and is validated separately in
+ * validators/aqi.validators.js via the same validateAqiRangesArray above.
  *
  * @returns {boolean}
  */
 function isValidAqiRangesShape(value) {
   if (!value || typeof value !== "object") return false;
-  const { AQI_CATEGORY_KEYS } = constants;
-  const ranges = value.ranges;
-  if (!Array.isArray(ranges) || ranges.length !== AQI_CATEGORY_KEYS.length) {
-    return false;
-  }
-
-  let prevMax = -Infinity;
-  for (let i = 0; i < AQI_CATEGORY_KEYS.length; i += 1) {
-    const range = ranges[i];
-    const isLast = i === AQI_CATEGORY_KEYS.length - 1;
-    if (!range || range.key !== AQI_CATEGORY_KEYS[i]) return false;
-    if (typeof range.label !== "string" || !range.label.trim()) return false;
-    if (!/^[0-9A-Fa-f]{6}$/.test(range.color || "")) return false;
-
-    if (isLast) {
-      if (range.max_value !== null) return false;
-    } else {
-      if (typeof range.max_value !== "number" || !(range.max_value > prevMax)) {
-        return false;
-      }
-      prevMax = range.max_value;
-    }
-  }
-  return true;
+  return validateAqiRangesArray(value.ranges, { hexHasPrefix: false }) === null;
 }
 
 /**
@@ -303,16 +342,30 @@ function buildResolvedFromCustom(value) {
   const AQI_COLOR_NAMES = {};
   const AQI_CATEGORY_KEYS = [];
 
-  value.ranges.forEach((range) => {
+  // min_value is derived here, not trusted from the stored doc — same
+  // reasoning as buildRangesWithDerivedMin in aqi.controller.js: a doc that
+  // was hand-edited outside the API (isValidAqiRangesShape only checks
+  // max_value/key order/color/label, not min_value) could otherwise leave
+  // AQI_RANGES[key].min undefined in the GET response.
+  let prevMax = 0;
+  value.ranges.forEach((range, index) => {
     AQI_CATEGORY_KEYS.push(range.key);
+    const min = index === 0 ? 0 : prevMax;
     AQI_RANGES[range.key] = {
-      min: range.min_value,
+      min,
       max: range.max_value,
     };
+    if (range.max_value !== null) {
+      prevMax = range.max_value;
+    }
     AQI_CATEGORIES[range.key] = range.label;
     AQI_COLORS[range.key] = range.color;
+    const customColorName =
+      typeof range.color_name === "string" && range.color_name.trim()
+        ? range.color_name.trim()
+        : null;
     AQI_COLOR_NAMES[range.key] =
-      range.color_name || constants.AQI_COLOR_NAMES[range.key] || null;
+      customColorName || constants.AQI_COLOR_NAMES[range.key] || null;
   });
 
   return {
@@ -342,7 +395,19 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
     return cached.value;
   }
 
-  let resolved = { ...constants, source: "default" };
+  // Built explicitly from only the fields the contract needs — matching
+  // buildResolvedFromCustom's shape exactly (not `{...constants, source}`,
+  // which would drag in every unrelated constant and leave a "default"
+  // result structurally different from a "custom" one for anything doing a
+  // deep comparison).
+  let resolved = {
+    AQI_RANGES: constants.AQI_RANGES,
+    AQI_CATEGORIES: constants.AQI_CATEGORIES,
+    AQI_COLORS: constants.AQI_COLORS,
+    AQI_COLOR_NAMES: constants.AQI_COLOR_NAMES,
+    AQI_CATEGORY_KEYS: constants.AQI_CATEGORY_KEYS,
+    source: "default",
+  };
   try {
     const doc = await SystemConfigModel(tenant)
       .findOne({ key: AQI_RANGES_CONFIG_KEY })
@@ -373,6 +438,14 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
  * Invalidate the cached resolved config for a tenant — call after a
  * successful PUT/DELETE write so the writing pod reflects the change
  * immediately rather than waiting out the TTL.
+ *
+ * Only clears THIS pod's cache. Other replicas keep serving whatever they
+ * last cached for up to AQI_RANGES_CACHE_TTL_MS — there's no cross-pod
+ * invalidation today (see the PR description for the accepted tradeoff). If
+ * atomic cross-replica updates ever become necessary, options include a
+ * pub/sub invalidation broadcast or moving the version check into
+ * SystemConfig itself (e.g. compare `version` on every read) rather than
+ * time-based expiry.
  */
 function invalidateAqiRangesCache(tenant = "airqo") {
   _aqiRangesCache.delete(tenant);
@@ -383,6 +456,7 @@ module.exports = {
   getAqiIndexMongoExpression,
   categoryFromConcentration,
   listRanges,
+  validateAqiRangesArray,
   isValidAqiRangesShape,
   resolveActiveAqiRanges,
   invalidateAqiRangesCache,

--- a/src/device-registry/utils/aqi.util.js
+++ b/src/device-registry/utils/aqi.util.js
@@ -24,6 +24,12 @@
 // Single source of truth for PM2.5 AQI breakpoints
 const constants = require("@config/constants");
 const { PM25_AQI_BREAKPOINTS } = constants;
+const SystemConfigModel = require("@models/SystemConfig");
+const log4js = require("log4js");
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- aqi-util`);
+
+const AQI_RANGES_CONFIG_KEY = "aqi_ranges";
+const AQI_RANGES_CACHE_TTL_MS = 60 * 1000; // rare writes, but staleness is user-visible in a public legend
 
 // Fail fast at module load time if the breakpoint table is misconfigured.
 // This prevents Infinity/NaN slopes from silently propagating into the
@@ -166,9 +172,13 @@ function getAqiIndexMongoExpression(fieldPath = "$pm2_5.value") {
  * ever computed for a single reading's own pm2_5 value.
  *
  * @param {number|null|undefined} concentration - PM2.5 concentration in µg/m³
+ * @param {{AQI_RANGES: object, AQI_CATEGORY_KEYS: string[]}|null} [resolved] -
+ *   optional resolved config (see resolveActiveAqiRanges) to classify against
+ *   instead of the hardcoded defaults. Omit to use constants.AQI_RANGES, same
+ *   as before this parameter existed — fully backward compatible.
  * @returns {string|null} one of AQI_CATEGORY_KEYS, or null if invalid
  */
-function categoryFromConcentration(concentration) {
+function categoryFromConcentration(concentration, resolved = null) {
   if (
     concentration === null ||
     concentration === undefined ||
@@ -179,7 +189,7 @@ function categoryFromConcentration(concentration) {
     return null;
   }
 
-  const { AQI_RANGES, AQI_CATEGORY_KEYS } = constants;
+  const { AQI_RANGES, AQI_CATEGORY_KEYS } = resolved || constants;
 
   // AQI_RANGES boundaries leave thousandths-place gaps between adjacent
   // categories (e.g. good max 9.1, moderate min 9.101) — fine for single
@@ -200,16 +210,30 @@ function categoryFromConcentration(concentration) {
  * Assemble the canonical AQI category ranges (bands, labels, colors) for
  * dynamic frontend rendering — replaces hard-coded AQI legends.
  *
- * @returns {{success: boolean, message: string, data: {standard: string, ranges: Array}}}
+ * @param {{AQI_RANGES, AQI_CATEGORIES, AQI_COLORS, AQI_COLOR_NAMES, AQI_CATEGORY_KEYS, source}|null} [resolved] -
+ *   optional resolved config (see resolveActiveAqiRanges). Omit to use the
+ *   hardcoded defaults, same as before this parameter existed.
+ * @returns {{success: boolean, message: string, data: {standard: string, source: string, ranges: Array}}}
  */
-function listRanges() {
-  const { AQI_RANGES, AQI_CATEGORIES, AQI_COLORS, AQI_COLOR_NAMES, AQI_CATEGORY_KEYS } = constants;
+function listRanges(resolved = null) {
+  const {
+    AQI_RANGES,
+    AQI_CATEGORIES,
+    AQI_COLORS,
+    AQI_COLOR_NAMES,
+    AQI_CATEGORY_KEYS,
+  } = resolved || constants;
+  const source = resolved ? resolved.source : "default";
 
   const ranges = AQI_CATEGORY_KEYS.map((key, index) => ({
     key,
     label: AQI_CATEGORIES[key],
     min_value: AQI_RANGES[key].min,
     max_value: AQI_RANGES[key].max,
+    // AQI_COLORS stores hex without a leading # internally — a resolved
+    // custom config's colors are already normalized to that same bare-hex
+    // form by resolveActiveAqiRanges, so this prefix is always applied
+    // exactly once regardless of source.
     color: `#${AQI_COLORS[key]}`,
     color_name: AQI_COLOR_NAMES[key],
     display_order: index + 1,
@@ -220,9 +244,138 @@ function listRanges() {
     message: "Successfully retrieved AQI ranges",
     data: {
       standard: "US EPA PM2.5 AQI (2024 NAAQS revision)",
+      source,
       ranges,
     },
   };
+}
+
+/**
+ * Validate that a stored/candidate AQI ranges value has the exact shape
+ * categoryFromConcentration/listRanges require: all AQI_CATEGORY_KEYS present
+ * in order, max_value strictly increasing with the last one null, colors
+ * valid 6-hex-digit codes. Used both to defensively re-check a doc that may
+ * have been hand-edited outside the API, and to validate a PUT body.
+ *
+ * @returns {boolean}
+ */
+function isValidAqiRangesShape(value) {
+  if (!value || typeof value !== "object") return false;
+  const { AQI_CATEGORY_KEYS } = constants;
+  const ranges = value.ranges;
+  if (!Array.isArray(ranges) || ranges.length !== AQI_CATEGORY_KEYS.length) {
+    return false;
+  }
+
+  let prevMax = -Infinity;
+  for (let i = 0; i < AQI_CATEGORY_KEYS.length; i += 1) {
+    const range = ranges[i];
+    const isLast = i === AQI_CATEGORY_KEYS.length - 1;
+    if (!range || range.key !== AQI_CATEGORY_KEYS[i]) return false;
+    if (typeof range.label !== "string" || !range.label.trim()) return false;
+    if (!/^[0-9A-Fa-f]{6}$/.test(range.color || "")) return false;
+
+    if (isLast) {
+      if (range.max_value !== null) return false;
+    } else {
+      if (typeof range.max_value !== "number" || !(range.max_value > prevMax)) {
+        return false;
+      }
+      prevMax = range.max_value;
+    }
+  }
+  return true;
+}
+
+/**
+ * Build a resolved-config object (same shape categoryFromConcentration and
+ * listRanges expect) from a validated stored `{ranges: [...]}` value. Always
+ * constructs fresh objects — never mutates constants.AQI_RANGES, which is a
+ * plain object shared by reference across the whole process, including
+ * reading-ingestion classification (models/Event.js's generateAqiAddFields)
+ * and health-tip validation that intentionally still use the hardcoded
+ * defaults regardless of any admin override (see docs for why).
+ */
+function buildResolvedFromCustom(value) {
+  const AQI_RANGES = {};
+  const AQI_CATEGORIES = {};
+  const AQI_COLORS = {};
+  const AQI_COLOR_NAMES = {};
+  const AQI_CATEGORY_KEYS = [];
+
+  value.ranges.forEach((range) => {
+    AQI_CATEGORY_KEYS.push(range.key);
+    AQI_RANGES[range.key] = {
+      min: range.min_value,
+      max: range.max_value,
+    };
+    AQI_CATEGORIES[range.key] = range.label;
+    AQI_COLORS[range.key] = range.color;
+    AQI_COLOR_NAMES[range.key] =
+      range.color_name || constants.AQI_COLOR_NAMES[range.key] || null;
+  });
+
+  return {
+    AQI_RANGES,
+    AQI_CATEGORIES,
+    AQI_COLORS,
+    AQI_COLOR_NAMES,
+    AQI_CATEGORY_KEYS,
+    source: "custom",
+  };
+}
+
+// Pod-local in-memory cache — see docs/NEXUS_AIR_QUALITY_API_GUIDE.md and the
+// PR description for the accepted staleness tradeoff (up to
+// AQI_RANGES_CACHE_TTL_MS across other replicas after a write).
+const _aqiRangesCache = new Map(); // tenant -> { value, expiresAt }
+
+/**
+ * Resolve the currently-active AQI ranges config for a tenant: a cached or
+ * freshly-queried admin-set override if one exists and is valid, otherwise
+ * the hardcoded defaults. Call once per request/job-run and pass the result
+ * into categoryFromConcentration/listRanges — those stay synchronous.
+ */
+async function resolveActiveAqiRanges(tenant = "airqo") {
+  const cached = _aqiRangesCache.get(tenant);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  let resolved = { ...constants, source: "default" };
+  try {
+    const doc = await SystemConfigModel(tenant)
+      .findOne({ key: AQI_RANGES_CONFIG_KEY })
+      .lean();
+    if (doc) {
+      if (isValidAqiRangesShape(doc.value)) {
+        resolved = buildResolvedFromCustom(doc.value);
+      } else {
+        logger.error(
+          `🐛🐛 malformed ${AQI_RANGES_CONFIG_KEY} SystemConfig doc for tenant ${tenant} — falling back to defaults`
+        );
+      }
+    }
+  } catch (error) {
+    logger.error(
+      `🐛🐛 resolveActiveAqiRanges -- ${error.message} -- falling back to defaults`
+    );
+  }
+
+  _aqiRangesCache.set(tenant, {
+    value: resolved,
+    expiresAt: Date.now() + AQI_RANGES_CACHE_TTL_MS,
+  });
+  return resolved;
+}
+
+/**
+ * Invalidate the cached resolved config for a tenant — call after a
+ * successful PUT/DELETE write so the writing pod reflects the change
+ * immediately rather than waiting out the TTL.
+ */
+function invalidateAqiRangesCache(tenant = "airqo") {
+  _aqiRangesCache.delete(tenant);
 }
 
 module.exports = {
@@ -230,4 +383,8 @@ module.exports = {
   getAqiIndexMongoExpression,
   categoryFromConcentration,
   listRanges,
+  isValidAqiRangesShape,
+  resolveActiveAqiRanges,
+  invalidateAqiRangesCache,
+  AQI_RANGES_CONFIG_KEY,
 };

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -1801,6 +1801,12 @@ const createEvent = {
           maxTimeMS: constants.READINGS_AGGREGATE_TIMEOUT_MS,
         });
 
+      // Resolved once per request (not per row) so an admin-set custom AQI
+      // config (see utils/aqi.util.js's resolveActiveAqiRanges) is reflected
+      // here identically to what GET /aqi-ranges returns — the legend and
+      // these derived categories must never disagree.
+      const resolvedAqiRanges = await aqiUtil.resolveActiveAqiRanges(tenant);
+
       const generatedAt = new Date().toISOString();
       const data = rows.map((row, index) => {
         // Round once and derive both AQI fields from the same rounded value
@@ -1816,7 +1822,7 @@ const createEvent = {
             level === "country" ? constants.countryCodes[row._id] || null : null,
           avg_pm2_5: avgPm25,
           aqi_index: aqiUtil.calculatePm25Aqi(avgPm25),
-          aqi_category: aqiUtil.categoryFromConcentration(avgPm25),
+          aqi_category: aqiUtil.categoryFromConcentration(avgPm25, resolvedAqiRanges),
           site_count: row.site_count,
           generated_at: generatedAt,
         };
@@ -1878,6 +1884,10 @@ const createEvent = {
           site_count: (doc.contributing_sites || []).length,
         }));
 
+      // Resolved once per request, same reasoning as getAirQualityRankings —
+      // must never disagree with GET /aqi-ranges or the current rankings.
+      const resolvedAqiRanges = await aqiUtil.resolveActiveAqiRanges(tenant);
+
       const years = [];
       for (let y = startYear; y <= endYear; y += 1) years.push(y);
 
@@ -1903,7 +1913,7 @@ const createEvent = {
               year,
               avg_pm2_5: row ? row.avg_pm2_5 : null,
               aqi_category: row
-                ? aqiUtil.categoryFromConcentration(row.avg_pm2_5)
+                ? aqiUtil.categoryFromConcentration(row.avg_pm2_5, resolvedAqiRanges)
                 : null,
               site_count: row ? row.site_count : 0,
             };

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -1821,7 +1821,16 @@ const createEvent = {
           country_code:
             level === "country" ? constants.countryCodes[row._id] || null : null,
           avg_pm2_5: avgPm25,
-          aqi_index: aqiUtil.calculatePm25Aqi(avgPm25),
+          // aqi_index always comes from the fixed EPA numeric breakpoints
+          // (calculatePm25Aqi is not admin-configurable) — pairing it with a
+          // category derived from a *custom* range would show a number and
+          // a label that don't actually agree with each other, since a
+          // custom config has no guaranteed relationship to the EPA scale.
+          // Only emit it alongside the default, EPA-aligned ranges.
+          aqi_index:
+            resolvedAqiRanges.source === "custom"
+              ? null
+              : aqiUtil.calculatePm25Aqi(avgPm25),
           aqi_category: aqiUtil.categoryFromConcentration(avgPm25, resolvedAqiRanges),
           site_count: row.site_count,
           generated_at: generatedAt,

--- a/src/device-registry/utils/test/ut_aqi.util.js
+++ b/src/device-registry/utils/test/ut_aqi.util.js
@@ -535,8 +535,15 @@ describe("resolveActiveAqiRanges / invalidateAqiRangesCache", function() {
 
   beforeEach(function() {
     findOneStub = sinon.stub();
+    // @noCallThru: proxyquire otherwise falls back to the real module for
+    // anything this stub doesn't provide — irrelevant in practice since the
+    // stub is a full function replacement, not a partial object override,
+    // but explicit here so this test can never accidentally reach the real,
+    // unconnected SystemConfig model.
+    const systemConfigStub = () => ({ findOne: findOneStub });
+    systemConfigStub["@noCallThru"] = true;
     proxiedAqiUtil = proxyquire("../aqi.util", {
-      "@models/SystemConfig": () => ({ findOne: findOneStub }),
+      "@models/SystemConfig": systemConfigStub,
     });
   });
 
@@ -574,6 +581,83 @@ describe("resolveActiveAqiRanges / invalidateAqiRangesCache", function() {
     expect(resolved.source).to.equal("custom");
     expect(resolved.AQI_CATEGORIES.good).to.equal("Custom good");
     expect(resolved.AQI_COLORS.good).to.equal("ABCDEF");
+  });
+
+  it("derives min_value from the previous category's max_value rather than trusting a stored min_value", async function() {
+    // isValidAqiRangesShape doesn't check min_value at all, so a doc that was
+    // hand-edited outside the API (bypassing the controller's own derivation)
+    // could carry a bogus/missing min_value. The resolved config must never
+    // surface it as-is.
+    const storedValue = {
+      ranges: constants.AQI_CATEGORY_KEYS.map((key, i, arr) => ({
+        key,
+        label: "Custom " + key,
+        min_value: 99999, // deliberately wrong on every entry
+        max_value: i === arr.length - 1 ? null : (i + 1) * 10,
+        color: "ABCDEF",
+      })),
+    };
+    findOneStub.returns(mockFindOneChain({ value: storedValue }));
+
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    const keys = constants.AQI_CATEGORY_KEYS;
+    expect(resolved.AQI_RANGES[keys[0]].min).to.equal(0);
+    expect(resolved.AQI_RANGES[keys[1]].min).to.equal(resolved.AQI_RANGES[keys[0]].max);
+    expect(resolved.AQI_RANGES[keys[2]].min).to.equal(resolved.AQI_RANGES[keys[1]].max);
+  });
+
+  it("falls back to the default color_name when the stored one is not a string", async function() {
+    const storedValue = {
+      ranges: constants.AQI_CATEGORY_KEYS.map((key, i, arr) => ({
+        key,
+        label: "Custom " + key,
+        min_value: 0,
+        max_value: i === arr.length - 1 ? null : (i + 1) * 10,
+        color: "ABCDEF",
+        color_name: { not: "a string" },
+      })),
+    };
+    findOneStub.returns(mockFindOneChain({ value: storedValue }));
+
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    const goodKey = constants.AQI_CATEGORY_KEYS[0];
+    expect(resolved.AQI_COLOR_NAMES[goodKey]).to.equal(constants.AQI_COLOR_NAMES[goodKey]);
+  });
+
+  it("falls back to the default color_name when the stored one is an empty/whitespace string", async function() {
+    const storedValue = {
+      ranges: constants.AQI_CATEGORY_KEYS.map((key, i, arr) => ({
+        key,
+        label: "Custom " + key,
+        min_value: 0,
+        max_value: i === arr.length - 1 ? null : (i + 1) * 10,
+        color: "ABCDEF",
+        color_name: "   ",
+      })),
+    };
+    findOneStub.returns(mockFindOneChain({ value: storedValue }));
+
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    const goodKey = constants.AQI_CATEGORY_KEYS[0];
+    expect(resolved.AQI_COLOR_NAMES[goodKey]).to.equal(constants.AQI_COLOR_NAMES[goodKey]);
+  });
+
+  it("uses a valid stored color_name, trimmed", async function() {
+    const storedValue = {
+      ranges: constants.AQI_CATEGORY_KEYS.map((key, i, arr) => ({
+        key,
+        label: "Custom " + key,
+        min_value: 0,
+        max_value: i === arr.length - 1 ? null : (i + 1) * 10,
+        color: "ABCDEF",
+        color_name: "  Emerald  ",
+      })),
+    };
+    findOneStub.returns(mockFindOneChain({ value: storedValue }));
+
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    const goodKey = constants.AQI_CATEGORY_KEYS[0];
+    expect(resolved.AQI_COLOR_NAMES[goodKey]).to.equal("Emerald");
   });
 
   it("falls back to defaults when the stored document is malformed", async function() {

--- a/src/device-registry/utils/test/ut_aqi.util.js
+++ b/src/device-registry/utils/test/ut_aqi.util.js
@@ -2,6 +2,8 @@ require("module-alias/register");
 process.env.NODE_ENV = "development";
 
 const { expect } = require("chai");
+const sinon = require("sinon");
+const proxyquire = require("proxyquire");
 const constants = require("@config/constants");
 const { PM25_AQI_BREAKPOINTS } = constants;
 const {
@@ -9,6 +11,7 @@ const {
   getAqiIndexMongoExpression,
   categoryFromConcentration,
   listRanges,
+  isValidAqiRangesShape,
 } = require("@utils/aqi.util");
 
 // ---------------------------------------------------------------------------
@@ -383,5 +386,227 @@ describe("listRanges", function() {
     const hazardous = result.data.ranges[result.data.ranges.length - 1];
     expect(hazardous.key).to.equal("hazardous");
     expect(hazardous.max_value).to.equal(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// categoryFromConcentration / listRanges — with an injected "resolved"
+// override (the shape resolveActiveAqiRanges produces from a custom
+// SystemConfig doc), proving the admin-editable path actually changes output
+// and never falls back to the hardcoded defaults when an override is given.
+// ---------------------------------------------------------------------------
+describe("categoryFromConcentration / listRanges with a resolved override", function() {
+  const customResolved = {
+    AQI_RANGES: {
+      good: { min: 0, max: 5 },
+      moderate: { min: 5, max: 20 },
+      u4sg: { min: 20, max: 40 },
+      unhealthy: { min: 40, max: 80 },
+      very_unhealthy: { min: 80, max: 150 },
+      hazardous: { min: 150, max: null },
+    },
+    AQI_CATEGORIES: {
+      good: "Great",
+      moderate: "OK",
+      u4sg: "Caution",
+      unhealthy: "Bad",
+      very_unhealthy: "Very Bad",
+      hazardous: "Severe",
+    },
+    AQI_COLORS: {
+      good: "00FF00",
+      moderate: "FFFF00",
+      u4sg: "FFA500",
+      unhealthy: "FF0000",
+      very_unhealthy: "800080",
+      hazardous: "000000",
+    },
+    AQI_COLOR_NAMES: {
+      good: "Green",
+      moderate: "Yellow",
+      u4sg: "Orange",
+      unhealthy: "Red",
+      very_unhealthy: "Purple",
+      hazardous: "Black",
+    },
+    AQI_CATEGORY_KEYS: [
+      "good",
+      "moderate",
+      "u4sg",
+      "unhealthy",
+      "very_unhealthy",
+      "hazardous",
+    ],
+    source: "custom",
+  };
+
+  it("categoryFromConcentration classifies against the override, not the defaults", function() {
+    // 6 would be "moderate" under this override (good's max is 5) but is
+    // still well within default "good" (max 9.1) — proves the override wins.
+    expect(categoryFromConcentration(6, customResolved)).to.equal("moderate");
+    expect(categoryFromConcentration(6)).to.equal("good");
+  });
+
+  it("categoryFromConcentration with no override still uses the hardcoded defaults (backward compatible)", function() {
+    expect(categoryFromConcentration(20)).to.equal("moderate");
+  });
+
+  it("listRanges reflects the override's labels, colors, and source: custom", function() {
+    const result = listRanges(customResolved);
+    expect(result.data.source).to.equal("custom");
+    const good = result.data.ranges[0];
+    expect(good.label).to.equal("Great");
+    expect(good.max_value).to.equal(5);
+    expect(good.color).to.equal("#00FF00");
+  });
+
+  it("listRanges with no override reports source: default", function() {
+    const result = listRanges();
+    expect(result.data.source).to.equal("default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidAqiRangesShape — defensive re-validation of a stored/candidate value
+// ---------------------------------------------------------------------------
+describe("isValidAqiRangesShape", function() {
+  const validRanges = constants.AQI_CATEGORY_KEYS.map((key, index, arr) => ({
+    key,
+    label: constants.AQI_CATEGORIES[key],
+    max_value: index === arr.length - 1 ? null : (index + 1) * 10,
+    color: "34C759",
+  }));
+
+  it("accepts a well-formed value", function() {
+    expect(isValidAqiRangesShape({ ranges: validRanges })).to.equal(true);
+  });
+
+  it("rejects a missing/non-object value", function() {
+    expect(isValidAqiRangesShape(null)).to.equal(false);
+    expect(isValidAqiRangesShape(undefined)).to.equal(false);
+    expect(isValidAqiRangesShape("not an object")).to.equal(false);
+  });
+
+  it("rejects the wrong number of categories", function() {
+    expect(isValidAqiRangesShape({ ranges: validRanges.slice(0, 5) })).to.equal(false);
+  });
+
+  it("rejects out-of-order keys", function() {
+    const reordered = [...validRanges].reverse();
+    expect(isValidAqiRangesShape({ ranges: reordered })).to.equal(false);
+  });
+
+  it("rejects a non-increasing max_value", function() {
+    const broken = validRanges.map((r, i) => (i === 2 ? { ...r, max_value: 5 } : r));
+    expect(isValidAqiRangesShape({ ranges: broken })).to.equal(false);
+  });
+
+  it("rejects a non-null max_value on the last category", function() {
+    const broken = validRanges.map((r, i, arr) =>
+      i === arr.length - 1 ? { ...r, max_value: 999 } : r
+    );
+    expect(isValidAqiRangesShape({ ranges: broken })).to.equal(false);
+  });
+
+  it("rejects an invalid color", function() {
+    const broken = validRanges.map((r, i) => (i === 0 ? { ...r, color: "notahex" } : r));
+    expect(isValidAqiRangesShape({ ranges: broken })).to.equal(false);
+  });
+
+  it("rejects an empty label", function() {
+    const broken = validRanges.map((r, i) => (i === 0 ? { ...r, label: "  " } : r));
+    expect(isValidAqiRangesShape({ ranges: broken })).to.equal(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveActiveAqiRanges / invalidateAqiRangesCache — proxied so no real
+// Mongoose model is touched. Each test re-proxies aqi.util fresh (proxyquire
+// gives a new module instance, so the in-memory cache never leaks between
+// tests).
+// ---------------------------------------------------------------------------
+describe("resolveActiveAqiRanges / invalidateAqiRangesCache", function() {
+  let findOneStub;
+  let proxiedAqiUtil;
+
+  const mockFindOneChain = (doc) => ({
+    lean: () => Promise.resolve(doc),
+  });
+
+  beforeEach(function() {
+    findOneStub = sinon.stub();
+    proxiedAqiUtil = proxyquire("../aqi.util", {
+      "@models/SystemConfig": () => ({ findOne: findOneStub }),
+    });
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  it("returns the defaults when no override document exists", async function() {
+    findOneStub.returns(mockFindOneChain(null));
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(resolved.source).to.equal("default");
+    expect(resolved.AQI_RANGES).to.deep.equal(constants.AQI_RANGES);
+  });
+
+  it("does not mutate constants.AQI_RANGES when returning the defaults", async function() {
+    const before = JSON.stringify(constants.AQI_RANGES);
+    findOneStub.returns(mockFindOneChain(null));
+    await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(JSON.stringify(constants.AQI_RANGES)).to.equal(before);
+  });
+
+  it("returns a custom config built from a valid stored document", async function() {
+    const storedValue = {
+      ranges: constants.AQI_CATEGORY_KEYS.map((key, i, arr) => ({
+        key,
+        label: "Custom " + key,
+        min_value: i === 0 ? 0 : i * 10,
+        max_value: i === arr.length - 1 ? null : (i + 1) * 10,
+        color: "ABCDEF",
+      })),
+    };
+    findOneStub.returns(mockFindOneChain({ value: storedValue }));
+
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(resolved.source).to.equal("custom");
+    expect(resolved.AQI_CATEGORIES.good).to.equal("Custom good");
+    expect(resolved.AQI_COLORS.good).to.equal("ABCDEF");
+  });
+
+  it("falls back to defaults when the stored document is malformed", async function() {
+    findOneStub.returns(mockFindOneChain({ value: { ranges: [{ key: "not-enough" }] } }));
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(resolved.source).to.equal("default");
+  });
+
+  it("falls back to defaults (does not throw) when the query fails", async function() {
+    findOneStub.returns({ lean: () => Promise.reject(new Error("Mongo error")) });
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(resolved.source).to.equal("default");
+  });
+
+  it("serves from cache on a second call within the TTL — does not re-query", async function() {
+    findOneStub.returns(mockFindOneChain(null));
+    await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(findOneStub.calledOnce).to.equal(true);
+  });
+
+  it("invalidateAqiRangesCache forces a re-query on the next call", async function() {
+    findOneStub.returns(mockFindOneChain(null));
+    await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    proxiedAqiUtil.invalidateAqiRangesCache("airqo");
+    await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(findOneStub.calledTwice).to.equal(true);
+  });
+
+  it("caches per tenant independently", async function() {
+    findOneStub.returns(mockFindOneChain(null));
+    await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    await proxiedAqiUtil.resolveActiveAqiRanges("kcca");
+    expect(findOneStub.calledTwice).to.equal(true);
   });
 });

--- a/src/device-registry/utils/test/ut_event.util.js
+++ b/src/device-registry/utils/test/ut_event.util.js
@@ -3093,6 +3093,12 @@ describe("create Event utils", function() {
       aggregateStub = sinon.stub();
       proxiedEventUtil = proxyquire("../event.util", {
         "@models/Reading": () => ({ aggregate: aggregateStub }),
+        // resolveActiveAqiRanges queries this once per request — resolve null
+        // immediately (no override) so tests don't hit a real, unconnected
+        // Mongoose model and hang on the ~10s buffering timeout.
+        "@models/SystemConfig": () => ({
+          findOne: () => ({ lean: () => Promise.resolve(null) }),
+        }),
       });
       next = sinon.stub();
     });
@@ -3253,6 +3259,12 @@ describe("create Event utils", function() {
       findStub = sinon.stub();
       proxiedEventUtil = proxyquire("../event.util", {
         "@models/AirQualitySummary": () => ({ find: findStub }),
+        // resolveActiveAqiRanges queries this once per request — resolve null
+        // immediately (no override) so tests don't hit a real, unconnected
+        // Mongoose model and hang on the ~10s buffering timeout.
+        "@models/SystemConfig": () => ({
+          findOne: () => ({ lean: () => Promise.resolve(null) }),
+        }),
       });
       next = sinon.stub();
     });

--- a/src/device-registry/utils/test/ut_event.util.js
+++ b/src/device-registry/utils/test/ut_event.util.js
@@ -3155,6 +3155,69 @@ describe("create Event utils", function() {
       expect(result.data[0].aqi_category).to.equal("good");
     });
 
+    it("omits aqi_index when the active config is a custom override — it's always EPA-scale and would disagree with a custom category", async () => {
+      // Stub resolveActiveAqiRanges directly rather than mocking
+      // @models/SystemConfig again here: proxyquire caches nested modules
+      // (aqi.util.js) across separate proxyquire() calls in the same file,
+      // so a second call with a different @models/SystemConfig stub doesn't
+      // reliably get a fresh aqi.util.js instance. Stubbing the function
+      // this test actually cares about, with call-through left on for
+      // everything else (categoryFromConcentration/calculatePm25Aqi stay
+      // real), avoids that ambiguity entirely.
+      const customResolved = {
+        source: "custom",
+        AQI_RANGES: {
+          good: { min: 0, max: 5 },
+          moderate: { min: 5, max: 20 },
+          u4sg: { min: 20, max: 40 },
+          unhealthy: { min: 40, max: 80 },
+          very_unhealthy: { min: 80, max: 150 },
+          hazardous: { min: 150, max: null },
+        },
+        AQI_CATEGORY_KEYS: [
+          "good",
+          "moderate",
+          "u4sg",
+          "unhealthy",
+          "very_unhealthy",
+          "hazardous",
+        ],
+      };
+      const customProxiedEventUtil = proxyquire("../event.util", {
+        "@models/Reading": () => ({ aggregate: aggregateStub }),
+        "@utils/aqi.util": {
+          resolveActiveAqiRanges: async () => customResolved,
+        },
+      });
+      aggregateStub.returns(
+        mockAggregateChain([{ _id: "Kenya", avg_pm2_5: 6, site_count: 1 }])
+      );
+
+      const result = await customProxiedEventUtil.getAirQualityRankings(
+        { query: {} },
+        next
+      );
+
+      expect(result.data[0].aqi_category).to.equal("moderate"); // custom good.max=5
+      expect(result.data[0].aqi_index).to.equal(null);
+    });
+
+    it("still returns aqi_index when the active config is the default (EPA-aligned)", async () => {
+      // Uses the standard proxiedEventUtil from beforeEach — its
+      // @models/SystemConfig mock resolves null, so resolveActiveAqiRanges
+      // correctly produces the real "default" source end-to-end.
+      aggregateStub.returns(
+        mockAggregateChain([{ _id: "Kenya", avg_pm2_5: 20, site_count: 1 }])
+      );
+
+      const result = await proxiedEventUtil.getAirQualityRankings(
+        { query: {} },
+        next
+      );
+
+      expect(result.data[0].aqi_index).to.be.a("number");
+    });
+
     it("groups by city and leaves country_code null when level=city", async () => {
       aggregateStub.returns(
         mockAggregateChain([

--- a/src/device-registry/validators/aqi.validators.js
+++ b/src/device-registry/validators/aqi.validators.js
@@ -1,7 +1,10 @@
 // aqi.validators.js
-const { query } = require("express-validator");
+const { query, body } = require("express-validator");
 const constants = require("@config/constants");
 const { validate } = require("@validators/common");
+const { HttpError } = require("@utils/shared");
+const httpStatus = require("http-status");
+const crypto = require("crypto");
 
 const listRanges = [
   query("tenant")
@@ -16,6 +19,126 @@ const listRanges = [
   validate,
 ];
 
+// Copied locally rather than centralized — matches the existing convention
+// for this exact check (see validators/cohorts.validators.js,
+// utils/network.util.js, validators/network-creation-request.validators.js).
+// device-registry has no per-user auth; this shared-secret gate is the
+// established stand-in for admin-only write access.
+const requireAdminSecret = (req, res, next) => {
+  if (!constants.ADMIN_SETUP_SECRET) {
+    return next(
+      new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+        message: "Admin secret not configured on server",
+      })
+    );
+  }
+  const provided = Buffer.from(
+    req.body.admin_secret || req.query.admin_secret || ""
+  );
+  const expected = Buffer.from(constants.ADMIN_SETUP_SECRET);
+  if (
+    provided.length !== expected.length ||
+    !crypto.timingSafeEqual(provided, expected)
+  ) {
+    return next(
+      new HttpError("Forbidden", httpStatus.FORBIDDEN, {
+        message: "Invalid admin secret",
+      })
+    );
+  }
+  next();
+};
+
+const updateRanges = [
+  query("tenant")
+    .optional()
+    .notEmpty()
+    .bail()
+    .trim()
+    .toLowerCase()
+    .isIn(constants.TENANTS)
+    .withMessage("the tenant value is not among the expected ones"),
+  body("admin_secret")
+    .exists()
+    .withMessage("admin_secret is required")
+    .bail()
+    .isString()
+    .withMessage("admin_secret must be a string")
+    .bail()
+    .notEmpty()
+    .withMessage("admin_secret must not be empty"),
+  body("ranges")
+    .exists()
+    .withMessage("ranges is required")
+    .bail()
+    .isArray({ min: 6, max: 6 })
+    .withMessage("ranges must contain exactly 6 categories"),
+  // min_value is deliberately not accepted here — categoryFromConcentration
+  // classifies by upper bound only, so min_value is purely cosmetic in the
+  // GET response and is derived server-side from the previous category's
+  // max_value rather than doubling the validation surface for it.
+  body("ranges").custom((ranges) => {
+    const { AQI_CATEGORY_KEYS } = constants;
+    if (!Array.isArray(ranges)) {
+      throw new Error("ranges must be an array");
+    }
+    const keys = ranges.map((range) => range && range.key);
+    if (keys.join(",") !== AQI_CATEGORY_KEYS.join(",")) {
+      throw new Error(
+        `ranges must contain exactly these keys in order: ${AQI_CATEGORY_KEYS.join(", ")}`
+      );
+    }
+
+    let prevMax = -Infinity;
+    ranges.forEach((range, index) => {
+      const isLast = index === ranges.length - 1;
+      if (isLast) {
+        if (range.max_value !== null) {
+          throw new Error(`${range.key}.max_value must be null (unbounded)`);
+        }
+      } else {
+        if (typeof range.max_value !== "number" || !(range.max_value > prevMax)) {
+          throw new Error(
+            `${range.key}.max_value must be a number strictly greater than the previous category's max_value`
+          );
+        }
+        prevMax = range.max_value;
+      }
+
+      if (!/^#[0-9A-Fa-f]{6}$/.test(range.color || "")) {
+        throw new Error(
+          `${range.key}.color must be a 6-hex-digit code, e.g. #34C759`
+        );
+      }
+      if (typeof range.label !== "string" || !range.label.trim()) {
+        throw new Error(`${range.key}.label must be a non-empty string`);
+      }
+    });
+    return true;
+  }),
+  body("updated_by")
+    .optional()
+    .isString()
+    .withMessage("updated_by must be a string"),
+  validate,
+  requireAdminSecret,
+];
+
+const deleteRanges = [
+  query("tenant")
+    .optional()
+    .notEmpty()
+    .bail()
+    .trim()
+    .toLowerCase()
+    .isIn(constants.TENANTS)
+    .withMessage("the tenant value is not among the expected ones"),
+  validate,
+  requireAdminSecret,
+];
+
 module.exports = {
   listRanges,
+  updateRanges,
+  deleteRanges,
 };

--- a/src/device-registry/validators/aqi.validators.js
+++ b/src/device-registry/validators/aqi.validators.js
@@ -5,6 +5,7 @@ const { validate } = require("@validators/common");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
 const crypto = require("crypto");
+const aqiUtil = require("@utils/aqi.util");
 
 const listRanges = [
   query("tenant")
@@ -23,7 +24,10 @@ const listRanges = [
 // for this exact check (see validators/cohorts.validators.js,
 // utils/network.util.js, validators/network-creation-request.validators.js).
 // device-registry has no per-user auth; this shared-secret gate is the
-// established stand-in for admin-only write access.
+// established stand-in for admin-only write access. Kept consistent with
+// those other copies by still accepting the secret via body OR query — not
+// narrowed to body-only here, since that would diverge from every other use
+// of this exact pattern elsewhere in the codebase.
 const requireAdminSecret = (req, res, next) => {
   if (!constants.ADMIN_SETUP_SECRET) {
     return next(
@@ -32,9 +36,13 @@ const requireAdminSecret = (req, res, next) => {
       })
     );
   }
-  const provided = Buffer.from(
-    req.body.admin_secret || req.query.admin_secret || ""
-  );
+  // Coerced to a string before Buffer.from — a non-string admin_secret (a
+  // number, boolean, or plain object from a malformed JSON body) would
+  // otherwise make Buffer.from throw a TypeError that nothing here catches,
+  // turning a routine "wrong secret" case into an unhandled 500 instead of
+  // the intended 403.
+  const rawSecret = req.body.admin_secret || req.query.admin_secret || "";
+  const provided = Buffer.from(String(rawSecret));
   const expected = Buffer.from(constants.ADMIN_SETUP_SECRET);
   if (
     provided.length !== expected.length ||
@@ -78,50 +86,22 @@ const updateRanges = [
   // GET response and is derived server-side from the previous category's
   // max_value rather than doubling the validation surface for it.
   body("ranges").custom((ranges) => {
-    const { AQI_CATEGORY_KEYS } = constants;
-    if (!Array.isArray(ranges)) {
-      throw new Error("ranges must be an array");
+    const error = aqiUtil.validateAqiRangesArray(ranges, { hexHasPrefix: true });
+    if (error) {
+      throw new Error(error);
     }
-    const keys = ranges.map((range) => range && range.key);
-    if (keys.join(",") !== AQI_CATEGORY_KEYS.join(",")) {
-      throw new Error(
-        `ranges must contain exactly these keys in order: ${AQI_CATEGORY_KEYS.join(", ")}`
-      );
-    }
-
-    let prevMax = -Infinity;
-    ranges.forEach((range, index) => {
-      const isLast = index === ranges.length - 1;
-      if (isLast) {
-        if (range.max_value !== null) {
-          throw new Error(`${range.key}.max_value must be null (unbounded)`);
-        }
-      } else {
-        if (typeof range.max_value !== "number" || !(range.max_value > prevMax)) {
-          throw new Error(
-            `${range.key}.max_value must be a number strictly greater than the previous category's max_value`
-          );
-        }
-        prevMax = range.max_value;
-      }
-
-      if (!/^#[0-9A-Fa-f]{6}$/.test(range.color || "")) {
-        throw new Error(
-          `${range.key}.color must be a 6-hex-digit code, e.g. #34C759`
-        );
-      }
-      if (typeof range.label !== "string" || !range.label.trim()) {
-        throw new Error(`${range.key}.label must be a non-empty string`);
-      }
-    });
     return true;
   }),
   body("updated_by")
     .optional()
     .isString()
     .withMessage("updated_by must be a string"),
-  validate,
+  // Runs before field validation so an unauthenticated/wrong-secret caller
+  // gets a terse 403 rather than the detailed per-field error messages from
+  // the "ranges" validator above (which would otherwise leak the shape of
+  // the validation schema to someone who never proved they're an admin).
   requireAdminSecret,
+  validate,
 ];
 
 const deleteRanges = [
@@ -133,8 +113,16 @@ const deleteRanges = [
     .toLowerCase()
     .isIn(constants.TENANTS)
     .withMessage("the tenant value is not among the expected ones"),
-  validate,
+  // Optional/type-only check — requireAdminSecret (which also accepts the
+  // secret via query, see its own comment) is the actual gate; this just
+  // rejects an obviously-wrong body shape early with a clear message when a
+  // body is provided at all.
+  body("admin_secret")
+    .optional()
+    .isString()
+    .withMessage("admin_secret must be a string"),
   requireAdminSecret,
+  validate,
 ];
 
 module.exports = {

--- a/src/device-registry/validators/test/ut_aqi.validators.js
+++ b/src/device-registry/validators/test/ut_aqi.validators.js
@@ -73,16 +73,30 @@ describe("aqiValidations.updateRanges / deleteRanges", () => {
       expect(err).to.be.undefined;
     });
 
-    it("rejects a missing admin_secret with 400 (caught by field validation, before the secret check)", async () => {
+    it("rejects a missing admin_secret with 403 (auth runs before field validation, so no schema details leak to unauthenticated callers)", async () => {
       const req = mockRequest({ ranges: validRanges() });
       const err = await runChain(aqiValidations.updateRanges, req);
-      expect(err.statusCode).to.equal(400);
+      expect(err.statusCode).to.equal(403);
     });
 
     it("rejects a wrong admin_secret with 403", async () => {
       const req = mockRequest({ ranges: validRanges(), admin_secret: "wrong-secret" });
       const err = await runChain(aqiValidations.updateRanges, req);
       expect(err.statusCode).to.equal(403);
+    });
+
+    it("rejects a non-string admin_secret (e.g. a number) with 403 rather than crashing on Buffer.from", async () => {
+      const req = mockRequest({ ranges: validRanges(), admin_secret: 123456 });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(403);
+    });
+
+    it("still rejects a malformed ranges body with 400 once authenticated", async () => {
+      const ranges = validRanges();
+      ranges[0].label = "   "; // empty after trim
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
     });
 
     it("rejects the wrong number of categories", async () => {
@@ -150,6 +164,30 @@ describe("aqiValidations.updateRanges / deleteRanges", () => {
       expect(err).to.be.undefined;
     });
 
+    it("accepts a well-formed color_name when provided", async () => {
+      const ranges = validRanges();
+      ranges[0].color_name = "Emerald";
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err).to.be.undefined;
+    });
+
+    it("rejects a non-string color_name", async () => {
+      const ranges = validRanges();
+      ranges[0].color_name = { not: "a string" };
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("rejects an empty/whitespace color_name", async () => {
+      const ranges = validRanges();
+      ranges[0].color_name = "   ";
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
     it("deleteRanges accepts the correct admin_secret via query", async () => {
       const req = mockRequest({}, { admin_secret: TEST_SECRET });
       const err = await runChain(aqiValidations.deleteRanges, req);
@@ -160,6 +198,18 @@ describe("aqiValidations.updateRanges / deleteRanges", () => {
       const req = mockRequest({}, { admin_secret: "wrong" });
       const err = await runChain(aqiValidations.deleteRanges, req);
       expect(err.statusCode).to.equal(403);
+    });
+
+    it("deleteRanges rejects a non-string admin_secret (e.g. a number) with 403 rather than crashing on Buffer.from", async () => {
+      const req = mockRequest({}, { admin_secret: 123456 });
+      const err = await runChain(aqiValidations.deleteRanges, req);
+      expect(err.statusCode).to.equal(403);
+    });
+
+    it("deleteRanges accepts the correct admin_secret via body too", async () => {
+      const req = mockRequest({ admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.deleteRanges, req);
+      expect(err).to.be.undefined;
     });
   });
 });

--- a/src/device-registry/validators/test/ut_aqi.validators.js
+++ b/src/device-registry/validators/test/ut_aqi.validators.js
@@ -1,0 +1,165 @@
+require("module-alias/register");
+process.env.NODE_ENV = "development";
+const { expect } = require("chai");
+
+const constants = require("@config/constants");
+const aqiValidations = require("@validators/aqi.validators");
+
+const mockRequest = (body = {}, query = {}) => ({ body, query, params: {} });
+
+// Runs an array-style validator chain (as used directly as Express route
+// middleware, e.g. router.put("/", aqiValidations.updateRanges, ...)) and
+// resolves with whatever the final next() call received: undefined if every
+// middleware passed, or the HttpError instance passed by validate/requireAdminSecret
+// on the first failure.
+const runChain = (chain, req) =>
+  new Promise((resolve) => {
+    const res = {};
+    let index = 0;
+    const runNext = (err) => {
+      if (err || index >= chain.length) {
+        resolve(err);
+        return;
+      }
+      const middleware = chain[index++];
+      Promise.resolve(middleware(req, res, runNext)).catch(runNext);
+    };
+    runNext();
+  });
+
+const TEST_SECRET = "test-admin-secret-value";
+
+const validRanges = () =>
+  constants.AQI_CATEGORY_KEYS.map((key, i, arr) => ({
+    key,
+    label: "Custom " + key,
+    max_value: i === arr.length - 1 ? null : (i + 1) * 10,
+    color: "#ABCDEF",
+  }));
+
+describe("aqiValidations.updateRanges / deleteRanges", () => {
+  let originalSecret;
+
+  beforeEach(() => {
+    originalSecret = constants.ADMIN_SETUP_SECRET;
+  });
+
+  afterEach(() => {
+    constants.ADMIN_SETUP_SECRET = originalSecret;
+  });
+
+  describe("when ADMIN_SETUP_SECRET is not configured on the server", () => {
+    beforeEach(() => {
+      constants.ADMIN_SETUP_SECRET = "";
+    });
+
+    it("rejects with 500, distinct from a wrong-secret 403", async () => {
+      const req = mockRequest({ ranges: validRanges(), admin_secret: "anything" });
+      const err = await runChain(aqiValidations.updateRanges, req);
+
+      expect(err).to.exist;
+      expect(err.statusCode).to.equal(500);
+    });
+  });
+
+  describe("with ADMIN_SETUP_SECRET configured", () => {
+    beforeEach(() => {
+      constants.ADMIN_SETUP_SECRET = TEST_SECRET;
+    });
+
+    it("accepts a well-formed body with the correct admin_secret", async () => {
+      const req = mockRequest({ ranges: validRanges(), admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err).to.be.undefined;
+    });
+
+    it("rejects a missing admin_secret with 400 (caught by field validation, before the secret check)", async () => {
+      const req = mockRequest({ ranges: validRanges() });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("rejects a wrong admin_secret with 403", async () => {
+      const req = mockRequest({ ranges: validRanges(), admin_secret: "wrong-secret" });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(403);
+    });
+
+    it("rejects the wrong number of categories", async () => {
+      const req = mockRequest({
+        ranges: validRanges().slice(0, 5),
+        admin_secret: TEST_SECRET,
+      });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("rejects out-of-order keys", async () => {
+      const req = mockRequest({
+        ranges: [...validRanges()].reverse(),
+        admin_secret: TEST_SECRET,
+      });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("rejects a non-increasing max_value", async () => {
+      const ranges = validRanges();
+      ranges[2].max_value = ranges[1].max_value; // not strictly greater
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("rejects a non-null max_value on the last (hazardous) category", async () => {
+      const ranges = validRanges();
+      ranges[ranges.length - 1].max_value = 999;
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("rejects an invalid hex color", async () => {
+      const ranges = validRanges();
+      ranges[0].color = "not-a-color";
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("rejects a color missing the leading #", async () => {
+      const ranges = validRanges();
+      ranges[0].color = "ABCDEF";
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("rejects an empty label", async () => {
+      const ranges = validRanges();
+      ranges[0].label = "   ";
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err.statusCode).to.equal(400);
+    });
+
+    it("does not require min_value in the request body", async () => {
+      const ranges = validRanges(); // no min_value on any entry
+      const req = mockRequest({ ranges, admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.updateRanges, req);
+      expect(err).to.be.undefined;
+    });
+
+    it("deleteRanges accepts the correct admin_secret via query", async () => {
+      const req = mockRequest({}, { admin_secret: TEST_SECRET });
+      const err = await runChain(aqiValidations.deleteRanges, req);
+      expect(err).to.be.undefined;
+    });
+
+    it("deleteRanges rejects a wrong admin_secret with 403", async () => {
+      const req = mockRequest({}, { admin_secret: "wrong" });
+      const err = await runChain(aqiValidations.deleteRanges, req);
+      expect(err.statusCode).to.equal(403);
+    });
+  });
+});


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Makes the AQI category ranges (`GET /api/v2/devices/aqi-ranges`) admin-editable via API instead of requiring a code change and redeploy:

- New `PUT /api/v2/devices/aqi-ranges` — replace the active AQI category config (labels, colors, boundaries) in one call.
- New `DELETE /api/v2/devices/aqi-ranges` — revert to the hardcoded defaults.
- `GET /api/v2/devices/aqi-ranges` now returns a `source: "default"|"custom"` field so callers can see at a glance whether an override is active.
- The Nexus rankings endpoints (`GET .../readings/rankings` and `.../rankings/history`) now derive their AQI categories from the same active config, so the legend and the rankings never disagree with each other.
- New `SystemConfig` collection — a durable (no-TTL), tenant-scoped key/value store. This is the first use of it; other hardcoded values that shouldn't require a redeploy to change can follow the same pattern later without a new model each time.
- Write access is gated by a shared admin secret (`admin_secret` + `constants.ADMIN_SETUP_SECRET`), reusing the exact pattern already established elsewhere in this service (`validators/cohorts.validators.js`, `utils/network.util.js`) — see Additional Notes for why this, not per-user auth.

### Why is this change needed?

Came up while explaining why there's no update endpoint for the AQI legend: today, changing a category boundary or color requires a code change and a full deploy, which doesn't scale as a way to tune configuration. This PR resolves that for AQI ranges specifically, and establishes a reusable pattern (`SystemConfig`) for other similarly "should be admin-editable, not redeploy-gated" values identified later.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :sparkles: New feature
- [ ] :bug: Bug fix
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only.

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** New tests across four files — `utils/test/ut_aqi.util.js` (`resolveActiveAqiRanges` cache hit/miss/malformed-doc/query-failure/per-tenant isolation, `invalidateAqiRangesCache`, `isValidAqiRangesShape`, and `categoryFromConcentration`/`listRanges` both with and without an injected override, confirming backward compatibility), `controllers/test/ut_aqi.controller.js` (`updateRanges`/`deleteRanges` happy paths, cache invalidated only after a successful write, min_value derivation, `#`-stripping before persistence, write-failure handling), `validators/test/ut_aqi.validators.js` (new file — every validation rule, the admin-secret gate including the "not configured on server" 500 vs. "wrong secret" 403 distinction), and updated `utils/test/ut_event.util.js` (the two rankings functions now mock `@models/SystemConfig` too, since they call the resolver). Full suite: **188 passing, 0 failing, 105 pre-existing pending**.

**Manually verified live**, end-to-end, against a running server with a real admin secret set: wrong secret → 403; correct secret + well-formed body → 200, `GET` reflects `source: "custom"` immediately (proving cache invalidation, not waiting out the 60s TTL); inserted a real reading and confirmed `GET /rankings` categorized it using the **custom** boundaries, not the defaults; `DELETE` with the correct secret → reverts to defaults, confirmed `GET /rankings` reverts too; a malformed body (non-increasing `max_value`) → 400 with a clear field-level error message.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`GET /aqi-ranges`'s existing response shape is unchanged except for one additive field (`source`). The two new routes (`PUT`, `DELETE`) and the new `updated_by` field are all new surface area, not modifications to anything existing.

---

## :memo: Additional Notes

- **Why a shared admin secret and not per-user role-based auth:** investigated first — device-registry has no real authentication anywhere (confirmed: only CORS middleware runs on every route; `jsonwebtoken`/`passport` are installed but unused; the actual RBAC system lives entirely in `auth-service`'s own database, which device-registry has no access to). A real per-user admin check would need `auth-service` changes too (most tokens today don't even carry role claims) — a larger, cross-service PR. The shared-secret pattern used here already exists and is already trusted for this exact purpose elsewhere in this codebase.
- **Explicit scope boundary, not an oversight:** this only changes the *public legend* and the *Nexus rankings'* derived categories. Reading-ingestion classification (`models/Event.js`'s `generateAqiAddFields`, used by the store-readings job), `generateFilter.js`'s category-based query filters, and `models/HealthTips.js`'s range validation all continue using the static hardcoded constants, unchanged. An admin-set custom range will **not** change what category gets stamped onto newly-ingested readings or how health tips match. Flagging this prominently since it's an easy thing to assume is also covered.
- **Cache staleness across replicas:** the resolved config is cached in-memory per pod for 60 seconds. A write invalidates the writing pod's cache immediately (verified above), but other replicas may serve the previous config for up to 60s. Acceptable for a rarely-written admin config; not hidden.
- `min_value` is intentionally not accepted in the `PUT` body — categorization only ever depends on `max_value` (upper-bound classification, fixed earlier this session specifically to remove a boundary-gap bug), so `min_value` is cosmetic and is derived server-side instead of doubling the validation surface for it.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-specific AQI range configuration with runtime caching and fallback defaults.
  * Added secured endpoints to update and delete AQI ranges.
  * AQI classifications, legends, rankings, and history now use active tenant-specific ranges.
  * Added validation for AQI categories, thresholds, labels, and colors.
* **Bug Fixes**
  * Ensured custom range updates derive minimum values server-side and normalize colors.
* **Tests**
  * Expanded coverage for configuration overrides, validation, caching, updates, deletions, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->