### PR TITLE
Add multi-location scope, subtitle, and colors to personal chart config

### DIFF
--- a/docs/NEXUS_AIR_QUALITY_API_GUIDE.md
+++ b/docs/NEXUS_AIR_QUALITY_API_GUIDE.md
@@ -1,17 +1,18 @@
 # Nexus Air Quality API Guide
 
-> **Audience:** Frontend engineers working on the AirQo Nexus redesign. This covers the endpoints built in response to the Nexus backend requirements doc: nearby air quality, African AQI rankings, historical comparisons, the dynamic AQI legend — plus chart configuration defaults.
+> **Audience:** Frontend engineers working on the AirQo Nexus redesign. This covers the endpoints built in response to the Nexus backend requirements doc: nearby air quality, African AQI rankings, historical comparisons, the dynamic AQI legend — plus chart configuration.
 
 **Updates since this guide was first shared:**
 1. Section 1's claim that device-registry and analytics were "now aligned" on AQI colors/breakpoints was premature — corrected below.
 2. Section 4 didn't include the actual endpoint path, which caused a mix-up with a different, similarly-named endpoint (`grids/nearby`, which returns polygons, not readings) — the correct path is now included.
-3. Section 5 previously pointed at the wrong endpoint (a per-user preference feature, not a group-wide default). The real capability didn't exist, so it was built — then refined again to support multiple devices/sites per saved default (see the section for the current contract).
+3. Section 5 previously pointed at the wrong endpoint (a per-user preference feature, not a group-wide default). The real capability didn't exist, so it was built — then refined to support multiple devices/sites per saved default.
+4. Direction changed again: rather than a group-wide default, users now configure their own chart locations and settings even within a group. Section 5 now documents the personal chart endpoints (no more `deviceId` in the URL, plus new `subTitle` and per-location `locationColors` fields) as the one to build against; the group-default endpoints are still there but no longer the recommended path.
 
 ---
 
 ## Overview
 
-All five capabilities from the requirements doc are ready to integrate, including chart configuration defaults (section 5).
+All five capabilities from the requirements doc are ready to integrate, including chart configuration (section 5).
 
 Everything below is described in terms of what you send and what comes back. Base URL and request conventions (headers, error format) match the rest of the AirQo API you're already integrating with.
 
@@ -94,41 +95,71 @@ We're intentionally not introducing a second nearby-readings endpoint — there 
 
 ---
 
-## 5. Chart configuration defaults
+## 5. Chart configuration
 
-**Group-wide DEFAULT chart configuration**, distinct from `/preferences/:deviceId/charts` (a *per-user* saved-chart feature, keyed on `user_id` + `group_id` — keep using that one for "my saved charts"). This is what a group manager sets so everyone viewing a group's data sees the same default chart, rather than each user needing their own saved view. Lives in **auth-service**, alongside the personal preferences it's a sibling of.
+**Direction change:** earlier drafts of this section covered group-wide *default* charts (one shared config every group member sees). Per direction from the Nexus side, that's no longer the model going forward — users configure their own locations and chart settings even within a group, rather than inheriting someone else's defaults. **Personal chart configuration is what you should build against.** The group-default endpoints still exist and still work (documented lower down for completeness), but they're not the recommended path anymore.
 
-**Read access:** any verified member of the group. **Write access:** group managers/admins only — a shared default shouldn't be something any single member can silently change for everyone else.
+### Personal chart configuration (build against this)
 
-**Scoped by `device_ids`/`site_ids` arrays, not a single device.** A saved default can apply to multiple devices and/or multiple sites at once (mirroring how the old, deprecated `/users/defaults` endpoint worked) — there is no `deviceId` in the URL for any of these routes; at least one of `device_ids` or `site_ids` must be provided and non-empty.
+`/api/v2/users/preferences/charts...` — keyed on `user_id` + `group_id`, each chart belongs to one user. Lives in **auth-service**.
 
-`POST /api/v2/users/preferences/groups/:grp_id/charts`
+**Scoped by `device_ids`/`site_ids` arrays, not a single device.** This changed since the last version of this doc — there's no `deviceId` in the URL anymore. One chart can compare multiple locations at once (e.g. Kampala + Jinja together), so scope is two arrays on the chart itself. At least one of `device_ids`/`site_ids` must be provided and non-empty.
 
-Body:
+**Two new chart fields, both raised as gaps in the previous version of this endpoint:**
+- **`subTitle`** — was present on the old netmanager preference doc but missing from the new chart-config object; it's back, as a field on each individual chart (alongside `title`).
+- **`locationColors`** — lets you assign a distinct color per selected device/site, so a multi-location chart doesn't default to one color throughout (e.g. Kampala in red, Jinja in yellow). Each entry is `{ "id": "<deviceOrSiteId>", "color": "<hex>" }`, and every `id` used here must already be present in that chart's `device_ids` or `site_ids` — assigning a color to a location the chart doesn't include is rejected. If a selected location has no entry in `locationColors`, it falls back to the chart-wide `color` field (unchanged, still there).
+
+#### Create a chart
+`POST /api/v2/users/preferences/charts`
+
 ```json
 {
-  "device_ids": ["<deviceId1>", "<deviceId2>"],
-  "site_ids": ["<siteId1>"],
+  "group_id": "<optional, defaults to your default group>",
+  "device_ids": ["<kampalaDeviceId>", "<jinjaDeviceId>"],
+  "site_ids": [],
   "chartConfig": {
     "fieldId": 1,
-    "title": "PM2.5",
-    "chartType": "Line"
+    "title": "PM2.5 — Kampala vs Jinja",
+    "subTitle": "Last 7 days",
+    "chartType": "Line",
+    "locationColors": [
+      { "id": "<kampalaDeviceId>", "color": "#FF0000" },
+      { "id": "<jinjaDeviceId>", "color": "#FFFF00" }
+    ]
   }
 }
 ```
-`chartConfig.fieldId` (1–8) is required; every other chart field from the personal-chart contract is supported here too (`chartType`, `days`, `results`, `referenceLines`, `comparisonPeriod`, etc.). `device_ids`/`site_ids` can be used together or independently — just at least one non-empty array.
+`chartConfig.fieldId` (1–8) is required; every other chart field you already know (`chartType`, `days`, `results`, `referenceLines`, `comparisonPeriod`, `showLegend`, etc.) is unchanged and still supported.
 
-`PUT /api/v2/users/preferences/groups/:grp_id/charts/:chartId` — partial update, send only the chart fields changing. `device_ids`/`site_ids` can also be sent here to change which devices/sites this saved default applies to.
+#### Update a chart
+`PUT /api/v2/users/preferences/charts/:chartId` — partial update, send only what's changing. No `deviceId` in the URL. `device_ids`/`site_ids` can be included to change scope, but the chart can't end up with both empty — clearing both in one request is rejected.
 
-`DELETE /api/v2/users/preferences/groups/:grp_id/charts/:chartId`
+```json
+{
+  "subTitle": "Last 30 days",
+  "locationColors": [{ "id": "<kampalaDeviceId>", "color": "#00AA00" }]
+}
+```
 
-`GET /api/v2/users/preferences/groups/:grp_id/charts` — list all group-default chart documents. Optional `?device_id=` / `?site_id=` query params narrow the list to defaults scoped to that device/site. Each item in the response is its own document with its own `device_ids`, `site_ids`, and `chartConfigurations`.
+#### Delete a chart
+`DELETE /api/v2/users/preferences/charts/:chartId` — no body, no `deviceId` in the URL.
 
-`GET /api/v2/users/preferences/groups/:grp_id/charts/:chartId` — a single chart, returned together with the `device_ids`/`site_ids` it applies to.
+#### List your charts
+`GET /api/v2/users/preferences/charts` — returns every chart you've configured for a group. Optional query params: `?group_id=` (defaults to your default group), `?device_id=`, `?site_id=` (narrows to charts scoped to that location).
 
-All require the same auth header you're already using elsewhere. A write from someone who isn't a manager/admin of `:grp_id` returns `403`, not a silent no-op.
+#### Get a single chart
+`GET /api/v2/users/preferences/charts/:chartId`
 
