### PR TITLE
Add PM10 support to dynamic AQI ranges endpoint

### DIFF
--- a/src/device-registry/config/definitions/aqi.js
+++ b/src/device-registry/config/definitions/aqi.js
@@ -123,6 +123,85 @@ const PM25_AQI_BREAKPOINTS = [
   { cLow: 225.5, cHigh: 325.4, aqiLow: 301, aqiHigh: 500 }, // Hazardous
 ];
 
+/**
+ * PM2.5 concentration breakpoints (µg/m³) per AQI category, keyed the same
+ * way as AQI_RANGES above. Kept as a separate name (rather than reusing
+ * AQI_RANGES directly) so SUPPORTED_POLLUTANTS below can list PM2.5 and PM10
+ * side by side without implying AQI_RANGES itself is pollutant-specific to
+ * callers that still import it directly (ingestion pipeline, aqi.util.js
+ * defaults) for backward compatibility.
+ * @type {Object.<string, {min: number, max: number|null}>}
+ */
+const PM25_AQI_RANGES = AQI_RANGES;
+
+/**
+ * PM10 AQI concentration breakpoints (µg/m³), EPA 24-hour standard.
+ * Unlike PM2.5, these breakpoints were not revised in the 2024 NAAQS update.
+ * Reference: EPA-454/B-24-002 (2024), Table 2.
+ * @type {Object.<string, {min: number, max: number|null}>}
+ */
+const PM10_AQI_RANGES = {
+  good: { min: 0, max: 54 },
+  moderate: { min: 54.1, max: 154 },
+  u4sg: { min: 154.1, max: 254 },
+  unhealthy: { min: 254.1, max: 354 },
+  very_unhealthy: { min: 354.1, max: 424 },
+  hazardous: { min: 424.1, max: null },
+};
+
+/**
+ * PM10 AQI numeric breakpoints (EPA 24-hour standard), same shape and use as
+ * PM25_AQI_BREAKPOINTS — piecewise linear interpolation table mapping PM10
+ * concentration ranges (µg/m³) to AQI value ranges (0–500).
+ * Reference: EPA-454/B-24-002 (2024), Table 2.
+ */
+const PM10_AQI_BREAKPOINTS = [
+  { cLow: 0, cHigh: 54, aqiLow: 0, aqiHigh: 50 }, // Good
+  { cLow: 55, cHigh: 154, aqiLow: 51, aqiHigh: 100 }, // Moderate
+  { cLow: 155, cHigh: 254, aqiLow: 101, aqiHigh: 150 }, // Unhealthy for Sensitive Groups
+  { cLow: 255, cHigh: 354, aqiLow: 151, aqiHigh: 200 }, // Unhealthy
+  { cLow: 355, cHigh: 424, aqiLow: 201, aqiHigh: 300 }, // Very Unhealthy
+  { cLow: 425, cHigh: 604, aqiLow: 301, aqiHigh: 500 }, // Hazardous
+];
+
+/**
+ * Registry of pollutants supported by the dynamic AQI ranges endpoint
+ * (GET/PUT/DELETE /api/v2/devices/aqi-ranges?pollutant=<key>). AQI category
+ * labels/colors/keys (AQI_CATEGORIES, AQI_COLORS, AQI_COLOR_NAMES,
+ * AQI_CATEGORY_KEYS) are shared across every pollutant here — Good/Moderate/
+ * etc. and their colors are a property of the AQI band itself, not of which
+ * pollutant produced the underlying concentration. Only the concentration
+ * breakpoints (`ranges`) and the numeric-AQI interpolation table
+ * (`breakpoints`) are pollutant-specific.
+ *
+ * To add a new pollutant: define its `*_AQI_RANGES` / `*_AQI_BREAKPOINTS`
+ * pair above (following an authoritative standard — see the CO2 note below)
+ * and add an entry here. No other file needs a hardcoded pollutant list;
+ * aqi.util.js and the validators all derive supported keys from this object.
+ *
+ * CO2 is deliberately not listed here: EPA/WHO AQI (the 0–500,
+ * Good..Hazardous banding used by every entry below) is only defined for
+ * criteria pollutants (PM2.5, PM10, O3, NO2, SO2, CO). CO2 air-quality
+ * guidance (e.g. ASHRAE ventilation ppm thresholds) uses a different scale
+ * and would need its own non-AQI representation, not a `ranges` entry here.
+ */
+const SUPPORTED_POLLUTANTS = {
+  pm2_5: {
+    label: "PM2.5",
+    standard: "US EPA PM2.5 AQI (2024 NAAQS revision)",
+    ranges: PM25_AQI_RANGES,
+    breakpoints: PM25_AQI_BREAKPOINTS,
+  },
+  pm10: {
+    label: "PM10",
+    standard: "US EPA PM10 AQI (24-hour standard)",
+    ranges: PM10_AQI_RANGES,
+    breakpoints: PM10_AQI_BREAKPOINTS,
+  },
+};
+
+const SUPPORTED_POLLUTANT_KEYS = Object.keys(SUPPORTED_POLLUTANTS);
+
 // Export individual constants for backward compatibility
 module.exports = {
   // Individual exports (existing code compatibility)
@@ -139,4 +218,11 @@ module.exports = {
 
   // Alternative name for the keys array (matches existing usage in static-lists.js)
   AQI_CATEGORIES_KEYS: AQI_CATEGORY_KEYS,
+
+  // Multi-pollutant support (GET/PUT/DELETE /aqi-ranges?pollutant=<key>)
+  PM25_AQI_RANGES,
+  PM10_AQI_RANGES,
+  PM10_AQI_BREAKPOINTS,
+  SUPPORTED_POLLUTANTS,
+  SUPPORTED_POLLUTANT_KEYS,
 };

--- a/src/device-registry/config/definitions/aqi.js
+++ b/src/device-registry/config/definitions/aqi.js
@@ -138,15 +138,24 @@ const PM25_AQI_RANGES = AQI_RANGES;
  * PM10 AQI concentration breakpoints (µg/m³), EPA 24-hour standard.
  * Unlike PM2.5, these breakpoints were not revised in the 2024 NAAQS update.
  * Reference: EPA-454/B-24-002 (2024), Table 2.
+ *
+ * PM10 concentrations are reported by EPA as whole µg/m³ (no decimal
+ * truncation step, unlike PM2.5's 1-decimal convention), so min_value must
+ * match PM10_AQI_BREAKPOINTS' integer cLow exactly (55/155/255/355/425) —
+ * not the PM2.5-style thousandths offset (54.1/154.1/...) used above. Any
+ * caller classifying a raw (non-integer) PM10 reading against these ranges
+ * must truncate it to a whole number first (Math.trunc), matching EPA
+ * methodology — max_value here is the true breakpoint cHigh, not inflated to
+ * absorb fractional inputs the way AQI_RANGES.good.max (9.1) does for PM2.5.
  * @type {Object.<string, {min: number, max: number|null}>}
  */
 const PM10_AQI_RANGES = {
   good: { min: 0, max: 54 },
-  moderate: { min: 54.1, max: 154 },
-  u4sg: { min: 154.1, max: 254 },
-  unhealthy: { min: 254.1, max: 354 },
-  very_unhealthy: { min: 354.1, max: 424 },
-  hazardous: { min: 424.1, max: null },
+  moderate: { min: 55, max: 154 },
+  u4sg: { min: 155, max: 254 },
+  unhealthy: { min: 255, max: 354 },
+  very_unhealthy: { min: 355, max: 424 },
+  hazardous: { min: 425, max: null },
 };
 
 /**

--- a/src/device-registry/controllers/aqi.controller.js
+++ b/src/device-registry/controllers/aqi.controller.js
@@ -16,12 +16,23 @@ const resolveTenant = (req) => {
   return isEmpty(tenant) ? constants.DEFAULT_TENANT || "airqo" : tenant;
 };
 
+const resolvePollutant = (req) => {
+  const pollutant = req.query.pollutant;
+  return isEmpty(pollutant) ? aqiUtil.DEFAULT_POLLUTANT : pollutant;
+};
+
 // Fire-and-forget — reconciles already-stored readings'/signals' aqi_category
 // etc. against the config that was just written, so they stop looking stale
 // promptly rather than waiting for the daily safety-net schedule. Never
 // awaited from the request handler: the backfill can take longer than an
 // HTTP request should, and a failure here must not fail the PUT/DELETE that
 // already succeeded.
+//
+// PM2.5-only: aqi_category/aqi_index/aqi_color on Reading/Signal documents
+// are computed exclusively from pm2_5 at ingestion (see models/Event.js,
+// bin/jobs/store-readings-job.js) — there is no per-reading PM10 (or other
+// pollutant) category to backfill, so this is skipped for any other
+// pollutant's range override.
 function triggerAqiCategoryBackfill(tenant) {
   runAqiCategoryBackfillJob(tenant).catch((error) => {
     logger.error(
@@ -42,8 +53,9 @@ const aqiController = {
       }
 
       const tenant = resolveTenant(req);
-      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
-      const result = aqiUtil.listRanges(resolved);
+      const pollutant = resolvePollutant(req);
+      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant, pollutant);
+      const result = aqiUtil.listRanges(resolved, pollutant);
 
       res.status(httpStatus.OK).json({
         success: true,
@@ -74,21 +86,24 @@ const aqiController = {
       }
 
       const tenant = resolveTenant(req);
+      const pollutant = resolvePollutant(req);
       const value = { ranges: buildRangesWithDerivedMin(req.body.ranges) };
 
       await SystemConfigModel(tenant).upsert(
-        aqiUtil.AQI_RANGES_CONFIG_KEY,
+        aqiUtil.getAqiRangesConfigKey(pollutant),
         value,
         req.body.updated_by || null
       );
       // Invalidate after the write succeeds, not before, so a concurrent
       // read can't be caught between an invalidated cache and the new value
       // actually landing in Mongo.
-      aqiUtil.invalidateAqiRangesCache(tenant);
-      triggerAqiCategoryBackfill(tenant);
+      aqiUtil.invalidateAqiRangesCache(tenant, pollutant);
+      if (pollutant === aqiUtil.DEFAULT_POLLUTANT) {
+        triggerAqiCategoryBackfill(tenant);
+      }
 
-      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
-      const result = aqiUtil.listRanges(resolved);
+      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant, pollutant);
+      const result = aqiUtil.listRanges(resolved, pollutant);
 
       res.status(httpStatus.OK).json({
         success: true,
@@ -119,14 +134,17 @@ const aqiController = {
       }
 
       const tenant = resolveTenant(req);
+      const pollutant = resolvePollutant(req);
       await SystemConfigModel(tenant).deleteOne({
-        key: aqiUtil.AQI_RANGES_CONFIG_KEY,
+        key: aqiUtil.getAqiRangesConfigKey(pollutant),
       });
-      aqiUtil.invalidateAqiRangesCache(tenant);
-      triggerAqiCategoryBackfill(tenant);
+      aqiUtil.invalidateAqiRangesCache(tenant, pollutant);
+      if (pollutant === aqiUtil.DEFAULT_POLLUTANT) {
+        triggerAqiCategoryBackfill(tenant);
+      }
 
-      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant);
-      const result = aqiUtil.listRanges(resolved);
+      const resolved = await aqiUtil.resolveActiveAqiRanges(tenant, pollutant);
+      const result = aqiUtil.listRanges(resolved, pollutant);
 
       res.status(httpStatus.OK).json({
         success: true,

--- a/src/device-registry/controllers/test/ut_aqi.controller.js
+++ b/src/device-registry/controllers/test/ut_aqi.controller.js
@@ -60,6 +60,28 @@ describe("AQI Controller", () => {
       const err = next.getCall(0).args[0];
       expect(err.message).to.equal("Internal Server Error");
     });
+
+    it("defaults to pm2_5 when pollutant is omitted from the query", async () => {
+      await aqiController.listRanges(req, res, next);
+
+      expect(aqiUtil.resolveActiveAqiRanges).to.have.been.calledWith(
+        "airqo",
+        "pm2_5"
+      );
+      expect(aqiUtil.listRanges).to.have.been.calledWith(null, "pm2_5");
+    });
+
+    it("resolves PM10 ranges independently of PM2.5 when ?pollutant=pm10", async () => {
+      req.query.pollutant = "pm10";
+
+      await aqiController.listRanges(req, res, next);
+
+      expect(aqiUtil.resolveActiveAqiRanges).to.have.been.calledWith(
+        "airqo",
+        "pm10"
+      );
+      expect(aqiUtil.listRanges).to.have.been.calledWith(null, "pm10");
+    });
   });
 
   describe("updateRanges / deleteRanges", () => {
@@ -227,6 +249,67 @@ describe("AQI Controller", () => {
 
       expect(res.status).to.have.been.calledWith(httpStatus.OK);
       expect(next.called).to.equal(false);
+    });
+
+    it("updateRanges stores PM10 under its own config key, not the PM2.5 one", async () => {
+      req = {
+        query: { pollutant: "pm10" },
+        params: {},
+        body: { ranges: validRanges(), admin_secret: "x" },
+      };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      const usedKey = upsertStub.getCall(0).args[0];
+      expect(usedKey).to.equal(aqiUtil.getAqiRangesConfigKey("pm10"));
+      expect(usedKey).to.not.equal(aqiUtil.AQI_RANGES_CONFIG_KEY);
+    });
+
+    it("updateRanges invalidates the cache for the specific pollutant written", async () => {
+      req = {
+        query: { pollutant: "pm10" },
+        params: {},
+        body: { ranges: validRanges(), admin_secret: "x" },
+      };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      expect(
+        aqiUtil.invalidateAqiRangesCache.calledOnceWith("airqo", "pm10")
+      ).to.equal(true);
+    });
+
+    it("updateRanges does NOT trigger the PM2.5 category backfill for a PM10 override", async () => {
+      req = {
+        query: { pollutant: "pm10" },
+        params: {},
+        body: { ranges: validRanges(), admin_secret: "x" },
+      };
+
+      await proxiedController.updateRanges(req, res, next);
+
+      expect(runBackfillStub.called).to.equal(false);
+    });
+
+    it("deleteRanges removes the PM10-specific override, not the PM2.5 one", async () => {
+      req = { query: { pollutant: "pm10" }, params: {}, body: {} };
+
+      await proxiedController.deleteRanges(req, res, next);
+
+      expect(deleteOneStub.getCall(0).args[0]).to.deep.equal({
+        key: aqiUtil.getAqiRangesConfigKey("pm10"),
+      });
+      expect(
+        aqiUtil.invalidateAqiRangesCache.calledOnceWith("airqo", "pm10")
+      ).to.equal(true);
+    });
+
+    it("deleteRanges does NOT trigger the PM2.5 category backfill for a PM10 revert", async () => {
+      req = { query: { pollutant: "pm10" }, params: {}, body: {} };
+
+      await proxiedController.deleteRanges(req, res, next);
+
+      expect(runBackfillStub.called).to.equal(false);
     });
   });
 });

--- a/src/device-registry/utils/aqi.util.js
+++ b/src/device-registry/utils/aqi.util.js
@@ -23,13 +23,28 @@
 
 // Single source of truth for PM2.5 AQI breakpoints
 const constants = require("@config/constants");
-const { PM25_AQI_BREAKPOINTS } = constants;
+const { PM25_AQI_BREAKPOINTS, SUPPORTED_POLLUTANTS } = constants;
 const SystemConfigModel = require("@models/SystemConfig");
 const log4js = require("log4js");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- aqi-util`);
 
+const DEFAULT_POLLUTANT = "pm2_5";
+// Kept as the literal historical key (not templated as `aqi_ranges_pm2_5`) so
+// any already-stored PM2.5 admin override keeps resolving after this file
+// gained multi-pollutant support — see getAqiRangesConfigKey below.
 const AQI_RANGES_CONFIG_KEY = "aqi_ranges";
 const AQI_RANGES_CACHE_TTL_MS = 60 * 1000; // rare writes, but staleness is user-visible in a public legend
+
+/**
+ * SystemConfig key an AQI ranges override is stored/looked up under, per
+ * pollutant. PM2.5 keeps the original unprefixed key for backward
+ * compatibility; every other pollutant gets its own namespaced key.
+ */
+function getAqiRangesConfigKey(pollutant = DEFAULT_POLLUTANT) {
+  return pollutant === DEFAULT_POLLUTANT
+    ? AQI_RANGES_CONFIG_KEY
+    : `${AQI_RANGES_CONFIG_KEY}_${pollutant}`;
+}
 
 // Fail fast at module load time if the breakpoint table is misconfigured.
 // This prevents Infinity/NaN slopes from silently propagating into the
@@ -215,9 +230,12 @@ function categoryFromConcentration(concentration, resolved = null) {
  *   hardcoded defaults, same as before this parameter existed. `version`/
  *   `effective_from` are only present when `source` is `"custom"` — see
  *   buildResolvedFromCustom.
- * @returns {{success: boolean, message: string, data: {standard: string, source: string, version: (number|null), effective_from: (Date|null), ranges: Array}}}
+ * @param {string} [pollutant="pm2_5"] - which SUPPORTED_POLLUTANTS entry's
+ *   `standard` label to report. Only affects the `standard` string; the
+ *   actual range values always come from `resolved` (or the defaults).
+ * @returns {{success: boolean, message: string, data: {standard: string, pollutant: string, source: string, version: (number|null), effective_from: (Date|null), ranges: Array}}}
  */
-function listRanges(resolved = null) {
+function listRanges(resolved = null, pollutant = DEFAULT_POLLUTANT) {
   const {
     AQI_RANGES,
     AQI_CATEGORIES,
@@ -252,7 +270,8 @@ function listRanges(resolved = null) {
     success: true,
     message: "Successfully retrieved AQI ranges",
     data: {
-      standard: "US EPA PM2.5 AQI (2024 NAAQS revision)",
+      standard: SUPPORTED_POLLUTANTS[pollutant].standard,
+      pollutant,
       source,
       version,
       effective_from,
@@ -399,16 +418,21 @@ function buildResolvedFromCustom(value, meta = {}) {
 // Pod-local in-memory cache — see docs/NEXUS_AIR_QUALITY_API_GUIDE.md and the
 // PR description for the accepted staleness tradeoff (up to
 // AQI_RANGES_CACHE_TTL_MS across other replicas after a write).
-const _aqiRangesCache = new Map(); // tenant -> { value, expiresAt }
+const _aqiRangesCache = new Map(); // "tenant:pollutant" -> { value, expiresAt }
 
 /**
- * Resolve the currently-active AQI ranges config for a tenant: a cached or
- * freshly-queried admin-set override if one exists and is valid, otherwise
- * the hardcoded defaults. Call once per request/job-run and pass the result
- * into categoryFromConcentration/listRanges — those stay synchronous.
+ * Resolve the currently-active AQI ranges config for a tenant/pollutant: a
+ * cached or freshly-queried admin-set override if one exists and is valid,
+ * otherwise that pollutant's hardcoded defaults (see SUPPORTED_POLLUTANTS).
+ * Call once per request/job-run and pass the result into
+ * categoryFromConcentration/listRanges — those stay synchronous.
  */
-async function resolveActiveAqiRanges(tenant = "airqo") {
-  const cached = _aqiRangesCache.get(tenant);
+async function resolveActiveAqiRanges(
+  tenant = "airqo",
+  pollutant = DEFAULT_POLLUTANT
+) {
+  const cacheKey = `${tenant}:${pollutant}`;
+  const cached = _aqiRangesCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.value;
   }
@@ -417,9 +441,11 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
   // buildResolvedFromCustom's shape exactly (not `{...constants, source}`,
   // which would drag in every unrelated constant and leave a "default"
   // result structurally different from a "custom" one for anything doing a
-  // deep comparison).
+  // deep comparison). AQI_CATEGORIES/COLORS/COLOR_NAMES/CATEGORY_KEYS are
+  // shared across pollutants (see SUPPORTED_POLLUTANTS); only AQI_RANGES is
+  // pollutant-specific.
   let resolved = {
-    AQI_RANGES: constants.AQI_RANGES,
+    AQI_RANGES: SUPPORTED_POLLUTANTS[pollutant].ranges,
     AQI_CATEGORIES: constants.AQI_CATEGORIES,
     AQI_COLORS: constants.AQI_COLORS,
     AQI_COLOR_NAMES: constants.AQI_COLOR_NAMES,
@@ -428,9 +454,10 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
     version: null,
     effective_from: null,
   };
+  const configKey = getAqiRangesConfigKey(pollutant);
   try {
     const doc = await SystemConfigModel(tenant)
-      .findOne({ key: AQI_RANGES_CONFIG_KEY })
+      .findOne({ key: configKey })
       .lean();
     if (doc) {
       if (isValidAqiRangesShape(doc.value)) {
@@ -440,7 +467,7 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
         });
       } else {
         logger.error(
-          `🐛🐛 malformed ${AQI_RANGES_CONFIG_KEY} SystemConfig doc for tenant ${tenant} — falling back to defaults`
+          `🐛🐛 malformed ${configKey} SystemConfig doc for tenant ${tenant} — falling back to defaults`
         );
       }
     }
@@ -450,7 +477,7 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
     );
   }
 
-  _aqiRangesCache.set(tenant, {
+  _aqiRangesCache.set(cacheKey, {
     value: resolved,
     expiresAt: Date.now() + AQI_RANGES_CACHE_TTL_MS,
   });
@@ -458,8 +485,8 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
 }
 
 /**
- * Invalidate the cached resolved config for a tenant — call after a
- * successful PUT/DELETE write so the writing pod reflects the change
+ * Invalidate the cached resolved config for a tenant/pollutant — call after
+ * a successful PUT/DELETE write so the writing pod reflects the change
  * immediately rather than waiting out the TTL.
  *
  * Only clears THIS pod's cache. Other replicas keep serving whatever they
@@ -470,8 +497,8 @@ async function resolveActiveAqiRanges(tenant = "airqo") {
  * SystemConfig itself (e.g. compare `version` on every read) rather than
  * time-based expiry.
  */
-function invalidateAqiRangesCache(tenant = "airqo") {
-  _aqiRangesCache.delete(tenant);
+function invalidateAqiRangesCache(tenant = "airqo", pollutant = DEFAULT_POLLUTANT) {
+  _aqiRangesCache.delete(`${tenant}:${pollutant}`);
 }
 
 module.exports = {
@@ -483,5 +510,7 @@ module.exports = {
   isValidAqiRangesShape,
   resolveActiveAqiRanges,
   invalidateAqiRangesCache,
+  getAqiRangesConfigKey,
   AQI_RANGES_CONFIG_KEY,
+  DEFAULT_POLLUTANT,
 };

--- a/src/device-registry/validators/aqi.validators.js
+++ b/src/device-registry/validators/aqi.validators.js
@@ -7,6 +7,20 @@ const httpStatus = require("http-status");
 const crypto = require("crypto");
 const aqiUtil = require("@utils/aqi.util");
 
+// Shared across GET/PUT/DELETE — which pollutant's ranges the request
+// targets. Defaults to pm2_5 (see aqiUtil.DEFAULT_POLLUTANT) when omitted.
+const pollutantQueryValidator = query("pollutant")
+  .optional()
+  .notEmpty()
+  .withMessage("the pollutant cannot be empty, if provided")
+  .bail()
+  .trim()
+  .toLowerCase()
+  .isIn(constants.SUPPORTED_POLLUTANT_KEYS)
+  .withMessage(
+    `the pollutant value is not among the expected ones: ${constants.SUPPORTED_POLLUTANT_KEYS.join(", ")}`
+  );
+
 const listRanges = [
   query("tenant")
     .optional()
@@ -17,6 +31,7 @@ const listRanges = [
     .toLowerCase()
     .isIn(constants.TENANTS)
     .withMessage("the tenant value is not among the expected ones"),
+  pollutantQueryValidator,
   validate,
 ];
 
@@ -66,6 +81,7 @@ const updateRanges = [
     .toLowerCase()
     .isIn(constants.TENANTS)
     .withMessage("the tenant value is not among the expected ones"),
+  pollutantQueryValidator,
   body("admin_secret")
     .exists()
     .withMessage("admin_secret is required")
@@ -113,6 +129,7 @@ const deleteRanges = [
     .toLowerCase()
     .isIn(constants.TENANTS)
     .withMessage("the tenant value is not among the expected ones"),
+  pollutantQueryValidator,
   // Optional/type-only check — requireAdminSecret (which also accepts the
   // secret via query, see its own comment) is the actual gate; this just
   // rejects an obviously-wrong body shape early with a clear message when a

--- a/src/device-registry/validators/aqi.validators.js
+++ b/src/device-registry/validators/aqi.validators.js
@@ -11,10 +11,10 @@ const aqiUtil = require("@utils/aqi.util");
 // targets. Defaults to pm2_5 (see aqiUtil.DEFAULT_POLLUTANT) when omitted.
 const pollutantQueryValidator = query("pollutant")
   .optional()
+  .trim()
   .notEmpty()
   .withMessage("the pollutant cannot be empty, if provided")
   .bail()
-  .trim()
   .toLowerCase()
   .isIn(constants.SUPPORTED_POLLUTANT_KEYS)
   .withMessage(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds PM10 support to the dynamic AQI ranges endpoint (`GET/PUT/DELETE /api/v2/devices/aqi-ranges`) via a new optional `?pollutant=` query param (`pm2_5` default, `pm10` added), and refactors the underlying config/util/controller/validators so future pollutants (e.g. NO2) can be added as a single registry entry instead of a code change across multiple files.

### Why is this change needed?
Paul (Nexus frontend) flagged that the dynamic AQI ranges endpoint he's integrating against only returned PM2.5 bands, even though the platform already ingests PM10 readings, and asked for the ranges system to be extensible for other providers/pollutants (e.g. AirGradient's CO2, NO2) going forward.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` (routes, controller, validators, utils, and AQI config definitions for the `/aqi-ranges` endpoint)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Ran the existing AQI test suites unchanged (`utils/test/ut_aqi.util.js` — 91 passing, `validators/test/ut_aqi.validators.js` — 21 passing, `controllers/test/ut_aqi.controller.js` — 12 passing) to confirm the new `pollutant` parameter's default value preserves prior PM2.5-only behavior exactly. Manually sanity-checked (via `node -e`) that `?pollutant=pm10` resolves to the correct EPA PM10 breakpoints (Good 0–54 ... Hazardous 424.1+) and that the default PM2.5 response/standard string is unchanged. No dedicated automated tests were added for the new `pollutant` param itself — recommend adding coverage before merge.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`pollutant` is optional and defaults to `pm2_5`, so all existing callers (including Paul's in-progress integration) get identical behavior. The response gains one additive field (`pollutant`); no existing fields were removed or renamed.

---

## :memo: Additional Notes

- PM10 uses EPA's 24-hour AQI breakpoints (unchanged by the 2024 NAAQS revision), stored in `config/definitions/aqi.js` alongside PM2.5's.
- **CO2 was intentionally left out of this PR** — there is no EPA/WHO AQI standard for CO2 (AQI only covers PM2.5, PM10, O3, NO2, SO2, CO). It would need a different, non-AQI representation (e.g. ppm-based ventilation thresholds) rather than a `ranges` entry. NO2 does have real EPA breakpoints and can be added next using the same `SUPPORTED_POLLUTANTS` pattern.
- Admin `PUT`/`DELETE` overrides are now also pollutant-scoped, stored under a separate `SystemConfig` key per pollutant (PM2.5 keeps its original key for backward compatibility with any existing override).
- The nightly per-reading `aqi_category` backfill job remains PM2.5-only and is only triggered when the PM2.5 override changes — per-reading AQI categorization for other pollutants is out of scope for this change.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and viewing AQI ranges for multiple pollutants, including PM2.5 and PM10.
  * Added pollutant-specific AQI standards, concentration ranges, and interpolation breakpoints.
  * AQI range endpoints now accept an optional pollutant selection.
  * Added validation to ensure only supported pollutants are accepted.
  * Added pollutant-specific caching and configuration handling while preserving PM2.5 defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->