### PR TITLE
Fix missing createdActivity in claim auto-recall Kafka messages

### DIFF
--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2903,8 +2903,9 @@ const deviceUtil = {
           );
         }
 
+        let createdActivity;
         try {
-          await ActivityModel(tenant).create({
+          createdActivity = await ActivityModel(tenant).create({
             activityType: "recallment",
             device: device.name,
             device_id: device._id,
@@ -2923,32 +2924,43 @@ const deviceUtil = {
           .findById(device._id)
           .lean();
 
-        // Publish recall message to Kafka
-        try {
-          const recallTopic = constants.RECALL_TOPIC || "recall-topic";
-          const kafkaProducer = kafka.producer({
-            groupId: constants.UNIQUE_PRODUCER_GROUP,
-          });
-          await kafkaProducer.connect();
-          await kafkaProducer.send({
-            topic: recallTopic,
-            messages: [
-              {
-                action: "create",
-                value: JSON.stringify({
-                  updatedDevice: recalledDevice,
-                  user_id: user_id,
-                }),
-              },
-            ],
-          });
-          await kafkaProducer.disconnect();
-          logText(
-            `Successfully published automatic recall event for device ${device.name} to Kafka topic ${recallTopic}`,
-          );
-        } catch (error) {
+        // Publish recall message to Kafka. Include createdActivity (same
+        // shape as activity.util.js's processRecall) so the consumer's
+        // required-fields check doesn't reject this message.
+        if (createdActivity) {
+          try {
+            const recallTopic = constants.RECALL_TOPIC || "recall-topic";
+            const kafkaProducer = kafka.producer({
+              groupId: constants.UNIQUE_PRODUCER_GROUP,
+            });
+            await kafkaProducer.connect();
+            await kafkaProducer.send({
+              topic: recallTopic,
+              messages: [
+                {
+                  action: "create",
+                  value: JSON.stringify({
+                    createdActivity: createdActivity.toObject
+                      ? createdActivity.toObject()
+                      : createdActivity,
+                    updatedDevice: recalledDevice,
+                    user_id: user_id,
+                  }),
+                },
+              ],
+            });
+            await kafkaProducer.disconnect();
+            logText(
+              `Successfully published automatic recall event for device ${device.name} to Kafka topic ${recallTopic}`,
+            );
+          } catch (error) {
+            logger.error(
+              `internal server error -- while publishing recall message to Kafka -- ${error.message}`,
+            );
+          }
+        } else {
           logger.error(
-            `internal server error -- while publishing recall message to Kafka -- ${error.message}`,
+            `Skipped Kafka recall notification for ${device.name}: activity creation failed, so createdActivity is unavailable.`,
           );
         }
 
@@ -3156,8 +3168,9 @@ const deviceUtil = {
               throw new Error("Device status changed during recall operation");
             }
 
+            let createdActivity;
             try {
-              await ActivityModel(tenant).create({
+              createdActivity = await ActivityModel(tenant).create({
                 activityType: "recallment",
                 device: device.name,
                 device_id: device._id,
@@ -3176,32 +3189,43 @@ const deviceUtil = {
               .findById(device._id)
               .lean();
 
-            // Publish recall message to Kafka
-            try {
-              const recallTopic = constants.RECALL_TOPIC || "recall-topic";
-              const kafkaProducer = kafka.producer({
-                groupId: constants.UNIQUE_PRODUCER_GROUP,
-              });
-              await kafkaProducer.connect();
-              await kafkaProducer.send({
-                topic: recallTopic,
-                messages: [
-                  {
-                    action: "create",
-                    value: JSON.stringify({
-                      updatedDevice: recalledDevice,
-                      user_id: user_id,
-                    }),
-                  },
-                ],
-              });
-              await kafkaProducer.disconnect();
-              logText(
-                `Successfully published automatic recall event for device ${device.name} to Kafka topic ${recallTopic}`,
-              );
-            } catch (error) {
+            // Publish recall message to Kafka. Include createdActivity (same
+            // shape as activity.util.js's processRecall) so the consumer's
+            // required-fields check doesn't reject this message.
+            if (createdActivity) {
+              try {
+                const recallTopic = constants.RECALL_TOPIC || "recall-topic";
+                const kafkaProducer = kafka.producer({
+                  groupId: constants.UNIQUE_PRODUCER_GROUP,
+                });
+                await kafkaProducer.connect();
+                await kafkaProducer.send({
+                  topic: recallTopic,
+                  messages: [
+                    {
+                      action: "create",
+                      value: JSON.stringify({
+                        createdActivity: createdActivity.toObject
+                          ? createdActivity.toObject()
+                          : createdActivity,
+                        updatedDevice: recalledDevice,
+                        user_id: user_id,
+                      }),
+                    },
+                  ],
+                });
+                await kafkaProducer.disconnect();
+                logText(
+                  `Successfully published automatic recall event for device ${device.name} to Kafka topic ${recallTopic}`,
+                );
+              } catch (error) {
+                logger.error(
+                  `internal server error -- while publishing recall message to Kafka -- ${error.message}`,
+                );
+              }
+            } else {
               logger.error(
-                `internal server error -- while publishing recall message to Kafka -- ${error.message}`,
+                `Skipped Kafka recall notification for ${device.name}: activity creation failed, so createdActivity is unavailable.`,
               );
             }
 

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2925,20 +2925,18 @@ const deviceUtil = {
           .lean();
 
         // Publish recall message to Kafka. Include createdActivity (same
-        // shape as activity.util.js's processRecall) so the consumer's
+        // payload shape as activity.util.js's recall) so the consumer's
         // required-fields check doesn't reject this message.
         if (createdActivity) {
+          const recallTopic = constants.RECALL_TOPIC || "recall-topic";
+          let kafkaProducer;
           try {
-            const recallTopic = constants.RECALL_TOPIC || "recall-topic";
-            const kafkaProducer = kafka.producer({
-              groupId: constants.UNIQUE_PRODUCER_GROUP,
-            });
+            kafkaProducer = kafka.producer();
             await kafkaProducer.connect();
             await kafkaProducer.send({
               topic: recallTopic,
               messages: [
                 {
-                  action: "create",
                   value: JSON.stringify({
                     createdActivity: createdActivity.toObject
                       ? createdActivity.toObject()
@@ -2949,7 +2947,6 @@ const deviceUtil = {
                 },
               ],
             });
-            await kafkaProducer.disconnect();
             logText(
               `Successfully published automatic recall event for device ${device.name} to Kafka topic ${recallTopic}`,
             );
@@ -2957,6 +2954,16 @@ const deviceUtil = {
             logger.error(
               `internal server error -- while publishing recall message to Kafka -- ${error.message}`,
             );
+          } finally {
+            if (kafkaProducer) {
+              try {
+                await kafkaProducer.disconnect();
+              } catch (disconnectError) {
+                logger.error(
+                  `Failed to disconnect Kafka producer after recall notification for ${device.name}: ${disconnectError.message}`,
+                );
+              }
+            }
           }
         } else {
           logger.error(
@@ -3190,20 +3197,18 @@ const deviceUtil = {
               .lean();
 
             // Publish recall message to Kafka. Include createdActivity (same
-            // shape as activity.util.js's processRecall) so the consumer's
+            // payload shape as activity.util.js's recall) so the consumer's
             // required-fields check doesn't reject this message.
             if (createdActivity) {
+              const recallTopic = constants.RECALL_TOPIC || "recall-topic";
+              let kafkaProducer;
               try {
-                const recallTopic = constants.RECALL_TOPIC || "recall-topic";
-                const kafkaProducer = kafka.producer({
-                  groupId: constants.UNIQUE_PRODUCER_GROUP,
-                });
+                kafkaProducer = kafka.producer();
                 await kafkaProducer.connect();
                 await kafkaProducer.send({
                   topic: recallTopic,
                   messages: [
                     {
-                      action: "create",
                       value: JSON.stringify({
                         createdActivity: createdActivity.toObject
                           ? createdActivity.toObject()
@@ -3214,7 +3219,6 @@ const deviceUtil = {
                     },
                   ],
                 });
-                await kafkaProducer.disconnect();
                 logText(
                   `Successfully published automatic recall event for device ${device.name} to Kafka topic ${recallTopic}`,
                 );
@@ -3222,6 +3226,16 @@ const deviceUtil = {
                 logger.error(
                   `internal server error -- while publishing recall message to Kafka -- ${error.message}`,
                 );
+              } finally {
+                if (kafkaProducer) {
+                  try {
+                    await kafkaProducer.disconnect();
+                  } catch (disconnectError) {
+                    logger.error(
+                      `Failed to disconnect Kafka producer after recall notification for ${device.name}: ${disconnectError.message}`,
+                    );
+                  }
+                }
               }
             } else {
               logger.error(


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes two Kafka producer call sites in `device.util.js` (auto-recall during single device claim, and auto-recall during bulk device claim) that published `recall-topic` messages without a `createdActivity` field. The recall activity is now captured from `ActivityModel.create()` and included in the Kafka payload, matching the pattern already used in `activity.util.js`'s `processRecall`. If activity creation fails, the Kafka publish is now skipped (with a clear log entry) instead of sending a payload that is guaranteed to fail downstream validation.

### Why is this change needed?
The `kafka-consumer` job in `auth-service` requires both `createdActivity` and `updatedDevice` to be present, and logs `"Invalid input data: Missing required fields (createdActivity or updatedDevice)"` otherwise. These two call sites only ever sent `updatedDevice` and `user_id`, so every recall triggered via device claiming was guaranteed to fail consumer validation and was silently dropped, generating recurring false-positive error logs on staging.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** device-registry

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified via `node --check` that both edited functions in `device.util.js` remain syntactically valid. Confirmed the new Kafka payload shape matches the already-working `processRecall` path in `activity.util.js` (`createdActivity`, `updatedDevice`, `user_id`), which the `auth-service` kafka-consumer accepts without error.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This is a continuation of the fix in commit `66528a58d` ("apply toObject() on Kafka payloads and fix $push overwrite bug in recall"), which fixed the main `processRecall` path but missed these two claim-triggered auto-recall paths (added earlier, in commit `999e8465f`). No other `recall-topic` producer call sites are missing `createdActivity`.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device claiming reliability by sending recall notifications only after activity creation succeeds.
  * Recall notifications now include the newly created activity details.
  * Failed activity creation is handled without sending incomplete notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->