-**On the duplicate-values error some testers hit separately:** that isn't from the chart endpoints at all — it comes from the general `POST /api/v2/users/preferences/` (plain create) endpoint. That one legitimately fails with a duplicate-key conflict for any user who already has a preference doc for that group, which is the common case, not an edge case — `POST /upsert` is the endpoint meant to be called repeatedly. The error response now includes a hint saying exactly that.
+#### Copy a chart
+`POST /api/v2/users/preferences/charts/:chartId/copy` — duplicates a chart (including its `device_ids`/`site_ids`/`locationColors`) as a new one, titled `"<original title> (Copy)"`.
+
+All of the above require the same auth header you're already using elsewhere, and `chartId` alone is enough to identify a chart for update/delete/get/copy — you don't need to also pass `group_id` for those.
+
+### Group-wide default charts (still live, not the recommended path)
+
+`/api/v2/users/preferences/groups/:grp_id/charts...` — one shared config per group, read by any member, written by managers/admins only. Same `device_ids`/`site_ids`/`chartConfig` shape as above. Kept working in case shared defaults come back into scope later, but don't build new work against this unless told otherwise.
+
+**On the duplicate-values error some testers hit separately:** that isn't from either chart endpoint family — it comes from the general `POST /api/v2/users/preferences/` (plain create) endpoint. That one legitimately fails with a duplicate-key conflict for any user who already has a preference doc for that group, which is the common case, not an edge case — `POST /upsert` is the endpoint meant to be called repeatedly. The error response now includes a hint saying exactly that.
 
 ---
 

--- a/docs/NEXUS_AIR_QUALITY_API_GUIDE.md
+++ b/docs/NEXUS_AIR_QUALITY_API_GUIDE.md
@@ -132,7 +132,9 @@ We're intentionally not introducing a second nearby-readings endpoint — there 
 `chartConfig.fieldId` (1–8) is required; every other chart field you already know (`chartType`, `days`, `results`, `referenceLines`, `comparisonPeriod`, `showLegend`, etc.) is unchanged and still supported.
 
 #### Update a chart
-`PUT /api/v2/users/preferences/charts/:chartId` — partial update, send only what's changing. No `deviceId` in the URL. `device_ids`/`site_ids` can be included to change scope, but the chart can't end up with both empty — clearing both in one request is rejected.
+`PUT /api/v2/users/preferences/charts/:chartId` — partial update, send only what's changing. No `deviceId` in the URL.
+
+**Field shape differs from create:** on create, `subTitle`/`locationColors`/etc. are nested inside `chartConfig`. On update, there's no `chartConfig` wrapper — send them as top-level body fields directly, same as `title` or `chartType` below. Nesting them under `chartConfig` here is silently ignored, not an error, so double-check this if a field update doesn't seem to take.
 
 ```json
 {
@@ -140,6 +142,10 @@ We're intentionally not introducing a second nearby-readings endpoint — there 
   "locationColors": [{ "id": "<kampalaDeviceId>", "color": "#00AA00" }]
 }
 ```
+
+`device_ids`/`site_ids` can be included to change scope, but the chart can't end up with neither set. Two ways that's rejected:
+- Sending both as empty arrays in the same request.
+- Sending just one as an empty array when the *other* is already empty on the existing chart (e.g. clearing `device_ids` on a chart that only ever had `device_ids`, never `site_ids`) — this can't be caught from the request body alone, so it's checked against the saved chart and rejected the same way.
 
 #### Delete a chart
 `DELETE /api/v2/users/preferences/charts/:chartId` — no body, no `deviceId` in the URL.

--- a/src/auth-service/controllers/preference.controller.js
+++ b/src/auth-service/controllers/preference.controller.js
@@ -695,10 +695,7 @@ const preferences = {
         );
       }
 
-      const request = {
-        ...req,
-        body: { ...req.body, deviceId: req.params.deviceId },
-      };
+      const request = req;
 
       const defaultTenant = constants.DEFAULT_TENANT || "airqo";
       request.query.tenant = isEmpty(req.query.tenant)
@@ -727,10 +724,7 @@ const preferences = {
         );
       }
 
-      const request = {
-        ...req,
-        body: { ...req.body, deviceId: req.params.deviceId },
-      };
+      const request = req;
 
       const defaultTenant = constants.DEFAULT_TENANT || "airqo";
       request.query.tenant = isEmpty(req.query.tenant)
@@ -759,10 +753,7 @@ const preferences = {
         );
       }
 
-      const request = {
-        ...req,
-        body: { ...req.body, deviceId: req.params.deviceId },
-      };
+      const request = req;
 
       const defaultTenant = constants.DEFAULT_TENANT || "airqo";
       request.query.tenant = isEmpty(req.query.tenant)
@@ -791,10 +782,7 @@ const preferences = {
         );
       }
 
-      const request = {
-        ...req,
-        body: { ...req.body, deviceId: req.params.deviceId },
-      };
+      const request = req;
 
       const defaultTenant = constants.DEFAULT_TENANT || "airqo";
       request.query.tenant = isEmpty(req.query.tenant)

