### PR TITLE
feat(calibrate): add CSV upload calibration with GCS country models

### DIFF
--- a/src/calibrate/.gitignore
+++ b/src/calibrate/.gitignore
@@ -9,3 +9,4 @@ data/
 venv/
 *.pkl
 *.csv
+*.json

--- a/src/calibrate/app.py
+++ b/src/calibrate/app.py
@@ -14,6 +14,11 @@ _logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
+# Allow a full 20 MiB CSV plus the small amount of multipart/form-data
+# metadata added by browsers and API clients. The file itself is checked
+# against the exact limit in the upload endpoint.
+app.config["MAX_CONTENT_LENGTH"] = 21 * 1024 * 1024
+
 # Allow cross-brower resource sharing
 CORS(app)
 
@@ -22,3 +27,11 @@ mongo = PyMongo(app)
 
 # register blueprints
 app.register_blueprint(calibrate_bp)
+
+
+@app.errorhandler(413)
+def request_too_large(_error):
+    return {
+        "message": "The uploaded CSV file cannot exceed 20 MB.",
+        "success": False,
+    }, 413

--- a/src/calibrate/calibrate.py
+++ b/src/calibrate/calibrate.py
@@ -1,69 +1,136 @@
 import pandas as pd
 from flask import Blueprint, request, jsonify, make_response
+from pandas.errors import EmptyDataError, ParserError
 
 from models import calibrate_tool as calibration_tool
-from models import regression as rg
 from models import train_calibrate_tool as training_tool
-import api
+import routes as api
 
 calibrate_bp = Blueprint("calibrate_bp", __name__)
+
+MAX_UPLOAD_BYTES = 20 * 1024 * 1024
+REQUIRED_CALIBRATION_COLUMNS = (
+    "datetime",
+    "pm10",
+    "s2_pm10",
+    "humidity",
+    "temperature",
+)
+PM2_5_SENSOR_COLUMNS = ("pm2_5", "s2_pm2_5")
+PM2_5_AVERAGE_COLUMN = "avg_pm2_5"
+CALIBRATION_COLUMNS = (
+    *REQUIRED_CALIBRATION_COLUMNS,
+    *PM2_5_SENSOR_COLUMNS,
+    PM2_5_AVERAGE_COLUMN,
+)
+
+
+def _error(message, status_code=400):
+    return jsonify({"message": message, "success": False}), status_code
+
+
+def _validate_csv_upload(file):
+    if not file or not file.filename:
+        return _error("Please upload a CSV file.")
+
+    if not file.filename.lower().endswith(".csv"):
+        return _error("Only CSV files are supported.")
+
+    stream = file.stream
+    current_position = stream.tell()
+    stream.seek(0, 2)
+    file_size = stream.tell()
+    stream.seek(current_position)
+
+    if file_size > MAX_UPLOAD_BYTES:
+        return _error("The uploaded CSV file cannot exceed 20 MB.", 413)
+
+    if file_size == 0:
+        return _error("The uploaded CSV file is empty.")
+
+    return None
+
+
+def _read_csv(file):
+    try:
+        return pd.read_csv(file), None
+    except (EmptyDataError, ParserError, UnicodeDecodeError, ValueError):
+        return None, _error("The uploaded file is not a valid CSV file.")
 
 
 @calibrate_bp.route(api.route["calibrate_tool"], methods=["POST"])
 def calibrate_tool():
     if "file" not in request.files:
-        return (
-            jsonify(
-                {
-                    "message": "File missing. Refer to the API documentation for details.",
-                    "success": False,
-                }
-            ),
-            400,
+        return _error(
+            "File missing. Refer to the API documentation for details."
         )
 
-    map_columns = request.form
+    map_columns = {
+        column: request.form.get(column) for column in CALIBRATION_COLUMNS
+    }
 
-    if not (
-        map_columns.get("datetime")
-        and map_columns.get("pm2_5")
-        and map_columns.get("s2_pm2_5")
-        and map_columns.get("pm10")
-        and map_columns.get("s2_pm10")
-        and map_columns.get("humidity")
-        and map_columns.get("temperature")
+    has_required_columns = all(
+        map_columns[column] for column in REQUIRED_CALIBRATION_COLUMNS
+    )
+    has_pm2_5_average = bool(map_columns[PM2_5_AVERAGE_COLUMN])
+    has_pm2_5_sensor_pair = all(
+        map_columns[column] for column in PM2_5_SENSOR_COLUMNS
+    )
+    if not has_required_columns or not (
+        has_pm2_5_average or has_pm2_5_sensor_pair
     ):
-        return (
-            jsonify(
-                {
-                    "message": "Please specify the corresponding datetime, sensor1 pm2.5, sensor2 pm2.5, "
-                    "sensor1 pm10, sensor1 pm10, temperature and humidity values. "
-                    "Refer to the API documentation for details.",
-                    "success": False,
-                }
-            ),
-            400,
+        return _error(
+            "Please map datetime, PM10 sensor 1, PM10 sensor 2, temperature, "
+            "humidity, and either avg_pm2_5 or both PM2.5 sensor columns. "
+            "Refer to the API documentation for details."
         )
 
     file = request.files.get("file")
-    df = pd.read_csv(file)
+    upload_error = _validate_csv_upload(file)
+    if upload_error:
+        return upload_error
 
-    if not set(list(map_columns.values())).issubset(set(list(df.columns))):
-        return (
-            jsonify(
-                {
-                    "message": "One or more keys are missing in the uploaded file.",
-                    "success": False,
-                }
-            ),
-            400,
+    df, csv_error = _read_csv(file)
+    if csv_error:
+        return csv_error
+
+    map_columns = {
+        column: csv_column
+        for column, csv_column in map_columns.items()
+        if csv_column
+    }
+
+    if len(set(map_columns.values())) != len(map_columns):
+        return _error("Each calibration field must map to a different CSV column.")
+
+    missing_columns = sorted(set(map_columns.values()) - set(df.columns))
+    if missing_columns:
+        return _error(
+            "The following mapped columns are missing from the uploaded file: "
+            + ", ".join(missing_columns)
         )
 
-    rg_model = calibration_tool.Regression()
+    country = request.form.get("country")
+    try:
+        rg_model = calibration_tool.Regression(country=country)
+    except ValueError as error:
+        return _error(str(error))
+    except calibration_tool.CalibrationModelError:
+        return _error(
+            "The requested calibration model is currently unavailable.", 503
+        )
 
     map_columns = {value: key for key, value in map_columns.items()}
-    calibrated_data = rg_model.compute_calibrated_val(map_columns, df)
-    resp = make_response(calibrated_data.to_csv())
+    try:
+        calibrated_data = rg_model.compute_calibrated_val(map_columns, df)
+    except (KeyError, TypeError, ValueError) as error:
+        return _error(f"The uploaded data could not be calibrated: {error}")
+    except calibration_tool.CalibrationModelError:
+        return _error(
+            "The requested calibration model could not process the data.", 503
+        )
+
+    resp = make_response(calibrated_data.to_csv(index=False))
     resp.headers["Content-Disposition"] = "attachment; filename=calibrated_data.csv"
     resp.headers["Content-Type"] = "text/csv"
     return resp

--- a/src/calibrate/models/calibrate_tool.py
+++ b/src/calibrate/models/calibrate_tool.py
@@ -1,75 +1,144 @@
+import io
 import os
-from pathlib import Path
+import re
+from functools import lru_cache
+
+import joblib
 import numpy as np
 import pandas as pd
-import pickle
-import gcsfs
-import joblib
-from dotenv import load_dotenv
+from google.cloud import storage
 
-BASE_DIR = Path(__file__).resolve().parent
-dotenv_path = os.path.join(BASE_DIR, ".env")
-load_dotenv(dotenv_path)
 
-RF_REG_MODEL = os.getenv("RF_REG_MODEL", "jobs/rf_reg_model.pkl")
-LASSO_MODEL = os.getenv("LASSO_MODEL", "jobs/lasso_model.pkl")
+CALIBRATION_MODELS_BUCKET = os.getenv(
+    "CALIBRATION_MODELS_BUCKET", "calibration_training_bucket"
+)
+CALIBRATION_MODEL_PREFIX = os.getenv("CALIBRATION_MODEL_PREFIX", "calibration")
+CALIBRATION_MODEL_BLOB = os.getenv("CALIBRATION_MODEL_BLOB")
+CALIBRATION_MODEL_COUNTRY = os.getenv("CALIBRATION_MODEL_COUNTRY", "uganda")
+GCP_PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("GCP_PROJECT_ID")
+
+DEFAULT_FEATURES = [
+    "hour",
+    "avg_pm2_5",
+    "avg_pm10",
+    "error_pm2_5",
+    "error_pm10",
+    "pm2_5_pm10",
+    "pm2_5_pm10_mod",
+]
+
+
+class CalibrationModelError(RuntimeError):
+    """Raised when a deployed calibration model cannot be loaded or used."""
+
+
+def _normalise_country(country):
+    country = (country or CALIBRATION_MODEL_COUNTRY or "").strip().lower()
+    if not country and CALIBRATION_MODEL_BLOB:
+        return "configured"
+    if not country:
+        raise ValueError("Please specify the country calibration model to use.")
+    if not re.fullmatch(r"[a-z0-9 _-]+", country):
+        raise ValueError("Country may contain only letters, numbers, spaces, _ or -.")
+    return country
+
+
+def _model_blob_name(country):
+    if CALIBRATION_MODEL_BLOB:
+        return CALIBRATION_MODEL_BLOB.strip("/")
+    prefix = CALIBRATION_MODEL_PREFIX.strip("/")
+    return f"{prefix}/{country}_pm2_5_cal_model.pkl"
+
+
+@lru_cache(maxsize=16)
+def _load_model_artifact(bucket_name, blob_name, project_id=None):
+    try:
+        client = storage.Client(project=project_id) if project_id else storage.Client()
+        model_bytes = client.bucket(bucket_name).blob(blob_name).download_as_bytes()
+        artifact = joblib.load(io.BytesIO(model_bytes))
+    except Exception as error:
+        raise CalibrationModelError(
+            f"Unable to load calibration model gs://{bucket_name}/{blob_name}."
+        ) from error
+
+    if isinstance(artifact, dict):
+        model = artifact.get("model")
+        features = artifact.get("features")
+    else:
+        model = artifact
+        features = DEFAULT_FEATURES
+
+    if model is None or not hasattr(model, "predict"):
+        raise CalibrationModelError("The calibration artifact has no usable model.")
+    if not isinstance(features, (list, tuple)) or not features:
+        raise CalibrationModelError("The calibration artifact has no feature list.")
+
+    return model, list(features)
 
 
 class Regression:
-    """
-    The class contains functionality for computing device calibrated values .
-    """
+    """Load a deployed country model from GCS and calibrate uploaded readings."""
 
-    def __init__(self):
-        self.rf_regressor = pickle.load(open(RF_REG_MODEL, "rb"))
-        self.lasso_regressor = pickle.load(open(LASSO_MODEL, "rb"))
-        # # load model from GCP
-        # rf_regressor = self.get_model('airqo-250220','airqo_prediction_bucket', 'PM2.5_calibrate_model.pkl')
+    def __init__(self, country=None):
+        self.country = _normalise_country(country)
+        self.blob_name = _model_blob_name(self.country)
+        self.model, self.features = _load_model_artifact(
+            CALIBRATION_MODELS_BUCKET,
+            self.blob_name,
+            GCP_PROJECT_ID,
+        )
 
-    # map_columns = {"datetime":"created_at"}
     def compute_calibrated_val(self, map_columns, df):
-        # Map columns from uploaded csv
-        df.rename(columns=map_columns, inplace=True)
-        df = df.dropna()
+        df = df.rename(columns=map_columns).copy()
+        df["datetime"] = pd.to_datetime(df["datetime"], utc=True, errors="coerce")
 
-        # features from datetime and PM
-        df["datetime"] = pd.to_datetime(df["datetime"])
-        # extract hour
+        has_average_pm2_5 = "avg_pm2_5" in df.columns
+        numeric_columns = ["pm10", "s2_pm10", "temperature", "humidity"]
+        if has_average_pm2_5:
+            numeric_columns.append("avg_pm2_5")
+        else:
+            numeric_columns.extend(["pm2_5", "s2_pm2_5"])
+        df[numeric_columns] = df[numeric_columns].apply(
+            pd.to_numeric, errors="coerce"
+        )
+        df.dropna(subset=["datetime", *numeric_columns], inplace=True)
+        if df.empty:
+            raise ValueError("No valid measurement rows were found.")
+
         df["hour"] = df["datetime"].dt.hour
+        if has_average_pm2_5:
+            # A pre-averaged reading cannot provide sensor-pair disagreement.
+            df["error_pm2_5"] = 0.0
+        else:
+            df["avg_pm2_5"] = df[["pm2_5", "s2_pm2_5"]].mean(axis=1)
+            df["error_pm2_5"] = (df["pm2_5"] - df["s2_pm2_5"]).abs()
+        df["avg_pm10"] = df[["pm10", "s2_pm10"]].mean(axis=1)
+        df["error_pm10"] = (df["pm10"] - df["s2_pm10"]).abs()
+        df["pm2_5_pm10"] = (df["avg_pm10"] - df["avg_pm2_5"]).abs()
+        denominator = df["avg_pm10"].replace(0, np.nan)
+        df["pm2_5_pm10_mod"] = df["pm2_5_pm10"] / denominator
+        df.replace([np.inf, -np.inf], np.nan, inplace=True)
 
-        df["avg_pm2_5"] = df[["pm2_5", "s2_pm2_5"]].mean(axis=1).round(2)
-        df["avg_pm10"] = df[["pm10", "s2_pm10"]].mean(axis=1).round(2)
-        df["error_pm10"] = np.abs(df["pm10"] - df["s2_pm10"])
-        df["error_pm2_5"] = np.abs(df["pm2_5"] - df["s2_pm2_5"])
-        df["pm2_5_pm10"] = df["avg_pm2_5"] - df["avg_pm10"]
-        df["pm2_5_pm10_mod"] = df["pm2_5_pm10"] / df["avg_pm10"]
-        # df = df.drop(['pm2_5','s2_pm2_5','pm10','s2_pm10'], axis=1)
+        missing_features = sorted(set(self.features) - set(df.columns))
+        if missing_features:
+            raise CalibrationModelError(
+                "The uploaded data cannot provide model features: "
+                + ", ".join(missing_features)
+            )
 
-        df_copy = df
+        valid_rows = df.dropna(subset=self.features)
+        if valid_rows.empty:
+            raise ValueError("No rows contain all values required by the model.")
 
-        df = df[
-            [
-                "avg_pm2_5",
-                "avg_pm10",
-                "temperature",
-                "humidity",
-                "hour",
-                "error_pm2_5",
-                "error_pm10",
-                "pm2_5_pm10",
-                "pm2_5_pm10_mod",
-            ]
-        ]
+        try:
+            calibrated_pm2_5 = self.model.predict(valid_rows[self.features])
+        except Exception as error:
+            raise CalibrationModelError(
+                "The deployed calibration model could not process the uploaded data."
+            ) from error
 
-        calibrated_pm2_5 = self.rf_regressor.predict(df)
-        calibrated_pm10 = self.lasso_regressor.predict(df)
-
-        calibrated_data = df_copy[["avg_pm2_5", "avg_pm10", "datetime"]]
-        calibrated_data["calibrated_pm2_5"] = calibrated_pm2_5.round(2)
-        calibrated_data["calibrated_pm10"] = calibrated_pm10.round(2)
-
+        calibrated_data = valid_rows[["avg_pm2_5", "avg_pm10", "datetime"]].copy()
+        calibrated_data["calibrated_pm2_5"] = np.asarray(
+            calibrated_pm2_5
+        ).round(2)
         return calibrated_data
-
-
-if __name__ == "__main__":
-    calibrateInstance = Regression()

--- a/src/calibrate/readme.md
+++ b/src/calibrate/readme.md
@@ -21,10 +21,50 @@ It is implicit that `mongodb` should be installed and running.
 
 ## Calibrate Tool Endpoint
 
-Make a `POST` request to http://localhost:4001/api/v1/calibrate_tool using form data: Form must contain:
+Make a `POST` request to `http://localhost:4001/api/v1/calibrate/tool` using
+`multipart/form-data`. The endpoint returns the calibrated data as a CSV download.
+The deployed training artifacts currently produce calibrated PM2.5 values.
 
-- A csv file containing the data you want to calibrate.
-- Mapping for `datetime`, `pm2_5`, `s2_pm2_5`, `pm10`, `s2_pm10`, `humidity`, `temperature`.
+The form must contain:
+
+- `file`: a non-empty CSV file no larger than 20 MB.
+- `country` (optional): country model name, such as `kenya`. This loads
+  `gs://calibration_training_bucket/calibration/<country>_pm2_5_cal_model.pkl`.
+  When omitted, the service uses the Uganda model.
+- A column-name mapping for `datetime`, `pm10`, `s2_pm10`, `humidity`,
+  and `temperature`.
+- PM2.5 mapped in either of these formats:
+  - `pm2_5` and `s2_pm2_5` for separate sensor readings.
+  - `avg_pm2_5` for one pre-averaged PM2.5 column. In this format, the
+    unavailable sensor-pair error feature is treated as `0`.
+
+Each mapping value must be the name of a distinct column in the uploaded CSV.
+
+Example:
+
+```bash
+curl --request POST http://localhost:4001/api/v1/calibrate/tool \
+  --form "file=@uncalibrated_data.csv;type=text/csv" \
+  --form "country=uganda" \
+  --form "datetime=created_at" \
+  --form "pm2_5=pm2_5" \
+  --form "s2_pm2_5=s2_pm2_5" \
+  --form "pm10=pm10" \
+  --form "s2_pm10=s2_pm10" \
+  --form "humidity=humidity" \
+  --form "temperature=temperature" \
+  --output calibrated_data.csv
+```
+
+The service uses Google Application Default Credentials. Its runtime service
+account needs `storage.objects.get` access to `calibration_training_bucket`.
+The bucket, prefix, project, or a single fixed model can be overridden with:
+
+- `CALIBRATION_MODELS_BUCKET` (default: `calibration_training_bucket`)
+- `CALIBRATION_MODEL_PREFIX` (default: `calibration`)
+- `GOOGLE_CLOUD_PROJECT` or `GCP_PROJECT_ID`
+- `CALIBRATION_MODEL_BLOB` for a fixed blob path
+- `CALIBRATION_MODEL_COUNTRY` to override the default country (`uganda`)
 
 ### Sample contents for csv file containing uncalibrated data
 

--- a/src/calibrate/tests/test_calibrate.py
+++ b/src/calibrate/tests/test_calibrate.py
@@ -1,0 +1,144 @@
+import io
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+
+class FakeRegression:
+    def __init__(self, country=None):
+        self.country = country
+
+    def compute_calibrated_val(self, map_columns, dataframe):
+        return pd.DataFrame(
+            {
+                "datetime": [dataframe["created_at"].iloc[0]],
+                "calibrated_pm2_5": [12.5],
+                "calibrated_pm10": [18.0],
+            }
+        )
+
+
+# Isolate API tests from MongoDB, cloud libraries, and local pickle artifacts.
+flask_pymongo = types.ModuleType("flask_pymongo")
+flask_pymongo.PyMongo = lambda _app: None
+sys.modules["flask_pymongo"] = flask_pymongo
+
+models = types.ModuleType("models")
+calibration_tool = types.ModuleType("models.calibrate_tool")
+calibration_tool.Regression = FakeRegression
+training_tool = types.ModuleType("models.train_calibrate_tool")
+training_tool.Train_calibrate_tool = object
+models.calibrate_tool = calibration_tool
+models.train_calibrate_tool = training_tool
+sys.modules["models"] = models
+sys.modules["models.calibrate_tool"] = calibration_tool
+sys.modules["models.train_calibrate_tool"] = training_tool
+
+from app import app
+
+
+COLUMN_MAPPING = {
+    "country": "uganda",
+    "datetime": "created_at",
+    "pm2_5": "pm2_5",
+    "s2_pm2_5": "s2_pm2_5",
+    "pm10": "pm10",
+    "s2_pm10": "s2_pm10",
+    "humidity": "humidity",
+    "temperature": "temperature",
+}
+
+
+class CalibrateToolTestCase(unittest.TestCase):
+    def setUp(self):
+        app.config.update(TESTING=True)
+        self.client = app.test_client()
+
+    def _post(self, content, filename="measurements.csv", mapping=None):
+        data = dict(COLUMN_MAPPING if mapping is None else mapping)
+        data["file"] = (io.BytesIO(content), filename)
+        return self.client.post(
+            "/api/v1/calibrate/tool",
+            data=data,
+            content_type="multipart/form-data",
+        )
+
+    @patch("calibrate.calibration_tool.Regression", return_value=FakeRegression())
+    def test_calibrates_valid_csv(self, _regression):
+        csv = (
+            b"created_at,pm2_5,s2_pm2_5,pm10,s2_pm10,humidity,temperature\n"
+            b"2026-01-01T00:00:00Z,10,11,20,21,60,24\n"
+        )
+
+        response = self._post(csv)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "text/csv")
+        self.assertIn("calibrated_data.csv", response.headers["Content-Disposition"])
+        self.assertNotIn(b"Unnamed: 0", response.data)
+
+    def test_rejects_non_csv_file(self):
+        response = self._post(b"not a csv", filename="measurements.txt")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["message"], "Only CSV files are supported.")
+
+    def test_rejects_file_larger_than_20_mb(self):
+        response = self._post(b"x" * (20 * 1024 * 1024 + 1))
+
+        self.assertEqual(response.status_code, 413)
+        self.assertIn("20 MB", response.get_json()["message"])
+
+    def test_reports_missing_mapped_columns(self):
+        response = self._post(b"created_at,pm2_5\n2026-01-01,10\n")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("missing from the uploaded file", response.get_json()["message"])
+
+    def test_requires_all_column_mappings(self):
+        mapping = dict(COLUMN_MAPPING)
+        del mapping["temperature"]
+
+        response = self._post(b"created_at\n2026-01-01\n", mapping=mapping)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Please map", response.get_json()["message"])
+
+    @patch("calibrate.calibration_tool.Regression", return_value=FakeRegression())
+    def test_accepts_one_pre_averaged_pm25_column(self, _regression):
+        mapping = dict(COLUMN_MAPPING)
+        del mapping["pm2_5"]
+        del mapping["s2_pm2_5"]
+        mapping["avg_pm2_5"] = "average_pm25"
+        csv = (
+            b"created_at,average_pm25,pm10,s2_pm10,humidity,temperature\n"
+            b"2026-01-01T00:00:00Z,12,20,21,60,24\n"
+        )
+
+        response = self._post(csv, mapping=mapping)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "text/csv")
+
+    @patch("calibrate.calibration_tool.Regression", return_value=FakeRegression())
+    def test_allows_country_to_be_omitted_for_default_model(self, regression):
+        mapping = dict(COLUMN_MAPPING)
+        del mapping["country"]
+
+        response = self._post(
+            (
+                b"created_at,pm2_5,s2_pm2_5,pm10,s2_pm10,humidity,temperature\n"
+                b"2026-01-01T00:00:00Z,10,11,20,21,60,24\n"
+            ),
+            mapping=mapping,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        regression.assert_called_once_with(country=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/calibrate/tests/test_gcs_model.py
+++ b/src/calibrate/tests/test_gcs_model.py
@@ -1,0 +1,127 @@
+import io
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import Mock, patch
+
+import joblib
+import numpy as np
+import pandas as pd
+
+
+MODEL_PATH = Path(__file__).parents[1] / "models" / "calibrate_tool.py"
+SPEC = importlib.util.spec_from_file_location("gcs_calibrate_tool", MODEL_PATH)
+gcs_calibrate_tool = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gcs_calibrate_tool)
+
+
+class FakeModel:
+    def predict(self, features):
+        return np.full(len(features), 12.345)
+
+
+class GcsCalibrationModelTestCase(unittest.TestCase):
+    def setUp(self):
+        gcs_calibrate_tool._load_model_artifact.cache_clear()
+
+    def test_loads_country_artifact_from_expected_gcs_blob(self):
+        artifact_bytes = io.BytesIO()
+        joblib.dump(
+            {"model": FakeModel(), "features": ["hour", "avg_pm2_5"]},
+            artifact_bytes,
+        )
+        blob = Mock()
+        blob.download_as_bytes.return_value = artifact_bytes.getvalue()
+        bucket = Mock()
+        bucket.blob.return_value = blob
+        client = Mock()
+        client.bucket.return_value = bucket
+
+        with patch.object(gcs_calibrate_tool.storage, "Client", return_value=client):
+            regression = gcs_calibrate_tool.Regression(country="Uganda")
+
+        client.bucket.assert_called_once_with("calibration_training_bucket")
+        bucket.blob.assert_called_once_with(
+            "calibration/uganda_pm2_5_cal_model.pkl"
+        )
+        self.assertEqual(regression.features, ["hour", "avg_pm2_5"])
+
+    def test_defaults_to_uganda_model_when_country_is_omitted(self):
+        self.assertEqual(gcs_calibrate_tool._normalise_country(None), "uganda")
+        self.assertEqual(
+            gcs_calibrate_tool._model_blob_name(
+                gcs_calibrate_tool._normalise_country(None)
+            ),
+            "calibration/uganda_pm2_5_cal_model.pkl",
+        )
+
+    def test_uses_artifact_features_to_calibrate_pm25(self):
+        regression = object.__new__(gcs_calibrate_tool.Regression)
+        regression.model = FakeModel()
+        regression.features = ["hour", "avg_pm2_5", "pm2_5_pm10_mod"]
+        dataframe = pd.DataFrame(
+            {
+                "created_at": ["2026-01-01T05:00:00Z"],
+                "sensor_1_pm25": [10],
+                "sensor_2_pm25": [14],
+                "sensor_1_pm10": [20],
+                "sensor_2_pm10": [24],
+                "rh": [60],
+                "temp": [25],
+            }
+        )
+        mapping = {
+            "created_at": "datetime",
+            "sensor_1_pm25": "pm2_5",
+            "sensor_2_pm25": "s2_pm2_5",
+            "sensor_1_pm10": "pm10",
+            "sensor_2_pm10": "s2_pm10",
+            "rh": "humidity",
+            "temp": "temperature",
+        }
+
+        result = regression.compute_calibrated_val(mapping, dataframe)
+
+        self.assertEqual(result["calibrated_pm2_5"].iloc[0], 12.34)
+        self.assertEqual(result["avg_pm2_5"].iloc[0], 12)
+
+    def test_accepts_pre_averaged_pm25_and_uses_zero_sensor_error(self):
+        class CapturingModel:
+            def __init__(self):
+                self.features = None
+
+            def predict(self, features):
+                self.features = features.copy()
+                return np.array([9.876])
+
+        regression = object.__new__(gcs_calibrate_tool.Regression)
+        regression.model = CapturingModel()
+        regression.features = ["hour", "avg_pm2_5", "error_pm2_5"]
+        dataframe = pd.DataFrame(
+            {
+                "created_at": ["2026-01-01T05:00:00Z"],
+                "average_pm25": [11.5],
+                "sensor_1_pm10": [20],
+                "sensor_2_pm10": [24],
+                "rh": [60],
+                "temp": [25],
+            }
+        )
+        mapping = {
+            "created_at": "datetime",
+            "average_pm25": "avg_pm2_5",
+            "sensor_1_pm10": "pm10",
+            "sensor_2_pm10": "s2_pm10",
+            "rh": "humidity",
+            "temp": "temperature",
+        }
+
+        result = regression.compute_calibrated_val(mapping, dataframe)
+
+        self.assertEqual(result["avg_pm2_5"].iloc[0], 11.5)
+        self.assertEqual(regression.model.features["error_pm2_5"].iloc[0], 0)
+        self.assertEqual(result["calibrated_pm2_5"].iloc[0], 9.88)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
### What does this PR do?
<!-- Brief summary of the changes -->
## What this PR does

Adds an upload-based calibration workflow to the Calibrate API.

- Accepts CSV files up to 20 MB.
- Validates file type, size, required mappings, and CSV contents.
- Supports PM2.5 data supplied as either:
  - Two sensor columns: `pm2_5` and `s2_pm2_5`
  - One pre-averaged column: `avg_pm2_5`
- Loads country-specific calibration models from:
  `gs://calibration_training_bucket/calibration/<country>_pm2_5_cal_model.pkl`
- Defaults to the Uganda model when no country is specified.
- Uses the model artifact’s stored feature list.
- Returns calibrated PM2.5 results as a downloadable CSV.
- Returns clear `400`, `413`, and `503` errors for invalid uploads or unavailable models.
- Documents the endpoint, configuration, permissions, and usage.
- Adds 11 tests covering uploads, mappings, GCS loading, country selection, and both PM2.5 formats.
### Why is this change needed?
<!-- Explain the motivation/problem this solves -->
## Why this PR is needed

Users need a simple way to calibrate their own air-quality datasets without manually running calibration scripts.

This PR provides a self-service API that:

- Accepts different PM2.5 dataset formats.
- Applies the appropriate country-specific model.
- Uses Uganda as a safe default when no country is selected.
- Reuses the latest models stored centrally in GCS.
- Protects the service from oversized or invalid uploads.
- Returns calibrated results in a downloadable CSV format.
---

## 🔗 Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Enhancement/improvement
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] 🗑️ Removal/deprecation

---

## 🏗️ Affected Services
**Microservices changed:**
<!-- List the affected services or mark N/A -->

---

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
<!-- Brief description of testing approach -->

---

## 💥 Breaking Changes
- [ ] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## 📝 Additional Notes
<!-- Any additional context, dependencies, or concerns -->

---

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV calibration through the `/api/v1/calibrate/tool` endpoint.
  * Supports country-specific calibration and either averaged PM2.5 data or sensor-based PM2.5 inputs.
  * Returns calibrated PM2.5 results as a downloadable CSV.
* **Bug Fixes**
  * Added validation for file type, size, required columns, mappings, empty files, and invalid data.
  * Oversized uploads now receive a clear JSON error response.
* **Documentation**
  * Expanded setup, configuration, requirements, and usage instructions with a complete request example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->