### PR TITLE
Fix password validation regex rejecting valid special characters

### DIFF
--- a/src/auth-service/config/core/numericals.js
+++ b/src/auth-service/config/core/numericals.js
@@ -16,7 +16,7 @@ const TOKEN_STRATEGIES = Object.freeze({
 
 const numericals = {
   TOKEN_STRATEGIES,
-  PASSWORD_REGEX: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d@#?!$%^&*,.]{6,}$/,
+  PASSWORD_REGEX: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d@#?!$%^&*,.()+_-]{6,}$/,
   JWT_EXPIRES_IN_SECONDS: Number.isFinite(
     Number(process.env.JWT_EXPIRES_IN_SECONDS),
   )

--- a/src/auth-service/config/test/ut_numericals.js
+++ b/src/auth-service/config/test/ut_numericals.js
@@ -5,10 +5,10 @@ const constants = require("@config/constants");
 describe("PASSWORD_REGEX", () => {
   describe("accepts passwords using the full allowed special-character set", () => {
     const validPasswords = [
-      "Allahisgreat99##",
-      "Pluto@!#$%^&*()+_-1",
-      "Password1",
-      "abc123!@#?.,",
+      "Zx9Qw7##",
+      "Xz9!#$%^&*()+_-Q",
+      "Qw12Er34",
+      "ab12!@#?.,",
     ];
 
     validPasswords.forEach((password) => {
@@ -20,11 +20,11 @@ describe("PASSWORD_REGEX", () => {
 
   describe("rejects passwords that fail the requirements", () => {
     const invalidPasswords = {
-      "no digit": "NoDigitsHere!!",
-      "no letter": "123456!!",
+      "no digit": "NoDigitsXY!!",
+      "no letter": "000000!!",
       "too short": "Ab1!",
-      "disallowed character (space)": "Password 1",
-      "disallowed character (backslash)": "Password1\\",
+      "disallowed character (space)": "Testval 1",
+      "disallowed character (backslash)": "Testval1\\",
     };
 
     Object.entries(invalidPasswords).forEach(([reason, password]) => {

--- a/src/auth-service/config/test/ut_numericals.js
+++ b/src/auth-service/config/test/ut_numericals.js
@@ -1,0 +1,36 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const constants = require("@config/constants");
+
+describe("PASSWORD_REGEX", () => {
+  describe("accepts passwords using the full allowed special-character set", () => {
+    const validPasswords = [
+      "Allahisgreat99##",
+      "Pluto@!#$%^&*()+_-1",
+      "Password1",
+      "abc123!@#?.,",
+    ];
+
+    validPasswords.forEach((password) => {
+      it(`accepts "${password}"`, () => {
+        expect(constants.PASSWORD_REGEX.test(password)).to.be.true;
+      });
+    });
+  });
+
+  describe("rejects passwords that fail the requirements", () => {
+    const invalidPasswords = {
+      "no digit": "NoDigitsHere!!",
+      "no letter": "123456!!",
+      "too short": "Ab1!",
+      "disallowed character (space)": "Password 1",
+      "disallowed character (backslash)": "Password1\\",
+    };
+
+    Object.entries(invalidPasswords).forEach(([reason, password]) => {
+      it(`rejects "${password}" (${reason})`, () => {
+        expect(constants.PASSWORD_REGEX.test(password)).to.be.false;
+      });
+    });
+  });
+});

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -522,7 +522,7 @@ const createUserModule = {
         isValid: false,
         error: new HttpError("Validation Error", httpStatus.BAD_REQUEST, {
           message:
-            "The password does not meet the security requirements. It must be at least 6 characters long and contain at least one letter and one digit. Special characters (@#?!$%^&*,.) are allowed.",
+            "The password does not meet the security requirements. It must be at least 6 characters long and contain at least one letter and one digit. Special characters (@#?!$%^&*,.()+_-) are allowed.",
         }),
       };
     }

--- a/src/auth-service/validators/requests.validators.js
+++ b/src/auth-service/validators/requests.validators.js
@@ -117,7 +117,7 @@ const acceptInvitation = [
       .bail()
       .matches(constants.PASSWORD_REGEX)
       .withMessage(
-        "password must contain at least one letter and one number, and only allowed special characters: @#?!$%^&*.,",
+        "password must contain at least one letter and one number, and only allowed special characters: @#?!$%^&*,.()+_-",
       ),
   ],
 ];

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -634,7 +634,9 @@ const createUser = [
       .withMessage("Password must be between 6 and 30 characters long")
       .bail()
       .matches(constants.PASSWORD_REGEX)
-      .withMessage("Password must contain at least one letter and one number"),
+      .withMessage(
+        "Password must contain at least one letter and one number. Special characters (@#?!$%^&*,.()+_-) are allowed.",
+      ),
     ...createInterestValidation(),
   ],
 ];
@@ -1130,7 +1132,9 @@ const setPassword = [
     .withMessage("Password must be between 6 and 30 characters long")
     .bail()
     .matches(constants.PASSWORD_REGEX)
-    .withMessage("Password must contain at least one letter and one number"),
+    .withMessage(
+      "Password must contain at least one letter and one number. Special characters (@#?!$%^&*,.()+_-) are allowed.",
+    ),
   body("confirmPassword")
     .exists()
     .withMessage("confirmPassword is required")
@@ -1164,7 +1168,7 @@ const resetPassword = [
     .bail()
     .matches(constants.PASSWORD_REGEX)
     .withMessage(
-      "Password must be at least 6 characters long and contain at least one letter and one number. Special characters (@#?!$%^&*,.) are allowed.",
+      "Password must be at least 6 characters long and contain at least one letter and one number. Special characters (@#?!$%^&*,.()+_-) are allowed.",
     ),
   body("confirmPassword")
     .exists()
@@ -1243,7 +1247,9 @@ const registerViaOrgSlug = [
     .withMessage("Password must be between 6 and 30 characters long")
     .bail()
     .matches(constants.PASSWORD_REGEX)
-    .withMessage("Password must contain at least one letter and one number"),
+    .withMessage(
+      "Password must contain at least one letter and one number. Special characters (@#?!$%^&*,.()+_-) are allowed.",
+    ),
   body("captchaToken")
     .optional()
     .notEmpty()


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Expands the backend `PASSWORD_REGEX` special-character whitelist (adding `( ) + _ -`) used across registration, password reset, and account security endpoints, and updates the related validation error messages to explicitly list the allowed special characters.

### Why is this change needed?
Users with strong, valid passwords (e.g. containing `#`, `(`, `)`, `+`, `_`, `-`) were being rejected with a misleading "must contain at least one letter and one number" error, even though the password had all required elements. The regex was anchored to a narrow whitelist, so a single disallowed character failed the entire match. This also caused inconsistent password acceptance across different screens/endpoints.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- auth-service

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified via direct regex tests that previously-rejected valid passwords (e.g. `Allahisgreat99##`, `Pluto@!#$%^&*()+_-1`) now pass validation, while passwords missing a letter or digit are still correctly rejected. Confirmed no existing test suite references the old whitelist.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
Regex and error messages were unified across `users.validators.js` (registration, setPassword, resetPassword, registerViaOrgSlug), `requests.validators.js`, and `utils/user.util.js` (updatePasswordViaEmail). The unrelated regex in `organization-requests.validators.js` was left unchanged since it does not restrict special characters.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded password requirements to allow additional special characters, including parentheses, plus signs, underscores, and hyphens.
* **Bug Fixes**
  * Updated password validation messages across registration and invitation flows to accurately describe the supported characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->