--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -138,7 +138,7 @@ chartConfigSchema.pre("validate", function(next) {
     )
   );
   const unknownEntry = this.locationColors.find(
-    (entry) => !selectedIds.has(entry.id.toString())
+    (entry) => !entry.id || !selectedIds.has(entry.id.toString())
   );
 
   if (unknownEntry) {

--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -25,6 +25,22 @@ const { logObject, HttpError } = require("@utils/shared");
 const chartConfigSchema = new Schema({
   fieldId: { type: Number, required: true, min: 1, max: 8 }, // ThingSpeak field ID
   title: { type: String, default: "Chart Title" },
+  subTitle: { type: String },
+  // Which specific devices/sites this individual chart is about — lets one
+  // chart compare multiple locations (e.g. Kampala + Jinja together), same
+  // sites[]/devices[] flexibility the old, deprecated Defaults model had.
+  device_ids: [{ type: ObjectId, ref: "device" }],
+  site_ids: [{ type: ObjectId, ref: "site" }],
+  // Optional per-location color override for the ids selected above (e.g.
+  // Kampala in red, Jinja in yellow) — falls back to the chart-wide `color`
+  // below when a selected location has no entry here.
+  locationColors: [
+    {
+      id: { type: ObjectId, required: true },
+      color: { type: String, required: true },
+      _id: false,
+    },
+  ],
   xAxisLabel: { type: String, default: "Time" },
   yAxisLabel: { type: String, default: "Value" },
   color: { type: String, default: "#d62020" },
@@ -108,6 +124,32 @@ const chartConfigSchema = new Schema({
   ],
   isPublic: { type: Boolean, default: false },
   refreshInterval: { type: Number, default: 0 }, // 0 means no auto-refresh, value in seconds
+});
+
+// A locationColors entry only makes sense for an id the chart is actually
+// scoped to — otherwise it's a color assigned to a location this chart
+// never shows, which is silently confusing rather than a real config.
+chartConfigSchema.pre("validate", function(next) {
+  if (isEmpty(this.locationColors)) return next();
+
+  const selectedIds = new Set(
+    [...(this.device_ids || []), ...(this.site_ids || [])].map((id) =>
+      id.toString()
+    )
+  );
+  const unknownEntry = this.locationColors.find(
+    (entry) => !selectedIds.has(entry.id.toString())
+  );
+
+  if (unknownEntry) {
+    return next(
+      new Error(
+        `locationColors references id ${unknownEntry.id} which isn't in this chart's device_ids or site_ids`
+      )
+    );
+  }
+
+  next();
 });
 
 const periodSchema = new mongoose.Schema(

--- a/src/auth-service/models/test/ut_preference-chart-scope.model.js
+++ b/src/auth-service/models/test/ut_preference-chart-scope.model.js
@@ -1,0 +1,71 @@
+require("module-alias/register");
+const chai = require("chai");
+const { expect } = chai;
+const mongoose = require("mongoose");
+require("@config/database"); // fire-and-forget connect at module load — wait for it below
+const PreferenceModel = require("@models/Preference");
+
+describe("Preference model — chartConfigSchema locationColors scope", function() {
+  this.timeout(20000);
+
+  before(function(done) {
+    if (mongoose.connection.readyState === 1) return done();
+    mongoose.connection.once("connected", done);
+    mongoose.connection.once("error", done);
+  });
+
+  const deviceId = new mongoose.Types.ObjectId();
+  const siteId = new mongoose.Types.ObjectId();
+  const unrelatedId = new mongoose.Types.ObjectId();
+
+  function buildDoc(chartConfig) {
+    const Model = PreferenceModel("airqo");
+    return new Model({
+      user_id: new mongoose.Types.ObjectId(),
+      group_id: new mongoose.Types.ObjectId(),
+      period: { value: "Last 7 days", label: "Last 7 days", unitValue: 7, unit: "day" },
+      chartConfigurations: [chartConfig],
+    });
+  }
+
+  // save()/findOneAndUpdate({ runValidators: true }) — what the real create/
+  // update code paths use — run the async validate() pipeline, which is the
+  // only one that executes a subdocument's pre("validate") hook in this
+  // Mongoose version. validateSync() skips subdocument middleware entirely,
+  // so it can't be used to exercise this hook.
+  it("passes validation when a chart has no locationColors at all", async function() {
+    const doc = buildDoc({ fieldId: 1, device_ids: [deviceId] });
+    await doc.validate();
+  });
+
+  it("passes validation when every locationColors id is in device_ids or site_ids", async function() {
+    const doc = buildDoc({
+      fieldId: 1,
+      device_ids: [deviceId],
+      site_ids: [siteId],
+      locationColors: [
+        { id: deviceId, color: "#FF0000" },
+        { id: siteId, color: "#FFFF00" },
+      ],
+    });
+    await doc.validate();
+  });
+
+  it("fails validation when a locationColors id isn't in device_ids or site_ids", async function() {
+    const doc = buildDoc({
+      fieldId: 1,
+      device_ids: [deviceId],
+      locationColors: [{ id: unrelatedId, color: "#FF0000" }],
+    });
+
+    let err;
+    try {
+      await doc.validate();
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).to.not.equal(undefined);
+    expect(err.message).to.include("locationColors");
+  });
+});

--- a/src/auth-service/models/test/ut_preference-chart-scope.model.js
+++ b/src/auth-service/models/test/ut_preference-chart-scope.model.js
@@ -2,7 +2,14 @@ require("module-alias/register");
 const chai = require("chai");
 const { expect } = chai;
 const mongoose = require("mongoose");
-require("@config/database"); // fire-and-forget connect at module load — wait for it below
+// @models/Preference pulls in @config/database itself, which fires a
+// connect() at module load — this just waits for it. PreferenceModel(tenant)
+// hard-requires mongoose.connection.readyState === 1 (see
+// _resolveTenantDB in config/database.js, no fallback), so this wait isn't
+// optional: without it, buildDoc() below throws "Query database connection
+// not established or not ready" whenever this file runs before that
+// connection settles (e.g. run standalone rather than as part of the full
+// suite).
 const PreferenceModel = require("@models/Preference");
 
 describe("Preference model — chartConfigSchema locationColors scope", function() {
@@ -56,6 +63,24 @@ describe("Preference model — chartConfigSchema locationColors scope", function
       fieldId: 1,
       device_ids: [deviceId],
       locationColors: [{ id: unrelatedId, color: "#FF0000" }],
+    });
+
+    let err;
+    try {
+      await doc.validate();
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).to.not.equal(undefined);
+    expect(err.message).to.include("locationColors");
+  });
+
+  it("fails validation (rather than throwing a TypeError) when a locationColors entry has no id", async function() {
+    const doc = buildDoc({
+      fieldId: 1,
+      device_ids: [deviceId],
+      locationColors: [{ color: "#FF0000" }],
     });
 
     let err;

--- a/src/auth-service/routes/v2/preferences.routes.js
+++ b/src/auth-service/routes/v2/preferences.routes.js
@@ -96,29 +96,35 @@ router.get(
   preferenceController.listAll
 );
 
+// Personal chart configuration routes
+// ===========================================
+// Scoped by device_ids/site_ids arrays on the chart itself rather than a
+// single :deviceId path param, so one chart can compare multiple locations
+// at once (e.g. Kampala + Jinja together), each optionally colored via
+// locationColors.
 router.post(
-  "/:deviceId/charts",
+  "/charts",
   enhancedJWTAuth,
   preferenceValidations.createChart,
   preferenceController.createChart
 );
 
 router.put(
-  "/:deviceId/charts/:chartId",
+  "/charts/:chartId",
   enhancedJWTAuth,
   preferenceValidations.updateChart,
   preferenceController.updateChart
 );
 
 router.delete(
-  "/:deviceId/charts/:chartId",
+  "/charts/:chartId",
   enhancedJWTAuth,
   preferenceValidations.deleteChart,
   preferenceController.deleteChart
 );
 
 router.get(
-  "/:deviceId/charts",
+  "/charts",
   enhancedJWTAuth,
   pagination(),
   preferenceValidations.getChartConfigurations,
@@ -126,14 +132,14 @@ router.get(
 );
 
 router.post(
-  "/:deviceId/charts/:chartId/copy",
+  "/charts/:chartId/copy",
   enhancedJWTAuth,
   preferenceValidations.copyChart,
   preferenceController.copyChart
 );
 
 router.get(
-  "/:deviceId/charts/:chartId",
+  "/charts/:chartId",
   enhancedJWTAuth,
   preferenceValidations.getChartConfigurationById,
   preferenceController.getChartConfigurationById

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -179,6 +179,20 @@ const handleDefaultGroup = async (tenant, body, next) => {
   }
 };
 
+// A chart write can fail schema validation at the DB layer — e.g.
+// chartConfigSchema's pre-validate hook rejecting a locationColors entry
+// whose id isn't in device_ids/site_ids — which is a client mistake, not a
+// server fault. Classifying it here (rather than duplicating the hook's
+// check inline before every write) keeps both catch blocks a clean 400 for
+// any such schema rejection, present or future, without hand-copying the
+// hook's specific rule into the util layer.
+const chartValidationErrorResponse = (error) => ({
+  success: false,
+  message: "Bad Request Error",
+  errors: { message: error.message },
+  status: httpStatus.BAD_REQUEST,
+});
+
 // Define allowed properties for chart updates
 const allowedChartProperties = [
   "fieldId",
@@ -917,6 +931,9 @@ const preferences = {
         status: httpStatus.OK,
       };
     } catch (error) {
+      if (error.name === "ValidationError") {
+        return chartValidationErrorResponse(error);
+      }
       logger.error(`Error creating chart: ${error.message}`);
       return {
         success: false,
@@ -928,7 +945,10 @@ const preferences = {
   },
   updateChart: async (request, next) => {
     try {
-      const { tenant } = request.body;
+      // The controller always normalizes request.query.tenant; body.tenant
+      // is only ever populated if a caller duplicates it there too, which
+      // isn't the convention this API validates against.
+      const tenant = (request.query || {}).tenant || request.body.tenant;
       const { chartId } = request.params;
       const updates = request.body;
       const userId = request.user._id;
@@ -993,6 +1013,9 @@ const preferences = {
         status: httpStatus.OK,
       };
     } catch (error) {
+      if (error.name === "ValidationError") {
+        return chartValidationErrorResponse(error);
+      }
       logger.error(`Error updating chart: ${error.message}`);
       return {
         success: false,
@@ -1004,7 +1027,7 @@ const preferences = {
   },
   deleteChart: async (request, next) => {
     try {
-      const { tenant } = request.body;
+      const tenant = (request.query || {}).tenant || request.body.tenant;
       const { chartId } = request.params;
       const userId = request.user._id;
 
@@ -1020,7 +1043,12 @@ const preferences = {
         { $pull: { chartConfigurations: { _id: chartId } } }
       );
 
-      if (updateResult.matchedCount === 0) {
+      // This driver/mongoose combination returns the legacy { n, nModified,
+      // ok } shape from updateOne, not { matchedCount }, which is
+      // undefined here — checked defensively either way rather than
+      // trusting one specific shape.
+      const matchedCount = updateResult.matchedCount ?? updateResult.n;
+      if (matchedCount === 0) {
         return {
           success: false,
           message: "Chart configuration not found",
@@ -1154,7 +1182,7 @@ const preferences = {
   },
   copyChartConfiguration: async (request, next) => {
     try {
-      const { tenant } = request.body;
+      const tenant = (request.query || {}).tenant || request.body.tenant;
       const { chartId } = request.params;
       const userId = request.user._id;
 

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -183,6 +183,10 @@ const handleDefaultGroup = async (tenant, body, next) => {
 const allowedChartProperties = [
   "fieldId",
   "title",
+  "subTitle",
+  "device_ids",
+  "site_ids",
+  "locationColors",
   "xAxisLabel",
   "yAxisLabel",
   "color",
@@ -846,7 +850,11 @@ const preferences = {
   createChart: async (request, next) => {
     try {
       const { tenant } = request.query;
-      const { deviceId, chartConfig } = request.body;
+      const {
+        chartConfig,
+        device_ids: deviceIds = [],
+        site_ids: siteIds = [],
+      } = request.body;
       const userId = request.user._id; // Assuming JWT authentication
 
       // Basic validation
@@ -858,18 +866,34 @@ const preferences = {
         };
       }
 
+      // Enforced by the route validators too, but checked again here so a
+      // validator-bypassing call still fails as a clear 400 rather than
+      // hitting the schema's pre-validate hook and surfacing as a 500.
+      if (isEmpty(deviceIds) && isEmpty(siteIds)) {
+        return {
+          success: false,
+          message: "At least one of device_ids or site_ids is required",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
       const groupId = request.body.group_id || constants.DEFAULT_GROUP;
 
-      // Atomically add this device/chart to the user's preference doc for
-      // this group, creating the doc if it doesn't exist yet. Filtering by
-      // (user_id, group_id) -- rather than by device_ids -- prevents
-      // inserting a second doc with the same unique (user_id, group_id) pair
-      // when the device just isn't in the existing doc's device_ids yet.
+      // Scope lives on the chart itself now (device_ids/site_ids), not a
+      // single device tracked at the preference-document level, so one
+      // chart can compare multiple locations at once.
+      const chartToInsert = {
+        ...chartConfig,
+        device_ids: deviceIds,
+        site_ids: siteIds,
+      };
+
+      // Atomically add this chart to the user's preference doc for this
+      // group, creating the doc if it doesn't exist yet.
       const preference = await PreferenceModel(tenant).findOneAndUpdate(
         { user_id: userId, group_id: groupId },
         {
-          $addToSet: { device_ids: deviceId },
-          $push: { chartConfigurations: chartConfig },
+          $push: { chartConfigurations: chartToInsert },
           $setOnInsert: {
             user_id: userId,
             group_id: groupId,
@@ -908,20 +932,19 @@ const preferences = {
       const { chartId } = request.params;
       const updates = request.body;
       const userId = request.user._id;
-      const groupId = request.body.group_id || constants.DEFAULT_GROUP;
 
-      // Find preference record scoped to the requested group, and require
-      // the chart to actually exist within it.
+      // chartId (a subdocument _id) is globally unique on its own, so the
+      // chart's parent preference doc can be found by user_id + chartId
+      // alone — no need for the caller to also know/send group_id.
       const preference = await PreferenceModel(tenant).findOne({
         user_id: userId,
-        group_id: groupId,
         "chartConfigurations._id": chartId,
       });
 
       if (!preference) {
         return {
           success: false,
-          message: "Preference not found for this device",
+          message: "Chart configuration not found",
           status: httpStatus.NOT_FOUND,
         };
       }
@@ -939,19 +962,34 @@ const preferences = {
         };
       }
 
+      const chart = preference.chartConfigurations[chartIndex];
+
       // Update allowed properties
       Object.keys(updates)
         .filter((key) => allowedChartProperties.includes(key))
         .forEach((key) => {
-          preference.chartConfigurations[chartIndex][key] = updates[key];
+          chart[key] = updates[key];
         });
+
+      // Checked here (post-merge, pre-save) rather than left to the
+      // schema's pre-validate hook: a request can clear one array while
+      // leaving the other untouched, and only the merged result — not the
+      // request body alone — can tell us whether that leaves the chart
+      // with no scope at all.
+      if (isEmpty(chart.device_ids) && isEmpty(chart.site_ids)) {
+        return {
+          success: false,
+          message: "At least one of device_ids or site_ids is required",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
 
       await preference.save();
 
       return {
         success: true,
         message: "Chart configuration updated successfully",
-        data: preference.chartConfigurations[chartIndex],
+        data: chart,
         status: httpStatus.OK,
       };
     } catch (error) {
@@ -969,40 +1007,26 @@ const preferences = {
       const { tenant } = request.body;
       const { chartId } = request.params;
       const userId = request.user._id;
-      const groupId = request.body.group_id || constants.DEFAULT_GROUP;
 
-      // Find preference record scoped to the requested group, and require
-      // the chart to actually exist within it.
-      const preference = await PreferenceModel(tenant).findOne({
-        user_id: userId,
-        group_id: groupId,
-        "chartConfigurations._id": chartId,
-      });
-
-      if (!preference) {
-        return {
-          success: false,
-          message: "Preference not found for this device",
-          status: httpStatus.NOT_FOUND,
-        };
-      }
-
-      // Find the chart in the chartConfigurations array
-      const chartIndex = preference.chartConfigurations.findIndex(
-        (chart) => chart._id.toString() === chartId
+      // A single atomic $pull rather than findOne -> splice -> save avoids
+      // racing a concurrent delete/update on the same doc. Note this only
+      // ever removes the one chart, never the parent Preference document —
+      // unlike the group chart config's dedicated per-default documents,
+      // this doc also holds the user's other settings (pollutant, theme,
+      // frequency, etc.), so an empty chartConfigurations array doesn't
+      // mean the document itself is disposable.
+      const updateResult = await PreferenceModel(tenant).updateOne(
+        { user_id: userId, "chartConfigurations._id": chartId },
+        { $pull: { chartConfigurations: { _id: chartId } } }
       );
 
-      if (chartIndex === -1) {
+      if (updateResult.matchedCount === 0) {
         return {
           success: false,
           message: "Chart configuration not found",
           status: httpStatus.NOT_FOUND,
         };
       }
-
-      // Remove the chart
-      preference.chartConfigurations.splice(chartIndex, 1);
-      await preference.save();
 
       return {
         success: true,
@@ -1021,30 +1045,44 @@ const preferences = {
   },
   getChartConfigurations: async (request, next) => {
     try {
-      const { tenant, limit, skip } = request.query || {};
-      const { deviceId } = request.params;
+      const { tenant, limit, skip, device_id, site_id } =
+        request.query || {};
       const userId = request.user._id;
+      const groupId = request.query.group_id || constants.DEFAULT_GROUP;
 
-      // Find preference record
+      // One preference doc per (user_id, group_id) holds every chart the
+      // user has configured for that group — no per-device doc to look up
+      // anymore, since scope now lives on each chart itself.
       const preference = await PreferenceModel(tenant).findOne({
         user_id: userId,
-        device_ids: { $in: [deviceId] },
+        group_id: groupId,
       });
 
       if (!preference) {
         return {
           success: true,
-          message: "No chart configurations found for this device",
+          message: "No chart configurations found for this group",
           data: [],
           status: httpStatus.OK,
         };
+      }
+
+      let allCharts = preference.chartConfigurations || [];
+      if (device_id) {
+        allCharts = allCharts.filter((chart) =>
+          (chart.device_ids || []).some((id) => id.toString() === device_id)
+        );
+      }
+      if (site_id) {
+        allCharts = allCharts.filter((chart) =>
+          (chart.site_ids || []).some((id) => id.toString() === site_id)
+        );
       }
 
       // chartConfigurations is an array embedded in a single document, not
       // its own collection — pagination (set by the route's pagination()
       // middleware) is applied in memory rather than via a Mongo
       // .skip()/.limit() query.
-      const allCharts = preference.chartConfigurations || [];
       const skipNum = Number(skip) || 0;
       const limitNum = Number(limit) || allCharts.length || 1;
 
@@ -1067,19 +1105,20 @@ const preferences = {
   getChartConfigurationById: async (request, next) => {
     try {
       const { tenant } = request.query || {};
-      const { deviceId, chartId } = request.params;
+      const { chartId } = request.params;
       const userId = request.user._id;
 
-      // Find preference record
+      // chartId is unique on its own, so the parent preference doc can be
+      // found by user_id + chartId alone — no group_id needed.
       const preference = await PreferenceModel(tenant).findOne({
         user_id: userId,
-        device_ids: { $in: [deviceId] },
+        "chartConfigurations._id": chartId,
       });
 
       if (!preference) {
         return {
           success: false,
-          message: "Preference not found for this device",
+          message: "Chart configuration not found",
           status: httpStatus.NOT_FOUND,
         };
       }
@@ -1116,19 +1155,20 @@ const preferences = {
   copyChartConfiguration: async (request, next) => {
     try {
       const { tenant } = request.body;
-      const { deviceId, chartId } = request.params;
+      const { chartId } = request.params;
       const userId = request.user._id;
 
-      // Find preference record
+      // chartId is unique on its own, so the parent preference doc can be
+      // found by user_id + chartId alone — no group_id needed.
       const preference = await PreferenceModel(tenant).findOne({
         user_id: userId,
-        device_ids: { $in: [deviceId] },
+        "chartConfigurations._id": chartId,
       });
 
       if (!preference) {
         return {
           success: false,
-          message: "Preference not found for this device",
+          message: "Chart configuration not found",
           status: httpStatus.NOT_FOUND,
         };
       }

--- a/src/auth-service/utils/test/ut_preference.util.js
+++ b/src/auth-service/utils/test/ut_preference.util.js
@@ -475,3 +475,466 @@ describe("create preference UTIL", function () {
     });
   });
 });
+
+describe("preference chart UTIL", function() {
+  let origPreferenceModel;
+  const userId = "507f1f77bcf86cd799439011";
+  const groupId = "507f1f77bcf86cd799439012";
+  const deviceId = "507f1f77bcf86cd799439013";
+  const chartId = "507f1f77bcf86cd799439014";
+  const siteId = "507f1f77bcf86cd799439015";
+
+  afterEach(function() {
+    rewirePreferenceUtil.__set__("PreferenceModel", origPreferenceModel);
+    sinon.restore();
+  });
+
+  describe("createChart", function() {
+    let findOneAndUpdateStub;
+
+    beforeEach(function() {
+      origPreferenceModel = rewirePreferenceUtil.__get__("PreferenceModel");
+      findOneAndUpdateStub = sinon.stub();
+      rewirePreferenceUtil.__set__("PreferenceModel", () => ({
+        findOneAndUpdate: findOneAndUpdateStub,
+      }));
+    });
+
+    it("rejects a chartConfig with no fieldId", async function() {
+      const request = {
+        query: { tenant: "airqo" },
+        body: { chartConfig: {}, device_ids: [deviceId] },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.createChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(findOneAndUpdateStub.called).to.equal(false);
+    });
+
+    it("rejects when device_ids and site_ids are both omitted — same 400 the route validators enforce, so a validator-bypassing call still fails cleanly instead of hitting the schema and 500ing", async function() {
+      const request = {
+        query: { tenant: "airqo" },
+        body: { chartConfig: { fieldId: 1 } },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.createChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(findOneAndUpdateStub.called).to.equal(false);
+    });
+
+    it("pushes a chart scoped to the given device_ids/site_ids into the user's preference doc for the group, upserting if it doesn't exist yet", async function() {
+      const chartConfig = { fieldId: 1, title: "PM2.5" };
+      findOneAndUpdateStub.resolves({
+        chartConfigurations: [{ ...chartConfig, device_ids: [deviceId], site_ids: [siteId] }],
+      });
+      const request = {
+        query: { tenant: "airqo" },
+        body: {
+          chartConfig,
+          device_ids: [deviceId],
+          site_ids: [siteId],
+          group_id: groupId,
+        },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.createChart(request);
+
+      expect(findOneAndUpdateStub.calledOnce).to.equal(true);
+      const [filter, update, options] = findOneAndUpdateStub.getCall(0).args;
+      expect(filter).to.deep.equal({ user_id: userId, group_id: groupId });
+      expect(update.$push.chartConfigurations).to.deep.equal({
+        ...chartConfig,
+        device_ids: [deviceId],
+        site_ids: [siteId],
+      });
+      expect(options.upsert).to.equal(true);
+      expect(result.success).to.equal(true);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      findOneAndUpdateStub.rejects(new Error("Mongo down"));
+      const request = {
+        query: { tenant: "airqo" },
+        body: { chartConfig: { fieldId: 1 }, device_ids: [deviceId] },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.createChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe("updateChart", function() {
+    let findOneStub;
+
+    beforeEach(function() {
+      origPreferenceModel = rewirePreferenceUtil.__get__("PreferenceModel");
+      findOneStub = sinon.stub();
+      rewirePreferenceUtil.__set__("PreferenceModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    it("returns 404 when no preference doc contains this chartId (no group_id needed — chartId alone is unique)", async function() {
+      findOneStub.resolves(null);
+      const request = {
+        body: { tenant: "airqo", title: "New title" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+      expect(findOneStub.getCall(0).args[0]).to.deep.equal({
+        user_id: userId,
+        "chartConfigurations._id": chartId,
+      });
+    });
+
+    it("only applies whitelisted properties (including the new subTitle/locationColors fields) and persists via save()", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = {
+        _id: { toString: () => chartId },
+        title: "Old title",
+        device_ids: [deviceId],
+        site_ids: [],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: {
+          tenant: "airqo",
+          title: "New title",
+          subTitle: "New subtitle",
+          locationColors: [{ id: deviceId, color: "#FF0000" }],
+          notAllowedField: "ignore me",
+        },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(chart.title).to.equal("New title");
+      expect(chart.subTitle).to.equal("New subtitle");
+      expect(chart.locationColors).to.deep.equal([
+        { id: deviceId, color: "#FF0000" },
+      ]);
+      expect(chart.notAllowedField).to.equal(undefined);
+      expect(saveStub.calledOnce).to.equal(true);
+      expect(result.success).to.equal(true);
+    });
+
+    it("rejects (400, not a save() that trips the schema into a 500) when the update leaves the chart with no device_ids or site_ids", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = {
+        _id: { toString: () => chartId },
+        title: "Old title",
+        device_ids: [deviceId],
+        site_ids: [],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: { tenant: "airqo", device_ids: [] },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(saveStub.called).to.equal(false);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      findOneStub.rejects(new Error("Mongo down"));
+      const request = {
+        body: { tenant: "airqo", title: "New title" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe("deleteChart", function() {
+    let updateOneStub;
+
+    beforeEach(function() {
+      origPreferenceModel = rewirePreferenceUtil.__get__("PreferenceModel");
+      updateOneStub = sinon.stub();
+      rewirePreferenceUtil.__set__("PreferenceModel", () => ({
+        updateOne: updateOneStub,
+      }));
+    });
+
+    it("returns 404 when nothing matches user_id + chartId", async function() {
+      updateOneStub.resolves({ matchedCount: 0 });
+      const request = {
+        body: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.deleteChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("pulls only the matching chart, keyed on user_id + chartId — never deletes the whole preference doc, which also holds unrelated settings", async function() {
+      updateOneStub.resolves({ matchedCount: 1 });
+      const request = {
+        body: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.deleteChart(request);
+
+      expect(updateOneStub.calledOnce).to.equal(true);
+      const [filter, update] = updateOneStub.getCall(0).args;
+      expect(filter).to.deep.equal({
+        user_id: userId,
+        "chartConfigurations._id": chartId,
+      });
+      expect(update.$pull).to.deep.equal({
+        chartConfigurations: { _id: chartId },
+      });
+      expect(result.success).to.equal(true);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      updateOneStub.rejects(new Error("Mongo down"));
+      const request = {
+        body: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.deleteChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe("getChartConfigurations", function() {
+    let findOneStub;
+
+    beforeEach(function() {
+      origPreferenceModel = rewirePreferenceUtil.__get__("PreferenceModel");
+      findOneStub = sinon.stub();
+      rewirePreferenceUtil.__set__("PreferenceModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    it("returns an empty array (still success) when the user has no preference doc yet for this group", async function() {
+      findOneStub.resolves(null);
+      const request = {
+        query: { tenant: "airqo", group_id: groupId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.getChartConfigurations(
+        request
+      );
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.deep.equal([]);
+      expect(findOneStub.getCall(0).args[0]).to.deep.equal({
+        user_id: userId,
+        group_id: groupId,
+      });
+    });
+
+    it("narrows by device_id/site_id query params against each chart's own scope arrays", async function() {
+      const chartForDevice = {
+        fieldId: 1,
+        device_ids: [deviceId],
+        site_ids: [],
+      };
+      const chartForSite = { fieldId: 2, device_ids: [], site_ids: [siteId] };
+      findOneStub.resolves({
+        chartConfigurations: [chartForDevice, chartForSite],
+      });
+      const request = {
+        query: { tenant: "airqo", group_id: groupId, device_id: deviceId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.getChartConfigurations(
+        request
+      );
+
+      expect(result.data).to.deep.equal([chartForDevice]);
+    });
+
+    it("paginates the (embedded) chartConfigurations array in memory via limit/skip", async function() {
+      const docs = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      findOneStub.resolves({ chartConfigurations: docs });
+      const request = {
+        query: { tenant: "airqo", group_id: groupId, limit: 2, skip: 1 },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.getChartConfigurations(
+        request
+      );
+
+      expect(result.data).to.deep.equal([{ id: 2 }, { id: 3 }]);
+    });
+
+    it("returns an internal error response when the model throws", async function() {
+      findOneStub.rejects(new Error("Mongo down"));
+      const request = {
+        query: { tenant: "airqo", group_id: groupId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.getChartConfigurations(
+        request
+      );
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe("getChartConfigurationById", function() {
+    let findOneStub;
+
+    beforeEach(function() {
+      origPreferenceModel = rewirePreferenceUtil.__get__("PreferenceModel");
+      findOneStub = sinon.stub();
+      rewirePreferenceUtil.__set__("PreferenceModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    it("returns 404 when no preference doc contains this chartId", async function() {
+      findOneStub.resolves(null);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.getChartConfigurationById(
+        request
+      );
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("returns the chart when found, looked up by user_id + chartId only (no group_id needed)", async function() {
+      const chart = {
+        _id: { toString: () => chartId },
+        fieldId: 3,
+        device_ids: [deviceId],
+      };
+      findOneStub.resolves({ chartConfigurations: [chart] });
+      const request = {
+        query: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.getChartConfigurationById(
+        request
+      );
+
+      expect(findOneStub.getCall(0).args[0]).to.deep.equal({
+        user_id: userId,
+        "chartConfigurations._id": chartId,
+      });
+      expect(result.success).to.equal(true);
+      expect(result.data).to.equal(chart);
+    });
+  });
+
+  describe("copyChartConfiguration", function() {
+    let findOneStub;
+
+    beforeEach(function() {
+      origPreferenceModel = rewirePreferenceUtil.__get__("PreferenceModel");
+      findOneStub = sinon.stub();
+      rewirePreferenceUtil.__set__("PreferenceModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    it("returns 404 when no preference doc contains this chartId", async function() {
+      findOneStub.resolves(null);
+      const request = {
+        body: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.copyChartConfiguration(
+        request
+      );
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("copies the source chart (including its device_ids/site_ids/locationColors scope) as a new chart", async function() {
+      const saveStub = sinon.stub().resolves();
+      const sourceChart = {
+        _id: { toString: () => chartId },
+        toObject: () => ({
+          _id: chartId,
+          title: "PM2.5",
+          device_ids: [deviceId],
+          site_ids: [],
+          locationColors: [{ id: deviceId, color: "#FF0000" }],
+        }),
+      };
+      const chartConfigurations = [sourceChart];
+      chartConfigurations.push = Array.prototype.push.bind(
+        chartConfigurations
+      );
+      const doc = { chartConfigurations, save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.copyChartConfiguration(
+        request
+      );
+
+      expect(saveStub.calledOnce).to.equal(true);
+      expect(result.success).to.equal(true);
+      expect(result.data.title).to.equal("PM2.5 (Copy)");
+      expect(result.data.device_ids).to.deep.equal([deviceId]);
+      expect(result.data.locationColors).to.deep.equal([
+        { id: deviceId, color: "#FF0000" },
+      ]);
+      expect(result.data._id).to.equal(undefined);
+    });
+  });
+});

--- a/src/auth-service/utils/test/ut_preference.util.js
+++ b/src/auth-service/utils/test/ut_preference.util.js
@@ -571,6 +571,25 @@ describe("preference chart UTIL", function() {
       expect(result.success).to.equal(false);
       expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
     });
+
+    it("returns 400 (not 500) when the model rejects with a schema ValidationError — e.g. chartConfigSchema's locationColors referential check", async function() {
+      const validationError = new Error(
+        "locationColors references id 507f1f77bcf86cd799439099 which isn't in this chart's device_ids or site_ids"
+      );
+      validationError.name = "ValidationError";
+      findOneAndUpdateStub.rejects(validationError);
+      const request = {
+        query: { tenant: "airqo" },
+        body: { chartConfig: { fieldId: 1 }, device_ids: [deviceId] },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.createChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(result.errors.message).to.equal(validationError.message);
+    });
   });
 
   describe("updateChart", function() {
@@ -672,6 +691,36 @@ describe("preference chart UTIL", function() {
       expect(result.success).to.equal(false);
       expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
     });
+
+    it("returns 400 (not 500) when save() rejects with a schema ValidationError — e.g. locationColors referencing an id outside device_ids/site_ids", async function() {
+      const validationError = new Error(
+        "locationColors references id 507f1f77bcf86cd799439099 which isn't in this chart's device_ids or site_ids"
+      );
+      validationError.name = "ValidationError";
+      const saveStub = sinon.stub().rejects(validationError);
+      const chart = {
+        _id: { toString: () => chartId },
+        title: "Old title",
+        device_ids: [deviceId],
+        site_ids: [],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: {
+          tenant: "airqo",
+          locationColors: [{ id: "507f1f77bcf86cd799439099", color: "#FF0000" }],
+        },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(result.errors.message).to.equal(validationError.message);
+    });
   });
 
   describe("deleteChart", function() {
@@ -686,7 +735,10 @@ describe("preference chart UTIL", function() {
     });
 
     it("returns 404 when nothing matches user_id + chartId", async function() {
-      updateOneStub.resolves({ matchedCount: 0 });
+      // { n, nModified, ok } — the actual shape this driver/mongoose combo
+      // returns from updateOne here; matchedCount is not present (verified
+      // empirically against a live connection, not assumed).
+      updateOneStub.resolves({ n: 0, nModified: 0, ok: 1 });
       const request = {
         body: { tenant: "airqo" },
         params: { chartId },
@@ -700,7 +752,7 @@ describe("preference chart UTIL", function() {
     });
 
     it("pulls only the matching chart, keyed on user_id + chartId — never deletes the whole preference doc, which also holds unrelated settings", async function() {
-      updateOneStub.resolves({ matchedCount: 1 });
+      updateOneStub.resolves({ n: 1, nModified: 1, ok: 1 });
       const request = {
         body: { tenant: "airqo" },
         params: { chartId },
@@ -912,9 +964,6 @@ describe("preference chart UTIL", function() {
         }),
       };
       const chartConfigurations = [sourceChart];
-      chartConfigurations.push = Array.prototype.push.bind(
-        chartConfigurations
-      );
       const doc = { chartConfigurations, save: saveStub };
       findOneStub.resolves(doc);
       const request = {

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -129,6 +129,22 @@ const createNestedValidations = (prefix) => {
       .optional()
       .isString()
       .withMessage("Title must be a string"),
+    body(`${prefix}.subTitle`)
+      .optional()
+      .isString()
+      .withMessage("Subtitle must be a string"),
+    body(`${prefix}.locationColors`)
+      .optional()
+      .isArray()
+      .withMessage("locationColors must be an array"),
+    body(`${prefix}.locationColors.*.id`)
+      .optional()
+      .isMongoId()
+      .withMessage("locationColors[].id must be a valid ObjectId"),
+    body(`${prefix}.locationColors.*.color`)
+      .optional()
+      .isString()
+      .withMessage("locationColors[].color must be a string"),
     body(`${prefix}.xAxisLabel`)
       .optional()
       .isString()
@@ -1065,6 +1081,22 @@ const chartConfigValidation = [
     .isInt({ min: 1, max: 8 })
     .withMessage("Invalid fieldId"),
   body("title").optional().isString().withMessage("Title must be a string"),
+  body("subTitle")
+    .optional()
+    .isString()
+    .withMessage("Subtitle must be a string"),
+  body("locationColors")
+    .optional()
+    .isArray()
+    .withMessage("locationColors must be an array"),
+  body("locationColors.*.id")
+    .optional()
+    .isMongoId()
+    .withMessage("locationColors[].id must be a valid ObjectId"),
+  body("locationColors.*.color")
+    .optional()
+    .isString()
+    .withMessage("locationColors[].color must be a string"),
   body("xAxisLabel")
     .optional()
     .isString()
@@ -1241,6 +1273,43 @@ const chartConfigValidation = [
     .withMessage("Additional series color must be a string"),
 ];
 
+// A chart is scoped by device_ids/site_ids on the chart itself now (not a
+// single :deviceId path param), mirroring the group chart config design —
+// one chart can compare multiple locations at once, but has to be about at
+// least one.
+const chartScopeArrayValidations = [
+  ...validateArrayOfObjectIds("device_ids"),
+  ...validateArrayOfObjectIds("site_ids"),
+];
+
+const chartAtLeastOneScopeRequired = body().custom((_, { req }) => {
+  const { device_ids, site_ids } = req.body;
+  if (isEmpty(device_ids) && isEmpty(site_ids)) {
+    throw new Error(
+      "At least one of device_ids or site_ids is required, and must not be empty",
+    );
+  }
+  return true;
+});
+
+// On update, device_ids/site_ids are optional — a request may only touch
+// display fields and leave scope untouched. But if both are explicitly sent
+// and both empty, that's an unambiguous attempt to clear the scope
+// entirely, so it's rejected here. This can't catch every way to end up
+// with an empty scope (e.g. clearing just one array while the existing
+// chart's other array is already empty) — that needs the current document,
+// so it's guarded again in preference.util.js after merging with it.
+const chartScopeNotBothClearedOnUpdate = body().custom((_, { req }) => {
+  const { device_ids, site_ids } = req.body;
+  const bothProvided = Array.isArray(device_ids) && Array.isArray(site_ids);
+  if (bothProvided && isEmpty(device_ids) && isEmpty(site_ids)) {
+    throw new Error(
+      "device_ids and site_ids cannot both be cleared — at least one must remain",
+    );
+  }
+  return true;
+});
+
 const preferenceValidations = {
   validatePreferenceData: [
     ...commonValidations.tenant,
@@ -1375,12 +1444,8 @@ const preferenceValidations = {
   // Replace the existing createChart validation with this improved version
   createChart: [
     ...commonValidations.tenant,
-    param("deviceId")
-      .exists()
-      .withMessage("Device ID is required")
-      .bail()
-      .isMongoId()
-      .withMessage("Invalid Device ID"),
+    ...chartScopeArrayValidations,
+    chartAtLeastOneScopeRequired,
     body("chartConfig")
       .exists()
       .withMessage("chartConfig object is required")
@@ -1397,26 +1462,18 @@ const preferenceValidations = {
   ],
   updateChart: [
     ...commonValidations.tenant,
-    param("deviceId")
-      .exists()
-      .withMessage("Device ID is required")
-      .isMongoId()
-      .withMessage("Invalid Device ID"),
     param("chartId")
       .exists()
       .withMessage("Chart ID is required")
       .isMongoId()
       .withMessage("Invalid Chart ID"),
+    ...chartScopeArrayValidations,
+    chartScopeNotBothClearedOnUpdate,
     // Use all validations from chartConfigValidation
     ...chartConfigValidation,
   ],
   deleteChart: [
     ...commonValidations.tenant,
-    param("deviceId")
-      .exists()
-      .withMessage("Device ID is required")
-      .isMongoId()
-      .withMessage("Invalid Device ID"),
     param("chartId")
       .exists()
       .withMessage("Chart ID is required")
@@ -1425,19 +1482,21 @@ const preferenceValidations = {
   ],
   getChartConfigurations: [
     ...commonValidations.tenant,
-    param("deviceId")
-      .exists()
-      .withMessage("Device ID is required")
+    query("group_id")
+      .optional()
       .isMongoId()
-      .withMessage("Invalid Device ID"),
+      .withMessage("group_id must be a valid Group ID"),
+    query("device_id")
+      .optional()
+      .isMongoId()
+      .withMessage("device_id must be a valid Device ID"),
+    query("site_id")
+      .optional()
+      .isMongoId()
+      .withMessage("site_id must be a valid Site ID"),
   ],
   getChartConfigurationById: [
     ...commonValidations.tenant,
-    param("deviceId")
-      .exists()
-      .withMessage("Device ID is required")
-      .isMongoId()
-      .withMessage("Invalid Device ID"),
     param("chartId")
       .exists()
       .withMessage("Chart ID is required")
@@ -1446,11 +1505,6 @@ const preferenceValidations = {
   ],
   copyChart: [
     ...commonValidations.tenant,
-    param("deviceId")
-      .exists()
-      .withMessage("Device ID is required")
-      .isMongoId()
-      .withMessage("Invalid Device ID"),
     param("chartId")
       .exists()
       .withMessage("Chart ID is required")

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -137,12 +137,20 @@ const createNestedValidations = (prefix) => {
       .optional()
       .isArray()
       .withMessage("locationColors must be an array"),
+    // Each entry's id/color are optional only in the sense that the whole
+    // array is optional — once an entry exists, both fields are required on
+    // the schema (chartConfigSchema), so catching a missing one here as a
+    // clean 422 avoids it reaching the DB layer and surfacing as a 500.
     body(`${prefix}.locationColors.*.id`)
-      .optional()
+      .exists()
+      .withMessage("locationColors[].id is required")
+      .bail()
       .isMongoId()
       .withMessage("locationColors[].id must be a valid ObjectId"),
     body(`${prefix}.locationColors.*.color`)
-      .optional()
+      .exists()
+      .withMessage("locationColors[].color is required")
+      .bail()
       .isString()
       .withMessage("locationColors[].color must be a string"),
     body(`${prefix}.xAxisLabel`)
@@ -1089,12 +1097,18 @@ const chartConfigValidation = [
     .optional()
     .isArray()
     .withMessage("locationColors must be an array"),
+  // Same reasoning as createNestedValidations above: the array is optional,
+  // but once an entry is present both fields are required on the schema.
   body("locationColors.*.id")
-    .optional()
+    .exists()
+    .withMessage("locationColors[].id is required")
+    .bail()
     .isMongoId()
     .withMessage("locationColors[].id must be a valid ObjectId"),
   body("locationColors.*.color")
-    .optional()
+    .exists()
+    .withMessage("locationColors[].color is required")
+    .bail()
     .isString()
     .withMessage("locationColors[].color must be a string"),
   body("xAxisLabel")

--- a/src/auth-service/validators/test/ut_preferences-chart.validators.js
+++ b/src/auth-service/validators/test/ut_preferences-chart.validators.js
@@ -1,0 +1,245 @@
+require("module-alias/register");
+process.env.TENANTS = "kcca,airqo,airqount";
+const chai = require("chai");
+const { expect } = chai;
+const express = require("express");
+const request = require("supertest");
+const { validationResult } = require("express-validator");
+
+const {
+  createChart,
+  updateChart,
+  deleteChart,
+  getChartConfigurations,
+  getChartConfigurationById,
+  copyChart,
+} = require("@validators/preferences.validators");
+
+const mongoose = require("mongoose");
+const validId = () => new mongoose.Types.ObjectId().toHexString();
+
+function buildApp(middleware) {
+  const app = express();
+  app.use(express.json());
+  const handler = (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({ errors: errors.array() });
+    }
+    res.json({ success: true });
+  };
+  app.post("/test/charts", ...middleware, handler);
+  app.put("/test/charts/:chartId", ...middleware, handler);
+  app.delete("/test/charts/:chartId", ...middleware, handler);
+  app.get("/test/charts", ...middleware, handler);
+  app.get("/test/charts/:chartId", ...middleware, handler);
+  app.post("/test/charts/:chartId/copy", ...middleware, handler);
+  return app;
+}
+
+describe("personal chart validators", () => {
+  describe("createChart", () => {
+    const app = buildApp(createChart);
+
+    it("rejects when neither device_ids nor site_ids is provided", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({ chartConfig: { fieldId: 1 } });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "At least one of device_ids or site_ids is required"
+      );
+    });
+
+    it("rejects when device_ids/site_ids are present but both empty", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({ chartConfig: { fieldId: 1 }, device_ids: [], site_ids: [] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "At least one of device_ids or site_ids is required"
+      );
+    });
+
+    it("rejects a device_ids entry that isn't a valid ObjectId", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({ chartConfig: { fieldId: 1 }, device_ids: ["not-an-id"] });
+      expect(res.status).to.equal(422);
+    });
+
+    it("rejects a missing chartConfig", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({ device_ids: [validId()] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "chartConfig object is required"
+      );
+    });
+
+    it("rejects a chartConfig missing fieldId", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({ chartConfig: {}, device_ids: [validId()] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "fieldId is required in chartConfig"
+      );
+    });
+
+    it("rejects a chartConfig.locationColors entry with an invalid id", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: {
+            fieldId: 1,
+            locationColors: [{ id: "not-an-id", color: "#FF0000" }],
+          },
+          device_ids: [validId()],
+        });
+      expect(res.status).to.equal(422);
+    });
+
+    it("accepts a well-formed request scoped to device_ids only", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: {
+            fieldId: 1,
+            title: "PM2.5",
+            subTitle: "Kampala vs Jinja",
+          },
+          device_ids: [validId()],
+        });
+      expect(res.status).to.equal(200);
+    });
+
+    it("accepts a well-formed request with locationColors matching selected ids", async () => {
+      const deviceId = validId();
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: {
+            fieldId: 1,
+            locationColors: [{ id: deviceId, color: "#FF0000" }],
+          },
+          device_ids: [deviceId],
+        });
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe("updateChart", () => {
+    const app = buildApp(updateChart);
+
+    it("rejects an invalid chartId", async () => {
+      const res = await request(app)
+        .put("/test/charts/not-an-id")
+        .send({ title: "New" });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include("Invalid Chart ID");
+    });
+
+    it("rejects an invalid chartType", async () => {
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({ chartType: "NotARealType" });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include("Invalid chart type");
+    });
+
+    it("rejects when device_ids and site_ids are both explicitly sent empty", async () => {
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({ device_ids: [], site_ids: [] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "device_ids and site_ids cannot both be cleared"
+      );
+    });
+
+    it("accepts clearing just one scope array when the other is left untouched — the validator can't know the existing doc's scope, so this is allowed here and guarded again at the util layer", async () => {
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({ device_ids: [] });
+      expect(res.status).to.equal(200);
+    });
+
+    it("accepts a well-formed partial update including subTitle and locationColors", async () => {
+      const deviceId = validId();
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({
+          title: "New title",
+          subTitle: "New subtitle",
+          device_ids: [deviceId],
+          locationColors: [{ id: deviceId, color: "#00AA00" }],
+        });
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe("deleteChart", () => {
+    const app = buildApp(deleteChart);
+
+    it("rejects an invalid chartId", async () => {
+      const res = await request(app).delete("/test/charts/not-an-id");
+      expect(res.status).to.equal(422);
+    });
+
+    it("accepts a valid chartId", async () => {
+      const res = await request(app).delete(`/test/charts/${validId()}`);
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe("getChartConfigurations", () => {
+    const app = buildApp(getChartConfigurations);
+
+    it("accepts no filters", async () => {
+      const res = await request(app).get("/test/charts");
+      expect(res.status).to.equal(200);
+    });
+
+    it("accepts optional group_id/device_id/site_id query filters", async () => {
+      const res = await request(app).get(
+        `/test/charts?group_id=${validId()}&device_id=${validId()}&site_id=${validId()}`
+      );
+      expect(res.status).to.equal(200);
+    });
+
+    it("rejects an invalid device_id query filter", async () => {
+      const res = await request(app).get("/test/charts?device_id=not-an-id");
+      expect(res.status).to.equal(422);
+    });
+  });
+
+  describe("getChartConfigurationById", () => {
+    const app = buildApp(getChartConfigurationById);
+
+    it("rejects an invalid chartId", async () => {
+      const res = await request(app).get("/test/charts/not-an-id");
+      expect(res.status).to.equal(422);
+    });
+
+    it("accepts a valid chartId", async () => {
+      const res = await request(app).get(`/test/charts/${validId()}`);
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe("copyChart", () => {
+    const app = buildApp(copyChart);
+
+    it("rejects an invalid chartId", async () => {
+      const res = await request(app).post("/test/charts/not-an-id/copy");
+      expect(res.status).to.equal(422);
+    });
+
+    it("accepts a valid chartId", async () => {
+      const res = await request(app).post(`/test/charts/${validId()}/copy`);
+      expect(res.status).to.equal(200);
+    });
+  });
+});

--- a/src/auth-service/validators/test/ut_preferences-chart.validators.js
+++ b/src/auth-service/validators/test/ut_preferences-chart.validators.js
@@ -66,6 +66,9 @@ describe("personal chart validators", () => {
         .post("/test/charts")
         .send({ chartConfig: { fieldId: 1 }, device_ids: ["not-an-id"] });
       expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "device_ids must be an array of valid ObjectId strings"
+      );
     });
 
     it("rejects a missing chartConfig", async () => {
@@ -99,6 +102,51 @@ describe("personal chart validators", () => {
           device_ids: [validId()],
         });
       expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "locationColors[].id must be a valid ObjectId"
+      );
+    });
+
+    it("rejects a chartConfig.locationColors entry missing id", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: {
+            fieldId: 1,
+            locationColors: [{ color: "#FF0000" }],
+          },
+          device_ids: [validId()],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "locationColors[].id is required"
+      );
+    });
+
+    it("rejects a chartConfig.locationColors entry missing color", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: {
+            fieldId: 1,
+            locationColors: [{ id: validId() }],
+          },
+          device_ids: [validId()],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "locationColors[].color is required"
+      );
+    });
+
+    it("accepts a request with no locationColors at all", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: { fieldId: 1 },
+          device_ids: [validId()],
+        });
+      expect(res.status).to.equal(200);
     });
 
     it("accepts a well-formed request scoped to device_ids only", async () => {
@@ -177,6 +225,26 @@ describe("personal chart validators", () => {
           locationColors: [{ id: deviceId, color: "#00AA00" }],
         });
       expect(res.status).to.equal(200);
+    });
+
+    it("rejects a locationColors entry missing id", async () => {
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({ locationColors: [{ color: "#00AA00" }] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "locationColors[].id is required"
+      );
+    });
+
+    it("rejects a locationColors entry missing color", async () => {
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({ locationColors: [{ id: validId() }] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "locationColors[].color is required"
+      );
     });
   });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Reworks personal chart configuration (`/api/v2/users/preferences/charts...`) to drop the single `:deviceId` path param in favor of `device_ids`/`site_ids` arrays on each chart, so one chart can compare multiple locations at once (e.g. Kampala + Jinja together). Also adds two fields that were missing on the new chart-config object: `subTitle` and `locationColors` (assign a distinct color per selected device/site, falling back to the existing chart-wide `color` when unset). Updates `docs/NEXUS_AIR_QUALITY_API_GUIDE.md` with the new contract and examples.

### Why is this change needed?
Direction from the frontend/Nexus side moved away from group-wide default charts toward per-user personalization — users configure their own locations and chart settings even within a group. The personal chart endpoint still had the old single-device limitation the group endpoint used to have, and was missing subtitle support (present on the old netmanager preference doc) and any way to color multiple selected locations differently on the same chart.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `auth-service` — model (`chartConfigSchema`), routes, validators, utils, and controller for personal chart configuration, plus unit tests
- `docs` — updated Nexus Air Quality API guide (chart configuration section)

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added unit tests covering the new `chartConfigSchema` scope validation (device_ids/site_ids/locationColors referential check via async `validate()`), the reworked validators (multi-location scope requirements, subTitle/locationColors field validation), and the reworked util CRUD (create/update/delete/list/getById/copy) for the new request/response shape. Full affected test suite (model, validators, controller, utils) passing.

---

## :boom: Breaking Changes
- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

- Personal chart routes moved from `/preferences/:deviceId/charts...` to `/preferences/charts...` — no more `:deviceId` path param.
- `POST`/`PUT` now expect `device_ids`/`site_ids` arrays in the body instead of a single device in the URL.
- `GET .../charts` (list) and single-chart lookups no longer require `group_id` to identify a specific chart — `chartId` alone is sufficient.
- Chart objects gained two new optional fields (`subTitle`, `locationColors`) — additive, does not affect existing chart data.

This endpoint was not yet in wide frontend use, so no data migration is needed.

---

## :memo: Additional Notes
`locationColors` entries are validated against the chart's own `device_ids`/`site_ids` — assigning a color to a location the chart doesn't include is rejected. The group-wide default chart endpoints (shipped in a prior PR) are untouched and still functional, but are no longer the recommended path per current product direction.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for personal chart configurations across multiple devices and sites.
  * Added chart subtitles and location-specific color customization.
  * Added chart creation, editing, deletion, retrieval, copying, filtering, and pagination.
  * Added validation to ensure chart scopes and location colors are valid.
* **Documentation**
  * Updated the air quality API guide with the new chart configuration capabilities and recommended usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->