### PR TITLE
Add check-email endpoint for two-step login flow

### DIFF
--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -840,6 +840,23 @@ const userController = {
       handleError(error, next);
     }
   },
+  checkEmail: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+      const { email } = request.body;
+      const { tenant } = request.query;
+      const result = await userUtil.checkEmailExists({ email, tenant });
+
+      res.status(httpStatus.OK).json({
+        success: true,
+        exists: result.exists,
+        ...(result.exists ? { authMethods: result.authMethods } : {}),
+      });
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
   resetPassword: async (req, res, next) => {
     try {
       const errors = extractErrorsFromRequest(req);

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -602,6 +602,13 @@ router.post(
 );
 
 router.post(
+  "/check-email",
+  rateLimiter.login,
+  userValidations.checkEmail,
+  userController.checkEmail,
+);
+
+router.post(
   "/setPassword",
   enhancedJWTAuth,
   userValidations.setPassword,

--- a/src/auth-service/routes/v3/users.routes.js
+++ b/src/auth-service/routes/v3/users.routes.js
@@ -478,6 +478,13 @@ router.post(
 );
 
 router.post(
+  "/check-email",
+  rateLimiter.login,
+  userValidations.checkEmail,
+  userController.checkEmail
+);
+
+router.post(
   "/reset-password/:token",
   userValidations.resetPassword,
   userController.resetPassword

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -1163,6 +1163,75 @@ describe("create-user-util", function () {
     // Add more test cases to cover other scenarios
     // For example, when generating the reset token fails, when modifying the user fails, etc.
   });
+  describe("checkEmailExists", () => {
+    let origUserModel;
+    let findOneStub;
+    let selectStub;
+    let leanStub;
+
+    beforeEach(() => {
+      leanStub = sinon.stub();
+      selectStub = sinon.stub().returns({ lean: leanStub });
+      findOneStub = sinon.stub().returns({ select: selectStub });
+      origUserModel = rewireCreateUser.__get__("UserModel");
+      rewireCreateUser.__set__("UserModel", () => ({
+        findOne: findOneStub,
+      }));
+    });
+
+    afterEach(() => {
+      rewireCreateUser.__set__("UserModel", origUserModel);
+      sinon.restore();
+    });
+
+    it("should return exists:false when no account matches the email", async () => {
+      leanStub.resolves(null);
+
+      const response = await rewireCreateUser.checkEmailExists({
+        email: "unknown@example.com",
+        tenant: "airqo",
+      });
+
+      expect(response.success).to.equal(true);
+      expect(response.exists).to.equal(false);
+      expect(response).to.not.have.property("authMethods");
+      sinon.assert.calledWith(findOneStub, { email: "unknown@example.com" });
+    });
+
+    it("should return exists:true with authMethods when an account matches", async () => {
+      leanStub.resolves({
+        _id: "user_id",
+        password: "hashed",
+        hasSetPassword: true,
+        google_id: "google123",
+      });
+
+      const response = await rewireCreateUser.checkEmailExists({
+        email: "known@example.com",
+        tenant: "airqo",
+      });
+
+      expect(response.success).to.equal(true);
+      expect(response.exists).to.equal(true);
+      expect(response.authMethods.password).to.equal(true);
+      expect(response.authMethods.google).to.equal(true);
+      expect(response.authMethods.github).to.equal(false);
+    });
+
+    it("should throw an HttpError on a database failure", async () => {
+      leanStub.rejects(new Error("connection lost"));
+
+      try {
+        await rewireCreateUser.checkEmailExists({
+          email: "known@example.com",
+          tenant: "airqo",
+        });
+        expect.fail("should have thrown");
+      } catch (error) {
+        expect(error.statusCode).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+      }
+    });
+  });
   describe("updateForgottenPassword", () => {
     let origUserModel;
     let findOneAndUpdateStub;

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -1198,6 +1198,17 @@ describe("create-user-util", function () {
       sinon.assert.calledWith(findOneStub, { email: "unknown@example.com" });
     });
 
+    it("should normalize the email (lowercase + trim) before querying", async () => {
+      leanStub.resolves(null);
+
+      await rewireCreateUser.checkEmailExists({
+        email: "  Known@Example.COM  ",
+        tenant: "airqo",
+      });
+
+      sinon.assert.calledWith(findOneStub, { email: "known@example.com" });
+    });
+
     it("should return exists:true with authMethods when an account matches", async () => {
       leanStub.resolves({
         _id: "user_id",

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -4999,6 +4999,40 @@ const createUserModule = {
     }
   },
 
+  // Supports a two-step login flow (email first, then password/SSO based on
+  // the response). Unlike initiatePasswordReset, this intentionally reveals
+  // account existence — that's the point of the feature — mitigated by
+  // rate limiting at the route layer rather than a generic response here.
+  checkEmailExists: async ({ email, tenant }) => {
+    try {
+      const user = await UserModel(tenant)
+        .findOne({ email })
+        .select(
+          "password hasSetPassword google_id github_id linkedin_id microsoft_id twitter_id facebook_id apple_id",
+        )
+        .lean();
+
+      if (!user) {
+        return { success: true, exists: false };
+      }
+
+      return {
+        success: true,
+        exists: true,
+        authMethods: buildAuthMethods(user),
+      };
+    } catch (error) {
+      logger.error(
+        `🐛🐛 Internal Server Error in checkEmailExists: ${error.message}`,
+      );
+      throw new HttpError(
+        "Unable to check email",
+        httpStatus.INTERNAL_SERVER_ERROR,
+        { message: error.message },
+      );
+    }
+  },
+
   setPassword: async (request, next) => {
     try {
       const { password, confirmPassword } = request.body;

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -5005,8 +5005,9 @@ const createUserModule = {
   // rate limiting at the route layer rather than a generic response here.
   checkEmailExists: async ({ email, tenant }) => {
     try {
+      const normalizedEmail = (email || "").toLowerCase().trim();
       const user = await UserModel(tenant)
-        .findOne({ email })
+        .findOne({ email: normalizedEmail })
         .select(
           "password hasSetPassword google_id github_id linkedin_id microsoft_id twitter_id facebook_id apple_id",
         )
@@ -5028,7 +5029,7 @@ const createUserModule = {
       throw new HttpError(
         "Unable to check email",
         httpStatus.INTERNAL_SERVER_ERROR,
-        { message: error.message },
+        { message: "An internal error occurred while checking the email." },
       );
     }
   },

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1122,6 +1122,15 @@ const resetPasswordRequest = [
   //Potentially add tenant validation here as well, using the oneOf approach if necessary
 ];
 
+const checkEmail = [
+  body("email")
+    .exists()
+    .withMessage("Email is required")
+    .isEmail()
+    .withMessage("Invalid email format")
+    .trim(),
+];
+
 const setPassword = [
   body("password")
     .exists()
@@ -2016,6 +2025,7 @@ module.exports = {
   getUser,
   getEnhancedProfileForUser,
   resetPasswordRequest,
+  checkEmail,
   resetPassword,
   setPassword,
   verifyMobileEmail,

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1126,9 +1126,9 @@ const checkEmail = [
   body("email")
     .exists()
     .withMessage("Email is required")
+    .trim()
     .isEmail()
-    .withMessage("Invalid email format")
-    .trim(),
+    .withMessage("Invalid email format"),
 ];
 
 const setPassword = [


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a new `POST /users/check-email` endpoint (available on both v2 and v3) that lets the frontend check whether an account already exists for a given email — and, if it does, which auth methods are available (password, Google, GitHub, etc.) — before deciding what to show next.

### Why is this change needed?
Nexus wants the standard two-step login pattern: user enters their email first, the app checks if the account exists, then shows the password field (or an SSO prompt) accordingly. None of the current login endpoints support this — they all require email and password together in a single request, and no existing endpoint can answer "does this account exist" on its own.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `auth-service`

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added unit test coverage for the new `checkEmailExists` function covering the exists/doesn't-exist/database-failure paths. Ran the full relevant test suites — all passing, no regressions. One set of pre-existing, unrelated failures in the v2 users route test file was confirmed via `git stash` to predate this change.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely additive — a new endpoint only, no changes to any existing login endpoint's contract or behavior.

---

## :memo: Additional Notes
This endpoint intentionally reveals whether an account exists for a given email — that's inherent to the two-step login pattern being requested (the same tradeoff Google, GitHub, and Slack accept for this UX). It's mitigated with the existing login rate limiter rather than a generic/non-revealing response, since hiding existence would defeat the feature. Frontend implementation (the actual two-step form) is separate work on the Nexus side.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an email-check endpoint for supported API versions.
  - Users can determine whether an account exists and view available authentication methods.
  - Email input is validated and normalized, with rate limiting applied.

- **Bug Fixes**
  - Improved handling of account lookup failures with appropriate server errors.

- **Tests**
  - Added coverage for missing accounts, password and OAuth methods, and database errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->