### PR TITLE
Make AQI category ranges the single source of truth

### DIFF
--- a/src/device-registry/bin/jobs/aqi-category-backfill-job.js
+++ b/src/device-registry/bin/jobs/aqi-category-backfill-job.js
@@ -57,6 +57,11 @@ const BATCH_SIZE = 200;
 const LOCK_TTL_SECONDS = 30 * 60;
 const POD_ID = process.env.HOSTNAME || os.hostname();
 
+// Process-wide, not per-tenant — only "airqo" is an active tenant today (see
+// JobLockModel for the real per-tenant cross-pod lock). If a second tenant is
+// ever activated, a run for one tenant will make a concurrent trigger for
+// another tenant skip rather than queue; the daily safety-net schedule (see
+// JOB_SCHEDULE) still catches it on the next pass, so this degrades safely.
 let isJobRunning = false;
 
 async function acquireLock(tenant) {
@@ -129,6 +134,23 @@ function computeExpectedAqiFields(pm25Value, resolved) {
   };
 }
 
+// Both Reading and Signal already carry a partial index on
+// { time: -1, "pm2_5.value": 1 } (see models/Reading.js / models/Signal.js —
+// "Partial index for active readings/signals only"). The query below is
+// shaped to match it: `pm2_5.value > 0` satisfies both collections' partial
+// filter expressions, and the `time` lower bound lets the planner use the
+// index's leading field instead of falling back to a full collection scan.
+// A value of 0 or less (or non-numeric/absent) is deliberately excluded —
+// computeExpectedAqiFields/categoryFromConcentration treat any concentration
+// <= 0 as the config-invariant "unknown" fallback (or, for exactly 0, as
+// "good", whose min is always pinned to 0 regardless of any admin range
+// change) — so those documents' expected fields can never actually go stale
+// and are safe to skip entirely.
+// The 15-day window is a deliberate 1-day buffer over the 14-day TTL, not an
+// exact match — being slightly inclusive is safe (a few extra documents
+// read), being too tight risks missing documents near the boundary.
+const LOOKBACK_MS = 15 * 24 * 60 * 60 * 1000;
+
 /**
  * Streams one collection, comparing each document's stored AQI fields
  * against what they should be under `resolved`, and bulk-corrects the ones
@@ -140,7 +162,10 @@ async function reconcileModel(Model, resolved) {
   let skippedNoPm25 = 0;
   let batchOps = [];
 
-  const cursor = Model.find({ "pm2_5.value": { $ne: null, $type: "number" } })
+  const cursor = Model.find({
+    "pm2_5.value": { $gt: 0 },
+    time: { $gte: new Date(Date.now() - LOOKBACK_MS) },
+  })
     .select("_id pm2_5 aqi_color aqi_category aqi_color_name aqi_index")
     .batchSize(BATCH_SIZE)
     .lean()
@@ -191,14 +216,14 @@ async function reconcileModel(Model, resolved) {
   return { scanned, updated, skippedNoPm25 };
 }
 
-async function runAqiCategoryBackfillJob() {
+async function runAqiCategoryBackfillJob(tenant = TENANT) {
   if (isJobRunning) {
     logText(`${JOB_NAME} -- already running, skipping this execution`);
     return;
   }
   isJobRunning = true;
 
-  const lockAcquired = await acquireLock(TENANT);
+  const lockAcquired = await acquireLock(tenant);
   if (!lockAcquired) {
     logText(`${JOB_NAME} -- skipping run: another instance holds the lock`);
     isJobRunning = false;
@@ -207,13 +232,13 @@ async function runAqiCategoryBackfillJob() {
 
   const runStart = Date.now();
   try {
-    const resolved = await aqiUtil.resolveActiveAqiRanges(TENANT);
+    const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
     logText(
-      `${JOB_NAME} -- reconciling against source=${resolved.source} config`
+      `${JOB_NAME} -- reconciling tenant=${tenant} against source=${resolved.source} config`
     );
 
-    const readingsSummary = await reconcileModel(ReadingModel(TENANT), resolved);
-    const signalsSummary = await reconcileModel(SignalModel(TENANT), resolved);
+    const readingsSummary = await reconcileModel(ReadingModel(tenant), resolved);
+    const signalsSummary = await reconcileModel(SignalModel(tenant), resolved);
 
     const elapsed = ((Date.now() - runStart) / 1000).toFixed(1);
     jobLogger.info(
@@ -224,7 +249,7 @@ async function runAqiCategoryBackfillJob() {
   } catch (error) {
     logger.error(`🐛🐛 ${JOB_NAME} -- run failed: ${error.message}`);
   } finally {
-    await releaseLock(TENANT);
+    await releaseLock(tenant);
     isJobRunning = false;
   }
 }

--- a/src/device-registry/bin/jobs/aqi-category-backfill-job.js
+++ b/src/device-registry/bin/jobs/aqi-category-backfill-job.js
@@ -1,0 +1,243 @@
+/**
+ * aqi-category-backfill-job.js
+ *
+ * Reconciles the `aqi_category`/`aqi_color`/`aqi_color_name`/`aqi_index`
+ * fields already stored on Reading and Signal documents against the
+ * currently-active AQI config, after an admin changes it via
+ * PUT/DELETE /api/v2/devices/aqi-ranges.
+ *
+ * WHY:
+ *   Those fields are computed once, at ingestion time, and persisted —
+ *   they're a snapshot, not a live view. GET /aqi-ranges and the Nexus
+ *   rankings endpoints already reflect an admin override immediately, and
+ *   newly-ingested readings do too (see models/Event.js's fetchData/
+ *   generateAqiAddFields), but a reading stored *before* the change keeps
+ *   showing its old category until something walks the collection and
+ *   corrects it. This job is that "something."
+ *
+ * HOW:
+ *   1. Resolve the currently-active config once.
+ *   2. Stream each collection (Reading, then Signal) with a cursor, in
+ *      fixed-size batches.
+ *   3. For each document with a numeric pm2_5.value, recompute what its
+ *      aqi_category/aqi_color/aqi_color_name/aqi_index *should* be under the
+ *      active config. Only queue an update if it differs from what's
+ *      currently stored — an unchanged config (or a document whose category
+ *      was already correct) costs a read, never a write.
+ *   4. bulkWrite the differing docs, using an optimistic-concurrency filter
+ *      (only apply if the stored aqi_category still matches what was read)
+ *      so a concurrent, unrelated write to the same document is never
+ *      clobbered.
+ *
+ * Bounded scope: both collections have a 14-day TTL (see models/Reading.js),
+ * so this never reprocesses more than ~2 weeks of live data, regardless of
+ * how long the service has been running.
+ */
+
+const cron = require("node-cron");
+const os = require("os");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- /bin/jobs/aqi-category-backfill-job`
+);
+const jobLogger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- aqi-category-backfill-job -- ops-alerts`
+);
+const { logText } = require("@utils/shared");
+const ReadingModel = require("@models/Reading");
+const SignalModel = require("@models/Signal");
+const JobLockModel = require("@models/JobLock");
+const aqiUtil = require("@utils/aqi.util");
+
+const TENANT = constants.DEFAULT_TENANT || "airqo";
+const JOB_NAME = "aqi-category-backfill";
+const JOB_SCHEDULE = "0 5 * * *"; // Daily 05:00 — safety net; the real trigger is event-driven (see runAqiCategoryBackfillJob's caller in aqi.controller.js)
+const BATCH_SIZE = 200;
+const LOCK_TTL_SECONDS = 30 * 60;
+const POD_ID = process.env.HOSTNAME || os.hostname();
+
+let isJobRunning = false;
+
+async function acquireLock(tenant) {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + LOCK_TTL_SECONDS * 1000);
+  try {
+    const result = await JobLockModel(tenant).findOneAndUpdate(
+      {
+        $or: [
+          { jobName: JOB_NAME, expiresAt: { $lte: now } },
+          { jobName: JOB_NAME, expiresAt: { $exists: false } },
+          { jobName: { $exists: false } },
+        ],
+      },
+      {
+        $set: { acquiredBy: POD_ID, acquiredAt: now, expiresAt },
+        $setOnInsert: { jobName: JOB_NAME },
+      },
+      { upsert: true, new: true, rawResult: false }
+    );
+    return result && result.acquiredBy === POD_ID;
+  } catch (error) {
+    if (error.code === 11000) return false;
+    logger.error(`🐛🐛 ${JOB_NAME} -- lock acquisition error: ${error.message}`);
+    return false;
+  }
+}
+
+async function releaseLock(tenant) {
+  try {
+    await JobLockModel(tenant).findOneAndDelete({
+      jobName: JOB_NAME,
+      acquiredBy: POD_ID,
+    });
+  } catch (error) {
+    logger.error(`🐛🐛 ${JOB_NAME} -- lock release error: ${error.message}`);
+  }
+}
+
+/**
+ * What a document's AQI fields should be, under the given resolved config,
+ * for a given PM2.5 concentration. Mirrors models/Event.js's
+ * generateAqiAddFields() logic, computed in plain JS instead of a Mongo
+ * pipeline since this runs per-document over a cursor, not inside an
+ * aggregation.
+ */
+function computeExpectedAqiFields(pm25Value, resolved) {
+  if (typeof pm25Value !== "number" || isNaN(pm25Value)) {
+    return null;
+  }
+  const category = aqiUtil.categoryFromConcentration(pm25Value, resolved);
+  const { AQI_COLORS, AQI_CATEGORIES, AQI_COLOR_NAMES } = resolved;
+  if (!category) {
+    // Matches generateAqiAddFields()'s default branch in models/Event.js:
+    // the "unknown" fallback always uses the system default constants
+    // (stored bare, no leading "#" — same convention as every other stored
+    // aqi_color value), never a custom config's values.
+    return {
+      aqi_color: constants.AQI_COLORS.unknown,
+      aqi_category: constants.AQI_CATEGORIES.unknown,
+      aqi_color_name: constants.AQI_COLOR_NAMES.unknown,
+      aqi_index: aqiUtil.calculatePm25Aqi(pm25Value),
+    };
+  }
+  return {
+    aqi_color: AQI_COLORS[category],
+    aqi_category: AQI_CATEGORIES[category],
+    aqi_color_name: AQI_COLOR_NAMES[category],
+    aqi_index: aqiUtil.calculatePm25Aqi(pm25Value),
+  };
+}
+
+/**
+ * Streams one collection, comparing each document's stored AQI fields
+ * against what they should be under `resolved`, and bulk-corrects the ones
+ * that differ. Returns summary counts.
+ */
+async function reconcileModel(Model, resolved) {
+  let scanned = 0;
+  let updated = 0;
+  let skippedNoPm25 = 0;
+  let batchOps = [];
+
+  const cursor = Model.find({ "pm2_5.value": { $ne: null, $type: "number" } })
+    .select("_id pm2_5 aqi_color aqi_category aqi_color_name aqi_index")
+    .batchSize(BATCH_SIZE)
+    .lean()
+    .cursor();
+
+  const flush = async () => {
+    if (batchOps.length === 0) return;
+    try {
+      const result = await Model.bulkWrite(batchOps, { ordered: false });
+      updated += (result.modifiedCount || 0) + (result.upsertedCount || 0);
+    } catch (error) {
+      logger.error(`🐛🐛 ${JOB_NAME} -- bulkWrite error: ${error.message}`);
+    }
+    batchOps = [];
+  };
+
+  for await (const doc of cursor) {
+    scanned += 1;
+    const expected = computeExpectedAqiFields(doc.pm2_5?.value, resolved);
+    if (!expected) {
+      skippedNoPm25 += 1;
+      continue;
+    }
+
+    const alreadyCorrect =
+      doc.aqi_color === expected.aqi_color &&
+      doc.aqi_category === expected.aqi_category &&
+      doc.aqi_color_name === expected.aqi_color_name &&
+      doc.aqi_index === expected.aqi_index;
+    if (alreadyCorrect) continue;
+
+    batchOps.push({
+      updateOne: {
+        // Optimistic concurrency: only apply if the stored aqi_category
+        // hasn't changed since we read it, so a concurrent unrelated write
+        // to this same document is never clobbered.
+        filter: { _id: doc._id, aqi_category: doc.aqi_category },
+        update: { $set: expected },
+      },
+    });
+
+    if (batchOps.length >= BATCH_SIZE) {
+      await flush();
+    }
+  }
+  await flush();
+
+  return { scanned, updated, skippedNoPm25 };
+}
+
+async function runAqiCategoryBackfillJob() {
+  if (isJobRunning) {
+    logText(`${JOB_NAME} -- already running, skipping this execution`);
+    return;
+  }
+  isJobRunning = true;
+
+  const lockAcquired = await acquireLock(TENANT);
+  if (!lockAcquired) {
+    logText(`${JOB_NAME} -- skipping run: another instance holds the lock`);
+    isJobRunning = false;
+    return;
+  }
+
+  const runStart = Date.now();
+  try {
+    const resolved = await aqiUtil.resolveActiveAqiRanges(TENANT);
+    logText(
+      `${JOB_NAME} -- reconciling against source=${resolved.source} config`
+    );
+
+    const readingsSummary = await reconcileModel(ReadingModel(TENANT), resolved);
+    const signalsSummary = await reconcileModel(SignalModel(TENANT), resolved);
+
+    const elapsed = ((Date.now() - runStart) / 1000).toFixed(1);
+    jobLogger.info(
+      `${JOB_NAME} -- completed in ${elapsed}s -- ` +
+        `readings: scanned=${readingsSummary.scanned} updated=${readingsSummary.updated} ` +
+        `-- signals: scanned=${signalsSummary.scanned} updated=${signalsSummary.updated}`
+    );
+  } catch (error) {
+    logger.error(`🐛🐛 ${JOB_NAME} -- run failed: ${error.message}`);
+  } finally {
+    await releaseLock(TENANT);
+    isJobRunning = false;
+  }
+}
+
+cron.schedule(JOB_SCHEDULE, () => {
+  runAqiCategoryBackfillJob().catch((error) => {
+    logger.error(`🐛🐛 ${JOB_NAME} -- unhandled error: ${error.message}`);
+  });
+});
+
+logText(`${JOB_NAME} -- scheduled (${JOB_SCHEDULE})`);
+console.log(
+  `✅ ${JOB_NAME} started - daily safety net; also triggered right after an AQI config change`
+);
+
+module.exports = { runAqiCategoryBackfillJob };

