### PR TITLE
Batch rate-limit alerts into a daily Slack digest

### DIFF
--- a/src/device-registry/bin/jobs/rate-limit-digest-job.js
+++ b/src/device-registry/bin/jobs/rate-limit-digest-job.js
@@ -1,0 +1,179 @@
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- rate-limit-digest-job -- ops-alerts`,
+);
+const RateLimitEventModel = require("@models/RateLimitEvent");
+const cron = require("node-cron");
+const { logText } = require("@utils/shared");
+const { LogThrottleManager } = require("@utils/common");
+const moment = require("moment-timezone");
+
+const TIMEZONE = "Africa/Nairobi";
+const JOB_NAME = "rate-limit-digest-job";
+const JOB_SCHEDULE = "0 12 * * *"; // 12:00 PM EAT every day
+
+const LOG_TYPE = "rate-limit-digest";
+const logThrottleManager = new LogThrottleManager();
+
+const TOP_OFFENDERS_LIMIT = 10;
+
+let isJobRunning = false;
+let currentJobPromise = null;
+
+const generateRateLimitDigest = async () => {
+  try {
+    if (global.isShuttingDown) {
+      logText(`${JOB_NAME} stopping due to application shutdown`);
+      return;
+    }
+
+    const end = moment.tz(TIMEZONE).startOf("day");
+    const start = end.clone().subtract(1, "day");
+    const yesterdayStr = start.format("YYYY-MM-DD");
+
+    logText(`Generating rate limit digest for ${yesterdayStr}`);
+
+    const summary = await RateLimitEventModel("airqo").getSummary({
+      start: start.toDate(),
+      end: end.toDate(),
+    });
+
+    if (!summary || summary.length === 0) {
+      logText(`No rate limit events found for ${yesterdayStr}`);
+      return;
+    }
+
+    const totalTriggered = summary.reduce((sum, c) => sum + c.triggeredCount, 0);
+    const totalBlocked = summary.reduce((sum, c) => sum + c.blockedCount, 0);
+    const clientCount = summary.length;
+
+    const topOffenders = summary.slice(0, TOP_OFFENDERS_LIMIT);
+
+    const digestMessage = `
+🚦 Rate Limit Digest (${yesterdayStr})
+==================================================
+📈 Overall:
+   • Clients Rate-Limited: ${clientCount}
+   • Rate Limit Triggers: ${totalTriggered}
+   • Requests Blocked: ${totalBlocked}
+
+🔝 Top Offenders:
+${topOffenders
+  .map(
+    (c) =>
+      `   • client=${c._id} | triggered=${c.triggeredCount} | blocked=${c.blockedCount} | peak qpm=${c.maxQpm || "n/a"}`,
+  )
+  .join("\n")}
+    `;
+
+    logText(digestMessage);
+    logger.warn(digestMessage);
+  } catch (error) {
+    logger.error(
+      `🐛🐛 ${JOB_NAME} Error generating rate limit digest: ${error.message}`,
+    );
+    logger.error(`🐛🐛 Stack trace: ${error.stack}`);
+  }
+};
+
+const jobWrapper = async () => {
+  if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") {
+    return;
+  }
+
+  try {
+    const shouldRun = await logThrottleManager.shouldAllowLog(LOG_TYPE);
+    if (!shouldRun) {
+      return;
+    }
+  } catch (error) {
+    logText(
+      `Distributed lock check failed for ${JOB_NAME}: ${error.message}. Proceeding with local lock.`,
+    );
+  }
+
+  if (isJobRunning) {
+    return;
+  }
+
+  isJobRunning = true;
+  currentJobPromise = generateRateLimitDigest();
+  try {
+    await currentJobPromise;
+  } catch (error) {
+    logger.error(`🐛🐛 Error during ${JOB_NAME} execution: ${error.message}`);
+  } finally {
+    isJobRunning = false;
+    currentJobPromise = null;
+  }
+};
+
+const startRateLimitDigestJob = () => {
+  try {
+    if (global.cronJobs && global.cronJobs[JOB_NAME]) {
+      logText(`${JOB_NAME} already scheduled, skipping re-initialization.`);
+      return global.cronJobs[JOB_NAME];
+    }
+
+    const jobInstance = cron.schedule(JOB_SCHEDULE, jobWrapper, {
+      scheduled: true,
+      timezone: TIMEZONE,
+    });
+
+    if (!global.cronJobs) {
+      global.cronJobs = {};
+    }
+
+    global.cronJobs[JOB_NAME] = {
+      job: jobInstance,
+      name: JOB_NAME,
+      schedule: JOB_SCHEDULE,
+      stop: async () => {
+        logText(`🛑 Stopping ${JOB_NAME}...`);
+
+        try {
+          jobInstance.stop();
+          logText(`📅 ${JOB_NAME} schedule stopped`);
+
+          if (currentJobPromise) {
+            logText(
+              `⏳ Waiting for current ${JOB_NAME} execution to finish...`,
+            );
+            await currentJobPromise;
+            logText(`✅ Current ${JOB_NAME} execution completed`);
+          }
+          delete global.cronJobs[JOB_NAME];
+        } catch (error) {
+          logger.error(`❌ Error stopping ${JOB_NAME}: ${error.message}`);
+        }
+      },
+    };
+
+    logText(`✅ ${JOB_NAME} registered and started (${JOB_SCHEDULE} ${TIMEZONE})`);
+    return global.cronJobs[JOB_NAME];
+  } catch (error) {
+    logger.error(`❌ Failed to start ${JOB_NAME}: ${error.message}`);
+    throw error;
+  }
+};
+
+try {
+  startRateLimitDigestJob();
+  logText(`🎉 ${JOB_NAME} initialization complete`);
+} catch (error) {
+  logger.error(`💥 Failed to initialize ${JOB_NAME}: ${error.message}`);
+  process.exit(1);
+}
+
+module.exports = {
+  JOB_NAME,
+  JOB_SCHEDULE,
+  startRateLimitDigestJob,
+  generateRateLimitDigest,
+  stopJob: async () => {
+    if (global.cronJobs && global.cronJobs[JOB_NAME]) {
+      await global.cronJobs[JOB_NAME].stop();
+    }
+  },
+};

--- a/src/device-registry/bin/server.js
+++ b/src/device-registry/bin/server.js
@@ -217,6 +217,7 @@ try {
 }
 require("@bin/jobs/health-tip-checker-job");
 require("@bin/jobs/daily-activity-summary-job");
+require("@bin/jobs/rate-limit-digest-job");
 require("@bin/jobs/site-categorization-job");
 require("@bin/jobs/site-categorization-notification-job");
 require("@bin/jobs/refresh-grids-job");

--- a/src/device-registry/config/log4js.js
+++ b/src/device-registry/config/log4js.js
@@ -81,8 +81,9 @@ if (isDevelopment()) {
   // full category name explicitly. Always include the "app" appender so
   // INFO/WARN messages reach the log file regardless of environment;
   // slackWarn is added later only for production.
-  // Only the network status job gets WARN→Slack routing in production.
-  // All other jobs rely on the default category (ERROR only → Slack).
+  // WARN and above → Slack routing in production is enabled for the job names in
+  // OPS_ALERTS_JOB_NAMES below; all other categories rely on the default category
+  // (ERROR only → Slack).
   const OPS_ALERTS_JOB_NAMES = [
     "network-status-check-job",
     "rate-limit-digest-job",

--- a/src/device-registry/config/log4js.js
+++ b/src/device-registry/config/log4js.js
@@ -83,7 +83,10 @@ if (isDevelopment()) {
   // slackWarn is added later only for production.
   // Only the network status job gets WARN→Slack routing in production.
   // All other jobs rely on the default category (ERROR only → Slack).
-  const OPS_ALERTS_JOB_NAMES = ["network-status-check-job"];
+  const OPS_ALERTS_JOB_NAMES = [
+    "network-status-check-job",
+    "rate-limit-digest-job",
+  ];
   const env = constants.ENVIRONMENT;
   OPS_ALERTS_JOB_NAMES.forEach((jobName) => {
     config.categories[`${env} -- ${jobName} -- ops-alerts`] = {

--- a/src/device-registry/models/RateLimitEvent.js
+++ b/src/device-registry/models/RateLimitEvent.js
@@ -1,0 +1,117 @@
+const { Schema } = require("mongoose");
+const mongoose = require("mongoose");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- rate-limit-event-model`
+);
+
+// Durable log of rate-limit events, separate from QueryThrottle (which is a
+// short-lived TTL cache used for the in-request rate-limit decision itself).
+// Kept for 32 days so the daily digest job always has yesterday's data
+// available, then auto-expires to bound collection growth.
+const RATE_LIMIT_EVENT_TTL_DAYS = 32;
+
+const RateLimitEventSchema = new Schema(
+  {
+    eventType: {
+      type: String,
+      enum: ["TRIGGERED", "BLOCKED"],
+      required: true,
+      index: true,
+    },
+    clientId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    tenant: {
+      type: String,
+      lowercase: true,
+      default: "airqo",
+    },
+    qpm: {
+      type: Number,
+    },
+    blockedForMinutes: {
+      type: Number,
+    },
+    remainingSeconds: {
+      type: Number,
+    },
+    timestamp: {
+      type: Date,
+      required: true,
+      default: Date.now,
+      index: true,
+    },
+  },
+  {
+    timestamps: false,
+    collection: "rate_limit_events",
+  }
+);
+
+RateLimitEventSchema.index(
+  { timestamp: 1 },
+  { expireAfterSeconds: RATE_LIMIT_EVENT_TTL_DAYS * 24 * 60 * 60 }
+);
+
+RateLimitEventSchema.statics.recordEvent = async function(data) {
+  try {
+    await this.create(data);
+    return true;
+  } catch (error) {
+    logger.error(`Error recording rate limit event: ${error.message}`);
+    return false;
+  }
+};
+
+RateLimitEventSchema.statics.getSummary = async function({ start, end }) {
+  try {
+    const results = await this.aggregate([
+      {
+        $match: {
+          timestamp: { $gte: start, $lt: end },
+        },
+      },
+      {
+        $group: {
+          _id: "$clientId",
+          triggeredCount: {
+            $sum: { $cond: [{ $eq: ["$eventType", "TRIGGERED"] }, 1, 0] },
+          },
+          blockedCount: {
+            $sum: { $cond: [{ $eq: ["$eventType", "BLOCKED"] }, 1, 0] },
+          },
+          maxQpm: { $max: "$qpm" },
+        },
+      },
+      { $sort: { triggeredCount: -1, blockedCount: -1 } },
+    ]).option({ allowDiskUse: true }); // guards against a large-scale, many-client attack
+    return results;
+  } catch (error) {
+    logger.error(`Error getting rate limit summary: ${error.message}`);
+    return [];
+  }
+};
+
+const RateLimitEventModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    const rate_limit_events = mongoose.model("rate_limit_events");
+    return rate_limit_events;
+  } catch (error) {
+    const rate_limit_events = getModelByTenant(
+      dbTenant,
+      "rate_limit_event",
+      RateLimitEventSchema
+    );
+    return rate_limit_events;
+  }
+};
+
+module.exports = RateLimitEventModel;

