### PR TITLE
Expose AQI config version/timestamp and add rankings tiebreaker

### DIFF
--- a/src/device-registry/utils/aqi.util.js
+++ b/src/device-registry/utils/aqi.util.js
@@ -210,10 +210,12 @@ function categoryFromConcentration(concentration, resolved = null) {
  * Assemble the canonical AQI category ranges (bands, labels, colors) for
  * dynamic frontend rendering — replaces hard-coded AQI legends.
  *
- * @param {{AQI_RANGES, AQI_CATEGORIES, AQI_COLORS, AQI_COLOR_NAMES, AQI_CATEGORY_KEYS, source}|null} [resolved] -
+ * @param {{AQI_RANGES, AQI_CATEGORIES, AQI_COLORS, AQI_COLOR_NAMES, AQI_CATEGORY_KEYS, source, version, effective_from}|null} [resolved] -
  *   optional resolved config (see resolveActiveAqiRanges). Omit to use the
- *   hardcoded defaults, same as before this parameter existed.
- * @returns {{success: boolean, message: string, data: {standard: string, source: string, ranges: Array}}}
+ *   hardcoded defaults, same as before this parameter existed. `version`/
+ *   `effective_from` are only present when `source` is `"custom"` — see
+ *   buildResolvedFromCustom.
+ * @returns {{success: boolean, message: string, data: {standard: string, source: string, version: (number|null), effective_from: (Date|null), ranges: Array}}}
  */
 function listRanges(resolved = null) {
   const {

--- a/src/device-registry/utils/aqi.util.js
+++ b/src/device-registry/utils/aqi.util.js
@@ -224,6 +224,13 @@ function listRanges(resolved = null) {
     AQI_CATEGORY_KEYS,
   } = resolved || constants;
   const source = resolved ? resolved.source : "default";
+  // null for the untouched defaults — there's no admin "activation" event to
+  // report a version/timestamp for. Populated once a custom config exists
+  // (see buildResolvedFromCustom), so a caller polling this endpoint (e.g.
+  // analytics, keeping its own copy in sync) can detect a change without
+  // deep-comparing the ranges array.
+  const version = resolved ? resolved.version ?? null : null;
+  const effective_from = resolved ? resolved.effective_from ?? null : null;
 
   const ranges = AQI_CATEGORY_KEYS.map((key, index) => ({
     key,
@@ -245,6 +252,8 @@ function listRanges(resolved = null) {
     data: {
       standard: "US EPA PM2.5 AQI (2024 NAAQS revision)",
       source,
+      version,
+      effective_from,
       ranges,
     },
   };
@@ -333,8 +342,14 @@ function isValidAqiRangesShape(value) {
  * plain object shared by reference across the whole process and is still the
  * fallback every resolved-config consumer (ingestion, query filters,
  * health-tip validation) uses whenever no admin override is active.
+ *
+ * @param {object} value - the stored SystemConfig doc's `value` field.
+ * @param {object} [meta] - { version, effective_from } from the same
+ * SystemConfig doc, surfaced in GET /aqi-ranges so a caller (e.g. a frontend
+ * or another service polling this config) can detect a change without
+ * deep-comparing the ranges array.
  */
-function buildResolvedFromCustom(value) {
+function buildResolvedFromCustom(value, meta = {}) {
   const AQI_RANGES = {};
   const AQI_CATEGORIES = {};
   const AQI_COLORS = {};
@@ -374,6 +389,8 @@ function buildResolvedFromCustom(value) {
     AQI_COLOR_NAMES,
     AQI_CATEGORY_KEYS,
     source: "custom",
+    version: meta.version ?? null,
+    effective_from: meta.effective_from ?? null,
   };
 }
 
@@ -406,6 +423,8 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
     AQI_COLOR_NAMES: constants.AQI_COLOR_NAMES,
     AQI_CATEGORY_KEYS: constants.AQI_CATEGORY_KEYS,
     source: "default",
+    version: null,
+    effective_from: null,
   };
   try {
     const doc = await SystemConfigModel(tenant)
@@ -413,7 +432,10 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
       .lean();
     if (doc) {
       if (isValidAqiRangesShape(doc.value)) {
-        resolved = buildResolvedFromCustom(doc.value);
+        resolved = buildResolvedFromCustom(doc.value, {
+          version: doc.version,
+          effective_from: doc.updatedAt,
+        });
       } else {
         logger.error(
           `🐛🐛 malformed ${AQI_RANGES_CONFIG_KEY} SystemConfig doc for tenant ${tenant} — falling back to defaults`

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -1790,7 +1790,11 @@ const createEvent = {
           },
         },
         { $match: { _id: { $ne: null } } },
-        { $sort: { avg_pm2_5: sort === "worst" ? -1 : 1 } },
+        // Secondary sort on _id (entity name) breaks ties deterministically —
+        // without it, two entities with the same avg_pm2_5 could swap order
+        // between identical requests, since Mongo doesn't guarantee sort
+        // stability on its own.
+        { $sort: { avg_pm2_5: sort === "worst" ? -1 : 1, _id: 1 } },
         { $limit: Number(limit) },
       ];
 

--- a/src/device-registry/utils/test/ut_aqi.util.js
+++ b/src/device-registry/utils/test/ut_aqi.util.js
@@ -464,6 +464,23 @@ describe("categoryFromConcentration / listRanges with a resolved override", func
     const result = listRanges();
     expect(result.data.source).to.equal("default");
   });
+
+  it("listRanges surfaces version/effective_from from a custom override", function() {
+    const updatedAt = new Date("2026-01-15T00:00:00.000Z");
+    const result = listRanges({
+      ...customResolved,
+      version: 4,
+      effective_from: updatedAt,
+    });
+    expect(result.data.version).to.equal(4);
+    expect(result.data.effective_from).to.equal(updatedAt);
+  });
+
+  it("listRanges reports version/effective_from as null when there's no custom override", function() {
+    const result = listRanges();
+    expect(result.data.version).to.equal(null);
+    expect(result.data.effective_from).to.equal(null);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -581,6 +598,32 @@ describe("resolveActiveAqiRanges / invalidateAqiRangesCache", function() {
     expect(resolved.source).to.equal("custom");
     expect(resolved.AQI_CATEGORIES.good).to.equal("Custom good");
     expect(resolved.AQI_COLORS.good).to.equal("ABCDEF");
+  });
+
+  it("carries the stored doc's version/updatedAt through as version/effective_from", async function() {
+    const storedValue = {
+      ranges: constants.AQI_CATEGORY_KEYS.map((key, i, arr) => ({
+        key,
+        label: "Custom " + key,
+        max_value: i === arr.length - 1 ? null : (i + 1) * 10,
+        color: "ABCDEF",
+      })),
+    };
+    const updatedAt = new Date("2026-02-01T00:00:00.000Z");
+    findOneStub.returns(
+      mockFindOneChain({ value: storedValue, version: 7, updatedAt })
+    );
+
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(resolved.version).to.equal(7);
+    expect(resolved.effective_from).to.equal(updatedAt);
+  });
+
+  it("reports version/effective_from as null when using the defaults", async function() {
+    findOneStub.returns(mockFindOneChain(null));
+    const resolved = await proxiedAqiUtil.resolveActiveAqiRanges("airqo");
+    expect(resolved.version).to.equal(null);
+    expect(resolved.effective_from).to.equal(null);
   });
 
   it("derives min_value from the previous category's max_value rather than trusting a stored min_value", async function() {

--- a/src/device-registry/utils/test/ut_event.util.js
+++ b/src/device-registry/utils/test/ut_event.util.js
@@ -3267,6 +3267,18 @@ describe("create Event utils", function() {
       expect(sortStage.$sort.avg_pm2_5).to.equal(1);
     });
 
+    it("breaks ties deterministically with a secondary sort on entity name", async () => {
+      aggregateStub.returns(mockAggregateChain([]));
+
+      await proxiedEventUtil.getAirQualityRankings({ query: {} }, next);
+
+      const pipeline = aggregateStub.getCall(0).args[0];
+      const sortStage = pipeline.find(
+        (stage) => stage.$sort && "avg_pm2_5" in stage.$sort
+      );
+      expect(sortStage.$sort._id).to.equal(1);
+    });
+
     it("returns an empty array (not an error) when nothing qualifies", async () => {
       aggregateStub.returns(mockAggregateChain([]));
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Two small, independent fixes to the AQI rankings/config API surface, found while cross-checking device-registry's implementation against Nexus's original backend requirements doc:

- `GET /api/v2/devices/aqi-ranges` now returns `version` and `effective_from` alongside the existing `standard`/`source`/`ranges` fields — `null` when the defaults are active, populated (the `SystemConfig` doc's auto-incrementing version number and last-updated timestamp) once an admin sets a custom config.
- The live AQI rankings aggregation (`/readings/rankings`) now has a deterministic secondary sort key (`_id`, i.e. entity name) alongside `avg_pm2_5`, so two entities with an identical average no longer risk swapping order between otherwise-identical requests.

### Why is this change needed?

`analytics` needs a way to detect that device-registry's AQI config changed without deep-comparing the full ranges array on every poll — `version`/`effective_from` gives it a cheap, explicit signal to check instead. This was a direct, documented requirement from Nexus's original backend spec ("changes to the AQI configuration can be versioned or activated without requiring a frontend release") that wasn't yet exposed in the response.

The rankings tiebreaker closes a latent non-determinism gap: Mongo doesn't guarantee stable sort order for ties, so without a secondary key, two countries/cities with the same average PM2.5 could appear in a different relative order across identical, back-to-back requests — undesirable for a ranked leaderboard.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- device-registry

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Added unit tests covering: `version`/`effective_from` surfaced correctly on both the default and custom-config paths (`listRanges`, `resolveActiveAqiRanges`), and the rankings pipeline's secondary sort key. Verified live against local MongoDB: confirmed `version`/`effective_from` are `null` under defaults, populate correctly after a `PUT`, persist across a subsequent `GET`, and revert to `null` after `DELETE`. 193 tests passing across all touched files, 0 failing.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Both changes are purely additive — two new nullable response fields and an additional sort key. No existing field, endpoint, or behavior was removed or altered.

---

## :memo: Additional Notes

Follow-up to a cross-check against Nexus's original backend requirements doc, done while scoping a separate `analytics`-side task (syncing AQI ranges + building the true historical rankings endpoint there). These two items were the only device-registry-side gaps found worth closing directly.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AQI range responses now include configuration version and effective date metadata.
- **Bug Fixes**
  - Air quality rankings now use consistent tie-breaking when entities have identical PM2.5 averages, ensuring stable result ordering.
- **Tests**
  - Added/expanded unit tests to verify AQI metadata behavior (override vs defaults) and deterministic ranking sort construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->