--- a/src/device-registry/bin/jobs/store-readings-job.js
+++ b/src/device-registry/bin/jobs/store-readings-job.js
@@ -7,7 +7,7 @@ const logger = log4js.getLogger(
 const EventModel = require("@models/Event");
 const ReadingModel = require("@models/Reading");
 const { logObject, logText } = require("@utils/shared");
-const { calculatePm25Aqi } = require("@utils/aqi.util");
+const { calculatePm25Aqi, resolveActiveAqiRanges } = require("@utils/aqi.util");
 const asyncRetry = require("async-retry");
 const { stringify, generateFilter } = require("@utils/common");
 const cron = require("node-cron");
@@ -295,7 +295,14 @@ async function fetchAndStoreReadings() {
         brief: "yes",
       },
     };
-    const filter = generateFilter.fetch(request);
+    // index is never set on this job's own request (it fetches everything,
+    // not a category slice), so this doesn't change what gets fetched here —
+    // kept for consistency with the other generateFilter.fetch call sites.
+    // The AQI classification actually stamped onto stored readings comes
+    // from EventModel("airqo").fetch() below, which resolves its own
+    // up-to-date config internally (see models/Event.js's fetchData).
+    const resolvedAqiRanges = await resolveActiveAqiRanges("airqo");
+    const filter = generateFilter.fetch(request, null, resolvedAqiRanges);
 
     const jobStartMs = Date.now();
     logger.info(

--- a/src/device-registry/bin/jobs/store-signals-job.js
+++ b/src/device-registry/bin/jobs/store-signals-job.js
@@ -296,6 +296,16 @@ async function fetchAllRecentEvents(lastProcessedTime) {
     `🔍 Query window: ${startTime.toISOString()} to ${endTime.toISOString()}`
   );
 
+  // Resolved once before the loop, not per-iteration: this loop can span
+  // many batches, and re-resolving on every iteration risked using two
+  // different configs (if an admin changed ranges mid-run, or the 60s cache
+  // simply expired between iterations) within what should be a single,
+  // consistent run. index is never set on this job's own request, so this
+  // doesn't change what gets fetched here — kept for consistency. Actual
+  // classification comes from EventModel("airqo").fetch() below via
+  // Event.js's signalData.
+  const resolvedAqiRanges = await resolveActiveAqiRanges("airqo");
+
   while (hasMore && iteration < MAX_FETCH_ITERATIONS) {
     try {
       const request = {
@@ -319,11 +329,6 @@ async function fetchAllRecentEvents(lastProcessedTime) {
         request.query.startTime = startTime.toISOString();
       }
 
-      // See the identical note in store-readings-job.js — index is never
-      // set on this request, so this doesn't change what gets fetched;
-      // kept for consistency. Actual classification comes from
-      // EventModel("airqo").fetch() below via Event.js's signalData.
-      const resolvedAqiRanges = await resolveActiveAqiRanges("airqo");
       const filter = generateFilter.fetch(request, null, resolvedAqiRanges); // Use fetch, not signalsJob
       logger.debug(
         `📝 Filter for iteration ${iteration + 1}:`,

--- a/src/device-registry/bin/jobs/store-signals-job.js
+++ b/src/device-registry/bin/jobs/store-signals-job.js
@@ -8,7 +8,7 @@ const EventModel = require("@models/Event");
 const SignalModel = require("@models/Signal");
 const JobStateModel = require("@models/JobState");
 const { logObject, logText } = require("@utils/shared");
-const { calculatePm25Aqi } = require("@utils/aqi.util");
+const { calculatePm25Aqi, resolveActiveAqiRanges } = require("@utils/aqi.util");
 const asyncRetry = require("async-retry");
 const { stringify, generateFilter } = require("@utils/common");
 const cron = require("node-cron");
@@ -319,7 +319,12 @@ async function fetchAllRecentEvents(lastProcessedTime) {
         request.query.startTime = startTime.toISOString();
       }
 
-      const filter = generateFilter.fetch(request); // Use fetch, not signalsJob
+      // See the identical note in store-readings-job.js — index is never
+      // set on this request, so this doesn't change what gets fetched;
+      // kept for consistency. Actual classification comes from
+      // EventModel("airqo").fetch() below via Event.js's signalData.
+      const resolvedAqiRanges = await resolveActiveAqiRanges("airqo");
+      const filter = generateFilter.fetch(request, null, resolvedAqiRanges); // Use fetch, not signalsJob
       logger.debug(
         `📝 Filter for iteration ${iteration + 1}:`,
         JSON.stringify(filter)

--- a/src/device-registry/bin/jobs/test/ut_aqi-category-backfill-job.js
+++ b/src/device-registry/bin/jobs/test/ut_aqi-category-backfill-job.js
@@ -1,0 +1,204 @@
+require("module-alias/register");
+process.env.NODE_ENV = "development";
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const expect = chai.expect;
+chai.use(sinonChai);
+const proxyquire = require("proxyquire");
+const os = require("os");
+
+const POD_ID = process.env.HOSTNAME || os.hostname();
+
+describe("aqi-category-backfill-job", () => {
+  let bulkWriteStub;
+  let lockFindOneAndUpdateStub;
+  let lockFindOneAndDeleteStub;
+  let resolveActiveAqiRangesStub;
+  let proxiedJob;
+
+  // Mirrors ReadingModel(tenant).find(filter).select(...).batchSize(...).lean().cursor()
+  const mockModelFactory = (docs) => () => ({
+    find: () => ({
+      select: () => ({
+        batchSize: () => ({
+          lean: () => ({
+            cursor: () => (async function*() {
+              for (const doc of docs) yield doc;
+            })(),
+          }),
+        }),
+      }),
+    }),
+    bulkWrite: bulkWriteStub,
+  });
+
+  const defaultResolved = {
+    source: "default",
+    AQI_RANGES: {
+      good: { min: 0, max: 9.1 },
+      moderate: { min: 9.101, max: 35.49 },
+      u4sg: { min: 35.491, max: 55.49 },
+      unhealthy: { min: 55.491, max: 125.49 },
+      very_unhealthy: { min: 125.491, max: 225.49 },
+      hazardous: { min: 225.491, max: null },
+    },
+    AQI_CATEGORIES: {
+      good: "Good",
+      moderate: "Moderate",
+      u4sg: "Unhealthy for Sensitive Groups",
+      unhealthy: "Unhealthy",
+      very_unhealthy: "Very Unhealthy",
+      hazardous: "Hazardous",
+    },
+    AQI_COLORS: {
+      good: "34C759",
+      moderate: "ECAA06",
+      u4sg: "FF851F",
+      unhealthy: "F7453C",
+      very_unhealthy: "AC5CD9",
+      hazardous: "D95BA3",
+    },
+    AQI_COLOR_NAMES: {
+      good: "Green",
+      moderate: "Yellow",
+      u4sg: "Orange",
+      unhealthy: "Red",
+      very_unhealthy: "Purple",
+      hazardous: "Maroon",
+    },
+    AQI_CATEGORY_KEYS: [
+      "good",
+      "moderate",
+      "u4sg",
+      "unhealthy",
+      "very_unhealthy",
+      "hazardous",
+    ],
+  };
+
+  const proxyJob = (readingDocs, signalDocs = []) => {
+    lockFindOneAndUpdateStub = sinon
+      .stub()
+      .resolves({ acquiredBy: POD_ID });
+    lockFindOneAndDeleteStub = sinon.stub().resolves();
+    resolveActiveAqiRangesStub = sinon.stub().resolves(defaultResolved);
+
+    return proxyquire("../aqi-category-backfill-job", {
+      "@models/Reading": mockModelFactory(readingDocs),
+      "@models/Signal": mockModelFactory(signalDocs),
+      "@models/JobLock": () => ({
+        findOneAndUpdate: lockFindOneAndUpdateStub,
+        findOneAndDelete: lockFindOneAndDeleteStub,
+      }),
+      "@utils/aqi.util": {
+        resolveActiveAqiRanges: resolveActiveAqiRangesStub,
+        categoryFromConcentration: require("@utils/aqi.util")
+          .categoryFromConcentration,
+        calculatePm25Aqi: require("@utils/aqi.util").calculatePm25Aqi,
+      },
+    });
+  };
+
+  beforeEach(() => {
+    bulkWriteStub = sinon.stub().resolves({ modifiedCount: 0 });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("does not queue an update for a document whose stored fields already match the active config", async () => {
+    proxiedJob = proxyJob([
+      {
+        _id: "r1",
+        pm2_5: { value: 5 },
+        aqi_color: "34C759",
+        aqi_category: "Good",
+        aqi_color_name: "Green",
+        aqi_index: 28,
+      },
+    ]);
+
+    await proxiedJob.runAqiCategoryBackfillJob();
+
+    // Reading pass runs; Signal pass has no docs. bulkWrite should never be
+    // called since the one document is already correct.
+    expect(bulkWriteStub.called).to.equal(false);
+  });
+
+  it("queues an update for a document whose stored category is stale", async () => {
+    proxiedJob = proxyJob([
+      {
+        _id: "r1",
+        pm2_5: { value: 5 },
+        aqi_color: "OLDCOLOR",
+        aqi_category: "Stale",
+        aqi_color_name: "OldName",
+        aqi_index: 999,
+      },
+    ]);
+
+    await proxiedJob.runAqiCategoryBackfillJob();
+
+    expect(bulkWriteStub.calledOnce).to.equal(true);
+    const ops = bulkWriteStub.getCall(0).args[0];
+    expect(ops).to.have.lengthOf(1);
+    expect(ops[0].updateOne.filter).to.deep.equal({
+      _id: "r1",
+      aqi_category: "Stale", // optimistic-concurrency: matches what was read
+    });
+    expect(ops[0].updateOne.update.$set).to.deep.equal({
+      aqi_color: "34C759",
+      aqi_category: "Good",
+      aqi_color_name: "Green",
+      aqi_index: 28,
+    });
+  });
+
+  it("skips a document with no numeric pm2_5.value", async () => {
+    proxiedJob = proxyJob([
+      { _id: "r1", pm2_5: { value: null }, aqi_category: "Good" },
+      { _id: "r2", aqi_category: "Good" }, // pm2_5 missing entirely
+    ]);
+
+    await proxiedJob.runAqiCategoryBackfillJob();
+
+    expect(bulkWriteStub.called).to.equal(false);
+  });
+
+  it("reconciles both Reading and Signal collections in one run", async () => {
+    proxiedJob = proxyJob(
+      [{ _id: "r1", pm2_5: { value: 5 }, aqi_category: "Stale" }],
+      [{ _id: "s1", pm2_5: { value: 5 }, aqi_category: "Stale" }]
+    );
+
+    await proxiedJob.runAqiCategoryBackfillJob();
+
+    expect(bulkWriteStub.calledTwice).to.equal(true);
+  });
+
+  it("skips the run entirely when another instance already holds the lock", async () => {
+    proxiedJob = proxyJob([
+      { _id: "r1", pm2_5: { value: 5 }, aqi_category: "Stale" },
+    ]);
+    lockFindOneAndUpdateStub.resolves({ acquiredBy: "some-other-pod" });
+
+    await proxiedJob.runAqiCategoryBackfillJob();
+
+    expect(bulkWriteStub.called).to.equal(false);
+    expect(resolveActiveAqiRangesStub.called).to.equal(false);
+    expect(lockFindOneAndDeleteStub.called).to.equal(false);
+  });
+
+  it("releases the lock even when a bulkWrite fails", async () => {
+    proxiedJob = proxyJob([
+      { _id: "r1", pm2_5: { value: 5 }, aqi_category: "Stale" },
+    ]);
+    bulkWriteStub.rejects(new Error("Mongo error"));
+
+    await proxiedJob.runAqiCategoryBackfillJob();
+
+    expect(lockFindOneAndDeleteStub.calledOnce).to.equal(true);
+  });
+});

--- a/src/device-registry/bin/jobs/test/ut_aqi-category-backfill-job.js
+++ b/src/device-registry/bin/jobs/test/ut_aqi-category-backfill-job.js
@@ -18,20 +18,26 @@ describe("aqi-category-backfill-job", () => {
   let proxiedJob;
 
   // Mirrors ReadingModel(tenant).find(filter).select(...).batchSize(...).lean().cursor()
-  const mockModelFactory = (docs) => () => ({
-    find: () => ({
-      select: () => ({
-        batchSize: () => ({
-          lean: () => ({
-            cursor: () => (async function*() {
-              for (const doc of docs) yield doc;
-            })(),
+  const mockModelFactory = (docs, findSpy, tenantSpy) => (tenant) => {
+    if (tenantSpy) tenantSpy(tenant);
+    return {
+      find: (filter) => {
+        if (findSpy) findSpy(filter);
+        return {
+          select: () => ({
+            batchSize: () => ({
+              lean: () => ({
+                cursor: () => (async function*() {
+                  for (const doc of docs) yield doc;
+                })(),
+              }),
+            }),
           }),
-        }),
-      }),
-    }),
-    bulkWrite: bulkWriteStub,
-  });
+        };
+      },
+      bulkWrite: bulkWriteStub,
+    };
+  };
 
   const defaultResolved = {
     source: "default",
@@ -77,7 +83,7 @@ describe("aqi-category-backfill-job", () => {
     ],
   };
 
-  const proxyJob = (readingDocs, signalDocs = []) => {
+  const proxyJob = (readingDocs, signalDocs = [], findSpy, tenantSpy) => {
     lockFindOneAndUpdateStub = sinon
       .stub()
       .resolves({ acquiredBy: POD_ID });
@@ -85,8 +91,8 @@ describe("aqi-category-backfill-job", () => {
     resolveActiveAqiRangesStub = sinon.stub().resolves(defaultResolved);
 
     return proxyquire("../aqi-category-backfill-job", {
-      "@models/Reading": mockModelFactory(readingDocs),
-      "@models/Signal": mockModelFactory(signalDocs),
+      "@models/Reading": mockModelFactory(readingDocs, findSpy, tenantSpy),
+      "@models/Signal": mockModelFactory(signalDocs, findSpy, tenantSpy),
       "@models/JobLock": () => ({
         findOneAndUpdate: lockFindOneAndUpdateStub,
         findOneAndDelete: lockFindOneAndDeleteStub,
@@ -200,5 +206,52 @@ describe("aqi-category-backfill-job", () => {
     await proxiedJob.runAqiCategoryBackfillJob();
 
     expect(lockFindOneAndDeleteStub.calledOnce).to.equal(true);
+  });
+
+  it("queries with a filter shape that can use the existing time+pm2_5 partial index, not a full collection scan", async () => {
+    const findSpy = sinon.stub();
+    proxiedJob = proxyJob([], [], findSpy);
+
+    await proxiedJob.runAqiCategoryBackfillJob();
+
+    // Regression guard: {$ne: null, $type: "number"} with no time bound
+    // cannot use the { time: -1, "pm2_5.value": 1 } partial index on either
+    // Reading or Signal and forces a COLLSCAN on every admin PUT/DELETE —
+    // confirmed via .explain() against a real collection. {$gt: 0} satisfies
+    // both collections' partial filter expression, and the time lower bound
+    // lets the planner use the index's leading field.
+    expect(findSpy.called).to.equal(true);
+    findSpy.getCalls().forEach((call) => {
+      const filter = call.args[0];
+      expect(filter["pm2_5.value"]).to.deep.equal({ $gt: 0 });
+      expect(filter.time).to.have.property("$gte");
+      expect(filter.time.$gte).to.be.instanceOf(Date);
+    });
+  });
+
+  it("reconciles the tenant it's given, not always the hardcoded default — a PUT/DELETE for a non-default tenant must not silently reconcile the wrong one", async () => {
+    const tenantSpy = sinon.stub();
+    proxiedJob = proxyJob([], [], undefined, tenantSpy);
+
+    await proxiedJob.runAqiCategoryBackfillJob("kcca");
+
+    expect(lockFindOneAndUpdateStub.calledOnce).to.equal(true);
+    expect(resolveActiveAqiRangesStub.calledOnceWith("kcca")).to.equal(true);
+    // Called once for ReadingModel(tenant), once for SignalModel(tenant) —
+    // every call must use the tenant that was actually passed in, never the
+    // hardcoded default.
+    expect(tenantSpy.callCount).to.equal(2);
+    tenantSpy.getCalls().forEach((call) => {
+      expect(call.args[0]).to.equal("kcca");
+    });
+  });
+
+  it("defaults to the standard tenant when called with no argument (cron safety-net path)", async () => {
+    const tenantSpy = sinon.stub();
+    proxiedJob = proxyJob([], [], undefined, tenantSpy);
+
+    await proxiedJob.runAqiCategoryBackfillJob();
+
+    expect(tenantSpy.calledWith("airqo")).to.equal(true);
   });
 });

--- a/src/device-registry/bin/jobs/test/ut_aqi-category-backfill-job.js
+++ b/src/device-registry/bin/jobs/test/ut_aqi-category-backfill-job.js
@@ -91,6 +91,11 @@ describe("aqi-category-backfill-job", () => {
     resolveActiveAqiRangesStub = sinon.stub().resolves(defaultResolved);
 
     return proxyquire("../aqi-category-backfill-job", {
+      // Without this, every proxyquire() call below re-executes the module's
+      // top-level cron.schedule(...) for real, registering a live daily
+      // interval that outlives the test — this file's own suite alone left
+      // one stray schedule per test case running in the process.
+      "node-cron": { schedule: sinon.stub() },
       "@models/Reading": mockModelFactory(readingDocs, findSpy, tenantSpy),
       "@models/Signal": mockModelFactory(signalDocs, findSpy, tenantSpy),
       "@models/JobLock": () => ({

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -333,6 +333,20 @@ try {
   // Continue - server stays up
 }
 
+// AQI category backfill — daily safety net (05:00). Primary trigger is
+// event-driven: aqi.controller.js fires this immediately after a successful
+// PUT/DELETE on /aqi-ranges so already-stored readings/signals stop looking
+// stale promptly. This registration is what makes that require() elsewhere
+// return the same, already-scheduled module instead of scheduling twice.
+try {
+  require("@bin/jobs/aqi-category-backfill-job");
+} catch (jobError) {
+  global.dedupLogger.error(
+    `❌ aqi-category-backfill-job failed to start: ${jobError.message}`
+  );
+  // Continue - server stays up
+}
+
 // Private cohort alert — 3×/day (06:00, 14:00, 22:00 UTC)
 // Flags cohorts that are private but contain >2 operational devices,
 // preventing them from silently missing public map and recent-measurements visibility.

--- a/src/device-registry/controllers/aqi.controller.js
+++ b/src/device-registry/controllers/aqi.controller.js
@@ -22,8 +22,8 @@ const resolveTenant = (req) => {
 // awaited from the request handler: the backfill can take longer than an
 // HTTP request should, and a failure here must not fail the PUT/DELETE that
 // already succeeded.
-function triggerAqiCategoryBackfill() {
-  runAqiCategoryBackfillJob().catch((error) => {
+function triggerAqiCategoryBackfill(tenant) {
+  runAqiCategoryBackfillJob(tenant).catch((error) => {
     logger.error(
       `🐛🐛 aqi-category-backfill trigger failed: ${error.message}`
     );
@@ -85,7 +85,7 @@ const aqiController = {
       // read can't be caught between an invalidated cache and the new value
       // actually landing in Mongo.
       aqiUtil.invalidateAqiRangesCache(tenant);
-      triggerAqiCategoryBackfill();
+      triggerAqiCategoryBackfill(tenant);
 
       const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
       const result = aqiUtil.listRanges(resolved);
@@ -123,7 +123,7 @@ const aqiController = {
         key: aqiUtil.AQI_RANGES_CONFIG_KEY,
       });
       aqiUtil.invalidateAqiRangesCache(tenant);
-      triggerAqiCategoryBackfill();
+      triggerAqiCategoryBackfill(tenant);
 
       const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
       const result = aqiUtil.listRanges(resolved);

--- a/src/device-registry/controllers/aqi.controller.js
+++ b/src/device-registry/controllers/aqi.controller.js
@@ -7,11 +7,28 @@ const constants = require("@config/constants");
 const isEmpty = require("is-empty");
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- aqi-controller`);
+const {
+  runAqiCategoryBackfillJob,
+} = require("@bin/jobs/aqi-category-backfill-job");
 
 const resolveTenant = (req) => {
   const tenant = req.query.tenant;
   return isEmpty(tenant) ? constants.DEFAULT_TENANT || "airqo" : tenant;
 };
+
+// Fire-and-forget — reconciles already-stored readings'/signals' aqi_category
+// etc. against the config that was just written, so they stop looking stale
+// promptly rather than waiting for the daily safety-net schedule. Never
+// awaited from the request handler: the backfill can take longer than an
+// HTTP request should, and a failure here must not fail the PUT/DELETE that
+// already succeeded.
+function triggerAqiCategoryBackfill() {
+  runAqiCategoryBackfillJob().catch((error) => {
+    logger.error(
+      `🐛🐛 aqi-category-backfill trigger failed: ${error.message}`
+    );
+  });
+}
 
 const aqiController = {
   listRanges: async (req, res, next) => {
@@ -68,6 +85,7 @@ const aqiController = {
       // read can't be caught between an invalidated cache and the new value
       // actually landing in Mongo.
       aqiUtil.invalidateAqiRangesCache(tenant);
+      triggerAqiCategoryBackfill();
 
       const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
       const result = aqiUtil.listRanges(resolved);
@@ -105,6 +123,7 @@ const aqiController = {
         key: aqiUtil.AQI_RANGES_CONFIG_KEY,
       });
       aqiUtil.invalidateAqiRangesCache(tenant);
+      triggerAqiCategoryBackfill();
 
       const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
       const result = aqiUtil.listRanges(resolved);

--- a/src/device-registry/controllers/test/ut_aqi.controller.js
+++ b/src/device-registry/controllers/test/ut_aqi.controller.js
@@ -141,6 +141,18 @@ describe("AQI Controller", () => {
       expect(res.status).to.have.been.calledWith(httpStatus.OK);
     });
 
+    it("updateRanges triggers the backfill for the SAME tenant that was actually updated, not always the default", async () => {
+      req = {
+        query: { tenant: "kcca" },
+        params: {},
+        body: { ranges: validRanges(), admin_secret: "x" },
+      };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      expect(runBackfillStub.calledOnceWith("kcca")).to.equal(true);
+    });
+
     it("updateRanges derives min_value server-side rather than trusting the caller", async () => {
       req = { query: {}, params: {}, body: { ranges: validRanges(), admin_secret: "x" } };
 
@@ -182,6 +194,14 @@ describe("AQI Controller", () => {
       expect(
         runBackfillStub.calledAfter(aqiUtil.invalidateAqiRangesCache)
       ).to.equal(true);
+    });
+
+    it("deleteRanges triggers the backfill for the SAME tenant that was actually reverted, not always the default", async () => {
+      req = { query: { tenant: "kcca" }, params: {}, body: {} };
+
+      await proxiedController.deleteRanges(req, res, next);
+
+      expect(runBackfillStub.calledOnceWith("kcca")).to.equal(true);
     });
 
     it("forwards a Mongo write failure to next() as an HttpError", async () => {

--- a/src/device-registry/controllers/test/ut_aqi.controller.js
+++ b/src/device-registry/controllers/test/ut_aqi.controller.js
@@ -63,7 +63,13 @@ describe("AQI Controller", () => {
   });
 
   describe("updateRanges / deleteRanges", () => {
-    let req, res, next, upsertStub, deleteOneStub, proxiedController;
+    let req,
+      res,
+      next,
+      upsertStub,
+      deleteOneStub,
+      runBackfillStub,
+      proxiedController;
 
     const validRanges = () =>
       require("@config/constants").AQI_CATEGORY_KEYS.map((key, i, arr) => ({
@@ -82,11 +88,18 @@ describe("AQI Controller", () => {
 
       upsertStub = sinon.stub().resolves({});
       deleteOneStub = sinon.stub().resolves({});
+      // Fire-and-forget by design (see triggerAqiCategoryBackfill) — stubbed
+      // here so tests don't kick off a real backfill run against Mongoose
+      // models with no DB connection.
+      runBackfillStub = sinon.stub().resolves();
       proxiedController = proxyquire("../aqi.controller", {
         "@models/SystemConfig": () => ({
           upsert: upsertStub,
           deleteOne: deleteOneStub,
         }),
+        "@bin/jobs/aqi-category-backfill-job": {
+          runAqiCategoryBackfillJob: runBackfillStub,
+        },
       });
 
       sinon.stub(aqiUtil, "resolveActiveAqiRanges").resolves(null);
@@ -112,6 +125,19 @@ describe("AQI Controller", () => {
       expect(aqiUtil.invalidateAqiRangesCache.calledOnce).to.equal(true);
       // Cache must be invalidated only after the write succeeds.
       expect(aqiUtil.invalidateAqiRangesCache.calledAfter(upsertStub)).to.equal(true);
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+    });
+
+    it("updateRanges triggers the backfill job (fire-and-forget) after invalidating the cache", async () => {
+      req = { query: {}, params: {}, body: { ranges: validRanges(), admin_secret: "x" } };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      expect(runBackfillStub.calledOnce).to.equal(true);
+      expect(
+        runBackfillStub.calledAfter(aqiUtil.invalidateAqiRangesCache)
+      ).to.equal(true);
+      // A backfill failure must never surface as a request failure.
       expect(res.status).to.have.been.calledWith(httpStatus.OK);
     });
 
@@ -147,6 +173,17 @@ describe("AQI Controller", () => {
       expect(res.status).to.have.been.calledWith(httpStatus.OK);
     });
 
+    it("deleteRanges triggers the backfill job (fire-and-forget) after invalidating the cache", async () => {
+      req = { query: {}, params: {}, body: {} };
+
+      await proxiedController.deleteRanges(req, res, next);
+
+      expect(runBackfillStub.calledOnce).to.equal(true);
+      expect(
+        runBackfillStub.calledAfter(aqiUtil.invalidateAqiRangesCache)
+      ).to.equal(true);
+    });
+
     it("forwards a Mongo write failure to next() as an HttpError", async () => {
       upsertStub.rejects(new Error("Mongo write failed"));
       req = { query: {}, params: {}, body: { ranges: validRanges(), admin_secret: "x" } };
@@ -158,6 +195,18 @@ describe("AQI Controller", () => {
       expect(err.message).to.equal("Internal Server Error");
       // A failed write must not invalidate the cache — nothing changed.
       expect(aqiUtil.invalidateAqiRangesCache.called).to.equal(false);
+      // ...and therefore must not trigger a backfill either.
+      expect(runBackfillStub.called).to.equal(false);
+    });
+
+    it("does not let a rejected backfill promise crash or delay the request", async () => {
+      runBackfillStub.rejects(new Error("backfill blew up"));
+      req = { query: {}, params: {}, body: { ranges: validRanges(), admin_secret: "x" } };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(next.called).to.equal(false);
     });
   });
 });

--- a/src/device-registry/models/Event.js
+++ b/src/device-registry/models/Event.js
@@ -15,7 +15,10 @@ const isEmpty = require("is-empty");
 const httpStatus = require("http-status");
 const { getModelByTenant } = require("@config/database");
 const { getDeviceCategoriesAddFieldsStage } = require("@utils/device.util.js");
-const { getAqiIndexMongoExpression } = require("@utils/aqi.util");
+const {
+  getAqiIndexMongoExpression,
+  resolveActiveAqiRanges,
+} = require("@utils/aqi.util");
 
 const logger = require("log4js").getLogger(
   `${constants.ENVIRONMENT} -- event-model`,
@@ -30,81 +33,51 @@ const TIMEZONE = moment.tz.guess();
 const AGGREGATE_TIMEOUT_MS = 90000;
 const SLOW_QUERY_THRESHOLD_MS = 15000;
 
+// Kept as the fallback default — generateAqiAddFields() below now builds its
+// branches from an optional `resolved` config (see utils/aqi.util.js's
+// resolveActiveAqiRanges) instead of these module-load-time constants, so an
+// admin-set custom AQI range is reflected here too, not just in the legend
+// and Nexus rankings the prior PR covered.
 const AQI_COLORS = constants.AQI_COLORS;
 const AQI_CATEGORIES = constants.AQI_CATEGORIES;
 const AQI_COLOR_NAMES = constants.AQI_COLOR_NAMES;
 const AQI_RANGES = constants.AQI_RANGES;
 
-// Shared AQI condition branches to avoid duplication
-const AQI_BRANCHES = [
-  {
-    case: {
-      $and: [
-        { $gte: ["$pm2_5.value", "$aqi_ranges.good.min"] },
-        { $lte: ["$pm2_5.value", "$aqi_ranges.good.max"] },
-      ],
-    },
-    thenColor: AQI_COLORS.good,
-    thenCategory: AQI_CATEGORIES.good,
-    thenColorName: AQI_COLOR_NAMES.good,
-  },
-  {
-    case: {
-      $and: [
-        { $gte: ["$pm2_5.value", "$aqi_ranges.moderate.min"] },
-        { $lte: ["$pm2_5.value", "$aqi_ranges.moderate.max"] },
-      ],
-    },
-    thenColor: AQI_COLORS.moderate,
-    thenCategory: AQI_CATEGORIES.moderate,
-    thenColorName: AQI_COLOR_NAMES.moderate,
-  },
-  {
-    case: {
-      $and: [
-        { $gte: ["$pm2_5.value", "$aqi_ranges.u4sg.min"] },
-        { $lte: ["$pm2_5.value", "$aqi_ranges.u4sg.max"] },
-      ],
-    },
-    thenColor: AQI_COLORS.u4sg,
-    thenCategory: AQI_CATEGORIES.u4sg,
-    thenColorName: AQI_COLOR_NAMES.u4sg,
-  },
-  {
-    case: {
-      $and: [
-        { $gte: ["$pm2_5.value", "$aqi_ranges.unhealthy.min"] },
-        { $lte: ["$pm2_5.value", "$aqi_ranges.unhealthy.max"] },
-      ],
-    },
-    thenColor: AQI_COLORS.unhealthy,
-    thenCategory: AQI_CATEGORIES.unhealthy,
-    thenColorName: AQI_COLOR_NAMES.unhealthy,
-  },
-  {
-    case: {
-      $and: [
-        { $gte: ["$pm2_5.value", "$aqi_ranges.very_unhealthy.min"] },
-        { $lte: ["$pm2_5.value", "$aqi_ranges.very_unhealthy.max"] },
-      ],
-    },
-    thenColor: AQI_COLORS.very_unhealthy,
-    thenCategory: AQI_CATEGORIES.very_unhealthy,
-    thenColorName: AQI_COLOR_NAMES.very_unhealthy,
-  },
-  {
-    case: { $gte: ["$pm2_5.value", "$aqi_ranges.hazardous.min"] },
-    thenColor: AQI_COLORS.hazardous,
-    thenCategory: AQI_CATEGORIES.hazardous,
-    thenColorName: AQI_COLOR_NAMES.hazardous,
-  },
-];
+// Builds the shared AQI condition branches from a resolved config (custom
+// override or the hardcoded defaults) instead of a module-load-time
+// constant — same 6-category, ordered structure as before, just computed
+// per call so a runtime config change takes effect on the next pipeline
+// build rather than requiring a restart.
+const buildAqiBranches = ({ AQI_RANGES: ranges, AQI_COLORS: colors, AQI_CATEGORIES: categories, AQI_COLOR_NAMES: colorNames, AQI_CATEGORY_KEYS: keys }) =>
+  keys.map((key, index) => {
+    const range = ranges[key];
+    const isLast = index === keys.length - 1;
+    return {
+      case: isLast
+        ? { $gte: ["$pm2_5.value", `$aqi_ranges.${key}.min`] }
+        : {
+            $and: [
+              { $gte: ["$pm2_5.value", `$aqi_ranges.${key}.min`] },
+              { $lte: ["$pm2_5.value", `$aqi_ranges.${key}.max`] },
+            ],
+          },
+      thenColor: colors[key],
+      thenCategory: categories[key],
+      thenColorName: colorNames[key],
+    };
+  });
 
 // Helper function to build MongoDB $switch expressions
-// from the shared AQI branches using a specific "then" property
-const buildSwitchExpression = (thenProperty) => ({
+// from the shared AQI branches using a specific "then" property.
+// The "unknown"/default branch always uses the system default constants,
+// regardless of whether `resolved` is a custom config — a custom config
+// (built by buildResolvedFromCustom in utils/aqi.util.js) only ever defines
+// the 6 real categories, never an "unknown" fallback, since that's a
+// system-level "couldn't classify at all" case, not something an admin
+// tunes.
+const buildSwitchExpression = (branches, thenProperty) => ({
   $switch: {
-    branches: AQI_BRANCHES.map((branch) => ({
+    branches: branches.map((branch) => ({
       case: branch.case,
       then: branch[thenProperty],
     })),
@@ -116,33 +89,34 @@ const buildSwitchExpression = (thenProperty) => ({
   },
 });
 
-// MongoDB switch case expression for AQI color
-const getAqiColorExpression = () => buildSwitchExpression("thenColor");
-
-// MongoDB switch case expression for AQI category
-const getAqiCategoryExpression = () => buildSwitchExpression("thenCategory");
-
-// MongoDB switch case expression for AQI color name
-const getAqiColorNameExpression = () => buildSwitchExpression("thenColorName");
-
 // Function to generate the AQI addFields for MongoDB aggregation pipelines.
 //
-// NOTE: callers MUST push/apply a prior { $addFields: { aqi_ranges: AQI_RANGES } }
-// stage before this one, because the AQI_BRANCHES switch expressions reference
-// $aqi_ranges.good.min etc. via the document field.
+// NOTE: callers MUST push/apply a prior { $addFields: { aqi_ranges: <the
+// SAME resolved AQI_RANGES> } } stage before this one, because the branches
+// reference $aqi_ranges.good.min etc. via the document field — the range
+// comparison and the color/category/label values returned here must come
+// from the same resolved config or they'll disagree with each other.
 //
-// Existing behaviour of aqi_color / aqi_category / aqi_color_name is
-// intentionally preserved (raw pm2_5.value vs AQI_RANGES thresholds) to
-// maintain backward compatibility with deployed consumers.
-// aqi_index is a new additive field and does not affect any existing field.
-function generateAqiAddFields() {
+// @param {object|null} [resolved] - result of resolveActiveAqiRanges
+// (utils/aqi.util.js). Omit to use the hardcoded defaults, same as before
+// this parameter existed — fully backward compatible.
+function generateAqiAddFields(resolved = null) {
+  const active = resolved || {
+    AQI_RANGES,
+    AQI_COLORS,
+    AQI_CATEGORIES,
+    AQI_COLOR_NAMES,
+    AQI_CATEGORY_KEYS: constants.AQI_CATEGORY_KEYS,
+  };
+  const branches = buildAqiBranches(active);
+
   return {
     $addFields: {
       device: "$device",
-      aqi_color: getAqiColorExpression(),
-      aqi_category: getAqiCategoryExpression(),
-      aqi_color_name: getAqiColorNameExpression(),
-      aqi_ranges: AQI_RANGES,
+      aqi_color: buildSwitchExpression(branches, "thenColor"),
+      aqi_category: buildSwitchExpression(branches, "thenCategory"),
+      aqi_color_name: buildSwitchExpression(branches, "thenColorName"),
+      aqi_ranges: active.AQI_RANGES,
       // NEW — numeric AQI value (0–500) computed from PM2.5 using the EPA
       // piecewise linear formula (EPA-454/B-24-002, 2024 revision).
       // This is purely additive and does not change any existing field value.
@@ -1373,8 +1347,18 @@ async function fetchData(model, filter) {
       postGroupStages.push({ $project: projection });
 
       if (!isHistorical) {
-        postGroupStages.push({ $addFields: { aqi_ranges: AQI_RANGES } });
-        postGroupStages.push({ $addFields: generateAqiAddFields().$addFields });
+        // Resolved once here (cached ~60s, see resolveActiveAqiRanges) so an
+        // admin-set custom AQI range is reflected in both the ingestion job
+        // (which shares this same fetchData path via EventModel.fetch())
+        // and the public list/view/fetch read endpoints — not just the
+        // legend and Nexus rankings the prior PR covered.
+        const resolvedAqiRanges = await resolveActiveAqiRanges(tenant);
+        postGroupStages.push({
+          $addFields: { aqi_ranges: resolvedAqiRanges.AQI_RANGES },
+        });
+        postGroupStages.push({
+          $addFields: generateAqiAddFields(resolvedAqiRanges).$addFields,
+        });
       }
 
       // ── $facet: count + paginated data in ONE round-trip ──────────────
@@ -1728,6 +1712,8 @@ async function fetchData(model, filter) {
 
 async function signalData(model, filter) {
   let { skip, limit, page } = filter;
+  const tenant = filter.tenant || constants.DEFAULT_TENANT || "airqo";
+  const resolvedAqiRanges = await resolveActiveAqiRanges(tenant);
   const recent = "yes";
   const metadata = "site_id";
 
@@ -2023,9 +2009,9 @@ async function signalData(model, filter) {
     })
     .project(projection)
     .addFields({
-      aqi_ranges: AQI_RANGES,
+      aqi_ranges: resolvedAqiRanges.AQI_RANGES,
     })
-    .addFields(generateAqiAddFields().$addFields)
+    .addFields(generateAqiAddFields(resolvedAqiRanges).$addFields)
     .skip(skip)
     .limit(limit)
     .allowDiskUse(true);

--- a/src/device-registry/models/HealthTips.js
+++ b/src/device-registry/models/HealthTips.js
@@ -7,6 +7,7 @@ const isEmpty = require("is-empty");
 const constants = require("@config/constants");
 const httpStatus = require("http-status");
 const { getModelByTenant } = require("@config/database");
+const { resolveActiveAqiRanges } = require("@utils/aqi.util");
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- health-tip-model`);
 
@@ -94,8 +95,16 @@ tipsSchema.methods = {
 };
 
 const _removeInvalidTips = async function(model) {
-  // Get valid AQI ranges from the configuration
-  const validAqiRanges = Object.values(constants.AQI_INDEX);
+  // No per-tenant identity is threaded into this helper today (its callers
+  // only receive `this`, the already tenant-bound Mongoose model, not a
+  // tenant string) — defaults to the single active tenant, consistent with
+  // how other admin/write-path code in this service already defaults
+  // ("airqo" is the only tenant actively in use).
+  const resolved = await resolveActiveAqiRanges(
+    constants.DEFAULT_TENANT || "airqo",
+  );
+  // Get valid AQI ranges from the active config (admin override or default)
+  const validAqiRanges = Object.values(resolved.AQI_RANGES);
 
   // Build a query to find all tips with invalid AQI ranges
   const validRangeFilters = validAqiRanges.map((range) => {

--- a/src/device-registry/models/test/ut_health-tips-remove-invalid.js
+++ b/src/device-registry/models/test/ut_health-tips-remove-invalid.js
@@ -1,0 +1,159 @@
+require("module-alias/register");
+process.env.NODE_ENV = "development";
+const { expect } = require("chai");
+const sinon = require("sinon");
+const proxyquire = require("proxyquire");
+const mongoose = require("mongoose");
+
+// Covers HealthTips.js's private `_removeInvalidTips` helper, reached only
+// through the `removeInvalidTips`/`bulkModify` statics — there is no prior
+// working test coverage for this file (models/test/ut_health-tips.model.js
+// is entirely `describe.skip`'d and imports the wrong export shape).
+//
+// `TipsModel(tenant)` tries `mongoose.model("healthtips")` first and only
+// falls back to `getModelByTenant` if that throws. Since the mongoose model
+// registry is a global singleton, another test file requiring the real,
+// non-proxied HealthTips module earlier in the same run could register
+// "healthtips" first and make that branch succeed instead — so `mongoose`
+// itself is proxied here to force the fallback branch deterministically,
+// regardless of run order.
+const proxyHealthTips = (fakeModel, resolveActiveAqiRangesStub) =>
+  proxyquire("../HealthTips", {
+    mongoose: Object.assign({}, mongoose, {
+      model: () => {
+        throw new Error("not registered");
+      },
+    }),
+    "@config/database": {
+      // The real getModelByTenant compiles a Mongoose Model class that
+      // inherits the schema's statics (removeInvalidTips, bulkModify, ...).
+      // Mimic that here by binding the real statics — pulled off the schema
+      // instance passed in at call time — onto our duck-typed fake model,
+      // instead of standing up a real Mongoose connection.
+      getModelByTenant: (tenantId, modelName, schema) => {
+        Object.entries(schema.statics).forEach(([key, fn]) => {
+          fakeModel[key] = fn.bind(fakeModel);
+        });
+        return fakeModel;
+      },
+    },
+    "@utils/aqi.util": { resolveActiveAqiRanges: resolveActiveAqiRangesStub },
+  });
+
+const customResolved = {
+  source: "custom",
+  AQI_RANGES: {
+    good: { min: 0, max: 5 },
+    moderate: { min: 5, max: 20 },
+    u4sg: { min: 20, max: 40 },
+    unhealthy: { min: 40, max: 80 },
+    very_unhealthy: { min: 80, max: 150 },
+    hazardous: { min: 150, max: null },
+  },
+};
+
+const makeFakeModel = ({ tips = [], countByFilter = () => 1 } = {}) => {
+  const execify = (value) => ({ exec: () => Promise.resolve(value) });
+  return {
+    find: sinon.stub().returns(execify(tips)),
+    deleteMany: sinon.stub().returns(execify({ deletedCount: tips.length })),
+    countDocuments: sinon.stub().callsFake((filter) =>
+      execify(countByFilter(filter))
+    ),
+  };
+};
+
+describe("HealthTips — _removeInvalidTips (via removeInvalidTips/bulkModify statics)", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("removes tips whose stored aqi_category matches none of the active config's ranges", async () => {
+    const staleTip = {
+      title: "Stale",
+      aqi_category: { min: 999, max: 1000 }, // valid under neither default nor custom
+    };
+    const fakeModel = makeFakeModel({ tips: [staleTip], countByFilter: () => 1 });
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const TipsModel = proxyHealthTips(fakeModel, resolveStub);
+
+    const next = sinon.spy();
+    const result = await TipsModel("airqo").removeInvalidTips(next);
+
+    expect(resolveStub.calledOnce).to.equal(true);
+    expect(fakeModel.deleteMany.calledOnce).to.equal(true);
+    expect(result.success).to.equal(true);
+    expect(result.data.removedCount).to.equal(1);
+    expect(result.data.invalidTipsRemoved).to.deep.equal([
+      { title: "Stale", aqi_category: staleTip.aqi_category },
+    ]);
+  });
+
+  it("does not delete anything when every stored tip matches an active range", async () => {
+    const fakeModel = makeFakeModel({ tips: [], countByFilter: () => 1 });
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const TipsModel = proxyHealthTips(fakeModel, resolveStub);
+
+    const next = sinon.spy();
+    const result = await TipsModel("airqo").removeInvalidTips(next);
+
+    expect(fakeModel.deleteMany.called).to.equal(false);
+    expect(result.data.removedCount).to.equal(0);
+  });
+
+  it("reports categories from the active config that have no tips at all", async () => {
+    const fakeModel = makeFakeModel({ tips: [], countByFilter: () => 0 });
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const TipsModel = proxyHealthTips(fakeModel, resolveStub);
+
+    const next = sinon.spy();
+    const result = await TipsModel("airqo").removeInvalidTips(next);
+
+    expect(result.data.categoriesWithoutTips).to.have.lengthOf(6);
+    expect(result.data.categoriesWithoutTips).to.deep.include({
+      min: 0,
+      max: 5,
+    });
+  });
+
+  it("validates against the custom config's ranges, not the hardcoded defaults, once an override is active", async () => {
+    // Valid under the hardcoded default ("good" = 0-9.1) but not under the
+    // active custom config ("good" = 0-5) — must be treated as invalid.
+    const tipValidOnlyUnderDefault = {
+      title: "Old boundary",
+      aqi_category: { min: 0, max: 9.1 },
+    };
+    const fakeModel = makeFakeModel({
+      tips: [tipValidOnlyUnderDefault],
+      countByFilter: () => 1,
+    });
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const TipsModel = proxyHealthTips(fakeModel, resolveStub);
+
+    const next = sinon.spy();
+    const result = await TipsModel("airqo").removeInvalidTips(next);
+
+    expect(result.data.removedCount).to.equal(1);
+  });
+
+  it("bulkModify also invokes the same cleanup after applying updates", async () => {
+    const fakeModel = Object.assign(makeFakeModel({ tips: [], countByFilter: () => 1 }), {
+      bulkWrite: sinon.stub().resolves({ modifiedCount: 1, upsertedCount: 0 }),
+    });
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const TipsModel = proxyHealthTips(fakeModel, resolveStub);
+
+    const next = sinon.spy();
+    const updates = [
+      {
+        aqi_category: { min: 0, max: 5 },
+        tips: [{ title: "T1", tag_line: "line" }],
+      },
+    ];
+    const result = await TipsModel("airqo").bulkModify(updates, next);
+
+    expect(fakeModel.bulkWrite.calledOnce).to.equal(true);
+    expect(resolveStub.calledOnce).to.equal(true);
+    expect(result.success).to.equal(true);
+  });
+});

--- a/src/device-registry/utils/aqi.util.js
+++ b/src/device-registry/utils/aqi.util.js
@@ -330,10 +330,9 @@ function isValidAqiRangesShape(value) {
  * Build a resolved-config object (same shape categoryFromConcentration and
  * listRanges expect) from a validated stored `{ranges: [...]}` value. Always
  * constructs fresh objects — never mutates constants.AQI_RANGES, which is a
- * plain object shared by reference across the whole process, including
- * reading-ingestion classification (models/Event.js's generateAqiAddFields)
- * and health-tip validation that intentionally still use the hardcoded
- * defaults regardless of any admin override (see docs for why).
+ * plain object shared by reference across the whole process and is still the
+ * fallback every resolved-config consumer (ingestion, query filters,
+ * health-tip validation) uses whenever no admin override is active.
  */
 function buildResolvedFromCustom(value) {
   const AQI_RANGES = {};

--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -97,14 +97,38 @@ const handlePredefinedValueMatch = (
   return stringValue;
 };
 
+// Shared by `events` and `fetch` below — both set an identical
+// "values.pm2_5.value" range filter from the `?index=<category>` query param.
+// `resolved` (optional) is the result of utils/aqi.util.js's
+// resolveActiveAqiRanges — pass it to have the filter use an admin-set custom
+// AQI range instead of the hardcoded defaults (constants.AQI_RANGES). Omit it
+// to keep the existing behavior unchanged.
+function applyAqiIndexFilter(filter, index, resolved) {
+  const activeAqiRanges = (resolved || constants).AQI_RANGES;
+  if (!index) {
+    delete filter["values.pm2_5.value"];
+  } else if (Object.keys(activeAqiRanges).includes(index)) {
+    const range = activeAqiRanges[index];
+    filter["values.pm2_5.value"] = {};
+    filter["values.pm2_5.value"]["$gte"] = range.min;
+    // Only set $lte if max is not null
+    if (range.max !== null) {
+      filter["values.pm2_5.value"]["$lte"] = range.max;
+    }
+    filter["index"] = index;
+  } else {
+    delete filter["values.pm2_5.value"];
+  }
+}
+
 //startTime=2022-12-20T10:34:15.880Z
 const generateFilter = {
   // `resolved` (optional, trailing) is the result of
   // utils/aqi.util.js's resolveActiveAqiRanges — pass it to have the
   // `index`/category filter (e.g. ?index=good) use an admin-set custom AQI
-  // range instead of the hardcoded constants.AQI_INDEX. Omit it to keep the
-  // existing behavior unchanged (kept synchronous and backward compatible —
-  // this function has many callers that don't await it).
+  // range instead of the hardcoded defaults (constants.AQI_RANGES). Omit it
+  // to keep the existing behavior unchanged (kept synchronous and backward
+  // compatible — this function has many callers that don't await it).
   events: (request, next, resolved = null) => {
     const { query, params } = request;
     const {
@@ -161,27 +185,7 @@ const generateFilter = {
     }
 
     // Handle index filtering
-    const activeAqiRanges = (resolved || constants).AQI_RANGES;
-    if (!index) {
-      delete filter["values.pm2_5.value"];
-    } else if (Object.keys(activeAqiRanges).includes(index)) {
-      const range = activeAqiRanges[index];
-      // Pre-existing bug, unrelated to the dynamic-config change above:
-      // "values.pm2_5.value" is never seeded as an object in the initial
-      // filter (unlike generateFilter.fetch, which does this correctly) —
-      // every call with a valid ?index= value threw a TypeError here.
-      // Surfaced by adding test coverage for this branch; fixed since it
-      // blocks verifying the dynamic-ranges change for this function.
-      filter["values.pm2_5.value"] = {};
-      filter["values.pm2_5.value"]["$gte"] = range.min;
-      // Only set $lte if max is not null
-      if (range.max !== null) {
-        filter["values.pm2_5.value"]["$lte"] = range.max;
-      }
-      filter["index"] = index;
-    } else {
-      delete filter["values.pm2_5.value"];
-    }
+    applyAqiIndexFilter(filter, index, resolved);
 
     // Handle startTime and endTime filtering
     if (startTime) {
@@ -1279,21 +1283,7 @@ const generateFilter = {
     }
 
     // Handle index filtering
-    const activeAqiRanges = (resolved || constants).AQI_RANGES;
-    if (!index) {
-      delete filter["values.pm2_5.value"];
-    } else if (Object.keys(activeAqiRanges).includes(index)) {
-      const range = activeAqiRanges[index];
-      filter["values.pm2_5.value"] = {};
-      filter["values.pm2_5.value"]["$gte"] = range.min;
-      // Only set $lte if max is not null
-      if (range.max !== null) {
-        filter["values.pm2_5.value"]["$lte"] = range.max;
-      }
-      filter["index"] = index;
-    } else {
-      delete filter["values.pm2_5.value"];
-    }
+    applyAqiIndexFilter(filter, index, resolved);
 
     // Handle startTime and endTime filtering
     if (startTime) {

--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -99,7 +99,13 @@ const handlePredefinedValueMatch = (
 
 //startTime=2022-12-20T10:34:15.880Z
 const generateFilter = {
-  events: (request, next) => {
+  // `resolved` (optional, trailing) is the result of
+  // utils/aqi.util.js's resolveActiveAqiRanges — pass it to have the
+  // `index`/category filter (e.g. ?index=good) use an admin-set custom AQI
+  // range instead of the hardcoded constants.AQI_INDEX. Omit it to keep the
+  // existing behavior unchanged (kept synchronous and backward compatible —
+  // this function has many callers that don't await it).
+  events: (request, next, resolved = null) => {
     const { query, params } = request;
     const {
       device,
@@ -155,10 +161,18 @@ const generateFilter = {
     }
 
     // Handle index filtering
+    const activeAqiRanges = (resolved || constants).AQI_RANGES;
     if (!index) {
       delete filter["values.pm2_5.value"];
-    } else if (Object.keys(constants.AQI_INDEX).includes(index)) {
-      const range = constants.AQI_INDEX[index];
+    } else if (Object.keys(activeAqiRanges).includes(index)) {
+      const range = activeAqiRanges[index];
+      // Pre-existing bug, unrelated to the dynamic-config change above:
+      // "values.pm2_5.value" is never seeded as an object in the initial
+      // filter (unlike generateFilter.fetch, which does this correctly) —
+      // every call with a valid ?index= value threw a TypeError here.
+      // Surfaced by adding test coverage for this branch; fixed since it
+      // blocks verifying the dynamic-ranges change for this function.
+      filter["values.pm2_5.value"] = {};
       filter["values.pm2_5.value"]["$gte"] = range.min;
       // Only set $lte if max is not null
       if (range.max !== null) {
@@ -1200,7 +1214,9 @@ const generateFilter = {
       return;
     }
   },
-  fetch: (request, next) => {
+  // `resolved` (optional, trailing) — see the identical note on `events`
+  // above; same reasoning applies here.
+  fetch: (request, next, resolved = null) => {
     const { query, params } = request;
     const {
       device,
@@ -1263,10 +1279,11 @@ const generateFilter = {
     }
 
     // Handle index filtering
+    const activeAqiRanges = (resolved || constants).AQI_RANGES;
     if (!index) {
       delete filter["values.pm2_5.value"];
-    } else if (Object.keys(constants.AQI_INDEX).includes(index)) {
-      const range = constants.AQI_INDEX[index];
+    } else if (Object.keys(activeAqiRanges).includes(index)) {
+      const range = activeAqiRanges[index];
       filter["values.pm2_5.value"] = {};
       filter["values.pm2_5.value"]["$gte"] = range.min;
       // Only set $lte if max is not null

--- a/src/device-registry/utils/common/test/ut_generate-filter.util.js
+++ b/src/device-registry/utils/common/test/ut_generate-filter.util.js
@@ -65,4 +65,62 @@ describe("generateFilter Util", () => {
       });
     });
   });
+
+  // Nexus follow-up: events/fetch's ?index=<category> filter now accepts an
+  // optional trailing `resolved` config (see utils/aqi.util.js's
+  // resolveActiveAqiRanges) so an admin-set custom AQI range narrows the
+  // filter the same way the hardcoded defaults always have.
+  const customResolved = {
+    AQI_RANGES: {
+      good: { min: 0, max: 5 },
+      moderate: { min: 5, max: 20 },
+      u4sg: { min: 20, max: 40 },
+      unhealthy: { min: 40, max: 80 },
+      very_unhealthy: { min: 80, max: 150 },
+      hazardous: { min: 150, max: null },
+    },
+  };
+
+  describe("events — index filtering", () => {
+    it("uses the hardcoded defaults when no resolved config is passed (backward compatible)", () => {
+      const req = mockRequest({ index: "good" });
+      const result = generateFilter.events(req, null);
+      expect(result["values.pm2_5.value"]).to.deep.equal({ $gte: 0, $lte: 9.1 });
+    });
+
+    it("uses a resolved custom config's boundaries when one is passed", () => {
+      const req = mockRequest({ index: "good" });
+      const result = generateFilter.events(req, null, customResolved);
+      expect(result["values.pm2_5.value"]).to.deep.equal({ $gte: 0, $lte: 5 });
+    });
+
+    it("omits $lte for the unbounded last category under a custom config", () => {
+      const req = mockRequest({ index: "hazardous" });
+      const result = generateFilter.events(req, null, customResolved);
+      expect(result["values.pm2_5.value"]).to.deep.equal({ $gte: 150 });
+    });
+
+    it("drops the pm2_5 filter entirely for an index not present in the resolved config", () => {
+      const req = mockRequest({ index: "not-a-real-category" });
+      const result = generateFilter.events(req, null, customResolved);
+      expect(result).to.not.have.property("values.pm2_5.value");
+    });
+  });
+
+  describe("fetch — index filtering", () => {
+    it("uses the hardcoded defaults when no resolved config is passed (backward compatible)", () => {
+      const req = mockRequest({ index: "moderate" });
+      const result = generateFilter.fetch(req, null);
+      expect(result["values.pm2_5.value"]).to.deep.equal({
+        $gte: 9.101,
+        $lte: 35.49,
+      });
+    });
+
+    it("uses a resolved custom config's boundaries when one is passed", () => {
+      const req = mockRequest({ index: "moderate" });
+      const result = generateFilter.fetch(req, null, customResolved);
+      expect(result["values.pm2_5.value"]).to.deep.equal({ $gte: 5, $lte: 20 });
+    });
+  });
 });

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -2200,7 +2200,8 @@ const createEvent = {
           : "Using standard data query",
       );
 
-      const filter = generateFilter.events(request, next);
+      const resolvedAqiRanges = await aqiUtil.resolveActiveAqiRanges(tenant);
+      const filter = generateFilter.events(request, next, resolvedAqiRanges);
       filter.isHistorical = isHistorical;
 
       try {
@@ -2803,7 +2804,8 @@ const createEvent = {
   },
   fetchAndStoreData: async (request, next) => {
     try {
-      const filter = generateFilter.fetch(request);
+      const resolvedAqiRanges = await aqiUtil.resolveActiveAqiRanges("airqo");
+      const filter = generateFilter.fetch(request, next, resolvedAqiRanges);
       // Fetch the data
       const viewEventsResponse = await EventModel("airqo").fetch(filter);
       logText("we are running running the data insertion script");
@@ -3108,7 +3110,14 @@ const createEvent = {
                 brief: "yes",
               },
             };
-            const fallbackFilter = generateFilter.fetch(fallbackRequest);
+            const resolvedAqiRanges = await aqiUtil.resolveActiveAqiRanges(
+              tenant,
+            );
+            const fallbackFilter = generateFilter.fetch(
+              fallbackRequest,
+              next,
+              resolvedAqiRanges,
+            );
             const eventsResponse = await EventModel(tenant).fetch(
               fallbackFilter,
             );

--- a/src/device-registry/validators/test/ut_tips.validators.js
+++ b/src/device-registry/validators/test/ut_tips.validators.js
@@ -1,0 +1,127 @@
+require("module-alias/register");
+process.env.NODE_ENV = "development";
+const { expect } = require("chai");
+const sinon = require("sinon");
+const proxyquire = require("proxyquire");
+
+const constants = require("@config/constants");
+
+const mockRequest = (body = {}, query = {}) => ({ body, query, params: {} });
+
+// Mirrors validators/test/ut_aqi.validators.js's runChain helper — express-
+// validator's array-style chains are themselves (req, res, next) middleware.
+const runChain = (chain, req) =>
+  new Promise((resolve) => {
+    const res = {};
+    let index = 0;
+    const runNext = (err) => {
+      if (err || index >= chain.length) {
+        resolve(err);
+        return;
+      }
+      const middleware = chain[index++];
+      Promise.resolve(middleware(req, res, runNext)).catch(runNext);
+    };
+    runNext();
+  });
+
+const customResolved = {
+  source: "custom",
+  AQI_RANGES: {
+    good: { min: 0, max: 5 },
+    moderate: { min: 5, max: 20 },
+    u4sg: { min: 20, max: 40 },
+    unhealthy: { min: 40, max: 80 },
+    very_unhealthy: { min: 80, max: 150 },
+    hazardous: { min: 150, max: null },
+  },
+};
+
+const defaultResolved = { source: "default", AQI_RANGES: constants.AQI_RANGES };
+
+// One update entry, valid other than aqi_category, so the chain reaches the
+// aqi_category custom validator under test.
+const updateWithCategory = (aqi_category) => ({
+  aqi_category,
+  tips: [{ tag_line: "Some tag line" }],
+});
+
+describe("tipsValidations.bulkUpdateTips — aqi_category range check", () => {
+  const proxyValidators = (resolveActiveAqiRangesStub) =>
+    proxyquire("../tips.validators", {
+      "@utils/aqi.util": {
+        resolveActiveAqiRanges: resolveActiveAqiRangesStub,
+      },
+    });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("accepts an aqi_category matching the default config when no custom override exists", async () => {
+    const resolveStub = sinon.stub().resolves(defaultResolved);
+    const { bulkUpdateTips } = proxyValidators(resolveStub);
+
+    const req = mockRequest({
+      updates: [updateWithCategory({ min: 0, max: 9.1 })],
+    });
+    const err = await runChain(bulkUpdateTips, req);
+
+    expect(err).to.be.undefined;
+    expect(resolveStub.called).to.equal(true);
+  });
+
+  it("rejects a range that only matches the hardcoded default once a custom override is active", async () => {
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const { bulkUpdateTips } = proxyValidators(resolveStub);
+
+    // 0-9.1 is a valid "good" range under the hardcoded default, but the
+    // active (custom) config's "good" range is 0-5 — this must now fail,
+    // proving the validator follows the active config, not the constant.
+    const req = mockRequest({
+      updates: [updateWithCategory({ min: 0, max: 9.1 })],
+    });
+    const err = await runChain(bulkUpdateTips, req);
+
+    expect(err).to.exist;
+    expect(err.statusCode).to.equal(400);
+  });
+
+  it("accepts a range matching the active custom override's boundaries", async () => {
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const { bulkUpdateTips } = proxyValidators(resolveStub);
+
+    const req = mockRequest({
+      updates: [updateWithCategory({ min: 0, max: 5 })],
+    });
+    const err = await runChain(bulkUpdateTips, req);
+
+    expect(err).to.be.undefined;
+  });
+
+  it("accepts the unbounded (null max) hazardous range under a custom override", async () => {
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const { bulkUpdateTips } = proxyValidators(resolveStub);
+
+    const req = mockRequest({
+      updates: [updateWithCategory({ min: 150, max: null })],
+    });
+    const err = await runChain(bulkUpdateTips, req);
+
+    expect(err).to.be.undefined;
+  });
+
+  it("resolves against the default tenant when none is provided on the request", async () => {
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const { bulkUpdateTips } = proxyValidators(resolveStub);
+
+    const req = mockRequest({
+      updates: [updateWithCategory({ min: 0, max: 5 })],
+    });
+    await runChain(bulkUpdateTips, req);
+
+    expect(resolveStub.calledWith(constants.DEFAULT_TENANT || "airqo")).to.equal(
+      true
+    );
+  });
+});

--- a/src/device-registry/validators/test/ut_tips.validators.js
+++ b/src/device-registry/validators/test/ut_tips.validators.js
@@ -124,4 +124,22 @@ describe("tipsValidations.bulkUpdateTips — aqi_category range check", () => {
       true
     );
   });
+
+  it("defers to the dedicated min/max validators on non-numeric input instead of resolving a config and throwing a generic range error", async () => {
+    const resolveStub = sinon.stub().resolves(customResolved);
+    const { bulkUpdateTips } = proxyValidators(resolveStub);
+
+    const req = mockRequest({
+      updates: [updateWithCategory({ min: "not-a-number", max: 5 })],
+    });
+    const err = await runChain(bulkUpdateTips, req);
+
+    // Still rejected overall (aqi_category.min's own isNumeric check catches
+    // it), but the range-match custom validator must not be the one that
+    // fired — it should have skipped rather than resolving a config for
+    // input it can't meaningfully compare.
+    expect(err).to.exist;
+    expect(err.statusCode).to.equal(400);
+    expect(resolveStub.called).to.equal(false);
+  });
 });

--- a/src/device-registry/validators/tips.validators.js
+++ b/src/device-registry/validators/tips.validators.js
@@ -11,8 +11,11 @@ const ObjectId = mongoose.Types.ObjectId;
 const isEmpty = require("is-empty");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
+const { resolveActiveAqiRanges } = require("@utils/aqi.util");
 
-// Centralized AQI Range Configuration
+// Centralized AQI Range Configuration — kept as the fallback default; the
+// bulk-update validator below now resolves the active (possibly admin-set
+// custom) config instead of always reading this directly.
 const AQI_RANGES = constants.AQI_RANGES;
 
 // Export AQI_RANGES so they can be used in other files if needed
@@ -140,10 +143,15 @@ const healthTipValidations = {
       .isObject()
       .withMessage("aqi_category must be an object")
       .bail()
-      .custom((aqi_category) => {
-        // Validate against predefined AQI ranges
+      .custom(async (aqi_category, { req }) => {
+        // Validate against the active AQI ranges — an admin-set custom
+        // config if one exists, the hardcoded defaults otherwise. express-
+        // validator awaits an async custom validator natively.
+        const tenant =
+          req.query.tenant || constants.DEFAULT_TENANT || "airqo";
+        const resolved = await resolveActiveAqiRanges(tenant);
         const { min, max } = aqi_category;
-        const isValidRange = Object.values(AQI_RANGES).some(
+        const isValidRange = Object.values(resolved.AQI_RANGES).some(
           (range) =>
             Math.abs(range.min - min) < 0.001 && // Using small epsilon for float comparison
             ((range.max === null && max === null) ||

--- a/src/device-registry/validators/tips.validators.js
+++ b/src/device-registry/validators/tips.validators.js
@@ -144,13 +144,27 @@ const healthTipValidations = {
       .withMessage("aqi_category must be an object")
       .bail()
       .custom(async (aqi_category, { req }) => {
+        // min/max's own required/type checks run later in this chain
+        // (aqi_category.min / aqi_category.max below) — skip the range-match
+        // check on a value either of those will already reject, so the
+        // response carries their specific message instead of a generic
+        // "Invalid AQI range: min=undefined, max=NaN" from here, and so a
+        // malformed value doesn't cost a config resolution for nothing.
+        const { min, max } = aqi_category || {};
+        if (
+          typeof min !== "number" ||
+          !Number.isFinite(min) ||
+          (max !== null && (typeof max !== "number" || !Number.isFinite(max)))
+        ) {
+          return true;
+        }
+
         // Validate against the active AQI ranges — an admin-set custom
         // config if one exists, the hardcoded defaults otherwise. express-
         // validator awaits an async custom validator natively.
         const tenant =
           req.query.tenant || constants.DEFAULT_TENANT || "airqo";
         const resolved = await resolveActiveAqiRanges(tenant);
-        const { min, max } = aqi_category;
         const isValidRange = Object.values(resolved.AQI_RANGES).some(
           (range) =>
             Math.abs(range.min - min) < 0.001 && // Using small epsilon for float comparison


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
Makes the admin-editable AQI category ranges (added in the prior `aqi-config-api` PR) the single source of truth everywhere in device-registry, not just the legend and Nexus rankings endpoints:

- **Ingestion classification** (`models/Event.js`'s `generateAqiAddFields()`, used by both `store-readings-job`/`store-signals-job` and the hot read path) now stamps `aqi_category`/`aqi_color`/`aqi_color_name`/`aqi_index` from the active config instead of hardcoded constants.
- **Category-filtered queries** (`?index=good` etc. on `/events` and the underlying `fetch`) now filter against the active config's boundaries.
- **Health tips** — both the bulk-update validator and the stale-tip cleanup job now validate/match against the active config.
- **New backfill job** (`bin/jobs/aqi-category-backfill-job.js`) reconciles already-stored Reading/Signal documents' `aqi_category` fields after an admin changes the config, so old data doesn't keep showing stale categories. Fires immediately after a `PUT`/`DELETE` on `/aqi-ranges` (fire-and-forget) and also runs on a daily safety-net schedule.
- Fixed a pre-existing bug found via new test coverage: `generateFilter.events`'s `?index=` filter threw a `TypeError` for any request with a valid category, because the filter path was never initialized before being written to (unlike `fetch`, which already did this correctly).

### Why is this change needed?
The prior PR deliberately scoped the admin-editable ranges to only the legend/rankings, leaving ingestion, query filters, and health-tip validation still reading the old hardcoded constants — so an admin-set custom range would silently disagree with what got stored and matched elsewhere. This closes that gap end-to-end.

---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
- device-registry

---

## 🧪 Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
182 tests passing across all touched files (generate-filter, aqi.controller, the new backfill job, aqi.util, event.util, tips.validators, and HealthTips's stale-tip cleanup — the latter two had zero prior working test coverage, so new proxyquire-based suites were added). Live end-to-end verification against a local MongoDB: set a custom config via `PUT`, confirmed a pre-existing reading's `aqi_category`/`aqi_color`/`aqi_index` were corrected by the fire-and-forget backfill trigger, then confirmed `DELETE` reverted both the config and the reading back to defaults via a second backfill pass.

---

## 💥 Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All new/changed function signatures use an optional trailing parameter that defaults to the existing hardcoded-constants behavior, so every caller that doesn't opt in is unaffected.

---

## 📝 Additional Notes
Deliberately left untouched (dead code, no live route/registration reaches them): `generateFilter.readings`/`.signals`, `Event.js`'s `signalData`/`signal` static's un-registered sibling paths, and the dormant beta/backup store-readings jobs — worth a separate cleanup PR.

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AQI categories, colors, indexes, and ranges now reflect active tenant-specific configurations across readings, signals, events, and health tips.
  * AQI range changes automatically trigger reconciliation of existing stored data.
  * A daily background process maintains consistency for previously stored readings and signals.

* **Bug Fixes**
  * Improved filtering for AQI index queries, including custom ranges and unbounded categories.
  * Prevented errors when applying PM2.5 filters.
  * Health tip validation and cleanup now honor active AQI ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->