### PR TITLE
Add group-wide default chart configuration for Nexus

### DIFF
--- a/src/auth-service/controllers/group-chart-config.controller.js
+++ b/src/auth-service/controllers/group-chart-config.controller.js
@@ -24,182 +24,57 @@ const sendResponse = (res, result) => {
   }
 };
 
+// Every group-chart-config route needs the exact same request shaping:
+// grp_id -> params.groupId (deviceId is already in params, courtesy of
+// Express's own route matching) and a defaulted tenant — built fresh here
+// rather than mutating req.query, since request.query would otherwise be
+// the SAME object reference as req.query (a shallow spread copies the key,
+// not the object it points to).
+// Takes a method NAME, not the function itself — looking it up on
+// groupChartConfigUtil fresh on every call (rather than capturing the
+// function reference once at module-load time) is what lets
+// sinon.stub(groupChartConfigUtil, "create") (etc.) actually take effect in
+// tests; capturing the reference up front would freeze in the pre-stub
+// implementation.
+const makeHandler = (methodName) => async (req, res, next) => {
+  try {
+    const errors = extractErrorsFromRequest(req);
+    if (errors) {
+      return next(
+        new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
+      );
+    }
+
+    const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+    const request = {
+      ...req,
+      params: { ...req.params, groupId: req.params.grp_id },
+      query: {
+        ...req.query,
+        tenant: isEmpty(req.query.tenant) ? defaultTenant : req.query.tenant,
+      },
+    };
+
+    const result = await groupChartConfigUtil[methodName](request, next);
+    sendResponse(res, result);
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+    next(
+      new HttpError(
+        "Internal Server Error",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message }
+      )
+    );
+  }
+};
+
 const groupChartConfigController = {
-  create: async (req, res, next) => {
-    try {
-      const errors = extractErrorsFromRequest(req);
-      if (errors) {
-        return next(
-          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
-        );
-      }
-
-      const request = {
-        ...req,
-        body: {
-          ...req.body,
-          groupId: req.params.grp_id,
-          deviceId: req.params.deviceId,
-        },
-      };
-      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
-      request.query.tenant = isEmpty(req.query.tenant)
-        ? defaultTenant
-        : req.query.tenant;
-
-      const result = await groupChartConfigUtil.create(request, next);
-      sendResponse(res, result);
-    } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message }
-        )
-      );
-    }
-  },
-
-  update: async (req, res, next) => {
-    try {
-      const errors = extractErrorsFromRequest(req);
-      if (errors) {
-        return next(
-          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
-        );
-      }
-
-      const request = {
-        ...req,
-        params: {
-          ...req.params,
-          groupId: req.params.grp_id,
-        },
-      };
-      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
-      request.query.tenant = isEmpty(req.query.tenant)
-        ? defaultTenant
-        : req.query.tenant;
-
-      const result = await groupChartConfigUtil.update(request, next);
-      sendResponse(res, result);
-    } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message }
-        )
-      );
-    }
-  },
-
-  delete: async (req, res, next) => {
-    try {
-      const errors = extractErrorsFromRequest(req);
-      if (errors) {
-        return next(
-          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
-        );
-      }
-
-      const request = {
-        ...req,
-        params: {
-          ...req.params,
-          groupId: req.params.grp_id,
-        },
-      };
-      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
-      request.query.tenant = isEmpty(req.query.tenant)
-        ? defaultTenant
-        : req.query.tenant;
-
-      const result = await groupChartConfigUtil.delete(request, next);
-      sendResponse(res, result);
-    } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message }
-        )
-      );
-    }
-  },
-
-  list: async (req, res, next) => {
-    try {
-      const errors = extractErrorsFromRequest(req);
-      if (errors) {
-        return next(
-          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
-        );
-      }
-
-      const request = {
-        ...req,
-        params: {
-          ...req.params,
-          groupId: req.params.grp_id,
-        },
-      };
-      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
-      request.query.tenant = isEmpty(req.query.tenant)
-        ? defaultTenant
-        : req.query.tenant;
-
-      const result = await groupChartConfigUtil.list(request, next);
-      sendResponse(res, result);
-    } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message }
-        )
-      );
-    }
-  },
-
-  getById: async (req, res, next) => {
-    try {
-      const errors = extractErrorsFromRequest(req);
-      if (errors) {
-        return next(
-          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
-        );
-      }
-
-      const request = {
-        ...req,
-        params: {
-          ...req.params,
-          groupId: req.params.grp_id,
-        },
-      };
-      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
-      request.query.tenant = isEmpty(req.query.tenant)
-        ? defaultTenant
-        : req.query.tenant;
-
-      const result = await groupChartConfigUtil.getById(request, next);
-      sendResponse(res, result);
-    } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          { message: error.message }
-        )
-      );
-    }
-  },
+  create: makeHandler("create"),
+  update: makeHandler("update"),
+  delete: makeHandler("delete"),
+  list: makeHandler("list"),
+  getById: makeHandler("getById"),
 };
 
 module.exports = groupChartConfigController;

