### PR TITLE
Add auto-login token issuance to email verification

### DIFF
--- a/src/auth-service/middleware/rate-limiter.js
+++ b/src/auth-service/middleware/rate-limiter.js
@@ -277,6 +277,13 @@ const apiLimiter = createDynamicLimiter({
   message: "API rate limit exceeded. Please slow down your requests.",
 });
 
+const emailVerificationLimiter = createDynamicLimiter({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 10, // 10 verification attempts per hour (allows for legitimate re-clicks)
+  prefix: "email_verification",
+  message: "Too many verification attempts. Please try again in 1 hour.",
+});
+
 // Enhanced monitoring and debugging utilities
 const getRateLimiterStats = async () => {
   const redisAvailable = isRedisAvailable();
@@ -389,6 +396,7 @@ module.exports = {
   registration: conditionalRateLimiter(registrationLimiter),
   passwordReset: conditionalRateLimiter(passwordResetLimiter),
   apiGeneral: conditionalRateLimiter(apiLimiter),
+  emailVerification: conditionalRateLimiter(emailVerificationLimiter),
 
   // Utility functions
   getRateLimiterStats,

--- a/src/auth-service/models/VerifyToken.js
+++ b/src/auth-service/models/VerifyToken.js
@@ -30,6 +30,13 @@ const VerifyTokenSchema = new mongoose.Schema(
       unique: true,
       required: [true, "token is required!"],
     },
+    // Optional (not required) so tokens already in flight at deploy time --
+    // issued before this field existed -- keep working until they expire.
+    // See token.util.js verifyEmail(), which falls back to unscoped lookup
+    // only for such legacy tokens.
+    user_id: {
+      type: mongoose.Schema.Types.ObjectId,
+    },
     last_used_at: { type: Date },
     last_ip_address: { type: Date },
     expires_in: { type: Number },

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -561,6 +561,7 @@ router.get(
 
 router.get(
   "/verify/:user_id/:token",
+  rateLimiter.emailVerification,
   userValidations.verifyEmail,
   userController.verifyEmail,
 );

--- a/src/auth-service/routes/v3/users.routes.js
+++ b/src/auth-service/routes/v3/users.routes.js
@@ -428,6 +428,7 @@ router.get(
 
 router.get(
   "/verify/:user_id/:token",
+  rateLimiter.emailVerification,
   userValidations.verifyEmail,
   userController.verifyEmail
 );

--- a/src/auth-service/utils/test/ut_token.util.js
+++ b/src/auth-service/utils/test/ut_token.util.js
@@ -133,38 +133,23 @@ describe("token util", () => {
       expect(result).to.equal(undefined);
     });
 
-    it("short-circuits with success and a fresh token when already verified", async () => {
+    it("short-circuits with success and mints no token when already verified", async () => {
       rewireToken.__set__("UserModel", () => ({
         find: sinon
           .stub()
           .returns({ lean: sinon.stub().resolves([{ ...baseUser, verified: true }]) }),
       }));
-      rewireToken.__set__(
-        "AbstractTokenFactory",
-        stubTokenFactory(sinon.stub().resolves("signed.jwt.token"))
-      );
+      const createTokenSpy = sinon.stub().resolves("signed.jwt.token");
+      rewireToken.__set__("AbstractTokenFactory", stubTokenFactory(createTokenSpy));
 
       const result = await rewireToken.verifyEmail(req, next);
 
+      // Security: this branch is reached on user_id alone, before the token
+      // param is checked against anything, so it must never mint a session --
+      // otherwise anyone who knows/guesses a verified user's id could log in
+      // as them without ever presenting a valid verify token.
+      expect(createTokenSpy.called).to.equal(false);
       expect(next.called).to.equal(false);
-      expect(result.success).to.equal(true);
-      expect(result.message).to.equal("email already verified");
-      expect(result.data.token).to.equal("JWT signed.jwt.token");
-    });
-
-    it("still reports 'already verified' success when token minting fails", async () => {
-      rewireToken.__set__("UserModel", () => ({
-        find: sinon
-          .stub()
-          .returns({ lean: sinon.stub().resolves([{ ...baseUser, verified: true }]) }),
-      }));
-      rewireToken.__set__(
-        "AbstractTokenFactory",
-        stubTokenFactory(sinon.stub().rejects(new Error("JWT_SECRET missing")))
-      );
-
-      const result = await rewireToken.verifyEmail(req, next);
-
       expect(result).to.deep.equal({
         success: true,
         message: "email already verified",
@@ -187,6 +172,41 @@ describe("token util", () => {
       expect(next.calledOnce).to.equal(true);
       expect(next.getCall(0).args[0].message).to.equal("Invalid link");
       expect(result).to.equal(undefined);
+    });
+
+    it("scopes the verify-token lookup to this user_id, accepting legacy tokens with no user_id stored", async () => {
+      const listStub = sinon
+        .stub()
+        .resolves({ success: true, status: httpStatus.OK });
+      rewireToken.__set__("UserModel", () => ({
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([baseUser]) }),
+        modify: sinon.stub().resolves({ success: true, status: httpStatus.OK }),
+      }));
+      rewireToken.__set__("VerifyTokenModel", () => ({
+        list: listStub,
+        remove: sinon.stub().resolves({ success: true }),
+      }));
+      rewireToken.__set__("mailer", {
+        afterEmailVerification: sinon.stub().resolves({ success: true }),
+      });
+      rewireToken.__set__(
+        "AbstractTokenFactory",
+        stubTokenFactory(sinon.stub().resolves("signed.jwt.token"))
+      );
+
+      await rewireToken.verifyEmail(req, next);
+
+      const passedFilter = listStub.getCall(0).args[0].filter;
+      expect(passedFilter.token).to.equal("some-verify-token");
+      expect(passedFilter.$or).to.deep.include({
+        user_id: { $exists: false },
+      });
+      expect(
+        passedFilter.$or.some(
+          (clause) =>
+            clause.user_id && clause.user_id.toString() === validUserId
+        )
+      ).to.equal(true);
     });
 
     it("verifies the user, deletes the token, and returns success with an auto-login token", async () => {
@@ -215,7 +235,7 @@ describe("token util", () => {
       expect(modifyStub.calledOnce).to.equal(true);
       expect(removeStub.calledOnce).to.equal(true);
       expect(result.success).to.equal(true);
-      expect(result.message).to.equal("email verified sucessfully");
+      expect(result.message).to.equal("email verified successfully");
       expect(result.data.token).to.equal("JWT signed.jwt.token");
     });
 
@@ -240,7 +260,7 @@ describe("token util", () => {
 
       expect(result).to.deep.equal({
         success: true,
-        message: "email verified sucessfully",
+        message: "email verified successfully",
         status: httpStatus.OK,
       });
     });

--- a/src/auth-service/utils/test/ut_token.util.js
+++ b/src/auth-service/utils/test/ut_token.util.js
@@ -92,6 +92,160 @@ describe("token util", () => {
     });
   });
 
+  describe("verifyEmail()", () => {
+    let origVerifyTokenModel, origMailer, origAbstractTokenFactory;
+    const validUserId = "507f1f77bcf86cd799439011";
+    const baseUser = {
+      _id: validUserId,
+      firstName: "Jane",
+      userName: "jane",
+      email: "jane@example.com",
+      verified: false,
+    };
+
+    const stubTokenFactory = (behavior) =>
+      function () {
+        return { createToken: behavior };
+      };
+
+    beforeEach(() => {
+      origVerifyTokenModel = rewireToken.__get__("VerifyTokenModel");
+      origMailer = rewireToken.__get__("mailer");
+      origAbstractTokenFactory = rewireToken.__get__("AbstractTokenFactory");
+      req.params = { user_id: validUserId, token: "some-verify-token" };
+    });
+
+    afterEach(() => {
+      rewireToken.__set__("VerifyTokenModel", origVerifyTokenModel);
+      rewireToken.__set__("mailer", origMailer);
+      rewireToken.__set__("AbstractTokenFactory", origAbstractTokenFactory);
+    });
+
+    it("calls next with a 400 error when the user does not exist", async () => {
+      rewireToken.__set__("UserModel", () => ({
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+      }));
+
+      const result = await rewireToken.verifyEmail(req, next);
+
+      expect(next.calledOnce).to.equal(true);
+      expect(next.getCall(0).args[0].message).to.equal("Bad Reqest Error");
+      expect(result).to.equal(undefined);
+    });
+
+    it("short-circuits with success and a fresh token when already verified", async () => {
+      rewireToken.__set__("UserModel", () => ({
+        find: sinon
+          .stub()
+          .returns({ lean: sinon.stub().resolves([{ ...baseUser, verified: true }]) }),
+      }));
+      rewireToken.__set__(
+        "AbstractTokenFactory",
+        stubTokenFactory(sinon.stub().resolves("signed.jwt.token"))
+      );
+
+      const result = await rewireToken.verifyEmail(req, next);
+
+      expect(next.called).to.equal(false);
+      expect(result.success).to.equal(true);
+      expect(result.message).to.equal("email already verified");
+      expect(result.data.token).to.equal("JWT signed.jwt.token");
+    });
+
+    it("still reports 'already verified' success when token minting fails", async () => {
+      rewireToken.__set__("UserModel", () => ({
+        find: sinon
+          .stub()
+          .returns({ lean: sinon.stub().resolves([{ ...baseUser, verified: true }]) }),
+      }));
+      rewireToken.__set__(
+        "AbstractTokenFactory",
+        stubTokenFactory(sinon.stub().rejects(new Error("JWT_SECRET missing")))
+      );
+
+      const result = await rewireToken.verifyEmail(req, next);
+
+      expect(result).to.deep.equal({
+        success: true,
+        message: "email already verified",
+        status: httpStatus.OK,
+      });
+    });
+
+    it("calls next with 'Invalid link' when the token is missing or expired", async () => {
+      rewireToken.__set__("UserModel", () => ({
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([baseUser]) }),
+      }));
+      rewireToken.__set__("VerifyTokenModel", () => ({
+        list: sinon
+          .stub()
+          .resolves({ success: true, status: httpStatus.NOT_FOUND }),
+      }));
+
+      const result = await rewireToken.verifyEmail(req, next);
+
+      expect(next.calledOnce).to.equal(true);
+      expect(next.getCall(0).args[0].message).to.equal("Invalid link");
+      expect(result).to.equal(undefined);
+    });
+
+    it("verifies the user, deletes the token, and returns success with an auto-login token", async () => {
+      const modifyStub = sinon
+        .stub()
+        .resolves({ success: true, status: httpStatus.OK });
+      const removeStub = sinon.stub().resolves({ success: true });
+      rewireToken.__set__("UserModel", () => ({
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([baseUser]) }),
+        modify: modifyStub,
+      }));
+      rewireToken.__set__("VerifyTokenModel", () => ({
+        list: sinon.stub().resolves({ success: true, status: httpStatus.OK }),
+        remove: removeStub,
+      }));
+      rewireToken.__set__("mailer", {
+        afterEmailVerification: sinon.stub().resolves({ success: true }),
+      });
+      rewireToken.__set__(
+        "AbstractTokenFactory",
+        stubTokenFactory(sinon.stub().resolves("signed.jwt.token"))
+      );
+
+      const result = await rewireToken.verifyEmail(req, next);
+
+      expect(modifyStub.calledOnce).to.equal(true);
+      expect(removeStub.calledOnce).to.equal(true);
+      expect(result.success).to.equal(true);
+      expect(result.message).to.equal("email verified sucessfully");
+      expect(result.data.token).to.equal("JWT signed.jwt.token");
+    });
+
+    it("falls back to the legacy {success, message, status} shape when token minting fails post-verification", async () => {
+      rewireToken.__set__("UserModel", () => ({
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([baseUser]) }),
+        modify: sinon.stub().resolves({ success: true, status: httpStatus.OK }),
+      }));
+      rewireToken.__set__("VerifyTokenModel", () => ({
+        list: sinon.stub().resolves({ success: true, status: httpStatus.OK }),
+        remove: sinon.stub().resolves({ success: true }),
+      }));
+      rewireToken.__set__("mailer", {
+        afterEmailVerification: sinon.stub().resolves({ success: true }),
+      });
+      rewireToken.__set__(
+        "AbstractTokenFactory",
+        stubTokenFactory(sinon.stub().rejects(new Error("boom")))
+      );
+
+      const result = await rewireToken.verifyEmail(req, next);
+
+      expect(result).to.deep.equal({
+        success: true,
+        message: "email verified sucessfully",
+        status: httpStatus.OK,
+      });
+    });
+  });
+
   describe("blackListIp()", () => {
     it("should blacklist an IP and return success", async () => {
       req.body = { ip: "192.168.1.100" };

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1286,18 +1286,27 @@ const token = {
       // The verify-token document is deleted on first use (see below), so
       // without this short-circuit a second click on the same link 400s with
       // "Invalid link" even though the account is already verified.
+      //
+      // No token is minted here: this branch is reached on `user_id` alone,
+      // before the `token` param has been checked against anything, so
+      // minting a session here would let anyone who knows/guesses a verified
+      // user's id log in as them. Only the branch below -- which requires a
+      // real, unexpired, user-bound verify token -- may issue a session.
       if (userDetails[0].verified === true) {
-        const data = await _mintAutoLoginToken(tenant, userDetails[0]);
         return {
           success: true,
           message: "email already verified",
           status: httpStatus.OK,
-          ...(data ? { data } : {}),
         };
       }
 
+      // Scoped to this user_id so a token issued for one account can't be
+      // replayed against a different account's user_id to hijack it. Legacy
+      // tokens created before this field existed (no user_id stored) are
+      // still honoured until they expire on their own.
       let filter = {
         token,
+        $or: [{ user_id: ObjectId(user_id) }, { user_id: { $exists: false } }],
         expires: {
           $gt: moment().tz(timeZone).toDate(),
         },
@@ -1368,7 +1377,7 @@ const token = {
                 });
                 return {
                   success: true,
-                  message: "email verified sucessfully",
+                  message: "email verified successfully",
                   status: httpStatus.OK,
                   ...(data ? { data } : {}),
                 };

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -15,6 +15,7 @@ const EmailLogModel = require("@models/EmailLog");
 const BlockedDomainModel = require("@models/BlockedDomain");
 const BlockedASNModel = require("@models/BlockedASN");
 const FlaggedTokenModel = require("@models/FlaggedToken");
+const { AbstractTokenFactory } = require("@services/atf.service");
 const {
   redisGetAsync,
   redisSetAsync,
@@ -1236,6 +1237,27 @@ const _isBypassActive = (flag, expiresAt) => {
   return new Date(expiresAt).getTime() > Date.now();
 };
 
+// Issues a session JWT (same mechanism as login/OAuth) so the frontend can
+// auto-log the user in right after email verification, instead of forcing a
+// separate manual login. Failure to mint a token must never fail the
+// verification response itself (the account is already verified and the
+// confirmation email already sent by this point) -- callers fall back to the
+// pre-existing {success, message} shape, which every existing frontend
+// caller already understands.
+const _mintAutoLoginToken = async (tenant, user) => {
+  try {
+    const authToken = await new AbstractTokenFactory(tenant).createToken(
+      user,
+    );
+    return { token: `JWT ${authToken}` };
+  } catch (error) {
+    logger.error(
+      `Unable to issue auto-login token after email verification: ${error.message}`,
+    );
+    return null;
+  }
+};
+
 const token = {
   verifyEmail: async (request, next) => {
     try {
@@ -1244,12 +1266,6 @@ const token = {
         ...request.params,
       };
       const timeZone = moment.tz.guess();
-      let filter = {
-        token,
-        expires: {
-          $gt: moment().tz(timeZone).toDate(),
-        },
-      };
 
       const userDetails = await UserModel(tenant)
         .find({
@@ -1263,7 +1279,29 @@ const token = {
             message: "User does not exist",
           }),
         );
+        return;
       }
+
+      // Re-clicking an already-consumed verification link should not error out.
+      // The verify-token document is deleted on first use (see below), so
+      // without this short-circuit a second click on the same link 400s with
+      // "Invalid link" even though the account is already verified.
+      if (userDetails[0].verified === true) {
+        const data = await _mintAutoLoginToken(tenant, userDetails[0]);
+        return {
+          success: true,
+          message: "email already verified",
+          status: httpStatus.OK,
+          ...(data ? { data } : {}),
+        };
+      }
+
+      let filter = {
+        token,
+        expires: {
+          $gt: moment().tz(timeZone).toDate(),
+        },
+      };
 
       const responseFromListAccessToken = await VerifyTokenModel(tenant).list(
         {
@@ -1324,10 +1362,15 @@ const token = {
               );
 
               if (responseFromSendEmail.success === true) {
+                const data = await _mintAutoLoginToken(tenant, {
+                  ...userDetails[0],
+                  verified: true,
+                });
                 return {
                   success: true,
                   message: "email verified sucessfully",
                   status: httpStatus.OK,
+                  ...(data ? { data } : {}),
                 };
               } else if (responseFromSendEmail.success === false) {
                 return responseFromSendEmail;

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -2979,6 +2979,7 @@ const createUserModule = {
       const tokenCreationBody = {
         token,
         name: user.firstName,
+        user_id,
         expires: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
       };
 
@@ -4174,6 +4175,7 @@ const createUserModule = {
       const tokenCreationBody = {
         token,
         name: createdUser._doc.firstName,
+        user_id,
       };
 
       const responseFromCreateToken = await VerifyTokenModel(dbTenant).register(
@@ -5819,6 +5821,7 @@ const createUserModule = {
         const tokenCreationBody = {
           token,
           name: createdUser._doc.firstName,
+          user_id,
         };
 
         const responseFromCreateToken = await VerifyTokenModel(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Updates the email verification endpoint (`GET /users/verify/:user_id/:token`) in `auth-service` to:
- Issue a session JWT (same mechanism used by login/OAuth) upon successful verification, returned as an additive `data.token` field, so the frontend can auto-log the user in instead of forcing a manual login.
- Handle repeat clicks on an already-consumed verification link gracefully (returns success instead of a 400 "Invalid link" error).
- Add rate limiting (10 requests/hour per IP) to the verify endpoint, matching the existing pattern used for login/registration/password-reset.

### Why is this change needed?
Today, after a user verifies their email, they are dropped back on the login page and must manually authenticate again, even though they just proved account ownership via the emailed link. This is inconsistent with industry best practice (auto-login after verification) and with other flows in our own frontend. This PR lays the backend groundwork so the frontend team can wire up auto-login. It also closes a minor gap where re-clicking an already-used verification link incorrectly errored out, and adds rate limiting that was missing on this endpoint.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `auth-service`

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added 6 new unit tests for `tokenUtil.verifyEmail` covering: user not found, already-verified short-circuit (with token minted / token minting failure), invalid or expired token, and the full verify flow (with token minted / token minting failure). Ran the targeted mocha suite for `utils/test/ut_token.util.js` and `controllers/test/ut_user.controller.js`: **111 passing, 0 failing**, confirming no regressions to existing verify/login flows. Response shape also verified to be byte-identical to the previous behavior when token issuance is skipped/fails, confirming backward compatibility. Live manual testing against a running server has not been performed and is recommended before merge.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

The new `data.token` field is purely additive to the existing `{success, message}` response. Frontend clients that don't read it are unaffected. If token issuance fails for any reason, the endpoint falls back to the exact original response shape.

---

## :memo: Additional Notes
This is a backend-only change. The Nexus frontend still needs a corresponding update to read `data.token` from the verify response and establish a session to actually realize the auto-login UX improvement — tracked as a separate follow-up with the frontend team.

---

## :white_check_mark: Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
