### PR TITLE
Fix intermittent 500s on readings endpoints: bound queries, shrink windows, add index

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -105,6 +105,25 @@ function envConfig(env) {
       return Number.isFinite(val) && val > 0 ? val : 1;
     })(),
 
+    // Lookback window specifically for the Nexus-facing /recent endpoint
+    // (createEventUtil.readRecentWithFilter). Narrower than the shared
+    // DIAGNOSTIC_WINDOW_DAYS default (used by mobile/other callers of
+    // ReadingModel.recent()) to keep the sort-then-group scan small under load.
+    RECENT_ENDPOINT_LOOKBACK_HOURS: (() => {
+      const val = parseInt(process.env.RECENT_ENDPOINT_LOOKBACK_HOURS, 10);
+      return Number.isFinite(val) && val > 0 ? val : 6;
+    })(),
+
+    // Default lookback window for ReadingModel.listForMap() when the caller
+    // supplies no explicit time filter. Previously hard-coded to 48h, which
+    // meant every unfiltered /map load sorted+grouped up to 48h of readings
+    // across every device just to surface one latest-per-site row. 6h keeps
+    // typical map usage covered while cutting the scan size dramatically.
+    MAP_DEFAULT_LOOKBACK_HOURS: (() => {
+      const val = parseInt(process.env.MAP_DEFAULT_LOOKBACK_HOURS, 10);
+      return Number.isFinite(val) && val > 0 ? val : 6;
+    })(),
+
     // Default lookback window for event/measurement queries (generate-filter fetch).
     DEFAULT_QUERY_RANGE_DAYS: (() => {
       const val = parseInt(process.env.DEFAULT_QUERY_RANGE_DAYS, 10);

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -75,9 +75,15 @@ const createSafePollutantLookup = (
 const clampMapTimeWindow = (callerTime) => {
   const fortyEightHoursAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
   const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+  // Default when the caller supplies no explicit time filter — deliberately
+  // narrower than the 48h/14d tiers below, which only govern how far back an
+  // *explicit* caller-supplied window is honoured before being clamped.
+  const defaultLookbackAgo = new Date(
+    Date.now() - constants.MAP_DEFAULT_LOOKBACK_HOURS * 60 * 60 * 1000,
+  );
 
   // Normalise: a plain Date is treated as a lower bound; an object may carry
-  // $gte; anything else (null/undefined) resolves to undefined → default 48 h.
+  // $gte; anything else (null/undefined) resolves to undefined → default lookback.
   const callerGte =
     callerTime instanceof Date
       ? callerTime
@@ -87,7 +93,7 @@ const clampMapTimeWindow = (callerTime) => {
 
   let effectiveGte;
   if (!callerGte) {
-    effectiveGte = fortyEightHoursAgo;
+    effectiveGte = defaultLookbackAgo;
   } else if (callerGte >= fortyEightHoursAgo) {
     effectiveGte = callerGte;
   } else if (callerGte >= fourteenDaysAgo) {
@@ -664,6 +670,20 @@ ReadingsSchema.index(
   },
 );
 
+// listForMap()'s $match always combines all three of time + pm2_5.value>0 +
+// deviceDetails.isActive!=false in a single query — time_pm25_map_idx and
+// time_device_active_idx above each cover only two of the three, so Mongo can
+// use at most one and must filter the remaining condition in memory. This
+// index covers all three together for that specific, always-present shape.
+ReadingsSchema.index(
+  { time: -1, "pm2_5.value": 1, "deviceDetails.isActive": 1 },
+  {
+    name: "map_time_pm25_active_idx",
+    partialFilterExpression: { "pm2_5.value": { $gt: 0 } },
+    background: true,
+  },
+);
+
 // Sparse index for non-null coordinates (mobile devices)
 ReadingsSchema.index(
   { "location.latitude.value": 1, "location.longitude.value": 1, time: -1 },
@@ -1011,13 +1031,27 @@ const DIAGNOSTIC_WINDOW_DAYS = constants.DIAGNOSTIC_WINDOW_DAYS;
 // that bogus reading would display as "the current reading" indefinitely.
 const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
+// lookbackDays lets a specific caller (e.g. the Nexus-facing /recent endpoint)
+// request a narrower window than the shared DIAGNOSTIC_WINDOW_DAYS default
+// that other callers (mobile app, signals) still rely on. Exported standalone
+// so its precedence/fallback logic is unit-testable without a DB connection.
+const resolveRecentLookbackDays = (lookbackDays, fallbackDays) =>
+  typeof lookbackDays === "number" && lookbackDays > 0
+    ? lookbackDays
+    : fallbackDays;
+
 ReadingsSchema.statics.recent = async function(
-  { filter = {}, limit = 1000, skip = 0 } = {},
+  { filter = {}, limit = 1000, skip = 0, lookbackDays } = {},
   next,
 ) {
   try {
-    let lookbackStart = new Date();
-    lookbackStart.setDate(lookbackStart.getDate() - DIAGNOSTIC_WINDOW_DAYS);
+    const effectiveLookbackDays = resolveRecentLookbackDays(
+      lookbackDays,
+      DIAGNOSTIC_WINDOW_DAYS,
+    );
+    const lookbackStart = new Date(
+      Date.now() - effectiveLookbackDays * 24 * 60 * 60 * 1000,
+    );
 
     // Guard against non-object filter values. The createEventUtil.read()
     // caller passes next (a function) as the filter argument when invoked
@@ -2089,7 +2123,13 @@ ReadingsSchema.statics.listForMap = async function(
       },
     ];
 
-    const results = await this.aggregate(pipeline).allowDiskUse(true);
+    // Bounded the same way as ReadingModel.recent() — without this, a slow
+    // match under load can hang past the point the Nexus proxy has already
+    // given up, holding a queryDB pool connection for nothing.
+    const results = await this.aggregate(pipeline).option({
+      allowDiskUse: true,
+      maxTimeMS: constants.READINGS_AGGREGATE_TIMEOUT_MS,
+    });
 
     const { paginatedResults = [], totalCount = [] } = results[0] || {};
     const total = totalCount[0]?.count || 0;
@@ -2204,5 +2244,12 @@ const ReadingModel = (tenant) => {
     return readings;
   }
 };
+
+// Exposed for direct unit testing without a DB connection — ReadingModel(tenant)
+// itself requires one (see above). `schema` lets tests introspect index
+// definitions via schema.indexes() without constructing a live model.
+ReadingModel.clampMapTimeWindow = clampMapTimeWindow;
+ReadingModel.resolveRecentLookbackDays = resolveRecentLookbackDays;
+ReadingModel.schema = ReadingsSchema;
 
 module.exports = ReadingModel;

--- a/src/device-registry/models/Reading.js
+++ b/src/device-registry/models/Reading.js
@@ -60,7 +60,9 @@ const createSafePollutantLookup = (
 // normalises it internally so both callers behave identically regardless
 // of how filter.time was passed.
 //
-//   • No callerTime / no resolvable $gte → 48 h default (partial index hit)
+//   • No callerTime / no resolvable $gte → MAP_DEFAULT_LOOKBACK_HOURS default
+//                                           (env-configurable, clamped to the
+//                                           14 d TTL floor; see below)
 //   • resolved $gte within 48 h          → honour as-is
 //   • resolved $gte within 14 d          → honour as-is
 //   • resolved $gte older than 14 d      → clamp to fourteenDaysAgo (TTL),
@@ -78,8 +80,14 @@ const clampMapTimeWindow = (callerTime) => {
   // Default when the caller supplies no explicit time filter — deliberately
   // narrower than the 48h/14d tiers below, which only govern how far back an
   // *explicit* caller-supplied window is honoured before being clamped.
+  // Clamped to the same 14 d TTL floor so a misconfigured (too-large)
+  // MAP_DEFAULT_LOOKBACK_HOURS can never trigger a full-collection scan —
+  // there's no data older than the TTL to scan anyway.
   const defaultLookbackAgo = new Date(
-    Date.now() - constants.MAP_DEFAULT_LOOKBACK_HOURS * 60 * 60 * 1000,
+    Math.max(
+      Date.now() - constants.MAP_DEFAULT_LOOKBACK_HOURS * 60 * 60 * 1000,
+      fourteenDaysAgo.getTime(),
+    ),
   );
 
   // Normalise: a plain Date is treated as a lower bound; an object may carry
@@ -1036,7 +1044,7 @@ const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 // that other callers (mobile app, signals) still rely on. Exported standalone
 // so its precedence/fallback logic is unit-testable without a DB connection.
 const resolveRecentLookbackDays = (lookbackDays, fallbackDays) =>
-  typeof lookbackDays === "number" && lookbackDays > 0
+  Number.isFinite(lookbackDays) && lookbackDays > 0
     ? lookbackDays
     : fallbackDays;
 

--- a/src/device-registry/models/test/ut_reading.model.js
+++ b/src/device-registry/models/test/ut_reading.model.js
@@ -1,5 +1,6 @@
 require("module-alias/register");
 const { expect } = require("chai");
+const proxyquire = require("proxyquire");
 const constants = require("@config/constants");
 const ReadingModel = require("@models/Reading");
 
@@ -59,6 +60,20 @@ describe("ReadingModel time-window helpers", () => {
       });
       expect(effectiveGte.getTime()).to.equal(fourteenDaysAgo.getTime());
     });
+
+    it("clamps a misconfigured (oversized) MAP_DEFAULT_LOOKBACK_HOURS to the 14d TTL floor", () => {
+      // Simulates MAP_DEFAULT_LOOKBACK_HOURS being set far too large (e.g. a
+      // typo'd env var) — proxyquire falls through to the real @config/constants
+      // for every field except the one overridden here.
+      const ReadingModelWithHugeDefault = proxyquire("@models/Reading", {
+        "@config/constants": { MAP_DEFAULT_LOOKBACK_HOURS: 24 * 365 },
+      });
+
+      const { effectiveGte, fourteenDaysAgo } =
+        ReadingModelWithHugeDefault.clampMapTimeWindow(undefined);
+
+      expect(effectiveGte.getTime()).to.equal(fourteenDaysAgo.getTime());
+    });
   });
 
   describe("resolveRecentLookbackDays", () => {
@@ -74,6 +89,15 @@ describe("ReadingModel time-window helpers", () => {
     it("falls back to the shared default for a zero or negative override", () => {
       expect(resolveRecentLookbackDays(0, 1)).to.equal(1);
       expect(resolveRecentLookbackDays(-2, 1)).to.equal(1);
+    });
+
+    it("falls back to the shared default for Infinity, -Infinity, and NaN", () => {
+      // Infinity previously slipped through the old `typeof x === "number"`
+      // check (Infinity > 0 is true), producing new Date(-Infinity) —
+      // an Invalid Date fed straight into the Mongo $gte query.
+      expect(resolveRecentLookbackDays(Infinity, 1)).to.equal(1);
+      expect(resolveRecentLookbackDays(-Infinity, 1)).to.equal(1);
+      expect(resolveRecentLookbackDays(NaN, 1)).to.equal(1);
     });
 
     it("falls back to the shared default for a non-numeric override", () => {

--- a/src/device-registry/models/test/ut_reading.model.js
+++ b/src/device-registry/models/test/ut_reading.model.js
@@ -1,0 +1,105 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const constants = require("@config/constants");
+const ReadingModel = require("@models/Reading");
+
+// Pure, DB-free logic exposed by Reading.js specifically for unit testing —
+// see the `ReadingModel.clampMapTimeWindow` / `ReadingModel.resolveRecentLookbackDays`
+// assignments at the bottom of models/Reading.js.
+const { clampMapTimeWindow, resolveRecentLookbackDays } = ReadingModel;
+
+// Allow a few seconds of slack for Date.now() drift between the function
+// call and the assertion.
+const ASSERTION_SLACK_MS = 5000;
+
+describe("ReadingModel time-window helpers", () => {
+  describe("clampMapTimeWindow", () => {
+    it("defaults to MAP_DEFAULT_LOOKBACK_HOURS when no caller time is given", () => {
+      const { effectiveGte } = clampMapTimeWindow(undefined);
+      const expected =
+        Date.now() - constants.MAP_DEFAULT_LOOKBACK_HOURS * 60 * 60 * 1000;
+      expect(effectiveGte.getTime()).to.be.closeTo(
+        expected,
+        ASSERTION_SLACK_MS,
+      );
+    });
+
+    it("defaults the same way when callerTime is null", () => {
+      const { effectiveGte } = clampMapTimeWindow(null);
+      const expected =
+        Date.now() - constants.MAP_DEFAULT_LOOKBACK_HOURS * 60 * 60 * 1000;
+      expect(effectiveGte.getTime()).to.be.closeTo(
+        expected,
+        ASSERTION_SLACK_MS,
+      );
+    });
+
+    it("honours an explicit bare-Date caller time within the last 48h", () => {
+      const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+      const { effectiveGte } = clampMapTimeWindow(sixHoursAgo);
+      expect(effectiveGte.getTime()).to.equal(sixHoursAgo.getTime());
+    });
+
+    it("honours an explicit { $gte } caller time within the last 48h", () => {
+      const twentyHoursAgo = new Date(Date.now() - 20 * 60 * 60 * 1000);
+      const { effectiveGte } = clampMapTimeWindow({ $gte: twentyHoursAgo });
+      expect(effectiveGte.getTime()).to.equal(twentyHoursAgo.getTime());
+    });
+
+    it("honours an explicit caller time between 48h and 14d old", () => {
+      const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+      const { effectiveGte } = clampMapTimeWindow({ $gte: fiveDaysAgo });
+      expect(effectiveGte.getTime()).to.equal(fiveDaysAgo.getTime());
+    });
+
+    it("clamps a caller time older than 14d up to fourteenDaysAgo (TTL floor)", () => {
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const { effectiveGte, fourteenDaysAgo } = clampMapTimeWindow({
+        $gte: thirtyDaysAgo,
+      });
+      expect(effectiveGte.getTime()).to.equal(fourteenDaysAgo.getTime());
+    });
+  });
+
+  describe("resolveRecentLookbackDays", () => {
+    it("uses the caller-supplied override when it is a positive number", () => {
+      expect(resolveRecentLookbackDays(0.25, 1)).to.equal(0.25);
+      expect(resolveRecentLookbackDays(3, 1)).to.equal(3);
+    });
+
+    it("falls back to the shared default when no override is given", () => {
+      expect(resolveRecentLookbackDays(undefined, 1)).to.equal(1);
+    });
+
+    it("falls back to the shared default for a zero or negative override", () => {
+      expect(resolveRecentLookbackDays(0, 1)).to.equal(1);
+      expect(resolveRecentLookbackDays(-2, 1)).to.equal(1);
+    });
+
+    it("falls back to the shared default for a non-numeric override", () => {
+      expect(resolveRecentLookbackDays("1", 1)).to.equal(1);
+      expect(resolveRecentLookbackDays(null, 1)).to.equal(1);
+    });
+  });
+
+  describe("map_time_pm25_active_idx", () => {
+    // listForMap()'s $match always combines time + pm2_5.value>0 +
+    // deviceDetails.isActive — this index must cover all three together so
+    // Mongo doesn't fall back to filtering one of them in memory.
+    it("covers time, pm2_5.value, and deviceDetails.isActive together", () => {
+      const [keys, options] = ReadingModel.schema
+        .indexes()
+        .find(([, opts]) => opts.name === "map_time_pm25_active_idx");
+
+      expect(keys).to.deep.equal({
+        time: -1,
+        "pm2_5.value": 1,
+        "deviceDetails.isActive": 1,
+      });
+      expect(options.partialFilterExpression).to.deep.equal({
+        "pm2_5.value": { $gt: 0 },
+      });
+      expect(options.background).to.equal(true);
+    });
+  });
+});

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -3128,6 +3128,16 @@ const createEvent = {
           // Fallback: query the events collection directly so callers always
           // get data while the readings pipeline issue is being investigated.
           try {
+            // generateFilter.fetch() defaults to a 3-day window (and would
+            // otherwise inherit a wider startTime/endTime from request.query,
+            // e.g. a job lookback) when no startTime is given — set explicitly
+            // here, after the spread so it takes precedence, to keep this
+            // fallback as narrow as the primary ReadingModel.recent() query
+            // above instead of reintroducing a wide scan on cache-miss.
+            const fallbackStartTime = new Date(
+              Date.now() -
+                constants.RECENT_ENDPOINT_LOOKBACK_HOURS * 60 * 60 * 1000,
+            ).toISOString();
             const fallbackRequest = {
               query: {
                 ...request.query,
@@ -3135,6 +3145,7 @@ const createEvent = {
                 metadata: "site_id",
                 active: "yes",
                 brief: "yes",
+                startTime: fallbackStartTime,
               },
             };
             const resolvedAqiRanges = await aqiUtil.resolveActiveAqiRanges(

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -3063,6 +3063,10 @@ const createEvent = {
         filter,
         skip,
         limit,
+        // Narrower than the shared DIAGNOSTIC_WINDOW_DAYS default — this call
+        // site is the Nexus /recent endpoint, which only needs current state,
+        // not a full day of history to scan through.
+        lookbackDays: constants.RECENT_ENDPOINT_LOOKBACK_HOURS / 24,
       });
       const dbQueryDuration = Date.now() - dbQueryStart;
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes intermittent 500 errors on the `/readings/map` and `/readings/recent` endpoints by bounding their MongoDB aggregations with a timeout, shrinking their default lookback windows, and adding a compound index to close a gap where two of the three `$match` conditions were each indexed separately.

Specifically:
- `ReadingModel.listForMap()` now sets `maxTimeMS` (same timeout `recent()` already used), so a slow query fails fast instead of hanging indefinitely and holding a shared connection-pool slot.
- `/map`'s default lookback (when no explicit time filter is supplied) drops from a hardcoded 48h to a configurable `MAP_DEFAULT_LOOKBACK_HOURS` (default 6h). Explicit caller-supplied windows are unaffected.
- `ReadingModel.recent()` accepts an optional `lookbackDays` override; only the Nexus-facing `/recent` call site (`readRecentWithFilter`) uses a narrower window via `RECENT_ENDPOINT_LOOKBACK_HOURS` (default 6h) instead of the shared 1-day default, so mobile app and other callers of `.recent()` are unaffected.
- Added `map_time_pm25_active_idx`, a compound partial index covering `time` + `pm2_5.value>0` + `deviceDetails.isActive` together — the two existing indexes each covered only two of these three conditions, forcing Mongo to filter the third in memory on every `/map` request.

### Why is this change needed?

Production Slack alerts and Nexus console logs (`airqo-frontend/src/nexus`) showed intermittent 500s on the map view and the Favorites page. Root cause: `listForMap`'s aggregation had no execution timeout and scanned up to 48h of readings across every device just to return one "latest" row per site, and `recent()`'s equivalent query was already known to run close to its 25s timeout (per an existing code comment). Under load, both endpoints would exceed reasonable response times, and `/map` could hang indefinitely holding a pooled DB connection — degrading other concurrent requests on the same service.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only.

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added `models/test/ut_reading.model.js` (previously no test file existed for this model), covering the default/override/clamp branches in `clampMapTimeWindow` and `resolveRecentLookbackDays`, the new index's exact definition, and — per two rounds of PR review feedback (Copilot) — a `proxyquire`-based test confirming a misconfigured (oversized) `MAP_DEFAULT_LOOKBACK_HOURS` clamps to the 14-day TTL floor, plus a test confirming `resolveRecentLookbackDays` rejects `Infinity`/`-Infinity`/`NaN` overrides (previously `Infinity` slipped through and produced an Invalid Date in the Mongo query). Also fixed the events-collection fallback in `readRecentWithFilter` to pin an explicit 6h `startTime`, since it previously fell through to `generateFilter.fetch()`'s 3-day default on a cache-miss-and-empty-readings path, undermining the narrowed window. All new tests are DB-free unit tests. Ran the full `device-registry` suite before and after the change (excluding a handful of pre-existing, unrelated files that fail to load even on unmodified `staging` due to stale imports from an earlier refactor): stable at **1027 passing / 291 pending / 43 failing**, same 43 pre-existing failures throughout, confirming no regressions (suite has a known, unrelated flake affecting 1-2 `createSite`-related tests intermittently — reproduced identically on unmodified code).

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All new lookback windows are env-var configurable (`MAP_DEFAULT_LOOKBACK_HOURS`, `RECENT_ENDPOINT_LOOKBACK_HOURS`) and fall back to sensible defaults. Only the *default* (no explicit time filter) window shrinks — explicit caller-supplied time ranges behave exactly as before. Note the tradeoff: a device that hasn't reported within the new, narrower window will briefly stop appearing as "latest"/"recent" instead of showing a stale last-known reading.

---

## :memo: Additional Notes

- New/changed env vars, all optional with defaults matching current behavior intent: `MAP_DEFAULT_LOOKBACK_HOURS` (default 6), `RECENT_ENDPOINT_LOOKBACK_HOURS` (default 6), existing `READINGS_AGGREGATE_TIMEOUT_MS` (default 25000ms) now also applied to `listForMap`.
- The new `map_time_pm25_active_idx` index is created with `background: true`; on a large production collection the index build will take some time after deploy but will not block reads.
- Follow-up worth tracking separately: whether recent 502s observed on Vertex (`airqo-frontend/src/vertex`) correlate with device-registry pod resource pressure during slow `/map`/`/recent` queries — Vertex doesn't call these endpoints directly, so this would be a shared-pod contention effect, not yet confirmed against AKS/ingress logs.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