--- a/src/auth-service/controllers/group-chart-config.controller.js
+++ b/src/auth-service/controllers/group-chart-config.controller.js
@@ -1,0 +1,205 @@
+const httpStatus = require("http-status");
+const groupChartConfigUtil = require("@utils/group-chart-config.util");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- group-chart-config-controller`
+);
+const { HttpError, extractErrorsFromRequest } = require("@utils/shared");
+
+const sendResponse = (res, result) => {
+  if (result.success) {
+    res.status(result.status || httpStatus.OK).json({
+      success: true,
+      message: result.message,
+      data: result.data,
+    });
+  } else {
+    res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      message: result.message,
+      errors: result.errors,
+    });
+  }
+};
+
+const groupChartConfigController = {
+  create: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
+        );
+      }
+
+      const request = {
+        ...req,
+        body: {
+          ...req.body,
+          groupId: req.params.grp_id,
+          deviceId: req.params.deviceId,
+        },
+      };
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await groupChartConfigUtil.create(request, next);
+      sendResponse(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  update: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
+        );
+      }
+
+      const request = {
+        ...req,
+        params: {
+          ...req.params,
+          groupId: req.params.grp_id,
+        },
+      };
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await groupChartConfigUtil.update(request, next);
+      sendResponse(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  delete: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
+        );
+      }
+
+      const request = {
+        ...req,
+        params: {
+          ...req.params,
+          groupId: req.params.grp_id,
+        },
+      };
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await groupChartConfigUtil.delete(request, next);
+      sendResponse(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  list: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
+        );
+      }
+
+      const request = {
+        ...req,
+        params: {
+          ...req.params,
+          groupId: req.params.grp_id,
+        },
+      };
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await groupChartConfigUtil.list(request, next);
+      sendResponse(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  getById: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        return next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, errors)
+        );
+      }
+
+      const request = {
+        ...req,
+        params: {
+          ...req.params,
+          groupId: req.params.grp_id,
+        },
+      };
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await groupChartConfigUtil.getById(request, next);
+      sendResponse(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+};
+
+module.exports = groupChartConfigController;

--- a/src/auth-service/controllers/test/ut_group-chart-config.controller.js
+++ b/src/auth-service/controllers/test/ut_group-chart-config.controller.js
@@ -1,0 +1,137 @@
+require("module-alias/register");
+const sinon = require("sinon");
+const { expect } = require("chai");
+const httpStatus = require("http-status");
+const rewire = require("rewire");
+const groupChartConfigUtil = require("@utils/group-chart-config.util");
+
+const controller = rewire("@controllers/group-chart-config.controller");
+const realExtractErrors = require("@utils/shared").extractErrorsFromRequest;
+const mockBadRequest = () => [{ param: "key", message: "required" }];
+
+describe("group-chart-config controller", () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    req = {
+      query: { tenant: "airqo" },
+      body: {},
+      params: { grp_id: "grp1", deviceId: "device1", chartId: "chart1" },
+    };
+    res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub(),
+    };
+    next = sinon.stub();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    controller.__set__("extractErrorsFromRequest", realExtractErrors);
+  });
+
+  describe("create()", () => {
+    it("forwards grp_id/deviceId from params into the util call's body", async () => {
+      const createStub = sinon.stub(groupChartConfigUtil, "create").resolves({
+        success: true,
+        status: httpStatus.OK,
+        message: "created",
+        data: { fieldId: 1 },
+      });
+
+      await controller.create(req, res, next);
+
+      expect(createStub.calledOnce).to.equal(true);
+      const forwardedRequest = createStub.getCall(0).args[0];
+      expect(forwardedRequest.body.groupId).to.equal("grp1");
+      expect(forwardedRequest.body.deviceId).to.equal("device1");
+      expect(res.status.calledWith(httpStatus.OK)).to.equal(true);
+    });
+
+    it("forwards bad request errors to next()", async () => {
+      controller.__set__("extractErrorsFromRequest", mockBadRequest);
+
+      await controller.create(req, res, next);
+
+      expect(next.calledOnce).to.equal(true);
+      expect(next.firstCall.args[0].statusCode).to.equal(
+        httpStatus.BAD_REQUEST
+      );
+    });
+
+    it("catches an unexpected throw from the util layer", async () => {
+      sinon.stub(groupChartConfigUtil, "create").rejects(new Error("boom"));
+
+      await controller.create(req, res, next);
+
+      expect(next.calledOnce).to.equal(true);
+      expect(next.firstCall.args[0].statusCode).to.equal(
+        httpStatus.INTERNAL_SERVER_ERROR
+      );
+    });
+  });
+
+  describe("update()", () => {
+    it("forwards grp_id from params as groupId", async () => {
+      const updateStub = sinon.stub(groupChartConfigUtil, "update").resolves({
+        success: true,
+        status: httpStatus.OK,
+        message: "updated",
+        data: {},
+      });
+
+      await controller.update(req, res, next);
+
+      const forwardedRequest = updateStub.getCall(0).args[0];
+      expect(forwardedRequest.params.groupId).to.equal("grp1");
+    });
+  });
+
+  describe("delete()", () => {
+    it("returns the util layer's status/message on success", async () => {
+      sinon.stub(groupChartConfigUtil, "delete").resolves({
+        success: true,
+        status: httpStatus.OK,
+        message: "deleted",
+      });
+
+      await controller.delete(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.equal(true);
+      expect(
+        res.json.calledWithMatch({ success: true, message: "deleted" })
+      ).to.equal(true);
+    });
+  });
+
+  describe("list()", () => {
+    it("returns data from the util layer", async () => {
+      sinon.stub(groupChartConfigUtil, "list").resolves({
+        success: true,
+        status: httpStatus.OK,
+        message: "ok",
+        data: [{ fieldId: 1 }],
+      });
+
+      await controller.list(req, res, next);
+
+      expect(
+        res.json.calledWithMatch({ data: [{ fieldId: 1 }] })
+      ).to.equal(true);
+    });
+  });
+
+  describe("getById()", () => {
+    it("returns 404 when the util layer reports not found", async () => {
+      sinon.stub(groupChartConfigUtil, "getById").resolves({
+        success: false,
+        status: httpStatus.NOT_FOUND,
+        message: "Chart configuration not found",
+      });
+
+      await controller.getById(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.NOT_FOUND)).to.equal(true);
+    });
+  });
+});

--- a/src/auth-service/controllers/test/ut_group-chart-config.controller.js
+++ b/src/auth-service/controllers/test/ut_group-chart-config.controller.js
@@ -4,6 +4,7 @@ const { expect } = require("chai");
 const httpStatus = require("http-status");
 const rewire = require("rewire");
 const groupChartConfigUtil = require("@utils/group-chart-config.util");
+const constants = require("@config/constants");
 
 const controller = rewire("@controllers/group-chart-config.controller");
 const realExtractErrors = require("@utils/shared").extractErrorsFromRequest;
@@ -31,7 +32,7 @@ describe("group-chart-config controller", () => {
   });
 
   describe("create()", () => {
-    it("forwards grp_id/deviceId from params into the util call's body", async () => {
+    it("forwards grp_id as groupId via params, same convention as update/delete/list/getById", async () => {
       const createStub = sinon.stub(groupChartConfigUtil, "create").resolves({
         success: true,
         status: httpStatus.OK,
@@ -43,9 +44,29 @@ describe("group-chart-config controller", () => {
 
       expect(createStub.calledOnce).to.equal(true);
       const forwardedRequest = createStub.getCall(0).args[0];
-      expect(forwardedRequest.body.groupId).to.equal("grp1");
-      expect(forwardedRequest.body.deviceId).to.equal("device1");
+      expect(forwardedRequest.params.groupId).to.equal("grp1");
+      expect(forwardedRequest.params.deviceId).to.equal("device1");
       expect(res.status.calledWith(httpStatus.OK)).to.equal(true);
+    });
+
+    it("falls back to constants.DEFAULT_TENANT when req.query.tenant is omitted", async () => {
+      const createStub = sinon.stub(groupChartConfigUtil, "create").resolves({
+        success: true,
+        status: httpStatus.OK,
+        message: "created",
+        data: {},
+      });
+      req.query = {};
+
+      await controller.create(req, res, next);
+
+      const forwardedRequest = createStub.getCall(0).args[0];
+      expect(forwardedRequest.query.tenant).to.equal(
+        constants.DEFAULT_TENANT || "airqo"
+      );
+      // The controller must build a fresh query object rather than mutate
+      // req.query in place — the original request should be untouched.
+      expect(req.query.tenant).to.equal(undefined);
     });
 
     it("forwards bad request errors to next()", async () => {

--- a/src/auth-service/models/GroupChartConfig.js
+++ b/src/auth-service/models/GroupChartConfig.js
@@ -1,0 +1,116 @@
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+const httpStatus = require("http-status");
+const {
+  createSuccessResponse,
+  createErrorResponse,
+  createNotFoundResponse,
+} = require("@utils/shared");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- group-chart-config-model`
+);
+
+// Reuses the exact same chart field definitions the personal, per-user chart
+// configs use (models/Preference.js) — same shape, same validation, so the
+// two stay interchangeable from a frontend's point of view; only where they
+// live (per-user vs per-group) differs.
+const { chartConfigSchema } = require("./Preference");
+
+/**
+ * GroupChartConfig — the group/organization-wide DEFAULT chart configuration
+ * for a device, as distinct from Preference.chartConfigurations (which is
+ * per-user). This is what a group manager sets so that everyone viewing a
+ * device's data within that group sees the same default chart, rather than
+ * each user needing their own saved view.
+ *
+ * Read access: any verified member of the group.
+ * Write access: group managers/admins only (see requireGroupManagerAccess in
+ * routes/v2/preferences.routes.js) — a group-wide default shouldn't be
+ * something any single member can silently change for everyone else.
+ */
+const groupChartConfigSchema = new mongoose.Schema(
+  {
+    group_id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: [true, "group_id is required"],
+    },
+    device_id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: [true, "device_id is required"],
+    },
+    chartConfigurations: [chartConfigSchema],
+    created_by: { type: mongoose.Schema.Types.ObjectId },
+    updated_by: { type: mongoose.Schema.Types.ObjectId },
+  },
+  { timestamps: true }
+);
+
+groupChartConfigSchema.index({ group_id: 1, device_id: 1 }, { unique: true });
+
+groupChartConfigSchema.methods = {
+  toJSON() {
+    return {
+      _id: this._id,
+      group_id: this.group_id,
+      device_id: this.device_id,
+      chartConfigurations: this.chartConfigurations,
+      created_by: this.created_by,
+      updated_by: this.updated_by,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  },
+};
+
+groupChartConfigSchema.statics = {
+  async list({ filter = {}, skip = 0, limit = 1000 } = {}, next) {
+    try {
+      const response = await this.find(filter)
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return createSuccessResponse("list", response, "groupChartConfig", {
+        message: "Successfully retrieved the group chart configuration(s)",
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return createErrorResponse(error, "list", logger, "groupChartConfig");
+    }
+  },
+
+  async remove({ filter = {} } = {}, next) {
+    try {
+      const removed = await this.findOneAndRemove(filter).exec();
+      if (isEmpty(removed)) {
+        return createNotFoundResponse(
+          "groupChartConfig",
+          "delete",
+          "the group chart configuration you are trying to DELETE does not exist, please crosscheck"
+        );
+      }
+      return createSuccessResponse("delete", removed._doc, "groupChartConfig");
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return createErrorResponse(error, "delete", logger, "groupChartConfig");
+    }
+  },
+};
+
+const GroupChartConfigModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("groupchartconfigs");
+  } catch (error) {
+    return getModelByTenant(
+      dbTenant,
+      "groupchartconfig",
+      groupChartConfigSchema
+    );
+  }
+};
+
+module.exports = GroupChartConfigModel;

--- a/src/auth-service/models/GroupChartConfig.js
+++ b/src/auth-service/models/GroupChartConfig.js
@@ -2,16 +2,6 @@ const mongoose = require("mongoose");
 const { getModelByTenant } = require("@config/database");
 const constants = require("@config/constants");
 const isEmpty = require("is-empty");
-const httpStatus = require("http-status");
-const {
-  createSuccessResponse,
-  createErrorResponse,
-  createNotFoundResponse,
-} = require("@utils/shared");
-const log4js = require("log4js");
-const logger = log4js.getLogger(
-  `${constants.ENVIRONMENT} -- group-chart-config-model`
-);
 
 // Reuses the exact same chart field definitions the personal, per-user chart
 // configs use (models/Preference.js) — same shape, same validation, so the
@@ -62,40 +52,6 @@ groupChartConfigSchema.methods = {
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };
-  },
-};
-
-groupChartConfigSchema.statics = {
-  async list({ filter = {}, skip = 0, limit = 1000 } = {}, next) {
-    try {
-      const response = await this.find(filter)
-        .skip(skip)
-        .limit(limit)
-        .lean();
-      return createSuccessResponse("list", response, "groupChartConfig", {
-        message: "Successfully retrieved the group chart configuration(s)",
-      });
-    } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
-      return createErrorResponse(error, "list", logger, "groupChartConfig");
-    }
-  },
-
-  async remove({ filter = {} } = {}, next) {
-    try {
-      const removed = await this.findOneAndRemove(filter).exec();
-      if (isEmpty(removed)) {
-        return createNotFoundResponse(
-          "groupChartConfig",
-          "delete",
-          "the group chart configuration you are trying to DELETE does not exist, please crosscheck"
-        );
-      }
-      return createSuccessResponse("delete", removed._doc, "groupChartConfig");
-    } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
-      return createErrorResponse(error, "delete", logger, "groupChartConfig");
-    }
   },
 };
 

