### PR TITLE
Align device-listing query timeout with Vertex proxy timeout to prevent 502s

### DIFF
--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -124,6 +124,18 @@ function envConfig(env) {
       return Number.isFinite(val) && val > 0 ? val : 6;
     })(),
 
+    // MongoDB maxTimeMS for the device-listing aggregations in device.util.js
+    // (list(), getDeviceCountSummary()) that back Vertex's /devices/summary,
+    // /devices/status/*, and /devices/summary/count. These were previously
+    // hard-coded to 45000ms, longer than Vertex's own 30s proxy timeout for
+    // the "devices" endpoint group — meaning a slow query would outlive the
+    // client's patience and keep holding a pooled connection for no benefit.
+    // Same reasoning as READINGS_AGGREGATE_TIMEOUT_MS, same default.
+    DEVICE_LIST_AGGREGATE_TIMEOUT_MS: (() => {
+      const val = parseInt(process.env.DEVICE_LIST_AGGREGATE_TIMEOUT_MS, 10);
+      return Number.isFinite(val) && val > 0 ? val : 25000;
+    })(),
+
     // Default lookback window for event/measurement queries (generate-filter fetch).
     DEFAULT_QUERY_RANGE_DAYS: (() => {
       const val = parseInt(process.env.DEFAULT_QUERY_RANGE_DAYS, 10);

--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -132,8 +132,11 @@ function envConfig(env) {
     // client's patience and keep holding a pooled connection for no benefit.
     // Same reasoning as READINGS_AGGREGATE_TIMEOUT_MS, same default.
     DEVICE_LIST_AGGREGATE_TIMEOUT_MS: (() => {
-      const val = parseInt(process.env.DEVICE_LIST_AGGREGATE_TIMEOUT_MS, 10);
-      return Number.isFinite(val) && val > 0 ? val : 25000;
+      // Number() (unlike parseInt) rejects partial parses ("25000ms") and
+      // requires the whole string to be numeric; isSafeInteger rejects
+      // fractional ("25000.5") and out-of-range values.
+      const val = Number(process.env.DEVICE_LIST_AGGREGATE_TIMEOUT_MS);
+      return Number.isSafeInteger(val) && val > 0 ? val : 25000;
     })(),
 
     // Default lookback window for event/measurement queries (generate-filter fetch).

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -571,7 +571,7 @@ const deviceUtil = {
 
       const results = await DeviceModel(tenant)
         .aggregate(pipeline)
-        .option({ maxTimeMS: 45000 })
+        .option({ maxTimeMS: constants.DEVICE_LIST_AGGREGATE_TIMEOUT_MS })
         .allowDiskUse(true);
 
       const summary = results[0] || {
@@ -1858,7 +1858,7 @@ const deviceUtil = {
 
       const results = await DeviceModel(tenant)
         .aggregate(facetPipeline)
-        .option({ maxTimeMS: 45000 })
+        .option({ maxTimeMS: constants.DEVICE_LIST_AGGREGATE_TIMEOUT_MS })
         .allowDiskUse(true);
 
       const paginatedResults = results[0].paginatedResults;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes a MongoDB `maxTimeMS` mismatch on the two device-listing aggregations that back Vertex's `/devices/summary`, `/devices/status/*`, and `/devices/summary/count` endpoints. Both were hard-coded to a 45-second timeout — longer than Vertex's own 30-second proxy timeout for the "devices" endpoint group. Replaced with a new `DEVICE_LIST_AGGREGATE_TIMEOUT_MS` constant (default 25s, env-configurable), matching the existing `READINGS_AGGREGATE_TIMEOUT_MS` pattern already used elsewhere in this service.

### Why is this change needed?

While investigating intermittent 502s reported on the Vertex UI, we found that if either aggregation ran slow, it would keep executing for up to 15 seconds *after* Vertex's proxy had already given up and disconnected — holding a shared MongoDB connection-pool slot for a request nobody was waiting on anymore. This is the same class of bug already fixed on the Nexus-facing readings endpoints in a prior PR, just on a different, Vertex-specific code path. Aligning the timeout to fail fast, safely under Vertex's own limit, removes that wasted holding time under load.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** No dedicated new tests added — this is a one-line constant swap on two call sites with no branching logic to unit test in isolation (unlike the earlier readings-perf PR, which added window/clamp logic worth testing directly). Ran the full `device-registry` suite before and after (excluding a handful of pre-existing, unrelated files that fail to load even on unmodified `staging` due to stale imports from an earlier refactor): stable at **1027 passing / 291 pending / 43 failing**, same pre-existing failures both times, confirming no regressions.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The new `DEVICE_LIST_AGGREGATE_TIMEOUT_MS` env var is optional and defaults to 25000ms. Only effect: a query that was previously allowed to run up to 45s will now fail with a timeout error at 25s instead. Two other functions in the same file (`getDeviceCountSummaryByNetwork`, `getDeviceCountSummaryByCohort`) still hard-code 45000ms — left untouched because neither is wired to any route, so they're unreachable and out of scope here.

---

## :memo: Additional Notes

- This addresses one confirmed, code-level contributor to the Vertex 502 reports. Two other possible contributors remain unconfirmed and are being monitored rather than acted on directly: (1) residual effects of shared MongoDB connection-pool contention from the previously-fixed Nexus readings endpoints, and (2) occasional third-party device-network outages (e.g. ThingSpeak, IQAir) that are designed to surface as 502s by intent, not a bug — neither can be confirmed without AKS pod-level metrics we don't currently have access to.
- Findings shared with Vertex's maintainer (Bwanika) for awareness and to rule in/out any frontend-side contributing factors.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added configurable timeouts for device list and count requests.
  * The timeout can be set through environment configuration, with validation and a 25-second default.
  * Improved consistency by applying the configured timeout across device aggregation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->