--- a/src/device-registry/models/RateLimitEvent.js
+++ b/src/device-registry/models/RateLimitEvent.js
@@ -45,7 +45,6 @@ const RateLimitEventSchema = new Schema(
       type: Date,
       required: true,
       default: Date.now,
-      index: true,
     },
   },
   {

--- a/src/device-registry/utils/common/throttle.util.js
+++ b/src/device-registry/utils/common/throttle.util.js
@@ -1,4 +1,5 @@
 const QueryThrottleModel = require("@models/QueryThrottle");
+const RateLimitEventModel = require("@models/RateLimitEvent");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- throttle-util`);
@@ -72,6 +73,22 @@ const throttleUtil = {
     } catch (error) {
       logger.error(`Error setting tracker: ${error.message}`);
       return false;
+    }
+  },
+
+  // Persists a rate-limit event for the daily digest job. Fire-and-forget:
+  // never throws, so a logging failure can't affect the request path.
+  logRateLimitEvent: async (eventType, clientId, extra = {}, tenant = "airqo") => {
+    try {
+      await RateLimitEventModel(tenant).recordEvent({
+        eventType,
+        clientId,
+        tenant,
+        timestamp: new Date(),
+        ...extra,
+      });
+    } catch (error) {
+      logger.error(`Error logging rate limit event: ${error.message}`);
     }
   },
 

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -2128,17 +2128,20 @@ const createEvent = {
             tenant,
           );
 
+          // Persist every blocked request for an accurate digest count;
+          // shouldLog only throttles the noisy warn line, not the count.
+          throttleUtil.logRateLimitEvent(
+            "BLOCKED",
+            clientId,
+            { remainingSeconds },
+            tenant,
+          );
+
           if (shouldLog) {
             // Individual events are batched into the daily digest
             // (rate-limit-digest-job) instead of alerting Slack in real time.
             logger.warn(
               `🚫 RATE LIMITED | client=${clientId} | ${remainingSeconds}s remaining`,
-            );
-            throttleUtil.logRateLimitEvent(
-              "BLOCKED",
-              clientId,
-              { remainingSeconds },
-              tenant,
             );
           }
 

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -2129,8 +2129,16 @@ const createEvent = {
           );
 
           if (shouldLog) {
-            logger.error(
+            // Individual events are batched into the daily digest
+            // (rate-limit-digest-job) instead of alerting Slack in real time.
+            logger.warn(
               `🚫 RATE LIMITED | client=${clientId} | ${remainingSeconds}s remaining`,
+            );
+            throttleUtil.logRateLimitEvent(
+              "BLOCKED",
+              clientId,
+              { remainingSeconds },
+              tenant,
             );
           }
 
@@ -2162,8 +2170,16 @@ const createEvent = {
 
           const blockedForSeconds = Math.round(BLOCK_DURATION / 1000);
           const blockedForMinutes = Math.round(BLOCK_DURATION / 60000);
-          logger.error(
+          // Individual events are batched into the daily digest
+          // (rate-limit-digest-job) instead of alerting Slack in real time.
+          logger.warn(
             `🚨 RATE LIMIT TRIGGERED | client=${clientId} | ${tracker.count} qpm | blocked=${blockedForMinutes}m`,
+          );
+          throttleUtil.logRateLimitEvent(
+            "TRIGGERED",
+            clientId,
+            { qpm: tracker.count, blockedForMinutes },
+            tenant,
           );
 
           return {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces real-time per-event Slack alerts for historical-data rate-limiting with a single daily digest. Rate-limit trigger/block events are now persisted to a new `rate_limit_events` collection (32-day TTL) instead of alerting Slack immediately, and a new cron job posts a consolidated summary (clients rate-limited, total triggers/blocks, top offenders) to `ops-alerts` at 12:00 PM EAT covering the previous day's activity.

### Why is this change needed?
The `event-util` rate limiter was posting a separate Slack message for every trigger and block event, flooding the `ops-alerts` channel during abuse spikes without adding actionable signal. A daily digest preserves visibility into abuse patterns while cutting real-time noise.

---

## :link: Related Issues
- [ ] Closes # N/A
- [ ] Fixes # N/A
- [ ] Related to # N/A

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Syntax-validated all new/modified files with `node -c`. Confirmed no existing test suite covers this code path (searched `*.test.js` for `RATE LIMIT`, `generateClientFingerprint`, `historicalQueryTracker` — no matches), so no existing tests were at risk of breaking. No automated test currently covers the rate-limiter or the new digest job; recommend a manual staging check against the real Slack `ops-alerts` channel before merge.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

API responses for rate-limited requests are unchanged; only internal logging/alerting behavior changed (per-event Slack alerts → daily digest).

---

## :memo: Additional Notes
- New collection `rate_limit_events` (32-day TTL index) records `TRIGGERED`/`BLOCKED` events; writes are fire-and-forget and never block the request path.
- New cron job `rate-limit-digest-job` (`bin/jobs/rate-limit-digest-job.js`), scheduled `0 12 * * *` in `Africa/Nairobi`, only runs in `PRODUCTION ENVIRONMENT`, and uses the existing `LogThrottleManager` distributed lock so multiple replicas won't double-post.
- Registered `rate-limit-digest-job` in `config/log4js.js`'s `OPS_ALERTS_JOB_NAMES` so its digest (logged at `warn`) reaches Slack; reuses the existing Slack appender configuration (`SLACK_TOKEN`/`SLACK_CHANNEL`/`SLACK_USERNAME`) — no new secrets needed.
- Digest aggregation uses `allowDiskUse: true` as a safety margin against a large-scale, many-client abuse event.
- If a day has no rate-limit events, the job skips silently — no "all clear" message is posted.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated daily digests of rate-limit activity, including totals and top offenders.
  * Added durable tracking of rate-limit events with automatic retention and summary reporting.
  * Rate-limit events are now recorded for blocked requests and newly triggered limits.

* **Bug Fixes**
  * Improved rate-limit event logging and monitoring while preserving existing response behavior.
  * Added safeguards to prevent duplicate digest jobs and support graceful shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->