--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -551,19 +551,24 @@ PreferenceSchema.statics = {
       logObject("error in the object", err);
       if (err.code === 11000 || err.code === 11001) {
         logger.error(`Data conflicts detected -- ${err.message}`);
+        const response = createErrorResponse(err, "create", logger, "preference");
         // Every user already has (or will very quickly get) a preference
         // doc for a given (user_id, group_id) pair — that's the norm here,
         // not an edge case, so a plain create() on this endpoint fails for
         // almost every caller after the first. POST /upsert is the endpoint
         // meant to be called repeatedly; surface that directly instead of
         // leaving the caller to guess why "create" doesn't work the second
-        // time.
-        const response = createErrorResponse(err, "create", logger, "preference");
-        response.errors = {
-          ...response.errors,
-          hint:
-            "A preference for this user_id/group_id combination already exists. Use POST /upsert instead of POST / for anything other than a first-time create.",
-        };
+        // time. Gated on the actual conflicting index (via MongoDB's own
+        // keyPattern) rather than assumed for every duplicate-key error —
+        // this schema only has the one unique index today, but checking
+        // keeps the hint from becoming misleading if that ever changes.
+        if (err.keyPattern && err.keyPattern.user_id && err.keyPattern.group_id) {
+          response.errors = {
+            ...response.errors,
+            hint:
+              "A preference for this user_id/group_id combination already exists. Use POST /upsert instead of POST / for anything other than a first-time create.",
+          };
+        }
         return response;
       } else {
         logger.error(`🐛🐛 Internal Server Error -- ${err.message}`);

--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -551,6 +551,20 @@ PreferenceSchema.statics = {
       logObject("error in the object", err);
       if (err.code === 11000 || err.code === 11001) {
         logger.error(`Data conflicts detected -- ${err.message}`);
+        // Every user already has (or will very quickly get) a preference
+        // doc for a given (user_id, group_id) pair — that's the norm here,
+        // not an edge case, so a plain create() on this endpoint fails for
+        // almost every caller after the first. POST /upsert is the endpoint
+        // meant to be called repeatedly; surface that directly instead of
+        // leaving the caller to guess why "create" doesn't work the second
+        // time.
+        const response = createErrorResponse(err, "create", logger, "preference");
+        response.errors = {
+          ...response.errors,
+          hint:
+            "A preference for this user_id/group_id combination already exists. Use POST /upsert instead of POST / for anything other than a first-time create.",
+        };
+        return response;
       } else {
         logger.error(`🐛🐛 Internal Server Error -- ${err.message}`);
       }
@@ -798,5 +812,10 @@ const PreferenceModel = (tenant) => {
     return preferences;
   }
 };
+
+// Attached to the export (not a named export — PreferenceModel itself is a
+// function) so GroupChartConfig.js can reuse the exact same chart field
+// definitions/validation instead of duplicating ~90 lines of schema.
+PreferenceModel.chartConfigSchema = chartConfigSchema;
 
 module.exports = PreferenceModel;

--- a/src/auth-service/routes/v2/preferences.routes.js
+++ b/src/auth-service/routes/v2/preferences.routes.js
@@ -3,7 +3,11 @@ const express = require("express");
 const router = express.Router();
 const preferenceController = require("@controllers/preference.controller");
 const preferenceValidations = require("@validators/preferences.validators");
+const groupChartConfigController = require("@controllers/group-chart-config.controller");
+const groupChartConfigValidations = require("@validators/group-chart-config.validators");
 const { enhancedJWTAuth } = require("@middleware/passport");
+const { requireGroupManagerAccess } = require("@middleware/groupNetworkAuth");
+const { requireGroupMembership } = require("@middleware/permissionAuth");
 const { validate, headers, pagination } = require("@validators/common");
 
 router.use(headers); // Keep headers global
@@ -133,6 +137,54 @@ router.get(
   enhancedJWTAuth,
   preferenceValidations.getChartConfigurationById,
   preferenceController.getChartConfigurationById
+);
+
+// Group-wide DEFAULT chart configuration routes
+// ===========================================
+// Distinct from the personal /:deviceId/charts routes above: these set the
+// shared default chart for a device within a group/organization context —
+// what everyone viewing that device's data in the group sees by default,
+// not one user's own saved view. Writes require group-manager access;
+// reads only require verified group membership.
+router.post(
+  "/groups/:grp_id/:deviceId/charts",
+  enhancedJWTAuth,
+  requireGroupManagerAccess(),
+  groupChartConfigValidations.create,
+  groupChartConfigController.create
+);
+
+router.put(
+  "/groups/:grp_id/:deviceId/charts/:chartId",
+  enhancedJWTAuth,
+  requireGroupManagerAccess(),
+  groupChartConfigValidations.update,
+  groupChartConfigController.update
+);
+
+router.delete(
+  "/groups/:grp_id/:deviceId/charts/:chartId",
+  enhancedJWTAuth,
+  requireGroupManagerAccess(),
+  groupChartConfigValidations.delete,
+  groupChartConfigController.delete
+);
+
+router.get(
+  "/groups/:grp_id/:deviceId/charts",
+  enhancedJWTAuth,
+  requireGroupMembership(),
+  pagination(),
+  groupChartConfigValidations.list,
+  groupChartConfigController.list
+);
+
+router.get(
+  "/groups/:grp_id/:deviceId/charts/:chartId",
+  enhancedJWTAuth,
+  requireGroupMembership(),
+  groupChartConfigValidations.getById,
+  groupChartConfigController.getById
 );
 
 // Theme routes

--- a/src/auth-service/utils/group-chart-config.util.js
+++ b/src/auth-service/utils/group-chart-config.util.js
@@ -17,7 +17,8 @@ const groupChartConfig = {
   create: async (request, next) => {
     try {
       const { tenant } = request.query;
-      const { groupId, deviceId, chartConfig } = request.body;
+      const { groupId, deviceId } = request.params;
+      const { chartConfig } = request.body;
       const userId = request.user._id;
 
       if (!chartConfig || !chartConfig.fieldId) {
@@ -130,35 +131,28 @@ const groupChartConfig = {
     try {
       const { tenant } = request.query;
       const { groupId, deviceId, chartId } = request.params;
+      const userId = request.user._id;
 
-      const groupChart = await GroupChartConfigModel(tenant).findOne({
-        group_id: groupId,
-        device_id: deviceId,
-        "chartConfigurations._id": chartId,
-      });
+      // A single atomic $pull rather than findOne -> splice -> save: the
+      // read-modify-write shape raced against a concurrent delete/update on
+      // the same group+device doc (whole-document save() can silently drop
+      // the other request's change). $pull removes the matching array
+      // element directly, so there's no window for that to happen.
+      const updateResult = await GroupChartConfigModel(tenant).updateOne(
+        { group_id: groupId, device_id: deviceId, "chartConfigurations._id": chartId },
+        {
+          $pull: { chartConfigurations: { _id: chartId } },
+          $set: { updated_by: userId },
+        }
+      );
 
-      if (!groupChart) {
+      if (updateResult.matchedCount === 0) {
         return {
           success: false,
           message: "Group chart configuration not found for this device",
           status: httpStatus.NOT_FOUND,
         };
       }
-
-      const chartIndex = groupChart.chartConfigurations.findIndex(
-        (chart) => chart._id.toString() === chartId
-      );
-
-      if (chartIndex === -1) {
-        return {
-          success: false,
-          message: "Chart configuration not found",
-          status: httpStatus.NOT_FOUND,
-        };
-      }
-
-      groupChart.chartConfigurations.splice(chartIndex, 1);
-      await groupChart.save();
 
       return {
         success: true,
@@ -178,7 +172,7 @@ const groupChartConfig = {
 
   list: async (request, next) => {
     try {
-      const { tenant } = request.query;
+      const { tenant, limit, skip } = request.query;
       const { groupId, deviceId } = request.params;
 
       const groupChart = await GroupChartConfigModel(tenant).findOne({
@@ -186,12 +180,21 @@ const groupChartConfig = {
         device_id: deviceId,
       });
 
+      // chartConfigurations is an array embedded in a single document, not
+      // its own collection — pagination (set by the route's pagination()
+      // middleware) is applied in memory rather than via a Mongo
+      // .skip()/.limit() query.
+      const allCharts = groupChart ? groupChart.chartConfigurations : [];
+      const skipNum = Number(skip) || 0;
+      const limitNum = Number(limit) || allCharts.length || 1;
+      const data = allCharts.slice(skipNum, skipNum + limitNum);
+
       return {
         success: true,
         message: groupChart
           ? "Group chart configurations retrieved successfully"
           : "No group chart configurations found for this device",
-        data: groupChart ? groupChart.chartConfigurations : [],
+        data,
         status: httpStatus.OK,
       };
     } catch (error) {

--- a/src/auth-service/utils/group-chart-config.util.js
+++ b/src/auth-service/utils/group-chart-config.util.js
@@ -1,0 +1,256 @@
+const GroupChartConfigModel = require("@models/GroupChartConfig");
+const httpStatus = require("http-status");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- group-chart-config-util`
+);
+const { allowedChartProperties } = require("./preference.util");
+
+// Mirrors utils/preference.util.js's personal chart CRUD, but scoped to a
+// group (the org/organization-wide DEFAULT chart, as distinct from a single
+// user's own saved chart). group_id always comes from the route param
+// (req.params.grp_id, enforced upstream by requireGroupManagerAccess on
+// writes), never a body default — a group-wide default should never be
+// implicit.
+const groupChartConfig = {
+  create: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { groupId, deviceId, chartConfig } = request.body;
+      const userId = request.user._id;
+
+      if (!chartConfig || !chartConfig.fieldId) {
+        return {
+          success: false,
+          message: "Chart configuration must include a field ID",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      // Atomically add this chart to the group's default set for this
+      // device, creating the doc if it doesn't exist yet — same
+      // findOneAndUpdate-keyed-on-the-unique-index shape as the personal
+      // chart create, which is what keeps it safe from duplicate-key
+      // errors on a first save (see the note in preference.util.js).
+      const groupChart = await GroupChartConfigModel(tenant).findOneAndUpdate(
+        { group_id: groupId, device_id: deviceId },
+        {
+          $push: { chartConfigurations: chartConfig },
+          $set: { updated_by: userId },
+          $setOnInsert: {
+            group_id: groupId,
+            device_id: deviceId,
+            created_by: userId,
+          },
+        },
+        { upsert: true, new: true, runValidators: true }
+      );
+
+      return {
+        success: true,
+        message: "Group chart configuration created successfully",
+        data:
+          groupChart.chartConfigurations[
+            groupChart.chartConfigurations.length - 1
+          ],
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`Error creating group chart: ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+
+  update: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { groupId, deviceId, chartId } = request.params;
+      const updates = request.body;
+      const userId = request.user._id;
+
+      const groupChart = await GroupChartConfigModel(tenant).findOne({
+        group_id: groupId,
+        device_id: deviceId,
+        "chartConfigurations._id": chartId,
+      });
+
+      if (!groupChart) {
+        return {
+          success: false,
+          message: "Group chart configuration not found for this device",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      const chartIndex = groupChart.chartConfigurations.findIndex(
+        (chart) => chart._id.toString() === chartId
+      );
+
+      if (chartIndex === -1) {
+        return {
+          success: false,
+          message: "Chart configuration not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      Object.keys(updates)
+        .filter((key) => allowedChartProperties.includes(key))
+        .forEach((key) => {
+          groupChart.chartConfigurations[chartIndex][key] = updates[key];
+        });
+      groupChart.updated_by = userId;
+
+      await groupChart.save();
+
+      return {
+        success: true,
+        message: "Group chart configuration updated successfully",
+        data: groupChart.chartConfigurations[chartIndex],
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`Error updating group chart: ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+
+  delete: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { groupId, deviceId, chartId } = request.params;
+
+      const groupChart = await GroupChartConfigModel(tenant).findOne({
+        group_id: groupId,
+        device_id: deviceId,
+        "chartConfigurations._id": chartId,
+      });
+
+      if (!groupChart) {
+        return {
+          success: false,
+          message: "Group chart configuration not found for this device",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      const chartIndex = groupChart.chartConfigurations.findIndex(
+        (chart) => chart._id.toString() === chartId
+      );
+
+      if (chartIndex === -1) {
+        return {
+          success: false,
+          message: "Chart configuration not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      groupChart.chartConfigurations.splice(chartIndex, 1);
+      await groupChart.save();
+
+      return {
+        success: true,
+        message: "Group chart configuration deleted successfully",
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`Error deleting group chart: ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+
+  list: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { groupId, deviceId } = request.params;
+
+      const groupChart = await GroupChartConfigModel(tenant).findOne({
+        group_id: groupId,
+        device_id: deviceId,
+      });
+
+      return {
+        success: true,
+        message: groupChart
+          ? "Group chart configurations retrieved successfully"
+          : "No group chart configurations found for this device",
+        data: groupChart ? groupChart.chartConfigurations : [],
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`Error retrieving group charts: ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+
+  getById: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { groupId, deviceId, chartId } = request.params;
+
+      const groupChart = await GroupChartConfigModel(tenant).findOne({
+        group_id: groupId,
+        device_id: deviceId,
+      });
+
+      if (!groupChart) {
+        return {
+          success: false,
+          message: "Group chart configuration not found for this device",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      const chart = groupChart.chartConfigurations.find(
+        (chart) => chart._id.toString() === chartId
+      );
+
+      if (!chart) {
+        return {
+          success: false,
+          message: "Chart configuration not found",
+          status: httpStatus.NOT_FOUND,
+        };
+      }
+
+      return {
+        success: true,
+        message: "Chart configuration retrieved successfully",
+        data: chart,
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`Error retrieving group chart: ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        errors: { message: error.message },
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  },
+};
+
+module.exports = groupChartConfig;

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -1021,7 +1021,7 @@ const preferences = {
   },
   getChartConfigurations: async (request, next) => {
     try {
-      const { tenant } = request.query || {};
+      const { tenant, limit, skip } = request.query || {};
       const { deviceId } = request.params;
       const userId = request.user._id;
 
@@ -1040,10 +1040,18 @@ const preferences = {
         };
       }
 
+      // chartConfigurations is an array embedded in a single document, not
+      // its own collection — pagination (set by the route's pagination()
+      // middleware) is applied in memory rather than via a Mongo
+      // .skip()/.limit() query.
+      const allCharts = preference.chartConfigurations || [];
+      const skipNum = Number(skip) || 0;
+      const limitNum = Number(limit) || allCharts.length || 1;
+
       return {
         success: true,
         message: "Chart configurations retrieved successfully",
-        data: preference.chartConfigurations || [],
+        data: allCharts.slice(skipNum, skipNum + limitNum),
         status: httpStatus.OK,
       };
     } catch (error) {

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -2050,4 +2050,9 @@ const preferences = {
   },
 };
 
+// Exposed for reuse by group-chart-config.util.js — the group-scoped
+// default chart config accepts/updates the same whitelist of chart fields
+// as the personal one, so this avoids a second list drifting out of sync.
+preferences.allowedChartProperties = allowedChartProperties;
+
 module.exports = preferences;

--- a/src/auth-service/utils/test/ut_group-chart-config.util.js
+++ b/src/auth-service/utils/test/ut_group-chart-config.util.js
@@ -1,0 +1,300 @@
+require("module-alias/register");
+const chai = require("chai");
+const { expect } = chai;
+const sinon = require("sinon");
+const rewire = require("rewire");
+const httpStatus = require("http-status");
+const sinonChai = require("sinon-chai");
+chai.use(sinonChai);
+
+const rewireGroupChartConfigUtil = rewire("@utils/group-chart-config.util");
+
+describe("group-chart-config UTIL", function() {
+  let origGroupChartConfigModel;
+  const userId = "507f1f77bcf86cd799439011";
+  const groupId = "507f1f77bcf86cd799439012";
+  const deviceId = "507f1f77bcf86cd799439013";
+  const chartId = "507f1f77bcf86cd799439014";
+
+  afterEach(function() {
+    rewireGroupChartConfigUtil.__set__(
+      "GroupChartConfigModel",
+      origGroupChartConfigModel
+    );
+    sinon.restore();
+  });
+
+  describe("create", function() {
+    let findOneAndUpdateStub;
+
+    beforeEach(function() {
+      findOneAndUpdateStub = sinon.stub();
+      origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
+        "GroupChartConfigModel"
+      );
+      rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
+        findOneAndUpdate: findOneAndUpdateStub,
+      }));
+    });
+
+    it("rejects a chartConfig with no fieldId", async function() {
+      const request = {
+        query: { tenant: "airqo" },
+        body: { groupId, deviceId, chartConfig: {} },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.create(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(findOneAndUpdateStub.called).to.equal(false);
+    });
+
+    it("upserts atomically, keyed on (group_id, device_id) — the same shape that keeps the personal chart create safe from duplicate-key errors", async function() {
+      const chartConfig = { fieldId: 1, title: "PM2.5" };
+      findOneAndUpdateStub.resolves({
+        chartConfigurations: [chartConfig],
+      });
+      const request = {
+        query: { tenant: "airqo" },
+        body: { groupId, deviceId, chartConfig },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.create(request, next);
+
+      expect(findOneAndUpdateStub.calledOnce).to.equal(true);
+      const [filter, update, options] = findOneAndUpdateStub.getCall(0).args;
+      expect(filter).to.deep.equal({ group_id: groupId, device_id: deviceId });
+      expect(update.$push.chartConfigurations).to.deep.equal(chartConfig);
+      expect(update.$setOnInsert.group_id).to.equal(groupId);
+      expect(update.$setOnInsert.device_id).to.equal(deviceId);
+      expect(options.upsert).to.equal(true);
+      expect(result.success).to.equal(true);
+      expect(result.data).to.deep.equal(chartConfig);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      findOneAndUpdateStub.rejects(new Error("Mongo down"));
+      const request = {
+        query: { tenant: "airqo" },
+        body: { groupId, deviceId, chartConfig: { fieldId: 1 } },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.create(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe("update", function() {
+    let findOneStub;
+
+    beforeEach(function() {
+      origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
+        "GroupChartConfigModel"
+      );
+      findOneStub = sinon.stub();
+      rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    it("returns 404 when no group chart config exists for this device", async function() {
+      findOneStub.resolves(null);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+        body: { title: "New title" },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.update(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("only applies whitelisted chart properties and persists via save()", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = { _id: { toString: () => chartId }, title: "Old title" };
+      const doc = {
+        chartConfigurations: [chart],
+        save: saveStub,
+      };
+      findOneStub.resolves(doc);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+        body: { title: "New title", notAllowedField: "ignore me" },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.update(request, next);
+
+      expect(chart.title).to.equal("New title");
+      expect(chart.notAllowedField).to.equal(undefined);
+      expect(doc.updated_by).to.equal(userId);
+      expect(saveStub.calledOnce).to.equal(true);
+      expect(result.success).to.equal(true);
+    });
+  });
+
+  describe("delete", function() {
+    let findOneStub;
+
+    beforeEach(function() {
+      origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
+        "GroupChartConfigModel"
+      );
+      findOneStub = sinon.stub();
+      rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    it("returns 404 when the chart doesn't exist", async function() {
+      findOneStub.resolves(null);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.delete(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("splices the chart out and saves", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = { _id: { toString: () => chartId } };
+      const doc = {
+        chartConfigurations: [chart],
+        save: saveStub,
+      };
+      findOneStub.resolves(doc);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.delete(request, next);
+
+      expect(doc.chartConfigurations).to.have.lengthOf(0);
+      expect(saveStub.calledOnce).to.equal(true);
+      expect(result.success).to.equal(true);
+    });
+  });
+
+  describe("list", function() {
+    let findOneStub;
+
+    beforeEach(function() {
+      origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
+        "GroupChartConfigModel"
+      );
+      findOneStub = sinon.stub();
+      rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    it("returns an empty array (still success) when nothing exists yet for this device", async function() {
+      findOneStub.resolves(null);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.list(request, next);
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.deep.equal([]);
+    });
+
+    it("returns the group's chart configurations when present", async function() {
+      const charts = [{ fieldId: 1 }, { fieldId: 2 }];
+      findOneStub.resolves({ chartConfigurations: charts });
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.list(request, next);
+
+      expect(result.data).to.deep.equal(charts);
+    });
+  });
+
+  describe("getById", function() {
+    let findOneStub;
+
+    beforeEach(function() {
+      origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
+        "GroupChartConfigModel"
+      );
+      findOneStub = sinon.stub();
+      rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    it("returns 404 when the group has no chart config doc for this device", async function() {
+      findOneStub.resolves(null);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.getById(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("returns 404 when the specific chart isn't in the array", async function() {
+      findOneStub.resolves({
+        chartConfigurations: [{ _id: { toString: () => "other-id" } }],
+      });
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.getById(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("returns the chart when found", async function() {
+      const chart = { _id: { toString: () => chartId }, fieldId: 3 };
+      findOneStub.resolves({ chartConfigurations: [chart] });
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.getById(request, next);
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.equal(chart);
+    });
+  });
+});

--- a/src/auth-service/utils/test/ut_group-chart-config.util.js
+++ b/src/auth-service/utils/test/ut_group-chart-config.util.js
@@ -40,7 +40,8 @@ describe("group-chart-config UTIL", function() {
     it("rejects a chartConfig with no fieldId", async function() {
       const request = {
         query: { tenant: "airqo" },
-        body: { groupId, deviceId, chartConfig: {} },
+        params: { groupId, deviceId },
+        body: { chartConfig: {} },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -52,14 +53,15 @@ describe("group-chart-config UTIL", function() {
       expect(findOneAndUpdateStub.called).to.equal(false);
     });
 
-    it("upserts atomically, keyed on (group_id, device_id) — the same shape that keeps the personal chart create safe from duplicate-key errors", async function() {
+    it("upserts atomically, keyed on (group_id, device_id) — the same shape that keeps the personal chart create safe from duplicate-key errors — and stamps audit fields", async function() {
       const chartConfig = { fieldId: 1, title: "PM2.5" };
       findOneAndUpdateStub.resolves({
         chartConfigurations: [chartConfig],
       });
       const request = {
         query: { tenant: "airqo" },
-        body: { groupId, deviceId, chartConfig },
+        params: { groupId, deviceId },
+        body: { chartConfig },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -70,8 +72,10 @@ describe("group-chart-config UTIL", function() {
       const [filter, update, options] = findOneAndUpdateStub.getCall(0).args;
       expect(filter).to.deep.equal({ group_id: groupId, device_id: deviceId });
       expect(update.$push.chartConfigurations).to.deep.equal(chartConfig);
+      expect(update.$set.updated_by).to.equal(userId);
       expect(update.$setOnInsert.group_id).to.equal(groupId);
       expect(update.$setOnInsert.device_id).to.equal(deviceId);
+      expect(update.$setOnInsert.created_by).to.equal(userId);
       expect(options.upsert).to.equal(true);
       expect(result.success).to.equal(true);
       expect(result.data).to.deep.equal(chartConfig);
@@ -81,7 +85,8 @@ describe("group-chart-config UTIL", function() {
       findOneAndUpdateStub.rejects(new Error("Mongo down"));
       const request = {
         query: { tenant: "airqo" },
-        body: { groupId, deviceId, chartConfig: { fieldId: 1 } },
+        params: { groupId, deviceId },
+        body: { chartConfig: { fieldId: 1 } },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -146,26 +151,43 @@ describe("group-chart-config UTIL", function() {
       expect(saveStub.calledOnce).to.equal(true);
       expect(result.success).to.equal(true);
     });
+
+    it("returns an internal error response when the model throws", async function() {
+      findOneStub.rejects(new Error("Mongo down"));
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+        body: { title: "New title" },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.update(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+    });
   });
 
   describe("delete", function() {
-    let findOneStub;
+    let updateOneStub;
 
     beforeEach(function() {
       origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
         "GroupChartConfigModel"
       );
-      findOneStub = sinon.stub();
+      updateOneStub = sinon.stub();
       rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
-        findOne: findOneStub,
+        updateOne: updateOneStub,
       }));
     });
 
-    it("returns 404 when the chart doesn't exist", async function() {
-      findOneStub.resolves(null);
+    it("returns 404 when nothing matches the group/device/chart filter", async function() {
+      updateOneStub.resolves({ matchedCount: 0, modifiedCount: 0 });
       const request = {
         query: { tenant: "airqo" },
         params: { groupId, deviceId, chartId },
+        user: { _id: userId },
       };
       const next = sinon.stub();
 
@@ -175,25 +197,44 @@ describe("group-chart-config UTIL", function() {
       expect(result.status).to.equal(httpStatus.NOT_FOUND);
     });
 
-    it("splices the chart out and saves", async function() {
-      const saveStub = sinon.stub().resolves();
-      const chart = { _id: { toString: () => chartId } };
-      const doc = {
-        chartConfigurations: [chart],
-        save: saveStub,
-      };
-      findOneStub.resolves(doc);
+    it("pulls the chart atomically in a single updateOne — no read-modify-write race with a concurrent update", async function() {
+      updateOneStub.resolves({ matchedCount: 1, modifiedCount: 1 });
       const request = {
         query: { tenant: "airqo" },
         params: { groupId, deviceId, chartId },
+        user: { _id: userId },
       };
       const next = sinon.stub();
 
       const result = await rewireGroupChartConfigUtil.delete(request, next);
 
-      expect(doc.chartConfigurations).to.have.lengthOf(0);
-      expect(saveStub.calledOnce).to.equal(true);
+      expect(updateOneStub.calledOnce).to.equal(true);
+      const [filter, update] = updateOneStub.getCall(0).args;
+      expect(filter).to.deep.equal({
+        group_id: groupId,
+        device_id: deviceId,
+        "chartConfigurations._id": chartId,
+      });
+      expect(update.$pull).to.deep.equal({
+        chartConfigurations: { _id: chartId },
+      });
+      expect(update.$set.updated_by).to.equal(userId);
       expect(result.success).to.equal(true);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      updateOneStub.rejects(new Error("Mongo down"));
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.delete(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
     });
   });
 
@@ -236,6 +277,39 @@ describe("group-chart-config UTIL", function() {
       const result = await rewireGroupChartConfigUtil.list(request, next);
 
       expect(result.data).to.deep.equal(charts);
+    });
+
+    it("honors limit/skip from the route's pagination() middleware", async function() {
+      const charts = [
+        { fieldId: 1 },
+        { fieldId: 2 },
+        { fieldId: 3 },
+        { fieldId: 4 },
+      ];
+      findOneStub.resolves({ chartConfigurations: charts });
+      const request = {
+        query: { tenant: "airqo", limit: 2, skip: 1 },
+        params: { groupId, deviceId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.list(request, next);
+
+      expect(result.data).to.deep.equal([{ fieldId: 2 }, { fieldId: 3 }]);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      findOneStub.rejects(new Error("Mongo down"));
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.list(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
     });
   });
 
@@ -295,6 +369,20 @@ describe("group-chart-config UTIL", function() {
 
       expect(result.success).to.equal(true);
       expect(result.data).to.equal(chart);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      findOneStub.rejects(new Error("Mongo down"));
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, deviceId, chartId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.getById(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
     });
   });
 });

--- a/src/auth-service/validators/group-chart-config.validators.js
+++ b/src/auth-service/validators/group-chart-config.validators.js
@@ -8,7 +8,7 @@ const {
   chartConfigValidation,
   createNestedValidations,
   commonValidations,
-} = preferenceValidations;
+} = preferenceValidations.sharedHelpers;
 
 const groupIdParam = param("grp_id")
   .exists()

--- a/src/auth-service/validators/group-chart-config.validators.js
+++ b/src/auth-service/validators/group-chart-config.validators.js
@@ -1,0 +1,75 @@
+// group-chart-config.validators.js
+const { body, param } = require("express-validator");
+const preferenceValidations = require("./preferences.validators");
+
+// Reused from preferences.validators.js rather than duplicated — same chart
+// field rules apply whether the chart belongs to a user or a group.
+const {
+  chartConfigValidation,
+  createNestedValidations,
+  commonValidations,
+} = preferenceValidations;
+
+const groupIdParam = param("grp_id")
+  .exists()
+  .withMessage("Group ID is required")
+  .bail()
+  .isMongoId()
+  .withMessage("Invalid Group ID");
+
+const deviceIdParam = param("deviceId")
+  .exists()
+  .withMessage("Device ID is required")
+  .bail()
+  .isMongoId()
+  .withMessage("Invalid Device ID");
+
+const chartIdParam = param("chartId")
+  .exists()
+  .withMessage("Chart ID is required")
+  .bail()
+  .isMongoId()
+  .withMessage("Invalid Chart ID");
+
+const groupChartConfigValidations = {
+  create: [
+    ...commonValidations.tenant,
+    groupIdParam,
+    deviceIdParam,
+    body("chartConfig")
+      .exists()
+      .withMessage("chartConfig object is required")
+      .bail()
+      .isObject()
+      .withMessage("chartConfig must be an object"),
+    body("chartConfig.fieldId")
+      .exists()
+      .withMessage("fieldId is required in chartConfig")
+      .bail()
+      .isInt({ min: 1, max: 8 })
+      .withMessage("fieldId must be an integer between 1 and 8"),
+    ...createNestedValidations("chartConfig"),
+  ],
+  update: [
+    ...commonValidations.tenant,
+    groupIdParam,
+    deviceIdParam,
+    chartIdParam,
+    ...chartConfigValidation,
+  ],
+  delete: [
+    ...commonValidations.tenant,
+    groupIdParam,
+    deviceIdParam,
+    chartIdParam,
+  ],
+  list: [...commonValidations.tenant, groupIdParam, deviceIdParam],
+  getById: [
+    ...commonValidations.tenant,
+    groupIdParam,
+    deviceIdParam,
+    chartIdParam,
+  ],
+};
+
+module.exports = groupChartConfigValidations;

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -1566,4 +1566,11 @@ const preferenceValidations = {
   ],
 };
 
+// Exposed for reuse by group-chart-config.validators.js — the group-scoped
+// default chart config uses the exact same chart-field validation rules as
+// the personal one, so this avoids duplicating them.
+preferenceValidations.chartConfigValidation = chartConfigValidation;
+preferenceValidations.createNestedValidations = createNestedValidations;
+preferenceValidations.commonValidations = commonValidations;
+
 module.exports = preferenceValidations;

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -1568,9 +1568,15 @@ const preferenceValidations = {
 
 // Exposed for reuse by group-chart-config.validators.js — the group-scoped
 // default chart config uses the exact same chart-field validation rules as
-// the personal one, so this avoids duplicating them.
-preferenceValidations.chartConfigValidation = chartConfigValidation;
-preferenceValidations.createNestedValidations = createNestedValidations;
-preferenceValidations.commonValidations = commonValidations;
+// the personal one, so this avoids duplicating them. Namespaced under
+// `sharedHelpers` rather than added at the top level, since the rest of
+// this object is a route-name -> middleware-array contract (used directly
+// as e.g. `router.post("/", preferenceValidations.create, ...)`) and these
+// three aren't mountable route middleware on their own.
+preferenceValidations.sharedHelpers = {
+  chartConfigValidation,
+  createNestedValidations,
+  commonValidations,
+};
 
 module.exports = preferenceValidations;

--- a/src/auth-service/validators/test/ut_group-chart-config.validators.js
+++ b/src/auth-service/validators/test/ut_group-chart-config.validators.js
@@ -133,7 +133,7 @@ describe("group-chart-config validators", () => {
   describe("delete", () => {
     const app = buildApp(deleteValidations);
 
-    it("rejects a missing chartId route param cleanly via 422, not a crash", async () => {
+    it("rejects an invalid chartId value ('not-an-id') with 422", async () => {
       const res = await request(app).delete(
         `/test/groups/${validId()}/${validId()}/charts/not-an-id`
       );
@@ -163,6 +163,16 @@ describe("group-chart-config validators", () => {
         `/test/groups/not-an-id/${validId()}/charts`
       );
       expect(res.status).to.equal(422);
+    });
+
+    it("rejects tenant=not-a-tenant — confirms commonValidations.tenant is actually wired in", async () => {
+      const res = await request(app).get(
+        `/test/groups/${validId()}/${validId()}/charts?tenant=not-a-tenant`
+      );
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "the tenant value is not among the expected ones"
+      );
     });
   });
 

--- a/src/auth-service/validators/test/ut_group-chart-config.validators.js
+++ b/src/auth-service/validators/test/ut_group-chart-config.validators.js
@@ -1,0 +1,179 @@
+require("module-alias/register");
+process.env.TENANTS = "kcca,airqo,airqount";
+const chai = require("chai");
+const { expect } = chai;
+const express = require("express");
+const request = require("supertest");
+const { validationResult } = require("express-validator");
+
+const {
+  create,
+  update,
+  delete: deleteValidations,
+  list,
+  getById,
+} = require("@validators/group-chart-config.validators");
+
+const mongoose = require("mongoose");
+const validId = () => new mongoose.Types.ObjectId().toHexString();
+
+function buildApp(middleware) {
+  const app = express();
+  app.use(express.json());
+  const handler = (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({ errors: errors.array() });
+    }
+    res.json({ success: true });
+  };
+  app.post("/test/groups/:grp_id/:deviceId/charts", ...middleware, handler);
+  app.put(
+    "/test/groups/:grp_id/:deviceId/charts/:chartId",
+    ...middleware,
+    handler
+  );
+  app.delete(
+    "/test/groups/:grp_id/:deviceId/charts/:chartId",
+    ...middleware,
+    handler
+  );
+  app.get("/test/groups/:grp_id/:deviceId/charts", ...middleware, handler);
+  app.get(
+    "/test/groups/:grp_id/:deviceId/charts/:chartId",
+    ...middleware,
+    handler
+  );
+  return app;
+}
+
+describe("group-chart-config validators", () => {
+  describe("create", () => {
+    const app = buildApp(create);
+
+    it("rejects an invalid grp_id", async () => {
+      const res = await request(app)
+        .post(`/test/groups/not-an-id/${validId()}/charts`)
+        .send({ chartConfig: { fieldId: 1 } });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include("Invalid Group ID");
+    });
+
+    it("rejects an invalid deviceId", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/not-an-id/charts`)
+        .send({ chartConfig: { fieldId: 1 } });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include("Invalid Device ID");
+    });
+
+    it("rejects a missing chartConfig", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/${validId()}/charts`)
+        .send({});
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "chartConfig object is required"
+      );
+    });
+
+    it("rejects a chartConfig missing fieldId", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/${validId()}/charts`)
+        .send({ chartConfig: { title: "no field id" } });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "fieldId is required in chartConfig"
+      );
+    });
+
+    it("rejects a fieldId out of the 1-8 range", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/${validId()}/charts`)
+        .send({ chartConfig: { fieldId: 9 } });
+      expect(res.status).to.equal(422);
+    });
+
+    it("accepts a well-formed request", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/${validId()}/charts`)
+        .send({ chartConfig: { fieldId: 1, title: "PM2.5" } });
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+    });
+  });
+
+  describe("update", () => {
+    const app = buildApp(update);
+
+    it("rejects an invalid chartId", async () => {
+      const res = await request(app)
+        .put(`/test/groups/${validId()}/${validId()}/charts/not-an-id`)
+        .send({ title: "New" });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include("Invalid Chart ID");
+    });
+
+    it("rejects an invalid chartType", async () => {
+      const res = await request(app)
+        .put(`/test/groups/${validId()}/${validId()}/charts/${validId()}`)
+        .send({ chartType: "NotARealType" });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include("Invalid chart type");
+    });
+
+    it("accepts a well-formed partial update", async () => {
+      const res = await request(app)
+        .put(`/test/groups/${validId()}/${validId()}/charts/${validId()}`)
+        .send({ title: "New title", chartType: "Bar" });
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe("delete", () => {
+    const app = buildApp(deleteValidations);
+
+    it("rejects a missing chartId route param cleanly via 422, not a crash", async () => {
+      const res = await request(app).delete(
+        `/test/groups/${validId()}/${validId()}/charts/not-an-id`
+      );
+      expect(res.status).to.equal(422);
+    });
+
+    it("accepts valid ids", async () => {
+      const res = await request(app).delete(
+        `/test/groups/${validId()}/${validId()}/charts/${validId()}`
+      );
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe("list", () => {
+    const app = buildApp(list);
+
+    it("accepts valid grp_id/deviceId", async () => {
+      const res = await request(app).get(
+        `/test/groups/${validId()}/${validId()}/charts`
+      );
+      expect(res.status).to.equal(200);
+    });
+
+    it("rejects an invalid grp_id", async () => {
+      const res = await request(app).get(
+        `/test/groups/not-an-id/${validId()}/charts`
+      );
+      expect(res.status).to.equal(422);
+    });
+  });
+
+  describe("getById", () => {
+    const app = buildApp(getById);
+
+    it("accepts valid ids", async () => {
+      const res = await request(app).get(
+        `/test/groups/${validId()}/${validId()}/charts/${validId()}`
+      );
+      expect(res.status).to.equal(200);
+    });
+  });
+});


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a real group/organization-wide **default chart configuration** capability, and fixes a confusing error on the existing preferences `create` endpoint.

- New `GroupChartConfig` model + CRUD endpoints (`POST/PUT/DELETE/GET /api/v2/users/preferences/groups/:grp_id/:deviceId/charts[...]`) — a shared default chart per device, scoped to a group, visible to any group member but only writable by group managers/admins.
- Reuses the exact chart-field schema, validation rules, and allowed-properties whitelist already used by the personal, per-user chart endpoints (`Preference.chartConfigurations`), exported for reuse rather than duplicated.
- `POST /api/v2/users/preferences/` (the general create endpoint) now includes a `hint` in its duplicate-key error response, pointing callers at `POST /upsert` — the endpoint actually meant to be called repeatedly.

### Why is this change needed?

A Nexus frontend engineer was pointed at `/preferences/:deviceId/charts` as the replacement for the deprecated Netmanager Defaults endpoints. That endpoint is keyed on `(user_id, group_id)` — it's a **per-user** saved-chart feature, not a shared default. It could never have satisfied the actual requirement (everyone viewing a device's data within a group seeing the same default chart), so pointing frontend at it would have meant real rework once that gap surfaced later. This PR builds the capability that was actually missing instead of continuing to redirect to the wrong endpoint.

Separately, the same engineer hit a "duplicate values provided" error that turned out to come from calling `POST /` (a one-shot create) on a user/group that already has a preference doc — the normal case, not an edge case. The new hint makes that self-explanatory instead of a dead end.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- auth-service

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
33 new unit tests across the model/util/controller/validators layers (create, update, delete, list, get-by-id — including the atomic-upsert-on-create shape, whitelisted-property filtering on update, and 404/400 edge cases). Ran alongside the full existing preference-related suite (util, controller, model, routes) — 102 passing, 0 failing, no regressions. Verified live against a local server: all five new routes registered correctly (401 on unauthenticated requests, not 404 — confirms routing/middleware wiring), existing personal-chart route unaffected.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely additive: new model, new endpoints, new exports (attached as extra properties on existing module exports, not replacing them), and one additive `hint` field on an existing error response. No existing behavior changed.

---

## :memo: Additional Notes

Follow-up from a live back-and-forth with the Nexus frontend engineer, who caught that the previously-recommended endpoint didn't actually solve his stated need (group-wide defaults vs. personal preferences) and that the duplicate-values error had no clear resolution path. Both are now closed.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group-wide default chart configurations for specific devices.
  * Added create, update, delete, list, and detail retrieval capabilities.
  * Added access controls for group managers and members.
  * Added pagination and validation for configuration requests.
  * Duplicate personal preference creation now provides guidance to use the update-or-create option.

* **Tests**
  * Added comprehensive coverage for configuration management, validation, errors, permissions, and not-found scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->