### PR TITLE
Re-enable selfie cleanup job with 2-year retention

### DIFF
--- a/src/auth-service/bin/jobs/selfie-cleanup-job.js
+++ b/src/auth-service/bin/jobs/selfie-cleanup-job.js
@@ -107,7 +107,7 @@ global.cronJobs = global.cronJobs || {};
 const schedule = "30 2 * * *"; // every day at 2:30 AM, after the feedback screenshot cleanup job
 const jobName = "selfie-cleanup-job";
 global.cronJobs[jobName] = cron.schedule(schedule, cleanupOldSelfies, {
-  scheduled: false, // temporarily disabled — selfie feature is currently unused, no cost pressure to prune recent event photos
+  scheduled: true,
   timezone: "Africa/Nairobi",
 });
 

--- a/src/auth-service/config/core/envs.js
+++ b/src/auth-service/config/core/envs.js
@@ -196,7 +196,7 @@ const envs = {
   CLEAN_AIR_FORUM_SELFIE_TAG: "clean-air-forum-selfie",
   CLEAN_AIR_FORUM_SELFIE_RETENTION_DAYS: parseNumber(
     process.env.CLEAN_AIR_FORUM_SELFIE_RETENTION_DAYS,
-    90,
+    730,
   ),
   // Optional pro/HTTPS-capable IP geolocation endpoint. When set, device.util
   // uses this URL for login location lookups; when absent, geolocation is


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Re-enables the previously disabled Clean Air Forum selfie cleanup cron job and updates the default retention period from 90 days to 2 years (730 days).

### Why is this change needed?
The selfie cleanup job was temporarily disabled to preserve recent event photos. We now want to resume automated pruning, but with a longer retention window (2 years instead of 90 days) so selfies are kept significantly longer before deletion from Cloudinary and MongoDB.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` — `bin/jobs/selfie-cleanup-job.js`, `config/core/envs.js`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified the cron job registers with `scheduled: true` and confirmed the default `CLEAN_AIR_FORUM_SELFIE_RETENTION_DAYS` resolves to 730 when the env var is unset.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
If `CLEAN_AIR_FORUM_SELFIE_RETENTION_DAYS` is explicitly set in any deployment environment/secrets, that value overrides the new 730-day default and should be reviewed separately.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automated cleanup of stored selfies on a schedule.

* **Configuration**
  * Increased the default selfie retention period from 90 days to 730 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->