### PR TITLE
Streamline group membership: auth fix, invite consolidation, discovery

### DIFF
--- a/src/auth-service/config/core/db-projections.js
+++ b/src/auth-service/config/core/db-projections.js
@@ -248,6 +248,8 @@ const dbProjections = {
     requestType: 1,
     targetId: 1,
     status: 1,
+    role_id: 1,
+    message: 1,
     createdAt: {
       $dateToString: {
         format: "%Y-%m-%d %H:%M:%S",

--- a/src/auth-service/controllers/group.controller.js
+++ b/src/auth-service/controllers/group.controller.js
@@ -551,11 +551,11 @@ const groupController = {
         : req.query.tenant;
       // Forced, never caller-overridable: only the lean, already-safe
       // "summary" projection (excludes grp_users/grp_manager) is exposed to
-      // this authenticated-only, membership-independent endpoint.
+      // this authenticated-only, membership-independent endpoint, and only
+      // ACTIVE groups are discoverable — a caller-supplied grp_status could
+      // otherwise be used to enumerate inactive/unconfigured groups.
       request.query.category = "summary";
-      request.query.grp_status = isEmpty(req.query.grp_status)
-        ? "ACTIVE"
-        : req.query.grp_status;
+      request.query.grp_status = "ACTIVE";
 
       const result = await groupUtil.list(request, next);
 

--- a/src/auth-service/controllers/group.controller.js
+++ b/src/auth-service/controllers/group.controller.js
@@ -7,6 +7,7 @@ const {
   extractErrorsFromRequest,
 } = require("@utils/shared");
 const groupUtil = require("@utils/group.util");
+const requestUtil = require("@utils/request.util");
 const isEmpty = require("is-empty");
 const constants = require("@config/constants");
 const log4js = require("log4js");
@@ -533,6 +534,64 @@ const groupController = {
     }
   },
 
+  discover: async (req, res, next) => {
+    try {
+      logText("discovering groups....");
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors),
+        );
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+      // Forced, never caller-overridable: only the lean, already-safe
+      // "summary" projection (excludes grp_users/grp_manager) is exposed to
+      // this authenticated-only, membership-independent endpoint.
+      request.query.category = "summary";
+      request.query.grp_status = isEmpty(req.query.grp_status)
+        ? "ACTIVE"
+        : req.query.grp_status;
+
+      const result = await groupUtil.list(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message,
+          groups: result.data,
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          message: result.message,
+          errors: result.errors ? result.errors : { message: "" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+      return;
+    }
+  },
+
   // Enhanced set manager with automatic role assignment
   enhancedSetManager: (req, res, next) => {
     logText("enhancedSetManager called");
@@ -735,8 +794,10 @@ const groupController = {
     }
   },
 
+  // Delegates to the same canonical implementation as
+  // POST /requests/emails/groups/:grp_id — see requestUtil.requestAccessToGroupByEmail.
   sendGroupInvitations: (req, res, next) =>
-    executeGroupAction(req, res, next, groupUtil.sendGroupInvitations),
+    executeGroupAction(req, res, next, requestUtil.requestAccessToGroupByEmail),
 
   listGroupInvitations: (req, res, next) =>
     executeGroupAction(req, res, next, groupUtil.listGroupInvitations),

--- a/src/auth-service/controllers/group.controller.js
+++ b/src/auth-service/controllers/group.controller.js
@@ -575,6 +575,7 @@ const groupController = {
           ? result.status
           : httpStatus.INTERNAL_SERVER_ERROR;
         return res.status(status).json({
+          success: false,
           message: result.message,
           errors: result.errors ? result.errors : { message: "" },
         });
@@ -796,8 +797,64 @@ const groupController = {
 
   // Delegates to the same canonical implementation as
   // POST /requests/emails/groups/:grp_id — see requestUtil.requestAccessToGroupByEmail.
-  sendGroupInvitations: (req, res, next) =>
-    executeGroupAction(req, res, next, requestUtil.requestAccessToGroupByEmail),
+  // Not routed through executeGroupAction: mirrors
+  // request.controller.js's requestAccessToGroupByEmail response shape
+  // (the `request` key, not `data`) so both routes return identical
+  // payloads for the same underlying operation.
+  sendGroupInvitations: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors),
+        );
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await requestUtil.requestAccessToGroupByEmail(
+        request,
+        next,
+      );
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message,
+          request: result.data,
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+        return res.status(status).json({
+          success: false,
+          message: result.message,
+          errors: result.errors
+            ? result.errors
+            : { message: "Internal Server Error" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
 
   listGroupInvitations: (req, res, next) =>
     executeGroupAction(req, res, next, groupUtil.listGroupInvitations),

--- a/src/auth-service/middleware/accessRequestAuth.js
+++ b/src/auth-service/middleware/accessRequestAuth.js
@@ -1,0 +1,72 @@
+// middleware/accessRequestAuth.js
+const httpStatus = require("http-status");
+const { HttpError } = require("@utils/shared");
+const constants = require("@config/constants");
+const AccessRequestModel = require("@models/AccessRequest");
+const { requireGroupManagerAccess } = require("@middleware/groupNetworkAuth");
+
+/**
+ * Resolves :request_id to its underlying AccessRequest, then authorizes the
+ * caller against the request's target group before allowing approve/reject.
+ * @param {string} requestIdParam - Parameter name containing the access request ID
+ * @returns {Function} Express middleware
+ */
+const requireAccessRequestManagerAccess = (requestIdParam = "request_id") => {
+  return async (req, res, next) => {
+    try {
+      const user = req.user;
+      const tenant = req.query.tenant || constants.DEFAULT_TENANT;
+      const requestId = req.params[requestIdParam];
+
+      if (!user || !user._id) {
+        return next(
+          new HttpError("Authentication required", httpStatus.UNAUTHORIZED, {
+            message: "You must be logged in to access this resource",
+          })
+        );
+      }
+
+      if (!requestId) {
+        return next(
+          new HttpError("Bad Request", httpStatus.BAD_REQUEST, {
+            message: "request_id is required",
+          })
+        );
+      }
+
+      const accessRequest = await AccessRequestModel(tenant)
+        .findById(requestId)
+        .lean();
+
+      if (!accessRequest) {
+        return next(
+          new HttpError("Not Found", httpStatus.NOT_FOUND, {
+            message: "Access request does not exist",
+          })
+        );
+      }
+
+      req.accessRequest = accessRequest;
+
+      if (accessRequest.requestType === "group") {
+        req.params.grp_id = accessRequest.targetId.toString();
+        return requireGroupManagerAccess("grp_id")(req, res, next);
+      }
+
+      return next(
+        new HttpError("Not Implemented", httpStatus.NOT_IMPLEMENTED, {
+          message:
+            "Approving/rejecting network access requests is not yet supported",
+        })
+      );
+    } catch (error) {
+      return next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  };
+};
+
+module.exports = { requireAccessRequestManagerAccess };

--- a/src/auth-service/middleware/accessRequestAuth.js
+++ b/src/auth-service/middleware/accessRequestAuth.js
@@ -1,5 +1,6 @@
 // middleware/accessRequestAuth.js
 const httpStatus = require("http-status");
+const mongoose = require("mongoose");
 const { HttpError } = require("@utils/shared");
 const constants = require("@config/constants");
 const AccessRequestModel = require("@models/AccessRequest");
@@ -30,6 +31,14 @@ const requireAccessRequestManagerAccess = (requestIdParam = "request_id") => {
         return next(
           new HttpError("Bad Request", httpStatus.BAD_REQUEST, {
             message: "request_id is required",
+          })
+        );
+      }
+
+      if (!mongoose.Types.ObjectId.isValid(requestId)) {
+        return next(
+          new HttpError("Bad Request", httpStatus.BAD_REQUEST, {
+            message: "request_id is not a valid Object ID",
           })
         );
       }

--- a/src/auth-service/models/AccessRequest.js
+++ b/src/auth-service/models/AccessRequest.js
@@ -64,6 +64,15 @@ const AccessRequestSchema = new Schema(
     expires_at: {
       type: Date,
     },
+    role_id: {
+      type: ObjectId,
+      ref: "role",
+    },
+    message: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
   },
   {
     timestamps: true,

--- a/src/auth-service/models/AccessRequest.js
+++ b/src/auth-service/models/AccessRequest.js
@@ -71,7 +71,7 @@ const AccessRequestSchema = new Schema(
     message: {
       type: String,
       trim: true,
-      maxlength: 500,
+      maxlength: 1000, // matches groupValidations.sendGroupInvitations' body("invitations.*.message") limit
     },
   },
   {

--- a/src/auth-service/routes/v2/requests.routes.js
+++ b/src/auth-service/routes/v2/requests.routes.js
@@ -5,6 +5,9 @@ const createRequestController = require("@controllers/request.controller");
 const requestValidations = require("@validators/requests.validators");
 const { enhancedJWTAuth, optionalJWTAuth } = require("@middleware/passport");
 const { requirePermissions } = require("@middleware/permissionAuth");
+const {
+  requireAccessRequestManagerAccess,
+} = require("@middleware/accessRequestAuth");
 const constants = require("@config/constants");
 const { validate, headers, pagination } = require("@validators/common");
 
@@ -58,6 +61,7 @@ router.post(
   "/:request_id/approve",
   requestValidations.approveAccessRequest,
   enhancedJWTAuth,
+  requireAccessRequestManagerAccess(),
   createRequestController.approveAccessRequest,
 );
 
@@ -65,6 +69,7 @@ router.post(
   "/:request_id/reject",
   requestValidations.rejectAccessRequest,
   enhancedJWTAuth,
+  requireAccessRequestManagerAccess(),
   createRequestController.rejectAccessRequest,
 );
 

--- a/src/auth-service/routes/v2/test/ut_requests.routes.js
+++ b/src/auth-service/routes/v2/test/ut_requests.routes.js
@@ -78,10 +78,19 @@ const permissionAuthStub = {
     next(),
 };
 
+// requireAccessRequestManagerAccess looks up the AccessRequest and delegates
+// to requireGroupManagerAccess, both of which need a real DB/RBACService —
+// stub it the same way as the other auth middleware above.
+const accessRequestAuthStub = {
+  requireAccessRequestManagerAccess: (requestIdParam) => (req, res, next) =>
+    next(),
+};
+
 const router = proxyquire("@routes/v2/requests.routes", {
   "@controllers/request.controller": createRequestControllerStub,
   "@middleware/passport": passportStub,
   "@middleware/permissionAuth": permissionAuthStub,
+  "@middleware/accessRequestAuth": accessRequestAuthStub,
 });
 
 // Realistic 24-char hex Mongo ObjectId strings, since the real validators

--- a/src/auth-service/routes/v3/groups.routes.js
+++ b/src/auth-service/routes/v3/groups.routes.js
@@ -76,6 +76,18 @@ router.get(
   groupController.listSummary,
 );
 
+// Group discovery — authenticated only, no GROUP_VIEW permission required.
+// GROUP_VIEW is only granted once a user already belongs to some group, so
+// a brand-new/outsider user (exactly who needs to browse groups to request
+// to join one) would otherwise get 403 on both /groups and /groups/summary.
+router.get(
+  "/discover",
+  groupValidations.listSummary,
+  validate,
+  enhancedJWTAuth,
+  groupController.discover,
+);
+
 // Group creation - requires system-level permissions
 router.post(
   "/",

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -1199,7 +1199,11 @@ module.exports = {
     </tr>
   `;
 
-    return constants.EMAIL_BODY({ email, content, name: contact_name });
+    return constants.EMAIL_BODY({
+      email,
+      content,
+      name: escapeHtml(contact_name),
+    });
   },
 
   notifyAdminsOfNewOrgRequest: ({

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -1171,6 +1171,37 @@ module.exports = {
     return constants.EMAIL_BODY({ email, content });
   },
 
+  notifyGroupManagerOfJoinRequest: ({
+    email,
+    contact_name,
+    requester_name,
+    requester_email,
+    entity_title,
+    request_id,
+  }) => {
+    const reviewLink = `${constants.NEXUS_BASE_URL}/org/member-requests?request_id=${request_id}`;
+
+    const content = `
+    <tr>
+      <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+        <p>Hello ${escapeHtml(contact_name)},</p>
+        <p><strong>${escapeHtml(requester_name)}</strong> (${escapeHtml(
+          requester_email,
+        )}) has requested to join "<strong>${escapeHtml(
+          entity_title,
+        )}</strong>" on AirQo Nexus.</p>
+        <div style="text-align: center; margin: 24px 0;">
+          <a href="${reviewLink}" style="display: inline-block; padding: 12px 24px; background-color: #135DFF; color: white; text-decoration: none; border-radius: 6px; font-weight: 600;">Review Request</a>
+        </div>
+        <p>You can approve or reject this request from your organization's member requests page.</p>
+        <p>Best,<br/>The AirQo Team</p>
+      </td>
+    </tr>
+  `;
+
+    return constants.EMAIL_BODY({ email, content, name: contact_name });
+  },
+
   notifyAdminsOfNewOrgRequest: ({
     organization_name,
     contact_name,

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -867,6 +867,9 @@ const getEmailSubject = (functionName, params) => {
     requestToJoinGroupByEmail: `Your AirQo Account Request to Access ${processString(
       params.entity_title || "",
     )} Team`,
+    notifyGroupManagerOfJoinRequest: `New Join Request: ${sanitizeEmailString(
+      params.entity_title || "",
+    )}`,
     afterAcceptingInvitation: `Welcome to ${
       params.entity_title ? processString(params.entity_title) : "the team"
     }!`,
@@ -981,6 +984,7 @@ const EMAIL_CATEGORIES = {
     "candidate",
     "request",
     "requestToJoinGroupByEmail",
+    "notifyGroupManagerOfJoinRequest",
     "afterAcceptingInvitation",
     "user",
     "assign",
@@ -1626,6 +1630,19 @@ const mailer = {
       ...baseMailOptions,
       bcc: params.inviterEmail,
     }),
+  ),
+  notifyGroupManagerOfJoinRequest: createMailerFunction(
+    "notifyGroupManagerOfJoinRequest", //
+    "USER_MANAGEMENT",
+    (params) =>
+      msgs.notifyGroupManagerOfJoinRequest({
+        email: params.email,
+        contact_name: params.contact_name,
+        requester_name: params.requester_name,
+        requester_email: params.requester_email,
+        entity_title: params.entity_title,
+        request_id: params.request_id,
+      }),
   ),
   inquiry: createMailerFunction("inquiry", "OPTIONAL", (params) =>
     msgs.inquiry(

--- a/src/auth-service/utils/group.util.js
+++ b/src/auth-service/utils/group.util.js
@@ -3287,138 +3287,6 @@ const groupUtil = {
   },
 
   /**
-   * Send group invitations via email
-   */
-  sendGroupInvitations: async (request, next) => {
-    try {
-      const { grp_id } = request.params;
-      const {
-        invitations,
-        expiry_hours = 72,
-        auto_approve = false,
-      } = request.body;
-      const { tenant } = request.query;
-
-      const group = await GroupModel(tenant).findById(grp_id).lean();
-      if (!group) {
-        next(
-          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
-            message: "Group not found",
-          }),
-        );
-        return;
-      }
-
-      const results = [];
-      const inviter = request.user;
-
-      for (const invitation of invitations) {
-        const { email, role_id, message } = invitation;
-
-        try {
-          // Check if user already exists
-          let existingUser = await UserModel(tenant).findOne({ email }).lean();
-
-          // Check if already a group member
-          if (existingUser) {
-            const isAlreadyMember = existingUser.group_roles?.some(
-              (gr) => gr.group.toString() === grp_id.toString(),
-            );
-
-            if (isAlreadyMember) {
-              results.push({
-                email,
-                status: "skipped",
-                reason: "User is already a group member",
-              });
-              continue;
-            }
-          }
-
-          // Create access request or direct assignment
-          const invitationData = {
-            email,
-            targetId: grp_id,
-            requestType: "group",
-            status: auto_approve ? "approved" : "pending",
-            inviter_id: inviter._id,
-            message,
-            role_id,
-            expiresAt: new Date(Date.now() + expiry_hours * 60 * 60 * 1000),
-          };
-
-          if (existingUser) {
-            invitationData.user_id = existingUser._id;
-          }
-
-          const accessRequest =
-            await AccessRequestModel(tenant).create(invitationData);
-
-          // If auto-approve and user exists, add to group immediately
-          if (auto_approve && existingUser && role_id) {
-            await UserModel(tenant).findByIdAndUpdate(existingUser._id, {
-              $addToSet: {
-                group_roles: {
-                  group: grp_id,
-                  role: role_id,
-                  userType: "user",
-                  createdAt: new Date(),
-                },
-              },
-            });
-          }
-
-          results.push({
-            email,
-            status: auto_approve ? "approved" : "invited",
-            invitation_id: accessRequest._id,
-            expires_at: invitationData.expiresAt,
-          });
-        } catch (error) {
-          results.push({
-            email,
-            status: "failed",
-            reason: error.message,
-          });
-        }
-      }
-
-      const successCount = results.filter(
-        (r) => r.status === "invited" || r.status === "approved",
-      ).length;
-
-      return {
-        success: true,
-        message: `${successCount}/${invitations.length} invitations processed successfully`,
-        data: {
-          invitations: results,
-          group_name: group.grp_title,
-          invited_by: inviter.email,
-          summary: {
-            total: invitations.length,
-            successful: successCount,
-            failed: results.filter((r) => r.status === "failed").length,
-            skipped: results.filter((r) => r.status === "skipped").length,
-          },
-        },
-        status: httpStatus.OK,
-      };
-    } catch (error) {
-      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
-      next(
-        new HttpError(
-          "Internal Server Error",
-          httpStatus.INTERNAL_SERVER_ERROR,
-          {
-            message: error.message,
-          },
-        ),
-      );
-      return;
-    }
-  },
-
-  /**
    * List group invitations and their status
    */
   listGroupInvitations: async (request, next) => {
@@ -4801,6 +4669,44 @@ const groupUtil = {
       );
     }
   },
+  getGroupManagementRecipients: async (tenant, grp_id) => {
+    const group = await GroupModel(tenant)
+      .findById(grp_id)
+      .select("grp_manager grp_title")
+      .lean();
+
+    const recipients = new Map();
+
+    if (group && group.grp_manager) {
+      const manager = await UserModel(tenant)
+        .findById(group.grp_manager)
+        .select("email firstName lastName")
+        .lean();
+      if (manager && manager.email) {
+        recipients.set(manager.email, manager);
+      }
+    }
+
+    const admins = await UserModel(tenant)
+      .find({
+        group_roles: {
+          $elemMatch: {
+            group: grp_id,
+            userType: { $in: ["admin", "manager", "super_admin"] },
+          },
+        },
+      })
+      .select("email firstName lastName")
+      .lean();
+
+    admins.forEach((admin) => {
+      if (admin.email) {
+        recipients.set(admin.email, admin);
+      }
+    });
+
+    return Array.from(recipients.values());
+  },
   leaveGroup: async (request, next) => {
     try {
       const { grp_id } = request.params;
@@ -4853,6 +4759,7 @@ const groupUtil = {
             new HttpError("Forbidden", httpStatus.FORBIDDEN, {
               message:
                 "You are the manager of this group. Please transfer ownership to another member before leaving.",
+              debugCode: "GROUP_MANAGER_MUST_TRANSFER_OWNERSHIP",
             }),
           );
         }

--- a/src/auth-service/utils/request.util.js
+++ b/src/auth-service/utils/request.util.js
@@ -15,6 +15,7 @@ const logger = require("log4js").getLogger(
 );
 const createNetworkUtil = require("@utils/network.util");
 const createGroupUtil = require("@utils/group.util");
+const RoleModel = require("@models/Role");
 const { logObject, HttpError, logText } = require("@utils/shared");
 
 const createAccessRequest = {
@@ -108,16 +109,61 @@ const createAccessRequest = {
           );
           return;
         }
-        const responseFromSendEmail = await mailer.request(
-          {
-            firstName,
-            lastName,
-            email: user.email,
-            tenant,
-            entity_title: group.grp_title,
-          },
-          next,
+        const recipients = await createGroupUtil.getGroupManagementRecipients(
+          tenant,
+          grp_id,
         );
+        if (recipients.length === 0) {
+          logger.warn(
+            `No group manager/admin found to notify for join request to group ${grp_id}`,
+          );
+        }
+        const requesterName = `${firstName} ${lastName}`;
+
+        const [requesterEmailResult, ...managerEmailResults] =
+          await Promise.allSettled([
+            mailer.request(
+              {
+                firstName,
+                lastName,
+                email: user.email,
+                tenant,
+                entity_title: group.grp_title,
+              },
+              next,
+            ),
+            ...recipients.map((recipient) =>
+              mailer.notifyGroupManagerOfJoinRequest(
+                {
+                  email: recipient.email,
+                  contact_name:
+                    [recipient.firstName, recipient.lastName]
+                      .filter(Boolean)
+                      .join(" ") || recipient.email,
+                  requester_name: requesterName,
+                  requester_email: user.email,
+                  entity_title: group.grp_title,
+                  request_id: createdAccessRequest._id,
+                  tenant,
+                },
+                next,
+              ),
+            ),
+          ]);
+
+        const managerEmailFailures = managerEmailResults.filter(
+          (r) => r.status === "rejected" || r.value?.success === false,
+        );
+        if (managerEmailFailures.length > 0) {
+          logger.error(
+            `Non-critical: ${managerEmailFailures.length}/${recipients.length} group-manager notification(s) failed for group ${grp_id}`,
+          );
+        }
+
+        const responseFromSendEmail =
+          requesterEmailResult.status === "fulfilled"
+            ? requesterEmailResult.value
+            : { success: false, message: requesterEmailResult.reason?.message };
 
         if (responseFromSendEmail.success === true) {
           return {
@@ -157,7 +203,15 @@ const createAccessRequest = {
 
   requestAccessToGroupByEmail: async (request, next) => {
     try {
-      const { tenant, emails, user, grp_id } = {
+      const {
+        tenant,
+        emails,
+        invitations,
+        auto_approve,
+        expiry_hours,
+        user,
+        grp_id,
+      } = {
         ...request,
         ...request.body,
         ...request.query,
@@ -227,36 +281,71 @@ const createAccessRequest = {
         return;
       }
 
-      if (!emails || !Array.isArray(emails) || emails.length === 0) {
+      // Accept either the plain `emails: string[]` contract (used by Nexus's
+      // "invite by email" flow) or the richer `invitations: [{email,
+      // role_id, message}]` contract (used by manager-initiated invites that
+      // want to pre-assign a role and/or auto-approve).
+      const rawInvitationEntries = [];
+      if (Array.isArray(emails)) {
+        emails.forEach((email) => rawInvitationEntries.push({ email }));
+      }
+      if (Array.isArray(invitations)) {
+        invitations.forEach((invitation) =>
+          rawInvitationEntries.push({
+            email: invitation?.email,
+            role_id: invitation?.role_id,
+            message: invitation?.message,
+          }),
+        );
+      }
+
+      if (rawInvitationEntries.length === 0) {
         next(
           new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
-            message: "Emails array is required and must not be empty",
+            message:
+              "Either 'emails' or 'invitations' is required and must not be empty",
           }),
         );
         return;
       }
 
-      const invalidEmails = emails.filter(
-        (email) => !email || typeof email !== "string" || !email.includes("@"),
+      const invalidEmails = rawInvitationEntries.filter(
+        (entry) =>
+          !entry.email ||
+          typeof entry.email !== "string" ||
+          !entry.email.includes("@"),
       );
       if (invalidEmails.length > 0) {
         next(
           new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
-            message: `Invalid email formats: ${invalidEmails.join(", ")}`,
+            message: `Invalid email formats: ${invalidEmails
+              .map((entry) => entry.email)
+              .join(", ")}`,
           }),
         );
         return;
       }
 
-      const uniqueEmails = [
-        ...new Set(emails.map((email) => email.toLowerCase())),
-      ];
-      if (uniqueEmails.length !== emails.length) {
+      // Dedup by lowercased email — first occurrence wins for role_id/message.
+      const invitationDetailsByEmail = new Map();
+      rawInvitationEntries.forEach((entry) => {
+        const normalizedEmail = entry.email.toLowerCase();
+        if (!invitationDetailsByEmail.has(normalizedEmail)) {
+          invitationDetailsByEmail.set(normalizedEmail, {
+            role_id: entry.role_id,
+            message: entry.message,
+          });
+        }
+      });
+      const uniqueEmails = [...invitationDetailsByEmail.keys()];
+      if (uniqueEmails.length !== rawInvitationEntries.length) {
         logger.warn("Duplicate emails found in invitation request", {
-          emails,
-          uniqueEmails,
+          rawCount: rawInvitationEntries.length,
+          uniqueCount: uniqueEmails.length,
         });
       }
+
+      const shouldAutoApprove = auto_approve === true || auto_approve === "true";
 
       const existingUsers = await UserModel(tenant)
         .find({ email: { $in: uniqueEmails } })
@@ -279,7 +368,8 @@ const createAccessRequest = {
         existingPendingRequests.map((req) => [req.email.toLowerCase(), req]),
       );
 
-      const INVITATION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+      const expiryHours = Number(expiry_hours) || 168; // default: 7 days, matches prior fixed expiry
+      const INVITATION_EXPIRY_MS = expiryHours * 60 * 60 * 1000;
 
       const existingRequests = [];
       const successResponses = [];
@@ -314,6 +404,8 @@ const createAccessRequest = {
 
           const invitationToken = crypto.randomBytes(32).toString("hex");
           const expiryDate = new Date(Date.now() + INVITATION_EXPIRY_MS);
+          const { role_id, message } =
+            invitationDetailsByEmail.get(normalizedEmail) || {};
 
           const accessRequestData = {
             email: normalizedEmail,
@@ -327,6 +419,13 @@ const createAccessRequest = {
             invitationTokenExpires: expiryDate,
           };
 
+          if (role_id) {
+            accessRequestData.role_id = role_id;
+          }
+          if (message) {
+            accessRequestData.message = message;
+          }
+
           if (existingUser) {
             accessRequestData.user_id = existingUser._id;
           }
@@ -339,6 +438,50 @@ const createAccessRequest = {
             const createdAccessRequest = responseFromCreateAccessRequest.data;
 
             const userExists = !!existingUser;
+
+            if (shouldAutoApprove && existingUser) {
+              try {
+                let autoApproveResult;
+                if (role_id) {
+                  const roleDoc = await RoleModel(tenant)
+                    .findOne({ _id: role_id, group_id: grp_id })
+                    .lean();
+                  if (!roleDoc) {
+                    logger.error(
+                      `Auto-approve skipped for ${email}: role_id ${role_id} does not belong to group ${grp_id}`,
+                    );
+                  } else {
+                    autoApproveResult = await UserModel(
+                      tenant,
+                    ).assignUserToGroup(existingUser._id, grp_id, role_id, "user");
+                  }
+                } else {
+                  autoApproveResult = await createGroupUtil.assignOneUser(
+                    {
+                      params: { grp_id, user_id: existingUser._id },
+                      query: { tenant },
+                    },
+                    next,
+                  );
+                }
+
+                if (autoApproveResult && autoApproveResult.success) {
+                  await AccessRequestModel(tenant).modify({
+                    filter: { _id: createdAccessRequest._id },
+                    update: { status: "approved" },
+                  });
+                  createdAccessRequest.status = "approved";
+                } else if (autoApproveResult) {
+                  logger.error(
+                    `Auto-approve failed for ${email} in group ${grp_id}: ${autoApproveResult.message}`,
+                  );
+                }
+              } catch (autoApproveError) {
+                logger.error(
+                  `Auto-approve error for ${email} in group ${grp_id}: ${autoApproveError.message}`,
+                );
+              }
+            }
 
             const responseFromSendEmail =
               await mailer.requestToJoinGroupByEmail(
@@ -414,7 +557,7 @@ const createAccessRequest = {
 
       const responseData = {
         summary: {
-          total_emails: emails.length,
+          total_emails: rawInvitationEntries.length,
           unique_emails: uniqueEmails.length,
           successful_invitations: successCount,
           failed_invitations: failureCount,

--- a/src/auth-service/utils/request.util.js
+++ b/src/auth-service/utils/request.util.js
@@ -5,6 +5,7 @@ const AccessRequestModel = require("@models/AccessRequest");
 const GroupModel = require("@models/Group");
 const NetworkModel = require("@models/Network");
 const isEmpty = require("is-empty");
+const validator = require("validator");
 const httpStatus = require("http-status");
 const constants = require("@config/constants");
 const { mailer, generateFilter } = require("@utils/common");
@@ -109,10 +110,17 @@ const createAccessRequest = {
           );
           return;
         }
-        const recipients = await createGroupUtil.getGroupManagementRecipients(
-          tenant,
-          grp_id,
-        );
+        let recipients = [];
+        try {
+          recipients = await createGroupUtil.getGroupManagementRecipients(
+            tenant,
+            grp_id,
+          );
+        } catch (recipientsError) {
+          logger.error(
+            `Failed to resolve group management recipients for group ${grp_id}: ${recipientsError.message}`,
+          );
+        }
         if (recipients.length === 0) {
           logger.warn(
             `No group manager/admin found to notify for join request to group ${grp_id}`,
@@ -120,34 +128,35 @@ const createAccessRequest = {
         }
         const requesterName = `${firstName} ${lastName}`;
 
+        // Note: no `next` passed to these mailer calls — they run inside
+        // Promise.allSettled as non-critical, best-effort notifications, and
+        // createMailerFunction's own next(error)-then-return behavior would
+        // otherwise resolve (not reject) with `undefined`, and could also
+        // attempt to write to the outer HTTP response from within what's
+        // meant to be a background operation. Omitting next makes failures
+        // throw and be captured cleanly as "rejected" instead.
         const [requesterEmailResult, ...managerEmailResults] =
           await Promise.allSettled([
-            mailer.request(
-              {
-                firstName,
-                lastName,
-                email: user.email,
-                tenant,
-                entity_title: group.grp_title,
-              },
-              next,
-            ),
+            mailer.request({
+              firstName,
+              lastName,
+              email: user.email,
+              tenant,
+              entity_title: group.grp_title,
+            }),
             ...recipients.map((recipient) =>
-              mailer.notifyGroupManagerOfJoinRequest(
-                {
-                  email: recipient.email,
-                  contact_name:
-                    [recipient.firstName, recipient.lastName]
-                      .filter(Boolean)
-                      .join(" ") || recipient.email,
-                  requester_name: requesterName,
-                  requester_email: user.email,
-                  entity_title: group.grp_title,
-                  request_id: createdAccessRequest._id,
-                  tenant,
-                },
-                next,
-              ),
+              mailer.notifyGroupManagerOfJoinRequest({
+                email: recipient.email,
+                contact_name:
+                  [recipient.firstName, recipient.lastName]
+                    .filter(Boolean)
+                    .join(" ") || recipient.email,
+                requester_name: requesterName,
+                requester_email: user.email,
+                entity_title: group.grp_title,
+                request_id: createdAccessRequest._id,
+                tenant,
+              }),
             ),
           ]);
 
@@ -313,7 +322,7 @@ const createAccessRequest = {
         (entry) =>
           !entry.email ||
           typeof entry.email !== "string" ||
-          !entry.email.includes("@"),
+          !validator.isEmail(entry.email),
       );
       if (invalidEmails.length > 0) {
         next(
@@ -368,7 +377,23 @@ const createAccessRequest = {
         existingPendingRequests.map((req) => [req.email.toLowerCase(), req]),
       );
 
-      const expiryHours = Number(expiry_hours) || 168; // default: 7 days, matches prior fixed expiry
+      let expiryHours = 168; // default: 7 days, matches prior fixed expiry
+      if (expiry_hours !== undefined && expiry_hours !== null) {
+        const parsedExpiryHours = Number(expiry_hours);
+        if (
+          !Number.isFinite(parsedExpiryHours) ||
+          parsedExpiryHours < 1 ||
+          parsedExpiryHours > 8760
+        ) {
+          next(
+            new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+              message: "expiry_hours must be between 1 and 8760 (1 year)",
+            }),
+          );
+          return;
+        }
+        expiryHours = parsedExpiryHours;
+      }
       const INVITATION_EXPIRY_MS = expiryHours * 60 * 60 * 1000;
 
       const existingRequests = [];
@@ -448,7 +473,7 @@ const createAccessRequest = {
                     .lean();
                   if (!roleDoc) {
                     logger.error(
-                      `Auto-approve skipped for ${email}: role_id ${role_id} does not belong to group ${grp_id}`,
+                      `Auto-approve skipped for user ${existingUser._id}: role_id ${role_id} does not belong to group ${grp_id}`,
                     );
                   } else {
                     autoApproveResult = await UserModel(
@@ -456,13 +481,15 @@ const createAccessRequest = {
                     ).assignUserToGroup(existingUser._id, grp_id, role_id, "user");
                   }
                 } else {
-                  autoApproveResult = await createGroupUtil.assignOneUser(
-                    {
-                      params: { grp_id, user_id: existingUser._id },
-                      query: { tenant },
-                    },
-                    next,
-                  );
+                  // No `next` passed here — a caught rejection below is the
+                  // correct outcome for a per-recipient, best-effort
+                  // auto-approve step; assignOneUser's failure branches call
+                  // next(error) unconditionally, which would otherwise reach
+                  // into the outer HTTP response from inside this loop.
+                  autoApproveResult = await createGroupUtil.assignOneUser({
+                    params: { grp_id, user_id: existingUser._id },
+                    query: { tenant },
+                  });
                 }
 
                 if (autoApproveResult && autoApproveResult.success) {
@@ -473,12 +500,12 @@ const createAccessRequest = {
                   createdAccessRequest.status = "approved";
                 } else if (autoApproveResult) {
                   logger.error(
-                    `Auto-approve failed for ${email} in group ${grp_id}: ${autoApproveResult.message}`,
+                    `Auto-approve failed for user ${existingUser._id} in group ${grp_id}: ${autoApproveResult.message}`,
                   );
                 }
               } catch (autoApproveError) {
                 logger.error(
-                  `Auto-approve error for ${email} in group ${grp_id}: ${autoApproveError.message}`,
+                  `Auto-approve error for user ${existingUser._id} in group ${grp_id}: ${autoApproveError.message}`,
                 );
               }
             }

--- a/src/auth-service/utils/request.util.js
+++ b/src/auth-service/utils/request.util.js
@@ -17,7 +17,43 @@ const logger = require("log4js").getLogger(
 const createNetworkUtil = require("@utils/network.util");
 const createGroupUtil = require("@utils/group.util");
 const RoleModel = require("@models/Role");
+const RBACService = require("@services/rbac.service");
 const { logObject, HttpError, logText } = require("@utils/shared");
+
+// Mirrors middleware/groupNetworkAuth.js's requireGroupManagerAccess — used
+// where a group-manager-level check is needed from inside a util function
+// rather than as route middleware (e.g. gating auto-approve below).
+const isGroupManagerOrAdmin = async (tenant, userId, groupId) => {
+  const rbacService = RBACService.getInstance(
+    tenant || constants.DEFAULT_TENANT,
+  );
+  const isSystemSuperAdmin = await rbacService.isSystemSuperAdmin(userId);
+  if (isSystemSuperAdmin) {
+    return true;
+  }
+  const [isGroupManager, hasManagerPermissions, hasManagerRole] =
+    await Promise.all([
+      rbacService.isGroupManager(userId, groupId),
+      rbacService.hasPermission(
+        userId,
+        [
+          constants.GROUP_MANAGEMENT,
+          constants.USER_MANAGEMENT,
+          constants.GROUP_SETTINGS,
+        ],
+        false,
+        groupId,
+        "group",
+      ),
+      rbacService.hasRole(
+        userId,
+        ["SUPER_ADMIN", "ADMIN", "MANAGER"],
+        groupId,
+        "group",
+      ),
+    ]);
+  return isGroupManager || hasManagerPermissions || hasManagerRole;
+};
 
 const createAccessRequest = {
   requestAccessToGroup: async (request, next) => {
@@ -355,6 +391,26 @@ const createAccessRequest = {
       }
 
       const shouldAutoApprove = auto_approve === true || auto_approve === "true";
+
+      if (shouldAutoApprove) {
+        const canAutoApprove = await isGroupManagerOrAdmin(
+          tenant,
+          inviterId,
+          grp_id,
+        );
+        if (!canAutoApprove) {
+          logger.warn(
+            `User ${inviterId} attempted to auto-approve invitations to group ${grp_id} without manager/admin rights`,
+          );
+          next(
+            new HttpError("Forbidden", httpStatus.FORBIDDEN, {
+              message:
+                "Only a group manager or admin can auto-approve invitations",
+            }),
+          );
+          return;
+        }
+      }
 
       const existingUsers = await UserModel(tenant)
         .find({ email: { $in: uniqueEmails } })

--- a/src/auth-service/utils/test/ut_request.util.js
+++ b/src/auth-service/utils/test/ut_request.util.js
@@ -457,7 +457,7 @@ describe("createAccessRequest Util", () => {
 
     it("should validate role_id and auto-approve an existing user via the invitations[] contract", async () => {
       const next = sinon.stub();
-      const roleId = "role_id_123";
+      const roleId = "60d21b4667d0d8992e610c87";
       const existingUser = {
         _id: "existing_user_id",
         email: "existing@example.com",

--- a/src/auth-service/utils/test/ut_request.util.js
+++ b/src/auth-service/utils/test/ut_request.util.js
@@ -400,11 +400,16 @@ describe("createAccessRequest Util", () => {
       group_roles: [{ group: grp_id }],
     };
 
+    let origIsGroupManagerOrAdmin;
+
     beforeEach(() => {
       origGroupModel = rewireAccessRequest.__get__("GroupModel");
       origUserModel = rewireAccessRequest.__get__("UserModel");
       origAccessRequestModel = rewireAccessRequest.__get__("AccessRequestModel");
       origRoleModel = rewireAccessRequest.__get__("RoleModel");
+      origIsGroupManagerOrAdmin = rewireAccessRequest.__get__(
+        "isGroupManagerOrAdmin",
+      );
     });
 
     afterEach(() => {
@@ -412,6 +417,10 @@ describe("createAccessRequest Util", () => {
       rewireAccessRequest.__set__("UserModel", origUserModel);
       rewireAccessRequest.__set__("AccessRequestModel", origAccessRequestModel);
       rewireAccessRequest.__set__("RoleModel", origRoleModel);
+      rewireAccessRequest.__set__(
+        "isGroupManagerOrAdmin",
+        origIsGroupManagerOrAdmin,
+      );
       sinon.restore();
     });
 
@@ -488,6 +497,10 @@ describe("createAccessRequest Util", () => {
           lean: sinon.stub().resolves({ _id: roleId, group_id: grp_id }),
         }),
       }));
+      rewireAccessRequest.__set__(
+        "isGroupManagerOrAdmin",
+        sinon.stub().resolves(true),
+      );
       sinon
         .stub(mailer, "requestToJoinGroupByEmail")
         .resolves({ success: true, status: httpStatus.OK });
@@ -520,6 +533,41 @@ describe("createAccessRequest Util", () => {
         status: "approved",
       });
       sinon.assert.notCalled(next);
+    });
+
+    it("should reject auto_approve with 403 when the inviter is not a group manager/admin", async () => {
+      const next = sinon.stub();
+
+      rewireAccessRequest.__set__("GroupModel", () => ({
+        findById: sinon.stub().returns({ lean: sinon.stub().resolves(groupDoc) }),
+      }));
+      rewireAccessRequest.__set__("UserModel", () => ({
+        findById: sinon.stub().returns({ lean: sinon.stub().resolves(inviterDetails) }),
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+      }));
+      rewireAccessRequest.__set__("AccessRequestModel", () => ({
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+      }));
+      rewireAccessRequest.__set__(
+        "isGroupManagerOrAdmin",
+        sinon.stub().resolves(false),
+      );
+
+      const request = {
+        params: { grp_id },
+        query: { tenant },
+        body: {
+          invitations: [{ email: "someone@example.com" }],
+          auto_approve: true,
+        },
+        user: inviter,
+      };
+
+      await rewireAccessRequest.requestAccessToGroupByEmail(request, next);
+
+      sinon.assert.calledOnce(next);
+      const err = next.firstCall.args[0];
+      expect(err.statusCode).to.equal(httpStatus.FORBIDDEN);
     });
   });
 

--- a/src/auth-service/utils/test/ut_request.util.js
+++ b/src/auth-service/utils/test/ut_request.util.js
@@ -68,6 +68,9 @@ describe("createAccessRequest Util", () => {
         register: registerStub,
       }));
       sinon.stub(mailer, "request").resolves({ success: true, status: httpStatus.OK });
+      sinon
+        .stub(createGroupUtil, "getGroupManagementRecipients")
+        .resolves([]);
 
       requestMock.query.tenant = tenant;
       requestMock.params.grp_id = groupId;
@@ -78,6 +81,47 @@ describe("createAccessRequest Util", () => {
       expect(response.status).to.equal(httpStatus.OK);
       expect(response.message).to.equal("Access Request completed successfully");
       sinon.assert.notCalled(next);
+    });
+
+    it("should notify group manager/admin recipients when a join request is created", async () => {
+      const tenant = "test_tenant";
+      const groupId = "test_group_id";
+      const groupTitle = "Test Group";
+      const next = sinon.stub();
+
+      const findByIdStub = sinon.stub().resolves({ _id: groupId, grp_title: groupTitle });
+      const userFindByIdStub = sinon.stub().returns({
+        lean: sinon.stub().resolves(null),
+      });
+      const findOneStub = sinon.stub().resolves(null);
+      const registerStub = sinon
+        .stub()
+        .resolves({ success: true, data: { _id: "access_request_id" } });
+
+      rewireAccessRequest.__set__("GroupModel", () => ({ findById: findByIdStub }));
+      rewireAccessRequest.__set__("UserModel", () => ({ findById: userFindByIdStub }));
+      rewireAccessRequest.__set__("AccessRequestModel", () => ({
+        findOne: findOneStub,
+        register: registerStub,
+      }));
+      sinon.stub(mailer, "request").resolves({ success: true, status: httpStatus.OK });
+      const notifyManagerStub = sinon
+        .stub(mailer, "notifyGroupManagerOfJoinRequest")
+        .resolves({ success: true, status: httpStatus.OK });
+      sinon.stub(createGroupUtil, "getGroupManagementRecipients").resolves([
+        { email: "manager@example.com", firstName: "Jane", lastName: "Manager" },
+      ]);
+
+      requestMock.query.tenant = tenant;
+      requestMock.params.grp_id = groupId;
+
+      const response = await rewireAccessRequest.requestAccessToGroup(requestMock, next);
+
+      expect(response.success).to.equal(true);
+      sinon.assert.calledOnce(notifyManagerStub);
+      const notifyArgs = notifyManagerStub.firstCall.args[0];
+      expect(notifyArgs.email).to.equal("manager@example.com");
+      expect(notifyArgs.entity_title).to.equal(groupTitle);
     });
 
     it("should handle the case where the group does not exist", async () => {
@@ -330,6 +374,152 @@ describe("createAccessRequest Util", () => {
       // Implementation returns value (not calls next) for email-missing case
       expect(response.success).to.equal(false);
       expect(response.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe("requestAccessToGroupByEmail()", () => {
+    let origGroupModel;
+    let origUserModel;
+    let origAccessRequestModel;
+    let origRoleModel;
+
+    const grp_id = "60d21b4667d0d8992e610c85";
+    const tenant = "test_tenant";
+    const inviterId = "60d21b4667d0d8992e610c86";
+    const inviter = { _id: inviterId, email: "inviter@example.com" };
+    const groupDoc = {
+      _id: grp_id,
+      grp_title: "Test Group",
+      grp_manager: null,
+      grp_description: "desc",
+    };
+    const inviterDetails = {
+      _id: inviterId,
+      firstName: "Jane",
+      lastName: "Doe",
+      group_roles: [{ group: grp_id }],
+    };
+
+    beforeEach(() => {
+      origGroupModel = rewireAccessRequest.__get__("GroupModel");
+      origUserModel = rewireAccessRequest.__get__("UserModel");
+      origAccessRequestModel = rewireAccessRequest.__get__("AccessRequestModel");
+      origRoleModel = rewireAccessRequest.__get__("RoleModel");
+    });
+
+    afterEach(() => {
+      rewireAccessRequest.__set__("GroupModel", origGroupModel);
+      rewireAccessRequest.__set__("UserModel", origUserModel);
+      rewireAccessRequest.__set__("AccessRequestModel", origAccessRequestModel);
+      rewireAccessRequest.__set__("RoleModel", origRoleModel);
+      sinon.restore();
+    });
+
+    it("should invite via the legacy emails[] contract", async () => {
+      const next = sinon.stub();
+
+      rewireAccessRequest.__set__("GroupModel", () => ({
+        findById: sinon.stub().returns({ lean: sinon.stub().resolves(groupDoc) }),
+      }));
+      rewireAccessRequest.__set__("UserModel", () => ({
+        findById: sinon.stub().returns({ lean: sinon.stub().resolves(inviterDetails) }),
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+      }));
+      rewireAccessRequest.__set__("AccessRequestModel", () => ({
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+        register: sinon
+          .stub()
+          .resolves({ success: true, data: { _id: "access_request_1" } }),
+      }));
+      sinon
+        .stub(mailer, "requestToJoinGroupByEmail")
+        .resolves({ success: true, status: httpStatus.OK });
+
+      const request = {
+        params: { grp_id },
+        query: { tenant },
+        body: { emails: ["invitee@example.com"] },
+        user: inviter,
+      };
+
+      const response = await rewireAccessRequest.requestAccessToGroupByEmail(
+        request,
+        next,
+      );
+
+      expect(response.success).to.equal(true);
+      expect(response.data.summary.successful_invitations).to.equal(1);
+      expect(response.data.results.successful[0].email).to.equal(
+        "invitee@example.com",
+      );
+      sinon.assert.notCalled(next);
+    });
+
+    it("should validate role_id and auto-approve an existing user via the invitations[] contract", async () => {
+      const next = sinon.stub();
+      const roleId = "role_id_123";
+      const existingUser = {
+        _id: "existing_user_id",
+        email: "existing@example.com",
+        group_roles: [],
+      };
+
+      rewireAccessRequest.__set__("GroupModel", () => ({
+        findById: sinon.stub().returns({ lean: sinon.stub().resolves(groupDoc) }),
+      }));
+      const assignUserToGroupStub = sinon
+        .stub()
+        .resolves({ success: true, data: {} });
+      rewireAccessRequest.__set__("UserModel", () => ({
+        findById: sinon.stub().returns({ lean: sinon.stub().resolves(inviterDetails) }),
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([existingUser]) }),
+        assignUserToGroup: assignUserToGroupStub,
+      }));
+      const modifyStub = sinon.stub().resolves({ success: true, data: {} });
+      rewireAccessRequest.__set__("AccessRequestModel", () => ({
+        find: sinon.stub().returns({ lean: sinon.stub().resolves([]) }),
+        register: sinon
+          .stub()
+          .resolves({ success: true, data: { _id: "access_request_2" } }),
+        modify: modifyStub,
+      }));
+      rewireAccessRequest.__set__("RoleModel", () => ({
+        findOne: sinon.stub().returns({
+          lean: sinon.stub().resolves({ _id: roleId, group_id: grp_id }),
+        }),
+      }));
+      sinon
+        .stub(mailer, "requestToJoinGroupByEmail")
+        .resolves({ success: true, status: httpStatus.OK });
+
+      const request = {
+        params: { grp_id },
+        query: { tenant },
+        body: {
+          invitations: [{ email: existingUser.email, role_id: roleId }],
+          auto_approve: true,
+        },
+        user: inviter,
+      };
+
+      const response = await rewireAccessRequest.requestAccessToGroupByEmail(
+        request,
+        next,
+      );
+
+      expect(response.success).to.equal(true);
+      sinon.assert.calledOnceWithExactly(
+        assignUserToGroupStub,
+        existingUser._id,
+        grp_id,
+        roleId,
+        "user",
+      );
+      sinon.assert.calledOnce(modifyStub);
+      expect(modifyStub.firstCall.args[0].update).to.deep.equal({
+        status: "approved",
+      });
+      sinon.assert.notCalled(next);
     });
   });
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
- Adds an authorization check to the access-request approve/reject endpoints, closing a gap where any authenticated user could approve or reject any group's join requests.
- Consolidates two inconsistent group-invite implementations into a single canonical path, fixing a schema bug that was silently dropping role/message fields on one of them.
- Notifies a group's manager/admins by email when someone requests to join, in addition to the existing requester confirmation.
- Adds a `GET /groups/discover` endpoint so a user with no existing group membership can browse groups to request to join.
- Adds a stable `debugCode` to the "manager must transfer ownership before leaving" error response.

### Why is this change needed?
There is currently no supported self-service path for a person to join a group. A recent real case required manually granting someone super admin as a workaround, and it still didn't work, because super admin status doesn't add a user to a group's membership and no frontend surface exposed the actual add/invite/join actions. This PR is the backend half of streamlining that flow so members can be added, removed, and group ownership transferred without ad hoc workarounds.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [x] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added new unit test coverage for the consolidated invite function (both the legacy `emails[]` contract and the new `invitations[]` + `auto_approve` contract) and for the group-manager notification path on self-join requests. Ran the full relevant test suites (request utils, group utils, group controller, request controller, request routes) — all passing, no regressions introduced. One unrelated, pre-existing broken test file was confirmed via `git stash` to predate this change and was left untouched.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`POST /groups/:grp_id/invitations` (previously unused by any frontend) now returns the same response shape as `POST /requests/emails/groups/:grp_id`, since both now share one implementation.

---

## :memo: Additional Notes
Approve/reject authorization currently covers group-type access requests only. Network-type access requests return a clear "not supported" response for now, rather than building out new network-manager authorization in this pass — scoped this way intentionally to keep the change focused.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated group discovery with active-group filtering and summary results.
  - Invitations now support roles, messages, and custom expiration periods.
  - Group join requests notify managers and administrators by email.
  - Added authorization protections for approving and rejecting access requests.

- **Improvements**
  - Enhanced invitation validation, duplicate handling, and optional auto-approval for existing members.
  - Added optional roles and messages to access requests.
  - Improved group invitation and access-request response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->