### PR TITLE
Support multiple devices and sites in group chart defaults

### DIFF
--- a/docs/NEXUS_AIR_QUALITY_API_GUIDE.md
+++ b/docs/NEXUS_AIR_QUALITY_API_GUIDE.md
@@ -1,0 +1,141 @@
+# Nexus Air Quality API Guide
+
+> **Audience:** Frontend engineers working on the AirQo Nexus redesign. This covers the endpoints built in response to the Nexus backend requirements doc: nearby air quality, African AQI rankings, historical comparisons, the dynamic AQI legend — plus chart configuration defaults.
+
+**Updates since this guide was first shared:**
+1. Section 1's claim that device-registry and analytics were "now aligned" on AQI colors/breakpoints was premature — corrected below.
+2. Section 4 didn't include the actual endpoint path, which caused a mix-up with a different, similarly-named endpoint (`grids/nearby`, which returns polygons, not readings) — the correct path is now included.
+3. Section 5 previously pointed at the wrong endpoint (a per-user preference feature, not a group-wide default). The real capability didn't exist, so it was built — then refined again to support multiple devices/sites per saved default (see the section for the current contract).
+
+---
+
+## Overview
+
+All five capabilities from the requirements doc are ready to integrate, including chart configuration defaults (section 5).
+
+Everything below is described in terms of what you send and what comes back. Base URL and request conventions (headers, error format) match the rest of the AirQo API you're already integrating with.
+
+---
+
+## 1. AQI legend / ranges
+
+**`GET /api/v2/devices/aqi-ranges`**
+
+Returns the AQI bands used across AirQo — labels, colors, and numeric ranges — so the legend can be built dynamically instead of hard-coded.
+
+No parameters required.
+
+Response gives you an ordered list of bands (Good → Hazardous), each with a label, a min/max PM2.5 range, a hex color, and a color name. The list also identifies which AQI standard is in effect, plus a `version` number and `effective_from` timestamp that change whenever an admin updates the config — useful if you (or any other service) want to detect a change without deep-comparing the ranges array.
+
+**Correction:** this guide previously said device-registry and analytics had been reconciled onto the same AQI boundaries/colors and were "now aligned." That was premature — **they are not currently aligned.** Device-registry uses the boundaries this endpoint returns; analytics still has its own separate, older hardcoded copy. Bringing analytics in sync (properly — fetching and caching this config, not a one-time value copy) is real, scoped work now in progress on the analytics side. Until then, don't assume analytics-sourced chart colors will match this legend.
+
+---
+
+## 2. African AQI rankings (leaderboard)
+
+**`GET /api/v2/devices/readings/rankings`**
+
+Returns a ranked list of African countries or cities by current air quality, for a leaderboard view.
+
+| Parameter | Required | Notes |
+|---|---|---|
+| `level` | No | `country` (default) or `city` |
+| `sort` | No | `best` (default, cleanest first) or `worst` (most polluted first) |
+| `limit` | No | Default 20, max 100 |
+
+Each ranked entry includes: rank position, name, country code (country-level only), average PM2.5, the derived AQI value and category, how many monitoring sites contributed, and when the ranking was generated.
+
+**Open questions, undocumented in the requirements doc:**
+- **Default sort order.** Currently defaults to cleanest-first ("best"). IQAir/WAQI-style "worst air quality" leaderboards typically lead with the most polluted place. Worth a gut-check on which framing fits Nexus.
+- **Freshness window.** Rankings only include a location if it has a reading from the last 3 days. A country/city with no recent data just won't appear in the list — it isn't shown as zero or "no data," it's simply absent. Site count is included per entry so you can show a confidence indicator if useful.
+
+---
+
+## 3. Historical African comparison (year-by-year)
+
+**Team direction, read this first:** going forward, anything requiring genuinely deep/multi-year history should be sourced from `analytics`, not this endpoint — that's where real long-term historical data actually lives. The endpoint below still exists and works, but treat it as a device-registry-side capability with growing-but-limited depth (see the coverage note), not the long-term answer for historical comparisons. Check with the backend team on the `analytics` equivalent's status before building against this one for anything beyond recent history.
+
+**`GET /api/v2/devices/readings/rankings/history`**
+
+Returns multi-year air quality history per country or city, shaped for a table with entities as rows and years as columns.
+
+| Parameter | Required | Notes |
+|---|---|---|
+| `level` | No | `country` (default) or `city` |
+| `start_year` | Yes | 4-digit year |
+| `end_year` | Yes | 4-digit year, must be ≥ `start_year`, and the span is capped at 5 years |
+
+Each entity in the response includes its name, country code (country-level only), and a list of yearly values — average PM2.5, derived AQI category, and how many sites contributed that year.
+
+**Important for rendering:** a year with no usable data comes back as `null`, never `0`. Please don't treat a missing year as "clean air" — render it as "no data" (grayed out, dash, etc.).
+
+**Coverage note, please read before demoing this:** this data is built up by a daily background process, not computed live — which also means it only accumulates from whenever that process started running. If you request years before that, you'll correctly get "no data" for them (never an error, never zero). In practice this means real historical depth builds up gradually over time rather than being available immediately for past years.
+
+**Scope note:** this is annual granularity only for now. Monthly/daily historical rollups are a larger effort and aren't in this round — flag if that's a near-term blocker.
+
+---
+
+## 4. Nearby air quality (GPS-based)
+
+**`GET /api/v2/devices/readings/nearest`**
+
+| Parameter | Required | Notes |
+|---|---|---|
+| `latitude` | Yes | Valid latitude |
+| `longitude` | Yes | Valid longitude |
+| `radius` | No | Search radius in km, default 15 |
+| `limit` | No | Default 5 |
+
+Returns nearby monitoring locations with distance, pollutant values, and a nearest-city fallback when nothing is within radius. Each result includes `is_stale` and `data_age_minutes` fields so the frontend can visually flag stale readings.
+
+**Important — do not confuse this with `GET /api/v2/devices/grids/nearby`.** That's a different, existing endpoint that returns grid *polygons*, not individual site readings. If you tested "nearby" and got polygon/boundary data back instead of pollutant values, that's the one you hit — this section's endpoint (`readings/nearest`) is the correct one for site-level air quality.
+
+We're intentionally not introducing a second nearby-readings endpoint — there were multiple overlapping ones already, and consolidating onto this one avoids fragmenting behavior further.
+
+---
+
+## 5. Chart configuration defaults
+
+**Group-wide DEFAULT chart configuration**, distinct from `/preferences/:deviceId/charts` (a *per-user* saved-chart feature, keyed on `user_id` + `group_id` — keep using that one for "my saved charts"). This is what a group manager sets so everyone viewing a group's data sees the same default chart, rather than each user needing their own saved view. Lives in **auth-service**, alongside the personal preferences it's a sibling of.
+
+**Read access:** any verified member of the group. **Write access:** group managers/admins only — a shared default shouldn't be something any single member can silently change for everyone else.
+
+**Scoped by `device_ids`/`site_ids` arrays, not a single device.** A saved default can apply to multiple devices and/or multiple sites at once (mirroring how the old, deprecated `/users/defaults` endpoint worked) — there is no `deviceId` in the URL for any of these routes; at least one of `device_ids` or `site_ids` must be provided and non-empty.
+
+`POST /api/v2/users/preferences/groups/:grp_id/charts`
+
+Body:
+```json
+{
+  "device_ids": ["<deviceId1>", "<deviceId2>"],
+  "site_ids": ["<siteId1>"],
+  "chartConfig": {
+    "fieldId": 1,
+    "title": "PM2.5",
+    "chartType": "Line"
+  }
+}
+```
+`chartConfig.fieldId` (1–8) is required; every other chart field from the personal-chart contract is supported here too (`chartType`, `days`, `results`, `referenceLines`, `comparisonPeriod`, etc.). `device_ids`/`site_ids` can be used together or independently — just at least one non-empty array.
+
+`PUT /api/v2/users/preferences/groups/:grp_id/charts/:chartId` — partial update, send only the chart fields changing. `device_ids`/`site_ids` can also be sent here to change which devices/sites this saved default applies to.
+
+`DELETE /api/v2/users/preferences/groups/:grp_id/charts/:chartId`
+
+`GET /api/v2/users/preferences/groups/:grp_id/charts` — list all group-default chart documents. Optional `?device_id=` / `?site_id=` query params narrow the list to defaults scoped to that device/site. Each item in the response is its own document with its own `device_ids`, `site_ids`, and `chartConfigurations`.
+
+`GET /api/v2/users/preferences/groups/:grp_id/charts/:chartId` — a single chart, returned together with the `device_ids`/`site_ids` it applies to.
+
+All require the same auth header you're already using elsewhere. A write from someone who isn't a manager/admin of `:grp_id` returns `403`, not a silent no-op.
+
+**On the duplicate-values error some testers hit separately:** that isn't from the chart endpoints at all — it comes from the general `POST /api/v2/users/preferences/` (plain create) endpoint. That one legitimately fails with a duplicate-key conflict for any user who already has a preference doc for that group, which is the common case, not an edge case — `POST /upsert` is the endpoint meant to be called repeatedly. The error response now includes a hint saying exactly that.
+
+---
+
+## Notes for the redesign conversation
+
+A few observations from working through this, offered as input rather than a prescription:
+
+- Since the redesign has leaned mobile-app/personalized over standard-dashboard, it's worth deciding **before** wiring these endpoints up whether the rankings/legend/history views are meant to be the primary, IQAir/WAQI-style entry point, or a secondary personalized layer — it changes how prominently they should feature in the layout.
+- Rankings and historical data are both scoped to Africa by design (matching the requirements doc). If there's ever a need to show a non-African location for context, that would need a small parameter addition — worth flagging now if it's on the roadmap rather than later.
+- Because "no recent data" and "zero pollution" are different things in this API (see sections 2 and 3), it's worth settling on one consistent visual treatment for "no data" across the leaderboard, the historical table, and the nearby view before implementation, rather than each screen inventing its own.

--- a/src/auth-service/controllers/group-chart-config.controller.js
+++ b/src/auth-service/controllers/group-chart-config.controller.js
@@ -25,11 +25,11 @@ const sendResponse = (res, result) => {
 };
 
 // Every group-chart-config route needs the exact same request shaping:
-// grp_id -> params.groupId (deviceId is already in params, courtesy of
-// Express's own route matching) and a defaulted tenant — built fresh here
-// rather than mutating req.query, since request.query would otherwise be
-// the SAME object reference as req.query (a shallow spread copies the key,
-// not the object it points to).
+// grp_id -> params.groupId and a defaulted tenant — built fresh here rather
+// than mutating req.query, since request.query would otherwise be the SAME
+// object reference as req.query (a shallow spread copies the key, not the
+// object it points to). device_ids/site_ids arrive in the body (create/
+// update) or query (list filters) and need no reshaping.
 // Takes a method NAME, not the function itself — looking it up on
 // groupChartConfigUtil fresh on every call (rather than capturing the
 // function reference once at module-load time) is what lets

--- a/src/auth-service/controllers/test/ut_group-chart-config.controller.js
+++ b/src/auth-service/controllers/test/ut_group-chart-config.controller.js
@@ -17,7 +17,7 @@ describe("group-chart-config controller", () => {
     req = {
       query: { tenant: "airqo" },
       body: {},
-      params: { grp_id: "grp1", deviceId: "device1", chartId: "chart1" },
+      params: { grp_id: "grp1", chartId: "chart1" },
     };
     res = {
       status: sinon.stub().returnsThis(),
@@ -45,7 +45,6 @@ describe("group-chart-config controller", () => {
       expect(createStub.calledOnce).to.equal(true);
       const forwardedRequest = createStub.getCall(0).args[0];
       expect(forwardedRequest.params.groupId).to.equal("grp1");
-      expect(forwardedRequest.params.deviceId).to.equal("device1");
       expect(res.status.calledWith(httpStatus.OK)).to.equal(true);
     });
 

--- a/src/auth-service/models/GroupChartConfig.js
+++ b/src/auth-service/models/GroupChartConfig.js
@@ -10,11 +10,16 @@ const isEmpty = require("is-empty");
 const { chartConfigSchema } = require("./Preference");
 
 /**
- * GroupChartConfig — the group/organization-wide DEFAULT chart configuration
- * for a device, as distinct from Preference.chartConfigurations (which is
- * per-user). This is what a group manager sets so that everyone viewing a
- * device's data within that group sees the same default chart, rather than
- * each user needing their own saved view.
+ * GroupChartConfig — a group/organization-wide DEFAULT chart configuration,
+ * as distinct from Preference.chartConfigurations (which is per-user). This
+ * is what a group manager sets so that everyone viewing data within that
+ * group sees the same default chart, rather than each user needing their
+ * own saved view.
+ *
+ * Scoped by device_ids/site_ids arrays rather than a single device — this
+ * mirrors the old, deprecated Defaults model (which had the same sites[]/
+ * devices[] shape) so one saved default can apply across multiple devices
+ * and/or sites at once, not just one device.
  *
  * Read access: any verified member of the group.
  * Write access: group managers/admins only (see requireGroupManagerAccess in
@@ -27,9 +32,13 @@ const groupChartConfigSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.ObjectId,
       required: [true, "group_id is required"],
     },
-    device_id: {
-      type: mongoose.Schema.Types.ObjectId,
-      required: [true, "device_id is required"],
+    device_ids: {
+      type: [mongoose.Schema.Types.ObjectId],
+      default: [],
+    },
+    site_ids: {
+      type: [mongoose.Schema.Types.ObjectId],
+      default: [],
     },
     chartConfigurations: [chartConfigSchema],
     created_by: { type: mongoose.Schema.Types.ObjectId },
@@ -38,14 +47,27 @@ const groupChartConfigSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-groupChartConfigSchema.index({ group_id: 1, device_id: 1 }, { unique: true });
+// A saved default has to apply to something — at least one device or site.
+groupChartConfigSchema.pre("validate", function (next) {
+  if (isEmpty(this.device_ids) && isEmpty(this.site_ids)) {
+    return next(
+      new Error("At least one of device_ids or site_ids is required")
+    );
+  }
+  next();
+});
+
+groupChartConfigSchema.index({ group_id: 1 });
+groupChartConfigSchema.index({ group_id: 1, device_ids: 1 });
+groupChartConfigSchema.index({ group_id: 1, site_ids: 1 });
 
 groupChartConfigSchema.methods = {
   toJSON() {
     return {
       _id: this._id,
       group_id: this.group_id,
-      device_id: this.device_id,
+      device_ids: this.device_ids,
+      site_ids: this.site_ids,
       chartConfigurations: this.chartConfigurations,
       created_by: this.created_by,
       updated_by: this.updated_by,

--- a/src/auth-service/routes/v2/preferences.routes.js
+++ b/src/auth-service/routes/v2/preferences.routes.js
@@ -141,13 +141,16 @@ router.get(
 
 // Group-wide DEFAULT chart configuration routes
 // ===========================================
-// Distinct from the personal /:deviceId/charts routes above: these set the
-// shared default chart for a device within a group/organization context —
-// what everyone viewing that device's data in the group sees by default,
-// not one user's own saved view. Writes require group-manager access;
-// reads only require verified group membership.
+// Distinct from the personal /:deviceId/charts routes above: these set a
+// shared default chart within a group/organization context — what everyone
+// viewing that data in the group sees by default, not one user's own saved
+// view. Scoped by device_ids/site_ids arrays in the request body/query
+// rather than a single :deviceId path param, so one saved default can cover
+// multiple devices and/or sites at once (mirrors the old, deprecated
+// Defaults model's sites[]/devices[] shape). Writes require group-manager
+// access; reads only require verified group membership.
 router.post(
-  "/groups/:grp_id/:deviceId/charts",
+  "/groups/:grp_id/charts",
   enhancedJWTAuth,
   requireGroupManagerAccess(),
   groupChartConfigValidations.create,
@@ -155,7 +158,7 @@ router.post(
 );
 
 router.put(
-  "/groups/:grp_id/:deviceId/charts/:chartId",
+  "/groups/:grp_id/charts/:chartId",
   enhancedJWTAuth,
   requireGroupManagerAccess(),
   groupChartConfigValidations.update,
@@ -163,7 +166,7 @@ router.put(
 );
 
 router.delete(
-  "/groups/:grp_id/:deviceId/charts/:chartId",
+  "/groups/:grp_id/charts/:chartId",
   enhancedJWTAuth,
   requireGroupManagerAccess(),
   groupChartConfigValidations.delete,
@@ -171,7 +174,7 @@ router.delete(
 );
 
 router.get(
-  "/groups/:grp_id/:deviceId/charts",
+  "/groups/:grp_id/charts",
   enhancedJWTAuth,
   requireGroupMembership(),
   pagination(),
@@ -180,7 +183,7 @@ router.get(
 );
 
 router.get(
-  "/groups/:grp_id/:deviceId/charts/:chartId",
+  "/groups/:grp_id/charts/:chartId",
   enhancedJWTAuth,
   requireGroupMembership(),
   groupChartConfigValidations.getById,

--- a/src/auth-service/utils/group-chart-config.util.js
+++ b/src/auth-service/utils/group-chart-config.util.js
@@ -1,6 +1,7 @@
 const GroupChartConfigModel = require("@models/GroupChartConfig");
 const httpStatus = require("http-status");
 const constants = require("@config/constants");
+const isEmpty = require("is-empty");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- group-chart-config-util`
@@ -34,6 +35,17 @@ const groupChartConfig = {
         return {
           success: false,
           message: "Chart configuration must include a field ID",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      // Enforced by the route validators too, but checked again here so a
+      // direct/validator-bypassing call fails as a clear 400 rather than
+      // hitting the schema's pre-validate hook and surfacing as a 500.
+      if (isEmpty(device_ids) && isEmpty(site_ids)) {
+        return {
+          success: false,
+          message: "At least one of device_ids or site_ids is required",
           status: httpStatus.BAD_REQUEST,
         };
       }
@@ -108,6 +120,20 @@ const groupChartConfig = {
       if (Array.isArray(device_ids)) groupChart.device_ids = device_ids;
       if (Array.isArray(site_ids)) groupChart.site_ids = site_ids;
 
+      // Checked here (post-merge, pre-save) rather than left to the
+      // schema's pre-validate hook: a request can clear one array while
+      // leaving the other untouched, and only the merged result — not the
+      // request body alone — can tell us whether that leaves the doc with
+      // no scope at all. Catching it here returns a normal 400 instead of
+      // an uncaught validation error surfacing as a 500.
+      if (isEmpty(groupChart.device_ids) && isEmpty(groupChart.site_ids)) {
+        return {
+          success: false,
+          message: "At least one of device_ids or site_ids is required",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
       groupChart.updated_by = userId;
 
       await groupChart.save();
@@ -135,25 +161,39 @@ const groupChartConfig = {
       const { groupId, chartId } = request.params;
       const userId = request.user._id;
 
-      // A single atomic $pull rather than findOne -> splice -> save: the
+      // findOneAndUpdate rather than findOne -> splice -> save: the
       // read-modify-write shape raced against a concurrent delete/update on
       // the same doc (whole-document save() can silently drop the other
-      // request's change). $pull removes the matching array element
-      // directly, so there's no window for that to happen.
-      const updateResult = await GroupChartConfigModel(tenant).updateOne(
+      // request's change). It's still a single atomic command like the
+      // $pull-only updateOne this replaced — the difference is it also
+      // hands back the updated document, which is what lets us detect (and
+      // clean up) a doc left with zero charts after this pull. Since
+      // create() always makes its own new document rather than merging
+      // into an existing one, nothing else can race to repopulate this
+      // specific doc's chartConfigurations between the pull and the
+      // cleanup delete below.
+      const updatedDoc = await GroupChartConfigModel(tenant).findOneAndUpdate(
         { group_id: groupId, "chartConfigurations._id": chartId },
         {
           $pull: { chartConfigurations: { _id: chartId } },
           $set: { updated_by: userId },
-        }
+        },
+        { new: true }
       );
 
-      if (updateResult.matchedCount === 0) {
+      if (!updatedDoc) {
         return {
           success: false,
           message: "Group chart configuration not found",
           status: httpStatus.NOT_FOUND,
         };
+      }
+
+      // A saved default with no charts left in it is dead weight — it'd
+      // otherwise keep showing up in list() (matching on group_id/scope)
+      // with an empty chartConfigurations array.
+      if (updatedDoc.chartConfigurations.length === 0) {
+        await GroupChartConfigModel(tenant).deleteOne({ _id: updatedDoc._id });
       }
 
       return {
@@ -185,19 +225,25 @@ const groupChartConfig = {
       if (device_id) filter.device_ids = device_id;
       if (site_id) filter.site_ids = site_id;
 
-      const groupCharts = await GroupChartConfigModel(tenant).find(filter);
-
+      // Paginated at the query level, not in memory — each saved default
+      // is its own document now (not one array embedded in a single doc),
+      // so a group with many saved defaults would otherwise mean loading
+      // all of them just to slice a page off in JS. skip(0)/limit(0) are
+      // both no-ops in MongoDB, so this is safe to chain unconditionally.
       const skipNum = Number(skip) || 0;
-      const limitNum = Number(limit) || groupCharts.length || 1;
-      const data = groupCharts.slice(skipNum, skipNum + limitNum);
+      const limitNum = Number(limit) || 0;
+      const groupCharts = await GroupChartConfigModel(tenant)
+        .find(filter)
+        .skip(skipNum)
+        .limit(limitNum);
 
       return {
         success: true,
         message:
-          data.length > 0
+          groupCharts.length > 0
             ? "Group chart configurations retrieved successfully"
             : "No group chart configurations found",
-        data,
+        data: groupCharts,
         status: httpStatus.OK,
       };
     } catch (error) {

--- a/src/auth-service/utils/group-chart-config.util.js
+++ b/src/auth-service/utils/group-chart-config.util.js
@@ -13,12 +13,21 @@ const { allowedChartProperties } = require("./preference.util");
 // (req.params.grp_id, enforced upstream by requireGroupManagerAccess on
 // writes), never a body default — a group-wide default should never be
 // implicit.
+//
+// Scoping is by device_ids/site_ids arrays (from the request body on
+// create/update, or ?device_id=/?site_id= query filters on list), not a
+// single :deviceId path param — this mirrors the old, deprecated Defaults
+// model's sites[]/devices[] shape, so one saved default can cover multiple
+// devices and/or sites. Each create makes its own document (no
+// findOneAndUpdate-merge into one doc per scope, since matching an exact
+// device_ids/site_ids array combination is unreliable) — same plain-insert
+// shape the old Defaults model used.
 const groupChartConfig = {
   create: async (request, next) => {
     try {
       const { tenant } = request.query;
-      const { groupId, deviceId } = request.params;
-      const { chartConfig } = request.body;
+      const { groupId } = request.params;
+      const { chartConfig, device_ids = [], site_ids = [] } = request.body;
       const userId = request.user._id;
 
       if (!chartConfig || !chartConfig.fieldId) {
@@ -29,32 +38,19 @@ const groupChartConfig = {
         };
       }
 
-      // Atomically add this chart to the group's default set for this
-      // device, creating the doc if it doesn't exist yet — same
-      // findOneAndUpdate-keyed-on-the-unique-index shape as the personal
-      // chart create, which is what keeps it safe from duplicate-key
-      // errors on a first save (see the note in preference.util.js).
-      const groupChart = await GroupChartConfigModel(tenant).findOneAndUpdate(
-        { group_id: groupId, device_id: deviceId },
-        {
-          $push: { chartConfigurations: chartConfig },
-          $set: { updated_by: userId },
-          $setOnInsert: {
-            group_id: groupId,
-            device_id: deviceId,
-            created_by: userId,
-          },
-        },
-        { upsert: true, new: true, runValidators: true }
-      );
+      const groupChart = await GroupChartConfigModel(tenant).create({
+        group_id: groupId,
+        device_ids,
+        site_ids,
+        chartConfigurations: [chartConfig],
+        created_by: userId,
+        updated_by: userId,
+      });
 
       return {
         success: true,
         message: "Group chart configuration created successfully",
-        data:
-          groupChart.chartConfigurations[
-            groupChart.chartConfigurations.length - 1
-          ],
+        data: groupChart.chartConfigurations[0],
         status: httpStatus.OK,
       };
     } catch (error) {
@@ -71,20 +67,19 @@ const groupChartConfig = {
   update: async (request, next) => {
     try {
       const { tenant } = request.query;
-      const { groupId, deviceId, chartId } = request.params;
-      const updates = request.body;
+      const { groupId, chartId } = request.params;
+      const { device_ids, site_ids, ...chartUpdates } = request.body;
       const userId = request.user._id;
 
       const groupChart = await GroupChartConfigModel(tenant).findOne({
         group_id: groupId,
-        device_id: deviceId,
         "chartConfigurations._id": chartId,
       });
 
       if (!groupChart) {
         return {
           success: false,
-          message: "Group chart configuration not found for this device",
+          message: "Group chart configuration not found",
           status: httpStatus.NOT_FOUND,
         };
       }
@@ -101,11 +96,18 @@ const groupChartConfig = {
         };
       }
 
-      Object.keys(updates)
+      Object.keys(chartUpdates)
         .filter((key) => allowedChartProperties.includes(key))
         .forEach((key) => {
-          groupChart.chartConfigurations[chartIndex][key] = updates[key];
+          groupChart.chartConfigurations[chartIndex][key] = chartUpdates[key];
         });
+
+      // device_ids/site_ids update the whole document's scope (which
+      // devices/sites this saved default applies to), not a single chart
+      // field, so they're applied separately from chartUpdates above.
+      if (Array.isArray(device_ids)) groupChart.device_ids = device_ids;
+      if (Array.isArray(site_ids)) groupChart.site_ids = site_ids;
+
       groupChart.updated_by = userId;
 
       await groupChart.save();
@@ -130,16 +132,16 @@ const groupChartConfig = {
   delete: async (request, next) => {
     try {
       const { tenant } = request.query;
-      const { groupId, deviceId, chartId } = request.params;
+      const { groupId, chartId } = request.params;
       const userId = request.user._id;
 
       // A single atomic $pull rather than findOne -> splice -> save: the
       // read-modify-write shape raced against a concurrent delete/update on
-      // the same group+device doc (whole-document save() can silently drop
-      // the other request's change). $pull removes the matching array
-      // element directly, so there's no window for that to happen.
+      // the same doc (whole-document save() can silently drop the other
+      // request's change). $pull removes the matching array element
+      // directly, so there's no window for that to happen.
       const updateResult = await GroupChartConfigModel(tenant).updateOne(
-        { group_id: groupId, device_id: deviceId, "chartConfigurations._id": chartId },
+        { group_id: groupId, "chartConfigurations._id": chartId },
         {
           $pull: { chartConfigurations: { _id: chartId } },
           $set: { updated_by: userId },
@@ -149,7 +151,7 @@ const groupChartConfig = {
       if (updateResult.matchedCount === 0) {
         return {
           success: false,
-          message: "Group chart configuration not found for this device",
+          message: "Group chart configuration not found",
           status: httpStatus.NOT_FOUND,
         };
       }
@@ -172,28 +174,29 @@ const groupChartConfig = {
 
   list: async (request, next) => {
     try {
-      const { tenant, limit, skip } = request.query;
-      const { groupId, deviceId } = request.params;
+      const { tenant, limit, skip, device_id, site_id } = request.query;
+      const { groupId } = request.params;
 
-      const groupChart = await GroupChartConfigModel(tenant).findOne({
-        group_id: groupId,
-        device_id: deviceId,
-      });
+      // Each saved default is now its own document with its own
+      // device_ids/site_ids scope (no longer one array embedded in a
+      // single per-device doc), so list returns matching documents
+      // themselves, optionally narrowed by a specific device/site.
+      const filter = { group_id: groupId };
+      if (device_id) filter.device_ids = device_id;
+      if (site_id) filter.site_ids = site_id;
 
-      // chartConfigurations is an array embedded in a single document, not
-      // its own collection — pagination (set by the route's pagination()
-      // middleware) is applied in memory rather than via a Mongo
-      // .skip()/.limit() query.
-      const allCharts = groupChart ? groupChart.chartConfigurations : [];
+      const groupCharts = await GroupChartConfigModel(tenant).find(filter);
+
       const skipNum = Number(skip) || 0;
-      const limitNum = Number(limit) || allCharts.length || 1;
-      const data = allCharts.slice(skipNum, skipNum + limitNum);
+      const limitNum = Number(limit) || groupCharts.length || 1;
+      const data = groupCharts.slice(skipNum, skipNum + limitNum);
 
       return {
         success: true,
-        message: groupChart
-          ? "Group chart configurations retrieved successfully"
-          : "No group chart configurations found for this device",
+        message:
+          data.length > 0
+            ? "Group chart configurations retrieved successfully"
+            : "No group chart configurations found",
         data,
         status: httpStatus.OK,
       };
@@ -211,17 +214,17 @@ const groupChartConfig = {
   getById: async (request, next) => {
     try {
       const { tenant } = request.query;
-      const { groupId, deviceId, chartId } = request.params;
+      const { groupId, chartId } = request.params;
 
       const groupChart = await GroupChartConfigModel(tenant).findOne({
         group_id: groupId,
-        device_id: deviceId,
+        "chartConfigurations._id": chartId,
       });
 
       if (!groupChart) {
         return {
           success: false,
-          message: "Group chart configuration not found for this device",
+          message: "Chart configuration not found",
           status: httpStatus.NOT_FOUND,
         };
       }
@@ -241,7 +244,11 @@ const groupChartConfig = {
       return {
         success: true,
         message: "Chart configuration retrieved successfully",
-        data: chart,
+        data: {
+          ...chart.toObject(),
+          device_ids: groupChart.device_ids,
+          site_ids: groupChart.site_ids,
+        },
         status: httpStatus.OK,
       };
     } catch (error) {

--- a/src/auth-service/utils/test/ut_group-chart-config.util.js
+++ b/src/auth-service/utils/test/ut_group-chart-config.util.js
@@ -81,13 +81,45 @@ describe("group-chart-config UTIL", function() {
       expect(result.data).to.deep.equal(chartConfig);
     });
 
-    it("defaults device_ids/site_ids to empty arrays when omitted from the body", async function() {
+    it("rejects when device_ids and site_ids are both omitted (defaulted to empty arrays)", async function() {
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId },
+        body: { chartConfig: { fieldId: 1 } },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.create(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(createStub.called).to.equal(false);
+    });
+
+    it("rejects when device_ids and site_ids are both explicitly empty arrays — same 400 the route validators enforce, so a validator-bypassing call still fails cleanly instead of hitting the schema and 500ing", async function() {
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId },
+        body: { chartConfig: { fieldId: 1 }, device_ids: [], site_ids: [] },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.create(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(createStub.called).to.equal(false);
+    });
+
+    it("defaults the omitted one to an empty array when only one of device_ids/site_ids is given", async function() {
       const chartConfig = { fieldId: 1 };
       createStub.resolves({ chartConfigurations: [chartConfig] });
       const request = {
         query: { tenant: "airqo" },
         params: { groupId },
-        body: { chartConfig },
+        body: { chartConfig, device_ids: [deviceId] },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -95,7 +127,7 @@ describe("group-chart-config UTIL", function() {
       await rewireGroupChartConfigUtil.create(request, next);
 
       const [doc] = createStub.getCall(0).args;
-      expect(doc.device_ids).to.deep.equal([]);
+      expect(doc.device_ids).to.deep.equal([deviceId]);
       expect(doc.site_ids).to.deep.equal([]);
     });
 
@@ -201,6 +233,56 @@ describe("group-chart-config UTIL", function() {
       expect(doc.site_ids).to.deep.equal([siteId]);
     });
 
+    it("rejects (400, not a save() that trips the schema into a 500) when both scope arrays are explicitly cleared", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = { _id: { toString: () => chartId }, title: "Old title" };
+      const doc = {
+        chartConfigurations: [chart],
+        device_ids: [deviceId],
+        site_ids: [siteId],
+        save: saveStub,
+      };
+      findOneStub.resolves(doc);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, chartId },
+        body: { device_ids: [], site_ids: [] },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.update(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(saveStub.called).to.equal(false);
+    });
+
+    it("rejects when clearing just one scope array leaves the doc's other array already empty — a case the validator layer alone can't see, since it needs the existing document", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = { _id: { toString: () => chartId }, title: "Old title" };
+      const doc = {
+        chartConfigurations: [chart],
+        device_ids: [deviceId],
+        site_ids: [], // already empty on the existing document
+        save: saveStub,
+      };
+      findOneStub.resolves(doc);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, chartId },
+        body: { device_ids: [] }, // site_ids untouched, but it's already []
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.update(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(saveStub.called).to.equal(false);
+    });
+
     it("returns an internal error response when the model throws", async function() {
       findOneStub.rejects(new Error("Mongo down"));
       const request = {
@@ -219,20 +301,23 @@ describe("group-chart-config UTIL", function() {
   });
 
   describe("delete", function() {
-    let updateOneStub;
+    let findOneAndUpdateStub;
+    let deleteOneStub;
 
     beforeEach(function() {
       origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
         "GroupChartConfigModel"
       );
-      updateOneStub = sinon.stub();
+      findOneAndUpdateStub = sinon.stub();
+      deleteOneStub = sinon.stub().resolves();
       rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
-        updateOne: updateOneStub,
+        findOneAndUpdate: findOneAndUpdateStub,
+        deleteOne: deleteOneStub,
       }));
     });
 
     it("returns 404 when nothing matches the group/chart filter", async function() {
-      updateOneStub.resolves({ matchedCount: 0, modifiedCount: 0 });
+      findOneAndUpdateStub.resolves(null);
       const request = {
         query: { tenant: "airqo" },
         params: { groupId, chartId },
@@ -244,10 +329,14 @@ describe("group-chart-config UTIL", function() {
 
       expect(result.success).to.equal(false);
       expect(result.status).to.equal(httpStatus.NOT_FOUND);
+      expect(deleteOneStub.called).to.equal(false);
     });
 
-    it("pulls the chart atomically in a single updateOne, keyed on group_id + chartId only — no read-modify-write race with a concurrent update", async function() {
-      updateOneStub.resolves({ matchedCount: 1, modifiedCount: 1 });
+    it("pulls the chart atomically via findOneAndUpdate, keyed on group_id + chartId only — no read-modify-write race with a concurrent update", async function() {
+      findOneAndUpdateStub.resolves({
+        _id: "doc1",
+        chartConfigurations: [{ fieldId: 2 }],
+      });
       const request = {
         query: { tenant: "airqo" },
         params: { groupId, chartId },
@@ -257,8 +346,8 @@ describe("group-chart-config UTIL", function() {
 
       const result = await rewireGroupChartConfigUtil.delete(request, next);
 
-      expect(updateOneStub.calledOnce).to.equal(true);
-      const [filter, update] = updateOneStub.getCall(0).args;
+      expect(findOneAndUpdateStub.calledOnce).to.equal(true);
+      const [filter, update, options] = findOneAndUpdateStub.getCall(0).args;
       expect(filter).to.deep.equal({
         group_id: groupId,
         "chartConfigurations._id": chartId,
@@ -267,11 +356,48 @@ describe("group-chart-config UTIL", function() {
         chartConfigurations: { _id: chartId },
       });
       expect(update.$set.updated_by).to.equal(userId);
+      expect(options.new).to.equal(true);
+      expect(result.success).to.equal(true);
+    });
+
+    it("leaves the parent document alone when other charts remain after the pull", async function() {
+      findOneAndUpdateStub.resolves({
+        _id: "doc1",
+        chartConfigurations: [{ fieldId: 2 }],
+      });
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, chartId },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      await rewireGroupChartConfigUtil.delete(request, next);
+
+      expect(deleteOneStub.called).to.equal(false);
+    });
+
+    it("cascades and removes the whole document once its last chart is pulled, so it doesn't linger in list() with an empty chartConfigurations array", async function() {
+      findOneAndUpdateStub.resolves({
+        _id: "doc1",
+        chartConfigurations: [],
+      });
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, chartId },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.delete(request, next);
+
+      expect(deleteOneStub.calledOnce).to.equal(true);
+      expect(deleteOneStub.getCall(0).args[0]).to.deep.equal({ _id: "doc1" });
       expect(result.success).to.equal(true);
     });
 
     it("returns an internal error response when the model throws", async function() {
-      updateOneStub.rejects(new Error("Mongo down"));
+      findOneAndUpdateStub.rejects(new Error("Mongo down"));
       const request = {
         query: { tenant: "airqo" },
         params: { groupId, chartId },
@@ -289,6 +415,30 @@ describe("group-chart-config UTIL", function() {
   describe("list", function() {
     let findStub;
 
+    // Mimics a real Mongoose Query: .skip()/.limit() are chainable (return
+    // the same object) and the object itself is awaitable. This is what
+    // lets the util's find(filter).skip(n).limit(n) actually paginate at
+    // the query level instead of loading everything into memory to slice.
+    function chainableFind(resolvedValue, rejectedError) {
+      const calls = {};
+      const chain = {
+        skip(n) {
+          calls.skip = n;
+          return chain;
+        },
+        limit(n) {
+          calls.limit = n;
+          return chain;
+        },
+        then(resolve, reject) {
+          return rejectedError
+            ? Promise.reject(rejectedError).then(resolve, reject)
+            : Promise.resolve(resolvedValue).then(resolve, reject);
+        },
+      };
+      return { chain, calls };
+    }
+
     beforeEach(function() {
       origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
         "GroupChartConfigModel"
@@ -300,7 +450,8 @@ describe("group-chart-config UTIL", function() {
     });
 
     it("returns an empty array (still success) when nothing exists yet for this group", async function() {
-      findStub.resolves([]);
+      const { chain } = chainableFind([]);
+      findStub.returns(chain);
       const request = {
         query: { tenant: "airqo" },
         params: { groupId },
@@ -321,7 +472,8 @@ describe("group-chart-config UTIL", function() {
         { group_id: groupId, device_ids: [deviceId], site_ids: [] },
         { group_id: groupId, device_ids: [], site_ids: [siteId] },
       ];
-      findStub.resolves(docs);
+      const { chain } = chainableFind(docs);
+      findStub.returns(chain);
       const request = {
         query: { tenant: "airqo" },
         params: { groupId },
@@ -334,7 +486,8 @@ describe("group-chart-config UTIL", function() {
     });
 
     it("narrows the filter by device_id/site_id query params when provided", async function() {
-      findStub.resolves([]);
+      const { chain } = chainableFind([]);
+      findStub.returns(chain);
       const request = {
         query: { tenant: "airqo", device_id: deviceId, site_id: siteId },
         params: { groupId },
@@ -350,9 +503,10 @@ describe("group-chart-config UTIL", function() {
       });
     });
 
-    it("honors limit/skip from the route's pagination() middleware", async function() {
-      const docs = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
-      findStub.resolves(docs);
+    it("paginates at the query level via skip()/limit(), not by loading everything and slicing in memory", async function() {
+      const docs = [{ id: 2 }, { id: 3 }];
+      const { chain, calls } = chainableFind(docs);
+      findStub.returns(chain);
       const request = {
         query: { tenant: "airqo", limit: 2, skip: 1 },
         params: { groupId },
@@ -361,11 +515,29 @@ describe("group-chart-config UTIL", function() {
 
       const result = await rewireGroupChartConfigUtil.list(request, next);
 
-      expect(result.data).to.deep.equal([{ id: 2 }, { id: 3 }]);
+      expect(calls.skip).to.equal(1);
+      expect(calls.limit).to.equal(2);
+      expect(result.data).to.deep.equal(docs);
+    });
+
+    it("defaults skip/limit to 0 — a MongoDB no-op — when omitted from the query", async function() {
+      const { chain, calls } = chainableFind([]);
+      findStub.returns(chain);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId },
+      };
+      const next = sinon.stub();
+
+      await rewireGroupChartConfigUtil.list(request, next);
+
+      expect(calls.skip).to.equal(0);
+      expect(calls.limit).to.equal(0);
     });
 
     it("returns an internal error response when the model throws", async function() {
-      findStub.rejects(new Error("Mongo down"));
+      const { chain } = chainableFind(null, new Error("Mongo down"));
+      findStub.returns(chain);
       const request = {
         query: { tenant: "airqo" },
         params: { groupId },

--- a/src/auth-service/utils/test/ut_group-chart-config.util.js
+++ b/src/auth-service/utils/test/ut_group-chart-config.util.js
@@ -15,6 +15,7 @@ describe("group-chart-config UTIL", function() {
   const groupId = "507f1f77bcf86cd799439012";
   const deviceId = "507f1f77bcf86cd799439013";
   const chartId = "507f1f77bcf86cd799439014";
+  const siteId = "507f1f77bcf86cd799439015";
 
   afterEach(function() {
     rewireGroupChartConfigUtil.__set__(
@@ -25,23 +26,23 @@ describe("group-chart-config UTIL", function() {
   });
 
   describe("create", function() {
-    let findOneAndUpdateStub;
+    let createStub;
 
     beforeEach(function() {
-      findOneAndUpdateStub = sinon.stub();
+      createStub = sinon.stub();
       origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
         "GroupChartConfigModel"
       );
       rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
-        findOneAndUpdate: findOneAndUpdateStub,
+        create: createStub,
       }));
     });
 
     it("rejects a chartConfig with no fieldId", async function() {
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId },
-        body: { chartConfig: {} },
+        params: { groupId },
+        body: { chartConfig: {}, device_ids: [deviceId] },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -50,43 +51,60 @@ describe("group-chart-config UTIL", function() {
 
       expect(result.success).to.equal(false);
       expect(result.status).to.equal(httpStatus.BAD_REQUEST);
-      expect(findOneAndUpdateStub.called).to.equal(false);
+      expect(createStub.called).to.equal(false);
     });
 
-    it("upserts atomically, keyed on (group_id, device_id) — the same shape that keeps the personal chart create safe from duplicate-key errors — and stamps audit fields", async function() {
+    it("creates a new document scoped to the given device_ids/site_ids and stamps audit fields", async function() {
       const chartConfig = { fieldId: 1, title: "PM2.5" };
-      findOneAndUpdateStub.resolves({
+      createStub.resolves({
         chartConfigurations: [chartConfig],
       });
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId },
-        body: { chartConfig },
+        params: { groupId },
+        body: { chartConfig, device_ids: [deviceId], site_ids: [siteId] },
         user: { _id: userId },
       };
       const next = sinon.stub();
 
       const result = await rewireGroupChartConfigUtil.create(request, next);
 
-      expect(findOneAndUpdateStub.calledOnce).to.equal(true);
-      const [filter, update, options] = findOneAndUpdateStub.getCall(0).args;
-      expect(filter).to.deep.equal({ group_id: groupId, device_id: deviceId });
-      expect(update.$push.chartConfigurations).to.deep.equal(chartConfig);
-      expect(update.$set.updated_by).to.equal(userId);
-      expect(update.$setOnInsert.group_id).to.equal(groupId);
-      expect(update.$setOnInsert.device_id).to.equal(deviceId);
-      expect(update.$setOnInsert.created_by).to.equal(userId);
-      expect(options.upsert).to.equal(true);
+      expect(createStub.calledOnce).to.equal(true);
+      const [doc] = createStub.getCall(0).args;
+      expect(doc.group_id).to.equal(groupId);
+      expect(doc.device_ids).to.deep.equal([deviceId]);
+      expect(doc.site_ids).to.deep.equal([siteId]);
+      expect(doc.chartConfigurations).to.deep.equal([chartConfig]);
+      expect(doc.created_by).to.equal(userId);
+      expect(doc.updated_by).to.equal(userId);
       expect(result.success).to.equal(true);
       expect(result.data).to.deep.equal(chartConfig);
     });
 
-    it("returns an internal error response when the model throws", async function() {
-      findOneAndUpdateStub.rejects(new Error("Mongo down"));
+    it("defaults device_ids/site_ids to empty arrays when omitted from the body", async function() {
+      const chartConfig = { fieldId: 1 };
+      createStub.resolves({ chartConfigurations: [chartConfig] });
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId },
-        body: { chartConfig: { fieldId: 1 } },
+        params: { groupId },
+        body: { chartConfig },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      await rewireGroupChartConfigUtil.create(request, next);
+
+      const [doc] = createStub.getCall(0).args;
+      expect(doc.device_ids).to.deep.equal([]);
+      expect(doc.site_ids).to.deep.equal([]);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      createStub.rejects(new Error("Mongo down"));
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId },
+        body: { chartConfig: { fieldId: 1 }, device_ids: [deviceId] },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -111,11 +129,11 @@ describe("group-chart-config UTIL", function() {
       }));
     });
 
-    it("returns 404 when no group chart config exists for this device", async function() {
+    it("returns 404 when no group chart config contains this chartId", async function() {
       findOneStub.resolves(null);
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
         body: { title: "New title" },
         user: { _id: userId },
       };
@@ -125,6 +143,10 @@ describe("group-chart-config UTIL", function() {
 
       expect(result.success).to.equal(false);
       expect(result.status).to.equal(httpStatus.NOT_FOUND);
+      expect(findOneStub.getCall(0).args[0]).to.deep.equal({
+        group_id: groupId,
+        "chartConfigurations._id": chartId,
+      });
     });
 
     it("only applies whitelisted chart properties and persists via save()", async function() {
@@ -132,12 +154,14 @@ describe("group-chart-config UTIL", function() {
       const chart = { _id: { toString: () => chartId }, title: "Old title" };
       const doc = {
         chartConfigurations: [chart],
+        device_ids: [deviceId],
+        site_ids: [],
         save: saveStub,
       };
       findOneStub.resolves(doc);
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
         body: { title: "New title", notAllowedField: "ignore me" },
         user: { _id: userId },
       };
@@ -152,11 +176,36 @@ describe("group-chart-config UTIL", function() {
       expect(result.success).to.equal(true);
     });
 
+    it("updates device_ids/site_ids on the whole document when provided", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = { _id: { toString: () => chartId }, title: "Old title" };
+      const doc = {
+        chartConfigurations: [chart],
+        device_ids: [deviceId],
+        site_ids: [],
+        save: saveStub,
+      };
+      findOneStub.resolves(doc);
+      const newDeviceIds = [deviceId, "507f1f77bcf86cd799439099"];
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, chartId },
+        body: { device_ids: newDeviceIds, site_ids: [siteId] },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      await rewireGroupChartConfigUtil.update(request, next);
+
+      expect(doc.device_ids).to.deep.equal(newDeviceIds);
+      expect(doc.site_ids).to.deep.equal([siteId]);
+    });
+
     it("returns an internal error response when the model throws", async function() {
       findOneStub.rejects(new Error("Mongo down"));
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
         body: { title: "New title" },
         user: { _id: userId },
       };
@@ -182,11 +231,11 @@ describe("group-chart-config UTIL", function() {
       }));
     });
 
-    it("returns 404 when nothing matches the group/device/chart filter", async function() {
+    it("returns 404 when nothing matches the group/chart filter", async function() {
       updateOneStub.resolves({ matchedCount: 0, modifiedCount: 0 });
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -197,11 +246,11 @@ describe("group-chart-config UTIL", function() {
       expect(result.status).to.equal(httpStatus.NOT_FOUND);
     });
 
-    it("pulls the chart atomically in a single updateOne — no read-modify-write race with a concurrent update", async function() {
+    it("pulls the chart atomically in a single updateOne, keyed on group_id + chartId only — no read-modify-write race with a concurrent update", async function() {
       updateOneStub.resolves({ matchedCount: 1, modifiedCount: 1 });
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -212,7 +261,6 @@ describe("group-chart-config UTIL", function() {
       const [filter, update] = updateOneStub.getCall(0).args;
       expect(filter).to.deep.equal({
         group_id: groupId,
-        device_id: deviceId,
         "chartConfigurations._id": chartId,
       });
       expect(update.$pull).to.deep.equal({
@@ -226,7 +274,7 @@ describe("group-chart-config UTIL", function() {
       updateOneStub.rejects(new Error("Mongo down"));
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
         user: { _id: userId },
       };
       const next = sinon.stub();
@@ -239,23 +287,23 @@ describe("group-chart-config UTIL", function() {
   });
 
   describe("list", function() {
-    let findOneStub;
+    let findStub;
 
     beforeEach(function() {
       origGroupChartConfigModel = rewireGroupChartConfigUtil.__get__(
         "GroupChartConfigModel"
       );
-      findOneStub = sinon.stub();
+      findStub = sinon.stub();
       rewireGroupChartConfigUtil.__set__("GroupChartConfigModel", () => ({
-        findOne: findOneStub,
+        find: findStub,
       }));
     });
 
-    it("returns an empty array (still success) when nothing exists yet for this device", async function() {
-      findOneStub.resolves(null);
+    it("returns an empty array (still success) when nothing exists yet for this group", async function() {
+      findStub.resolves([]);
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId },
+        params: { groupId },
       };
       const next = sinon.stub();
 
@@ -263,46 +311,64 @@ describe("group-chart-config UTIL", function() {
 
       expect(result.success).to.equal(true);
       expect(result.data).to.deep.equal([]);
+      expect(findStub.getCall(0).args[0]).to.deep.equal({
+        group_id: groupId,
+      });
     });
 
-    it("returns the group's chart configurations when present", async function() {
-      const charts = [{ fieldId: 1 }, { fieldId: 2 }];
-      findOneStub.resolves({ chartConfigurations: charts });
+    it("returns the group's saved chart config documents when present", async function() {
+      const docs = [
+        { group_id: groupId, device_ids: [deviceId], site_ids: [] },
+        { group_id: groupId, device_ids: [], site_ids: [siteId] },
+      ];
+      findStub.resolves(docs);
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId },
+        params: { groupId },
       };
       const next = sinon.stub();
 
       const result = await rewireGroupChartConfigUtil.list(request, next);
 
-      expect(result.data).to.deep.equal(charts);
+      expect(result.data).to.deep.equal(docs);
+    });
+
+    it("narrows the filter by device_id/site_id query params when provided", async function() {
+      findStub.resolves([]);
+      const request = {
+        query: { tenant: "airqo", device_id: deviceId, site_id: siteId },
+        params: { groupId },
+      };
+      const next = sinon.stub();
+
+      await rewireGroupChartConfigUtil.list(request, next);
+
+      expect(findStub.getCall(0).args[0]).to.deep.equal({
+        group_id: groupId,
+        device_ids: deviceId,
+        site_ids: siteId,
+      });
     });
 
     it("honors limit/skip from the route's pagination() middleware", async function() {
-      const charts = [
-        { fieldId: 1 },
-        { fieldId: 2 },
-        { fieldId: 3 },
-        { fieldId: 4 },
-      ];
-      findOneStub.resolves({ chartConfigurations: charts });
+      const docs = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      findStub.resolves(docs);
       const request = {
         query: { tenant: "airqo", limit: 2, skip: 1 },
-        params: { groupId, deviceId },
+        params: { groupId },
       };
       const next = sinon.stub();
 
       const result = await rewireGroupChartConfigUtil.list(request, next);
 
-      expect(result.data).to.deep.equal([{ fieldId: 2 }, { fieldId: 3 }]);
+      expect(result.data).to.deep.equal([{ id: 2 }, { id: 3 }]);
     });
 
     it("returns an internal error response when the model throws", async function() {
-      findOneStub.rejects(new Error("Mongo down"));
+      findStub.rejects(new Error("Mongo down"));
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId },
+        params: { groupId },
       };
       const next = sinon.stub();
 
@@ -326,11 +392,11 @@ describe("group-chart-config UTIL", function() {
       }));
     });
 
-    it("returns 404 when the group has no chart config doc for this device", async function() {
+    it("returns 404 when the group has no chart config doc containing this chartId", async function() {
       findOneStub.resolves(null);
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
       };
       const next = sinon.stub();
 
@@ -342,11 +408,13 @@ describe("group-chart-config UTIL", function() {
 
     it("returns 404 when the specific chart isn't in the array", async function() {
       findOneStub.resolves({
+        device_ids: [deviceId],
+        site_ids: [],
         chartConfigurations: [{ _id: { toString: () => "other-id" } }],
       });
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
       };
       const next = sinon.stub();
 
@@ -356,26 +424,39 @@ describe("group-chart-config UTIL", function() {
       expect(result.status).to.equal(httpStatus.NOT_FOUND);
     });
 
-    it("returns the chart when found", async function() {
-      const chart = { _id: { toString: () => chartId }, fieldId: 3 };
-      findOneStub.resolves({ chartConfigurations: [chart] });
+    it("returns the chart merged with the parent doc's device_ids/site_ids scope", async function() {
+      const chart = {
+        _id: { toString: () => chartId },
+        fieldId: 3,
+        toObject: () => ({ _id: chartId, fieldId: 3 }),
+      };
+      findOneStub.resolves({
+        device_ids: [deviceId],
+        site_ids: [siteId],
+        chartConfigurations: [chart],
+      });
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
       };
       const next = sinon.stub();
 
       const result = await rewireGroupChartConfigUtil.getById(request, next);
 
       expect(result.success).to.equal(true);
-      expect(result.data).to.equal(chart);
+      expect(result.data).to.deep.equal({
+        _id: chartId,
+        fieldId: 3,
+        device_ids: [deviceId],
+        site_ids: [siteId],
+      });
     });
 
     it("returns an internal error response when the model throws", async function() {
       findOneStub.rejects(new Error("Mongo down"));
       const request = {
         query: { tenant: "airqo" },
-        params: { groupId, deviceId, chartId },
+        params: { groupId, chartId },
       };
       const next = sinon.stub();
 

--- a/src/auth-service/validators/group-chart-config.validators.js
+++ b/src/auth-service/validators/group-chart-config.validators.js
@@ -46,6 +46,25 @@ const atLeastOneScopeRequired = body().custom((_, { req }) => {
   return true;
 });
 
+// On update, device_ids/site_ids are optional — a request may only touch
+// chart fields and leave scope untouched. But if both are explicitly sent
+// and both empty, that's an unambiguous attempt to clear the scope
+// entirely, so it's rejected here rather than left to fail later. This
+// can't catch every way to end up with an empty scope (e.g. clearing just
+// one array while the existing doc's other array is already empty) — that
+// case needs the current document, so it's guarded again in
+// group-chart-config.util.js after merging with the existing doc.
+const scopeNotBothClearedOnUpdate = body().custom((_, { req }) => {
+  const { device_ids, site_ids } = req.body;
+  const bothProvided = Array.isArray(device_ids) && Array.isArray(site_ids);
+  if (bothProvided && isEmpty(device_ids) && isEmpty(site_ids)) {
+    throw new Error(
+      "device_ids and site_ids cannot both be cleared — at least one must remain"
+    );
+  }
+  return true;
+});
+
 const deviceIdQuery = query("device_id")
   .optional()
   .isMongoId()
@@ -81,6 +100,7 @@ const groupChartConfigValidations = {
     groupIdParam,
     chartIdParam,
     ...scopeArrayValidations,
+    scopeNotBothClearedOnUpdate,
     ...chartConfigValidation,
   ],
   delete: [...commonValidations.tenant, groupIdParam, chartIdParam],

--- a/src/auth-service/validators/group-chart-config.validators.js
+++ b/src/auth-service/validators/group-chart-config.validators.js
@@ -1,5 +1,6 @@
 // group-chart-config.validators.js
-const { body, param } = require("express-validator");
+const { body, param, query } = require("express-validator");
+const isEmpty = require("is-empty");
 const preferenceValidations = require("./preferences.validators");
 
 // Reused from preferences.validators.js rather than duplicated — same chart
@@ -8,6 +9,7 @@ const {
   chartConfigValidation,
   createNestedValidations,
   commonValidations,
+  validateArrayOfObjectIds,
 } = preferenceValidations.sharedHelpers;
 
 const groupIdParam = param("grp_id")
@@ -17,13 +19,6 @@ const groupIdParam = param("grp_id")
   .isMongoId()
   .withMessage("Invalid Group ID");
 
-const deviceIdParam = param("deviceId")
-  .exists()
-  .withMessage("Device ID is required")
-  .bail()
-  .isMongoId()
-  .withMessage("Invalid Device ID");
-
 const chartIdParam = param("chartId")
   .exists()
   .withMessage("Chart ID is required")
@@ -31,11 +26,42 @@ const chartIdParam = param("chartId")
   .isMongoId()
   .withMessage("Invalid Chart ID");
 
+// A saved default can apply to more than one device and/or site at once
+// (mirrors the old, deprecated Defaults model's sites[]/devices[] arrays),
+// so both are optional arrays rather than a single required :deviceId path
+// param — but at least one has to be present, since a default has to apply
+// to something.
+const scopeArrayValidations = [
+  ...validateArrayOfObjectIds("device_ids"),
+  ...validateArrayOfObjectIds("site_ids"),
+];
+
+const atLeastOneScopeRequired = body().custom((_, { req }) => {
+  const { device_ids, site_ids } = req.body;
+  if (isEmpty(device_ids) && isEmpty(site_ids)) {
+    throw new Error(
+      "At least one of device_ids or site_ids is required, and must not be empty"
+    );
+  }
+  return true;
+});
+
+const deviceIdQuery = query("device_id")
+  .optional()
+  .isMongoId()
+  .withMessage("device_id must be a valid Device ID");
+
+const siteIdQuery = query("site_id")
+  .optional()
+  .isMongoId()
+  .withMessage("site_id must be a valid Site ID");
+
 const groupChartConfigValidations = {
   create: [
     ...commonValidations.tenant,
     groupIdParam,
-    deviceIdParam,
+    ...scopeArrayValidations,
+    atLeastOneScopeRequired,
     body("chartConfig")
       .exists()
       .withMessage("chartConfig object is required")
@@ -53,23 +79,18 @@ const groupChartConfigValidations = {
   update: [
     ...commonValidations.tenant,
     groupIdParam,
-    deviceIdParam,
     chartIdParam,
+    ...scopeArrayValidations,
     ...chartConfigValidation,
   ],
-  delete: [
+  delete: [...commonValidations.tenant, groupIdParam, chartIdParam],
+  list: [
     ...commonValidations.tenant,
     groupIdParam,
-    deviceIdParam,
-    chartIdParam,
+    deviceIdQuery,
+    siteIdQuery,
   ],
-  list: [...commonValidations.tenant, groupIdParam, deviceIdParam],
-  getById: [
-    ...commonValidations.tenant,
-    groupIdParam,
-    deviceIdParam,
-    chartIdParam,
-  ],
+  getById: [...commonValidations.tenant, groupIdParam, chartIdParam],
 };
 
 module.exports = groupChartConfigValidations;

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -1577,6 +1577,7 @@ preferenceValidations.sharedHelpers = {
   chartConfigValidation,
   createNestedValidations,
   commonValidations,
+  validateArrayOfObjectIds,
 };
 
 module.exports = preferenceValidations;

--- a/src/auth-service/validators/test/ut_group-chart-config.validators.js
+++ b/src/auth-service/validators/test/ut_group-chart-config.validators.js
@@ -172,6 +172,23 @@ describe("group-chart-config validators", () => {
       expect(res.status).to.equal(422);
     });
 
+    it("rejects when device_ids and site_ids are both explicitly sent empty — an unambiguous attempt to clear the scope entirely", async () => {
+      const res = await request(app)
+        .put(`/test/groups/${validId()}/charts/${validId()}`)
+        .send({ device_ids: [], site_ids: [] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "device_ids and site_ids cannot both be cleared"
+      );
+    });
+
+    it("accepts clearing just one scope array when the other is left untouched — the validator can't know the existing doc's scope, so this is allowed here and guarded again at the util layer", async () => {
+      const res = await request(app)
+        .put(`/test/groups/${validId()}/charts/${validId()}`)
+        .send({ device_ids: [] });
+      expect(res.status).to.equal(200);
+    });
+
     it("accepts a well-formed partial update", async () => {
       const res = await request(app)
         .put(`/test/groups/${validId()}/charts/${validId()}`)

--- a/src/auth-service/validators/test/ut_group-chart-config.validators.js
+++ b/src/auth-service/validators/test/ut_group-chart-config.validators.js
@@ -27,23 +27,11 @@ function buildApp(middleware) {
     }
     res.json({ success: true });
   };
-  app.post("/test/groups/:grp_id/:deviceId/charts", ...middleware, handler);
-  app.put(
-    "/test/groups/:grp_id/:deviceId/charts/:chartId",
-    ...middleware,
-    handler
-  );
-  app.delete(
-    "/test/groups/:grp_id/:deviceId/charts/:chartId",
-    ...middleware,
-    handler
-  );
-  app.get("/test/groups/:grp_id/:deviceId/charts", ...middleware, handler);
-  app.get(
-    "/test/groups/:grp_id/:deviceId/charts/:chartId",
-    ...middleware,
-    handler
-  );
+  app.post("/test/groups/:grp_id/charts", ...middleware, handler);
+  app.put("/test/groups/:grp_id/charts/:chartId", ...middleware, handler);
+  app.delete("/test/groups/:grp_id/charts/:chartId", ...middleware, handler);
+  app.get("/test/groups/:grp_id/charts", ...middleware, handler);
+  app.get("/test/groups/:grp_id/charts/:chartId", ...middleware, handler);
   return app;
 }
 
@@ -53,24 +41,50 @@ describe("group-chart-config validators", () => {
 
     it("rejects an invalid grp_id", async () => {
       const res = await request(app)
-        .post(`/test/groups/not-an-id/${validId()}/charts`)
-        .send({ chartConfig: { fieldId: 1 } });
+        .post(`/test/groups/not-an-id/charts`)
+        .send({ chartConfig: { fieldId: 1 }, device_ids: [validId()] });
       expect(res.status).to.equal(422);
       expect(JSON.stringify(res.body)).to.include("Invalid Group ID");
     });
 
-    it("rejects an invalid deviceId", async () => {
+    it("rejects when neither device_ids nor site_ids is provided", async () => {
       const res = await request(app)
-        .post(`/test/groups/${validId()}/not-an-id/charts`)
+        .post(`/test/groups/${validId()}/charts`)
         .send({ chartConfig: { fieldId: 1 } });
       expect(res.status).to.equal(422);
-      expect(JSON.stringify(res.body)).to.include("Invalid Device ID");
+      expect(JSON.stringify(res.body)).to.include(
+        "At least one of device_ids or site_ids is required"
+      );
+    });
+
+    it("rejects when device_ids/site_ids are present but both empty", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/charts`)
+        .send({
+          chartConfig: { fieldId: 1 },
+          device_ids: [],
+          site_ids: [],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "At least one of device_ids or site_ids is required"
+      );
+    });
+
+    it("rejects a device_ids entry that isn't a valid ObjectId", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/charts`)
+        .send({ chartConfig: { fieldId: 1 }, device_ids: ["not-an-id"] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "device_ids must be an array of valid ObjectId strings"
+      );
     });
 
     it("rejects a missing chartConfig", async () => {
       const res = await request(app)
-        .post(`/test/groups/${validId()}/${validId()}/charts`)
-        .send({});
+        .post(`/test/groups/${validId()}/charts`)
+        .send({ device_ids: [validId()] });
       expect(res.status).to.equal(422);
       expect(JSON.stringify(res.body)).to.include(
         "chartConfig object is required"
@@ -79,8 +93,11 @@ describe("group-chart-config validators", () => {
 
     it("rejects a chartConfig missing fieldId", async () => {
       const res = await request(app)
-        .post(`/test/groups/${validId()}/${validId()}/charts`)
-        .send({ chartConfig: { title: "no field id" } });
+        .post(`/test/groups/${validId()}/charts`)
+        .send({
+          chartConfig: { title: "no field id" },
+          device_ids: [validId()],
+        });
       expect(res.status).to.equal(422);
       expect(JSON.stringify(res.body)).to.include(
         "fieldId is required in chartConfig"
@@ -89,15 +106,41 @@ describe("group-chart-config validators", () => {
 
     it("rejects a fieldId out of the 1-8 range", async () => {
       const res = await request(app)
-        .post(`/test/groups/${validId()}/${validId()}/charts`)
-        .send({ chartConfig: { fieldId: 9 } });
+        .post(`/test/groups/${validId()}/charts`)
+        .send({ chartConfig: { fieldId: 9 }, device_ids: [validId()] });
       expect(res.status).to.equal(422);
     });
 
-    it("accepts a well-formed request", async () => {
+    it("accepts a well-formed request scoped to device_ids only", async () => {
       const res = await request(app)
-        .post(`/test/groups/${validId()}/${validId()}/charts`)
-        .send({ chartConfig: { fieldId: 1, title: "PM2.5" } });
+        .post(`/test/groups/${validId()}/charts`)
+        .send({
+          chartConfig: { fieldId: 1, title: "PM2.5" },
+          device_ids: [validId()],
+        });
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+    });
+
+    it("accepts a well-formed request scoped to site_ids only", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/charts`)
+        .send({
+          chartConfig: { fieldId: 1, title: "PM2.5" },
+          site_ids: [validId()],
+        });
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+    });
+
+    it("accepts a request scoped to both device_ids and site_ids", async () => {
+      const res = await request(app)
+        .post(`/test/groups/${validId()}/charts`)
+        .send({
+          chartConfig: { fieldId: 1, title: "PM2.5" },
+          device_ids: [validId(), validId()],
+          site_ids: [validId()],
+        });
       expect(res.status).to.equal(200);
       expect(res.body.success).to.equal(true);
     });
@@ -108,7 +151,7 @@ describe("group-chart-config validators", () => {
 
     it("rejects an invalid chartId", async () => {
       const res = await request(app)
-        .put(`/test/groups/${validId()}/${validId()}/charts/not-an-id`)
+        .put(`/test/groups/${validId()}/charts/not-an-id`)
         .send({ title: "New" });
       expect(res.status).to.equal(422);
       expect(JSON.stringify(res.body)).to.include("Invalid Chart ID");
@@ -116,16 +159,30 @@ describe("group-chart-config validators", () => {
 
     it("rejects an invalid chartType", async () => {
       const res = await request(app)
-        .put(`/test/groups/${validId()}/${validId()}/charts/${validId()}`)
+        .put(`/test/groups/${validId()}/charts/${validId()}`)
         .send({ chartType: "NotARealType" });
       expect(res.status).to.equal(422);
       expect(JSON.stringify(res.body)).to.include("Invalid chart type");
     });
 
+    it("rejects a device_ids entry that isn't a valid ObjectId", async () => {
+      const res = await request(app)
+        .put(`/test/groups/${validId()}/charts/${validId()}`)
+        .send({ device_ids: ["not-an-id"] });
+      expect(res.status).to.equal(422);
+    });
+
     it("accepts a well-formed partial update", async () => {
       const res = await request(app)
-        .put(`/test/groups/${validId()}/${validId()}/charts/${validId()}`)
+        .put(`/test/groups/${validId()}/charts/${validId()}`)
         .send({ title: "New title", chartType: "Bar" });
+      expect(res.status).to.equal(200);
+    });
+
+    it("accepts a device_ids/site_ids scope update alongside chart fields", async () => {
+      const res = await request(app)
+        .put(`/test/groups/${validId()}/charts/${validId()}`)
+        .send({ device_ids: [validId()], site_ids: [validId()] });
       expect(res.status).to.equal(200);
     });
   });
@@ -135,14 +192,14 @@ describe("group-chart-config validators", () => {
 
     it("rejects an invalid chartId value ('not-an-id') with 422", async () => {
       const res = await request(app).delete(
-        `/test/groups/${validId()}/${validId()}/charts/not-an-id`
+        `/test/groups/${validId()}/charts/not-an-id`
       );
       expect(res.status).to.equal(422);
     });
 
     it("accepts valid ids", async () => {
       const res = await request(app).delete(
-        `/test/groups/${validId()}/${validId()}/charts/${validId()}`
+        `/test/groups/${validId()}/charts/${validId()}`
       );
       expect(res.status).to.equal(200);
     });
@@ -151,23 +208,33 @@ describe("group-chart-config validators", () => {
   describe("list", () => {
     const app = buildApp(list);
 
-    it("accepts valid grp_id/deviceId", async () => {
+    it("accepts a valid grp_id with no filters", async () => {
+      const res = await request(app).get(`/test/groups/${validId()}/charts`);
+      expect(res.status).to.equal(200);
+    });
+
+    it("accepts optional device_id/site_id query filters", async () => {
       const res = await request(app).get(
-        `/test/groups/${validId()}/${validId()}/charts`
+        `/test/groups/${validId()}/charts?device_id=${validId()}&site_id=${validId()}`
       );
       expect(res.status).to.equal(200);
     });
 
-    it("rejects an invalid grp_id", async () => {
+    it("rejects an invalid device_id query filter", async () => {
       const res = await request(app).get(
-        `/test/groups/not-an-id/${validId()}/charts`
+        `/test/groups/${validId()}/charts?device_id=not-an-id`
       );
+      expect(res.status).to.equal(422);
+    });
+
+    it("rejects an invalid grp_id", async () => {
+      const res = await request(app).get(`/test/groups/not-an-id/charts`);
       expect(res.status).to.equal(422);
     });
 
     it("rejects tenant=not-a-tenant — confirms commonValidations.tenant is actually wired in", async () => {
       const res = await request(app).get(
-        `/test/groups/${validId()}/${validId()}/charts?tenant=not-a-tenant`
+        `/test/groups/${validId()}/charts?tenant=not-a-tenant`
       );
       expect(res.status).to.equal(422);
       expect(JSON.stringify(res.body)).to.include(
@@ -181,7 +248,7 @@ describe("group-chart-config validators", () => {
 
     it("accepts valid ids", async () => {
       const res = await request(app).get(
-        `/test/groups/${validId()}/${validId()}/charts/${validId()}`
+        `/test/groups/${validId()}/charts/${validId()}`
       );
       expect(res.status).to.equal(200);
     });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Reworks the group-wide default chart configuration endpoints (`/api/v2/users/preferences/groups/:grp_id/charts`) to scope by `device_ids`/`site_ids` arrays instead of a single `:deviceId` path param, so one saved default chart can apply to multiple devices and/or sites at once. Also adds `docs/NEXUS_AIR_QUALITY_API_GUIDE.md` so the Nexus-facing API contract can be maintained in-repo going forward.

### Why is this change needed?
The group chart config endpoints only supported a single device per saved chart, which surfaced as a point of confusion for the frontend team (Nexus redesign) and didn't match the multi-device/multi-site use case the old, deprecated `/users/defaults` endpoint used to support. A group needs to save one default chart across several devices/sites, not create a separate one per device.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `auth-service` — model, validators, routes, controllers, utils, and unit tests for group chart config
- `docs` — added Nexus Air Quality API guide

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Updated the group-chart-config unit tests (model/validator/util/controller layers) for the new `device_ids`/`site_ids` scoping, including the "at least one of device_ids or site_ids required" validation rule. 51 tests passing.

---

## :boom: Breaking Changes
- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

- Routes moved from `/groups/:grp_id/:deviceId/charts...` to `/groups/:grp_id/charts...` — no more `:deviceId` path param.
- `POST`/`PUT` now expect `device_ids`/`site_ids` arrays in the body instead of a single device in the URL.
- `GET .../charts` (list) now returns an array of chart-config documents (each with its own `device_ids`/`site_ids`/`chartConfigurations`) instead of a flattened array of charts for one device.

This endpoint was only just introduced and not yet in production use, so no data migration is needed.

---

## :memo: Additional Notes
Scoping mirrors the `sites[]`/`devices[]` array shape from the old, deprecated `/users/defaults` endpoint. `docs/NEXUS_AIR_QUALITY_API_GUIDE.md` was added so this contract can be kept current in-repo as refinements continue, instead of living only in an external doc.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group-wide chart defaults that can apply to multiple devices, sites, or both.
  * Updated chart configuration management to use group-level routes with optional device and site filtering.
  * Added validation for multi-device and multi-site scopes.
* **Documentation**
  * Added a guide covering air-quality capabilities, API behavior, authorization, freshness, coverage, and limitations.
* **Bug Fixes**
  * Improved chart configuration handling and retrieval for shared scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->