### PR TITLE
Add RBAC enforcement pilot for cohort device assignment

### DIFF
--- a/packages/airqo-rbac-middleware/package-lock.json
+++ b/packages/airqo-rbac-middleware/package-lock.json
@@ -1,0 +1,1577 @@
+{
+  "name": "@airqo-packages/rbac-middleware",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@airqo-packages/rbac-middleware",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.17.0"
+      },
+      "devDependencies": {
+        "chai": "^4.3.3",
+        "mocha": "^8.1.3",
+        "sinon": "^9.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/commons/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "deprecated": "Deprecated: no longer maintained and no longer used by Sinon packages. See\n  https://github.com/sinonjs/nise/issues/243 for replacement details.",
+      "dev": true
+    },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+      "dev": true,
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.0.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mocha/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nise": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
+      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "deprecated": "16.1.1",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/airqo-rbac-middleware/package.json
+++ b/packages/airqo-rbac-middleware/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@airqo-packages/rbac-middleware",
+  "version": "0.1.0",
+  "description": "Express middleware for AirQo backend services to enforce permission-based access control via auth-service's token-verify endpoint, without requiring direct database access to auth-service.",
+  "main": "src/index.js",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "test": "mocha test/**/*.test.js --exit"
+  },
+  "keywords": [
+    "airqo",
+    "rbac",
+    "permissions",
+    "middleware"
+  ],
+  "author": "AirQo",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/airqo-platform/AirQo-api.git",
+    "directory": "packages/airqo-rbac-middleware"
+  },
+  "bugs": {
+    "url": "https://github.com/airqo-platform/AirQo-api/issues"
+  },
+  "homepage": "https://github.com/airqo-platform/AirQo-api/tree/staging/packages/airqo-rbac-middleware#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "axios": "^1.17.0"
+  },
+  "devDependencies": {
+    "chai": "^4.3.3",
+    "mocha": "^8.1.3",
+    "sinon": "^9.2.4"
+  }
+}

--- a/packages/airqo-rbac-middleware/src/extractToken.js
+++ b/packages/airqo-rbac-middleware/src/extractToken.js
@@ -1,0 +1,11 @@
+/**
+ * Extract the raw API token from an Authorization header in the
+ * "JWT <token>" format (the AirQo convention — not a Bearer scheme).
+ */
+const extractToken = (req) => {
+  const auth = (req.headers && req.headers["authorization"]) || "";
+  const match = auth.match(/^JWT\s+(\S+)/i);
+  return match ? match[1] : null;
+};
+
+module.exports = { extractToken };

--- a/packages/airqo-rbac-middleware/src/index.js
+++ b/packages/airqo-rbac-middleware/src/index.js
@@ -1,0 +1,3 @@
+const { requirePermission } = require("./requirePermission");
+
+module.exports = { requirePermission };

--- a/packages/airqo-rbac-middleware/src/requirePermission.js
+++ b/packages/airqo-rbac-middleware/src/requirePermission.js
@@ -1,0 +1,142 @@
+const { extractToken } = require("./extractToken");
+const { verifyToken } = require("./verifyTokenClient");
+
+const HTTP_UNAUTHORIZED = 401;
+const HTTP_FORBIDDEN = 403;
+
+const parseBool = (value, defaultValue) => {
+  if (value === undefined || value === null || value === "") return defaultValue;
+  return String(value).toLowerCase() === "true";
+};
+
+const deny = (res, status, message, errorDetail) =>
+  res.status(status).json({
+    success: false,
+    message,
+    status,
+    errors: { message: errorDetail || message },
+  });
+
+/**
+ * requirePermission(permission, options?) => Express middleware
+ *
+ * Fails CLOSED (denies) whenever the required permission cannot be
+ * confirmed — a missing token, a rejected token, or an unreachable
+ * auth-service all result in denial. This is the opposite default of
+ * device-registry's resource-binding middleware, which fails open: that
+ * middleware protects a scoping nice-to-have, this one enforces an actual
+ * authorization boundary and must not silently grant access on failure.
+ *
+ * @param {string} permission - required permission string, e.g. "DEVICE_UPDATE"
+ * @param {object} [options]
+ * @param {string} [options.authServiceUrl] - default: process.env.AUTH_SERVICE_URL
+ * @param {string} [options.serviceJwtToken] - default: process.env.SERVICE_JWT_TOKEN
+ * @param {string} [options.killSwitchEnv] - env var name that, set to "false",
+ *   bypasses this check entirely (logged loudly). Default: "RBAC_ENFORCEMENT_ENABLED"
+ * @param {number} [options.timeoutMs] - verify call timeout. Default: 3000
+ * @param {object} [options.logger] - object with .warn()/.error(). Default: console
+ */
+const requirePermission = (permission, options = {}) => {
+  if (!permission) {
+    throw new Error(
+      "requirePermission(permission) requires a non-empty permission string"
+    );
+  }
+
+  const {
+    authServiceUrl = process.env.AUTH_SERVICE_URL,
+    serviceJwtToken = process.env.SERVICE_JWT_TOKEN,
+    killSwitchEnv = "RBAC_ENFORCEMENT_ENABLED",
+    timeoutMs = 3000,
+    logger = console,
+  } = options;
+
+  return async (req, res, next) => {
+    if (!parseBool(process.env[killSwitchEnv], true)) {
+      logger.warn(
+        `RBAC enforcement bypassed via ${killSwitchEnv}=false — path=${req.originalUrl} permission=${permission}`
+      );
+      return next();
+    }
+
+    const rawToken = extractToken(req);
+    if (!rawToken) {
+      return deny(
+        res,
+        HTTP_UNAUTHORIZED,
+        "Authentication required",
+        "Missing or malformed Authorization header"
+      );
+    }
+
+    if (!authServiceUrl) {
+      logger.error(
+        `RBAC check failed closed — authServiceUrl not configured, denying path=${req.originalUrl}`
+      );
+      return deny(
+        res,
+        HTTP_FORBIDDEN,
+        "Forbidden",
+        "Authorization service is not configured"
+      );
+    }
+
+    let verifyResult;
+    try {
+      verifyResult = await verifyToken(rawToken, req, {
+        authServiceUrl,
+        serviceJwtToken,
+        timeoutMs,
+      });
+    } catch (err) {
+      logger.error(`RBAC check failed closed — verify call threw: ${err.message}`);
+      return deny(
+        res,
+        HTTP_FORBIDDEN,
+        "Forbidden",
+        "Unable to verify authorization at this time"
+      );
+    }
+
+    if (verifyResult === null) {
+      // Network error / timeout reaching auth-service — fail CLOSED.
+      logger.error(
+        `RBAC check failed closed — auth-service unreachable, denying path=${req.originalUrl}`
+      );
+      return deny(
+        res,
+        HTTP_FORBIDDEN,
+        "Forbidden",
+        "Unable to verify authorization at this time"
+      );
+    }
+
+    if (!verifyResult.success) {
+      const status = verifyResult.status || HTTP_UNAUTHORIZED;
+      const defaultMessage = status === HTTP_FORBIDDEN ? "Forbidden" : "Unauthorized";
+      return res.status(status).json({
+        success: false,
+        message: verifyResult.message || defaultMessage,
+        status,
+        errors: verifyResult.errors || { message: verifyResult.message || defaultMessage },
+      });
+    }
+
+    const permissions = (verifyResult.data && verifyResult.data.permissions) || [];
+    if (!permissions.includes(permission)) {
+      logger.warn(
+        `RBAC denial — path=${req.originalUrl} required=${permission} userPermissions=${permissions.join(",")}`
+      );
+      return deny(
+        res,
+        HTTP_FORBIDDEN,
+        "Insufficient permissions",
+        `This action requires the '${permission}' permission`
+      );
+    }
+
+    return next();
+  };
+};
+
+module.exports = { requirePermission };

--- a/packages/airqo-rbac-middleware/src/verifyTokenClient.js
+++ b/packages/airqo-rbac-middleware/src/verifyTokenClient.js
@@ -1,0 +1,70 @@
+const axios = require("axios");
+
+const DEFAULT_TIMEOUT_MS = 3000;
+
+/**
+ * Calls auth-service's GET /api/v2/tokens/:token/verify and returns the
+ * parsed response body as-is (including its permissions data).
+ *
+ * Returns null only when the call never reached auth-service at all
+ * (network error / timeout) — the caller decides how to treat that.
+ * An explicit rejection from auth-service (invalid token, rate limited,
+ * etc.) is returned as-is so the caller can propagate its status/message.
+ *
+ * No caching: the result depends on request-context state (live rate-limit
+ * counters, per-request scope checks), so every call goes live to
+ * auth-service. Mirrors the same decision already made in device-registry's
+ * token-resource-binding.middleware.js.
+ */
+const verifyToken = async (rawToken, req, options = {}) => {
+  const {
+    authServiceUrl,
+    serviceJwtToken,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = options;
+
+  if (!authServiceUrl) {
+    throw new Error(
+      "verifyToken: authServiceUrl is required (pass explicitly or set AUTH_SERVICE_URL)"
+    );
+  }
+
+  const reqHeaders = (req && req.headers) || {};
+  const clientIp =
+    reqHeaders["x-client-ip"] ||
+    reqHeaders["x-client-original-ip"] ||
+    (req && req.ip);
+
+  // Forward only the specific headers auth-service needs for its checks —
+  // never forward all headers, to avoid leaking cookies/client material into
+  // an internal service call.
+  const headers = {
+    "x-client-ip": clientIp || "rbac-middleware-internal",
+  };
+  if (serviceJwtToken) {
+    headers["Authorization"] = `JWT ${serviceJwtToken}`;
+  }
+  if (reqHeaders["x-original-uri"]) {
+    headers["x-original-uri"] = reqHeaders["x-original-uri"];
+  }
+  if (reqHeaders["origin"]) {
+    headers["origin"] = reqHeaders["origin"];
+  }
+  if (reqHeaders["referer"]) {
+    headers["referer"] = reqHeaders["referer"];
+  }
+
+  const verifyUrl = `${authServiceUrl}/api/v2/tokens/${encodeURIComponent(rawToken)}/verify`;
+
+  try {
+    const response = await axios.get(verifyUrl, { headers, timeout: timeoutMs });
+    return response.data;
+  } catch (err) {
+    if (err.response) {
+      return err.response.data || { success: false, status: err.response.status };
+    }
+    return null;
+  }
+};
+
+module.exports = { verifyToken };

--- a/packages/airqo-rbac-middleware/test/requirePermission.test.js
+++ b/packages/airqo-rbac-middleware/test/requirePermission.test.js
@@ -1,0 +1,168 @@
+const chai = require("chai");
+const sinon = require("sinon");
+const axios = require("axios");
+const expect = chai.expect;
+
+const { requirePermission } = require("../src/requirePermission");
+
+const buildRes = () => {
+  const res = {};
+  res.status = sinon.stub().returns(res);
+  res.json = sinon.stub().returns(res);
+  return res;
+};
+
+const buildReq = (overrides = {}) => ({
+  headers: {},
+  originalUrl: "/api/v2/devices/cohorts/abc/devices",
+  ip: "127.0.0.1",
+  ...overrides,
+});
+
+describe("requirePermission middleware", () => {
+  let axiosGetStub;
+  const KILL_SWITCH_ENV = "TEST_RBAC_ENFORCEMENT_ENABLED";
+
+  beforeEach(() => {
+    axiosGetStub = sinon.stub(axios, "get");
+    delete process.env[KILL_SWITCH_ENV];
+  });
+
+  afterEach(() => {
+    axiosGetStub.restore();
+    delete process.env[KILL_SWITCH_ENV];
+  });
+
+  it("throws synchronously if no permission string is provided", () => {
+    expect(() => requirePermission()).to.throw(/non-empty permission string/);
+  });
+
+  it("returns 401 when no Authorization header is present", async () => {
+    const middleware = requirePermission("DEVICE_UPDATE", {
+      authServiceUrl: "http://auth-service.local",
+    });
+    const req = buildReq();
+    const res = buildRes();
+    const next = sinon.spy();
+
+    await middleware(req, res, next);
+
+    expect(res.status.calledWith(401)).to.be.true;
+    expect(next.called).to.be.false;
+  });
+
+  it("fails closed (403) when authServiceUrl is not configured", async () => {
+    const middleware = requirePermission("DEVICE_UPDATE", {
+      authServiceUrl: undefined,
+      logger: { warn: sinon.spy(), error: sinon.spy() },
+    });
+    const req = buildReq({ headers: { authorization: "JWT sometoken" } });
+    const res = buildRes();
+    const next = sinon.spy();
+
+    await middleware(req, res, next);
+
+    expect(res.status.calledWith(403)).to.be.true;
+    expect(next.called).to.be.false;
+  });
+
+  it("fails closed (403) when auth-service is unreachable (network error)", async () => {
+    axiosGetStub.rejects(new Error("connect ECONNREFUSED"));
+
+    const middleware = requirePermission("DEVICE_UPDATE", {
+      authServiceUrl: "http://auth-service.local",
+      logger: { warn: sinon.spy(), error: sinon.spy() },
+    });
+    const req = buildReq({ headers: { authorization: "JWT sometoken" } });
+    const res = buildRes();
+    const next = sinon.spy();
+
+    await middleware(req, res, next);
+
+    expect(res.status.calledWith(403)).to.be.true;
+    expect(next.called).to.be.false;
+  });
+
+  it("propagates auth-service's explicit rejection status/message", async () => {
+    axiosGetStub.resolves({
+      data: { success: false, status: 401, message: "Token expired" },
+    });
+
+    const middleware = requirePermission("DEVICE_UPDATE", {
+      authServiceUrl: "http://auth-service.local",
+    });
+    const req = buildReq({ headers: { authorization: "JWT sometoken" } });
+    const res = buildRes();
+    const next = sinon.spy();
+
+    await middleware(req, res, next);
+
+    expect(res.status.calledWith(401)).to.be.true;
+    expect(res.json.firstCall.args[0].message).to.equal("Token expired");
+    expect(next.called).to.be.false;
+  });
+
+  it("calls next() when the token's permissions include the required permission", async () => {
+    axiosGetStub.resolves({
+      data: {
+        success: true,
+        data: { permissions: ["DEVICE_VIEW", "DEVICE_UPDATE"] },
+      },
+    });
+
+    const middleware = requirePermission("DEVICE_UPDATE", {
+      authServiceUrl: "http://auth-service.local",
+    });
+    const req = buildReq({ headers: { authorization: "JWT sometoken" } });
+    const res = buildRes();
+    const next = sinon.spy();
+
+    await middleware(req, res, next);
+
+    expect(next.calledOnce).to.be.true;
+    expect(res.status.called).to.be.false;
+  });
+
+  it("returns 403 when the token's permissions do not include the required permission", async () => {
+    axiosGetStub.resolves({
+      data: {
+        success: true,
+        data: { permissions: ["DEVICE_VIEW"] },
+      },
+    });
+
+    const middleware = requirePermission("DEVICE_UPDATE", {
+      authServiceUrl: "http://auth-service.local",
+      logger: { warn: sinon.spy(), error: sinon.spy() },
+    });
+    const req = buildReq({ headers: { authorization: "JWT sometoken" } });
+    const res = buildRes();
+    const next = sinon.spy();
+
+    await middleware(req, res, next);
+
+    expect(res.status.calledWith(403)).to.be.true;
+    expect(next.called).to.be.false;
+  });
+
+  it("bypasses the check and logs a warning when the kill switch is set to false", async () => {
+    process.env[KILL_SWITCH_ENV] = "false";
+    const warnSpy = sinon.spy();
+
+    const middleware = requirePermission("DEVICE_UPDATE", {
+      authServiceUrl: "http://auth-service.local",
+      killSwitchEnv: KILL_SWITCH_ENV,
+      logger: { warn: warnSpy, error: sinon.spy() },
+    });
+    const req = buildReq({ headers: { authorization: "JWT sometoken" } });
+    const res = buildRes();
+    const next = sinon.spy();
+
+    await middleware(req, res, next);
+
+    expect(next.calledOnce).to.be.true;
+    expect(res.status.called).to.be.false;
+    expect(axiosGetStub.called).to.be.false;
+    expect(warnSpy.calledOnce).to.be.true;
+  });
+});

--- a/src/auth-service/utils/test/ut_token.util.js
+++ b/src/auth-service/utils/test/ut_token.util.js
@@ -820,4 +820,96 @@ describe("token util", () => {
       expect(threw).to.equal(false);
     });
   });
+
+  describe("verifyToken() - permissions in response", () => {
+    let origIsIPBlacklisted, origRBACService;
+
+    const stubHappyPathDeps = () => {
+      rewireToken.__set__("AccessTokenModel", () => ({
+        findOne: () => ({
+          select: sinon.stub().resolves({
+            client_id: "client-1",
+            token: "raw-token-123",
+            allowed_grids: [],
+            allowed_cohorts: [],
+            scopes: [],
+          }),
+        }),
+      }));
+
+      rewireToken.__set__("ClientModel", () => ({
+        findById: () => ({
+          select: sinon.stub().resolves({
+            isActive: true,
+            user_id: "user-1",
+            enforce_origin: false,
+          }),
+        }),
+      }));
+
+      rewireToken.__set__("UserModel", () => ({
+        updateOne: sinon.stub().resolves({}),
+      }));
+
+      rewireToken.__set__("isIPBlacklisted", sinon.stub().resolves(false));
+    };
+
+    beforeEach(() => {
+      origIsIPBlacklisted = rewireToken.__get__("isIPBlacklisted");
+      origRBACService = rewireToken.__get__("RBACService");
+    });
+
+    afterEach(() => {
+      rewireToken.__set__("isIPBlacklisted", origIsIPBlacklisted);
+      rewireToken.__set__("RBACService", origRBACService);
+    });
+
+    it("includes the token owner's permissions in a successful verify response", async () => {
+      stubHappyPathDeps();
+      rewireToken.__set__("RBACService", {
+        getInstance: sinon.stub().returns({
+          getUserPermissions: sinon
+            .stub()
+            .resolves(["DEVICE_VIEW", "DEVICE_UPDATE"]),
+        }),
+      });
+
+      const request = {
+        headers: { "x-client-ip": "1.2.3.4" },
+        params: { token: "raw-token-123" },
+      };
+
+      const result = await rewireToken.verifyToken(request, next);
+
+      expect(result.success).to.equal(true);
+      expect(result.data.permissions).to.deep.equal([
+        "DEVICE_VIEW",
+        "DEVICE_UPDATE",
+      ]);
+      // Existing fields must be preserved — this must be an additive change.
+      expect(result.data).to.have.property("allowed_grids");
+      expect(result.data).to.have.property("allowed_cohorts");
+    });
+
+    it("returns an empty permissions array (so callers fail closed) if permission lookup throws", async () => {
+      stubHappyPathDeps();
+      rewireToken.__set__("RBACService", {
+        getInstance: sinon.stub().returns({
+          getUserPermissions: sinon
+            .stub()
+            .rejects(new Error("RBAC lookup failed")),
+        }),
+      });
+
+      const request = {
+        headers: { "x-client-ip": "1.2.3.4" },
+        params: { token: "raw-token-123" },
+      };
+
+      const result = await rewireToken.verifyToken(request, next);
+
+      expect(result.success).to.equal(true);
+      expect(result.data.permissions).to.deep.equal([]);
+    });
+  });
 });

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -16,6 +16,7 @@ const BlockedDomainModel = require("@models/BlockedDomain");
 const BlockedASNModel = require("@models/BlockedASN");
 const FlaggedTokenModel = require("@models/FlaggedToken");
 const { AbstractTokenFactory } = require("@services/atf.service");
+const RBACService = require("@services/rbac.service");
 const {
   redisGetAsync,
   redisSetAsync,
@@ -1946,12 +1947,31 @@ const token = {
             endpoint: endpoint ? endpoint : "unknown",
           });
 
+          // Resolve the token owner's permissions so downstream services
+          // (e.g. device-registry) can enforce RBAC without direct DB access
+          // to auth-service. Non-critical: if this lookup fails, permissions
+          // stays empty and callers relying on it correctly fail closed
+          // rather than silently granting access.
+          let permissions = [];
+          if (client.user_id) {
+            try {
+              permissions = await RBACService.getInstance(
+                "airqo"
+              ).getUserPermissions(client.user_id);
+            } catch (permErr) {
+              logger.error(
+                `Non-critical: permission resolution failed for verify response: ${permErr.message}`
+              );
+            }
+          }
+
           // Return resource-binding data so downstream services (e.g.
           // device-registry) can enforce grid/cohort restrictions without a
           // second DB call.
           return createValidTokenResponse({
             allowed_grids:   accessToken.allowed_grids   || [],
             allowed_cohorts: accessToken.allowed_cohorts || [],
+            permissions,
           });
         }
       }

--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -83,6 +83,16 @@ function envConfig(env) {
       false,
     ),
 
+    // Kill switch for RBAC permission enforcement (@airqo-packages/rbac-middleware
+    // requirePermission()). Default ON (true) — unlike ENABLE_RESOURCE_BINDING,
+    // this guards an actual authorization boundary, so it fails closed by
+    // default. Set to "false" only as an ops emergency bypass; every bypassed
+    // request is logged at warn level.
+    RBAC_ENFORCEMENT_ENABLED: parseBool(
+      process.env.RBAC_ENFORCEMENT_ENABLED,
+      true,
+    ),
+
     // Integer (ms): maximum time the MongoDB driver waits for a response on an
     // open socket before aborting the operation.  Must be long enough to cover
     // the heaviest aggregation in the service — EventModel.fetch(recent=yes)

--- a/src/device-registry/package-lock.json
+++ b/src/device-registry/package-lock.json
@@ -8,6 +8,7 @@
       "name": "device-registry",
       "version": "0.0.0",
       "dependencies": {
+        "@airqo-packages/rbac-middleware": "file:../../packages/airqo-rbac-middleware",
         "@e965/xlsx": "^0.20.3",
         "@google-cloud/bigquery": "^5.5.0",
         "@google-cloud/iot": "^1.5.0",
@@ -115,6 +116,26 @@
       "engines": {
         "node": ">=18.19.0"
       }
+    },
+    "../../packages/airqo-rbac-middleware": {
+      "name": "@airqo-packages/rbac-middleware",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.17.0"
+      },
+      "devDependencies": {
+        "chai": "^4.3.3",
+        "mocha": "^8.1.3",
+        "sinon": "^9.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@airqo-packages/rbac-middleware": {
+      "resolved": "../../packages/airqo-rbac-middleware",
+      "link": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",

--- a/src/device-registry/package.json
+++ b/src/device-registry/package.json
@@ -57,6 +57,7 @@
     "@migrations": "migrations"
   },
   "dependencies": {
+    "@airqo-packages/rbac-middleware": "^0.1.0",
     "@e965/xlsx": "^0.20.3",
     "@google-cloud/bigquery": "^5.5.0",
     "@google-cloud/iot": "^1.5.0",

--- a/src/device-registry/routes/v2/cohorts.routes.js
+++ b/src/device-registry/routes/v2/cohorts.routes.js
@@ -8,6 +8,7 @@ const {
   verifyAndBindResources,
   enforceCohortBinding,
 } = require("@middleware/token-resource-binding.middleware");
+const { requirePermission } = require("@airqo-packages/rbac-middleware");
 
 router.use(headers);
 // Attach resource binding metadata to every request in this router.
@@ -96,6 +97,19 @@ router.get(
 router.post(
   "/:cohort_id/assign-devices",
   cohortValidations.assignManyDevicesToCohort,
+  createCohortController.assignManyDevicesToCohort,
+);
+
+// RBAC enforcement pilot (AirQo-api#6986). Same behaviour as
+// POST /:cohort_id/assign-devices above, gated behind a real permission
+// check instead of relying on the frontend alone to hide the button.
+// The old route above is untouched and still has no server-side check —
+// once this pilot proves out, other mutation routes will be migrated to
+// this pattern one at a time, coordinated with frontend.
+router.post(
+  "/:cohort_id/devices",
+  cohortValidations.assignManyDevicesToCohort,
+  requirePermission("DEVICE_UPDATE"),
   createCohortController.assignManyDevicesToCohort,
 );
 

--- a/src/device-registry/routes/v2/test/ut_cohorts-devices-pilot.routes.js
+++ b/src/device-registry/routes/v2/test/ut_cohorts-devices-pilot.routes.js
@@ -1,0 +1,132 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const express = require("express");
+const request = require("supertest");
+const proxyquire = require("proxyquire");
+
+const realController = require("@controllers/cohort.controller");
+
+const VALID_COHORT_ID = "507f1f77bcf86cd799439011";
+const VALID_DEVICE_ID = "507f1f77bcf86cd799439012";
+
+/**
+ * Loads a fresh copy of cohorts.routes.js with the real controller (minus
+ * assignManyDevicesToCohort, which is stubbed) and a stubbed
+ * @airqo-packages/rbac-middleware, so this test isolates route wiring —
+ * i.e. "is the new pilot route gated by requirePermission and does the old
+ * route remain ungated" — from both the controller/util business logic
+ * (covered elsewhere) and the requirePermission middleware's own logic
+ * (covered by packages/airqo-rbac-middleware/test/requirePermission.test.js).
+ */
+const loadRoutesWithStubs = ({ assignManyDevicesStub, requirePermissionMiddlewareFactory }) => {
+  const controllerStub = {
+    ...realController,
+    assignManyDevicesToCohort: assignManyDevicesStub,
+  };
+
+  const cohortsRoutes = proxyquire("@routes/v2/cohorts.routes", {
+    "@controllers/cohort.controller": controllerStub,
+    "@airqo-packages/rbac-middleware": {
+      requirePermission: requirePermissionMiddlewareFactory,
+    },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use("/cohorts", cohortsRoutes);
+  return app;
+};
+
+describe("cohorts.routes.js — RBAC pilot route (POST /:cohort_id/devices)", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("calls the controller when requirePermission grants access", async () => {
+    const assignManyDevicesStub = sinon.stub().callsFake((req, res) => {
+      res.status(200).json({ success: true, data: { assigned: [], already_assigned: [] } });
+    });
+    const requirePermissionMiddlewareFactory = sinon
+      .stub()
+      .returns((req, res, next) => next());
+
+    const app = loadRoutesWithStubs({
+      assignManyDevicesStub,
+      requirePermissionMiddlewareFactory,
+    });
+
+    const response = await request(app)
+      .post(`/cohorts/${VALID_COHORT_ID}/devices`)
+      .send({ device_ids: [VALID_DEVICE_ID] });
+
+    expect(requirePermissionMiddlewareFactory.calledWith("DEVICE_UPDATE")).to.equal(true);
+    expect(assignManyDevicesStub.calledOnce).to.equal(true);
+    expect(response.status).to.equal(200);
+  });
+
+  it("never reaches the controller when requirePermission denies access", async () => {
+    const assignManyDevicesStub = sinon.stub();
+    const requirePermissionMiddlewareFactory = sinon.stub().returns((req, res) => {
+      res.status(403).json({
+        success: false,
+        message: "Insufficient permissions",
+        status: 403,
+        errors: { message: "This action requires the 'DEVICE_UPDATE' permission" },
+      });
+    });
+
+    const app = loadRoutesWithStubs({
+      assignManyDevicesStub,
+      requirePermissionMiddlewareFactory,
+    });
+
+    const response = await request(app)
+      .post(`/cohorts/${VALID_COHORT_ID}/devices`)
+      .send({ device_ids: [VALID_DEVICE_ID] });
+
+    expect(response.status).to.equal(403);
+    expect(assignManyDevicesStub.called).to.equal(false);
+  });
+
+  it("still returns validation errors for a malformed body before reaching requirePermission", async () => {
+    const assignManyDevicesStub = sinon.stub();
+    const requirePermissionMiddlewareFactory = sinon.stub().returns((req, res, next) => next());
+
+    const app = loadRoutesWithStubs({
+      assignManyDevicesStub,
+      requirePermissionMiddlewareFactory,
+    });
+
+    const response = await request(app)
+      .post(`/cohorts/${VALID_COHORT_ID}/devices`)
+      .send({ device_ids: "not-an-array" });
+
+    expect(response.status).to.equal(400);
+    expect(assignManyDevicesStub.called).to.equal(false);
+    expect(requirePermissionMiddlewareFactory.called).to.equal(true); // factory runs at route-definition time regardless
+  });
+
+  it("leaves the existing POST /:cohort_id/assign-devices route ungated (no RBAC check today)", async () => {
+    const assignManyDevicesStub = sinon.stub().callsFake((req, res) => {
+      res.status(200).json({ success: true, data: { assigned: [], already_assigned: [] } });
+    });
+    // requirePermission is stubbed but must never be invoked as a per-request
+    // middleware for the OLD route, since that route doesn't reference it.
+    const requirePermissionMiddlewareFactory = sinon.stub().returns((req, res, next) => {
+      throw new Error("requirePermission should not run for the pre-existing assign-devices route");
+    });
+
+    const app = loadRoutesWithStubs({
+      assignManyDevicesStub,
+      requirePermissionMiddlewareFactory,
+    });
+
+    const response = await request(app)
+      .post(`/cohorts/${VALID_COHORT_ID}/assign-devices`)
+      .send({ device_ids: [VALID_DEVICE_ID] });
+
+    expect(response.status).to.equal(200);
+    expect(assignManyDevicesStub.calledOnce).to.equal(true);
+  });
+});

--- a/src/device-registry/routes/v2/test/ut_cohorts.routes.js
+++ b/src/device-registry/routes/v2/test/ut_cohorts.routes.js
@@ -3,276 +3,441 @@ const { expect } = require("chai");
 const sinon = require("sinon");
 const express = require("express");
 const request = require("supertest");
-const createCohortController = require("@controllers/create-cohort");
-const { check, oneOf, query, body, param } = require("express-validator");
-const constants = require("@config/constants");
-const mongoose = require("mongoose");
-const ObjectId = mongoose.Types.ObjectId;
-const { logElement, logText, logObject } = require("@utils/log");
-const isEmpty = require("is-empty");
-const log4js = require("log4js");
-const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- cohorts-route-v2`);
-const { getModelByTenant } = require("@config/database");
-const NetworkSchema = require("@models/Network");
+const proxyquire = require("proxyquire");
 
-const app = express();
-app.use(express.json());
+const realController = require("@controllers/cohort.controller");
 
-/*************************** Mocked Data ***************************/
-// Replace with relevant mocked data
+const VALID_COHORT_ID = "507f1f77bcf86cd799439011";
+const VALID_DEVICE_ID = "507f1f77bcf86cd799439012";
+const VALID_NET_ID = "507f1f77bcf86cd799439013";
 
-/*************************** Unit Test ***************************/
-describe("Cohort Controller", () => {
+/**
+ * Mounts the real cohorts.routes.js router with one or more controller
+ * methods stubbed (the real controller module is spread so every route
+ * still has a valid handler function to bind to at registration time —
+ * only the methods under test are overridden). @airqo-packages/rbac-middleware
+ * is left real; none of the routes covered here reference requirePermission
+ * (that's covered separately by ut_cohorts-devices-pilot.routes.js).
+ */
+const mountRoutesWithControllerStub = (controllerOverrides) => {
+  const controllerStub = { ...realController, ...controllerOverrides };
+  const cohortsRoutes = proxyquire("@routes/v2/cohorts.routes", {
+    "@controllers/cohort.controller": controllerStub,
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use("/cohorts", cohortsRoutes);
+  return app;
+};
+
+const okStub = () =>
+  sinon.stub().callsFake((req, res) => {
+    res.status(200).json({ success: true, message: "ok" });
+  });
+
+describe("cohorts.routes.js", () => {
   afterEach(() => {
     sinon.restore();
   });
 
   describe("DELETE /cohorts/:cohort_id", () => {
-    it("should delete a cohort", async () => {
-      const deleteStub = sinon.stub(createCohortController, "delete");
-      // Replace with relevant implementation and expected response
+    it("should call the delete controller for a valid cohort_id", async () => {
+      const deleteStub = okStub();
+      const app = mountRoutesWithControllerStub({ delete: deleteStub });
 
-      const response = await request(app).delete("/cohorts/:cohort_id");
+      const response = await request(app).delete(`/cohorts/${VALID_COHORT_ID}`);
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(deleteStub.calledOnce).to.equal(true);
+    });
+
+    it("should reject a non-ObjectId cohort_id with a 400 before reaching the controller", async () => {
+      const deleteStub = okStub();
+      const app = mountRoutesWithControllerStub({ delete: deleteStub });
+
+      const response = await request(app).delete("/cohorts/not-an-object-id");
+
+      expect(response.status).to.equal(400);
+      expect(deleteStub.called).to.equal(false);
+    });
+  });
+
+  describe("PUT /cohorts/:cohort_id/name", () => {
+    it("should call updateName for a valid rename request", async () => {
+      const updateNameStub = okStub();
+      const app = mountRoutesWithControllerStub({ updateName: updateNameStub });
+
+      const response = await request(app)
+        .put(`/cohorts/${VALID_COHORT_ID}/name`)
+        .send({
+          name: "renamed-cohort",
+          confirm_update: "true",
+          update_reason: "Correcting a typo in the original cohort name",
+        });
+
+      expect(response.status).to.equal(200);
+      expect(updateNameStub.calledOnce).to.equal(true);
     });
   });
 
   describe("PUT /cohorts/:cohort_id", () => {
-    it("should update a cohort", async () => {
-      const updateStub = sinon.stub(createCohortController, "update");
-      // Replace with relevant implementation and expected response
+    it("should call update for a valid update request", async () => {
+      const updateStub = okStub();
+      const app = mountRoutesWithControllerStub({ update: updateStub });
 
-      const response = await request(app).put("/cohorts/:cohort_id");
+      const response = await request(app)
+        .put(`/cohorts/${VALID_COHORT_ID}`)
+        .send({ description: "an updated description" });
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(updateStub.calledOnce).to.equal(true);
     });
   });
 
   describe("POST /cohorts", () => {
-    it("should create a new cohort", async () => {
-      const createStub = sinon.stub(createCohortController, "create");
-      // Replace with relevant implementation and expected response
+    it("should call create for a valid new cohort", async () => {
+      const createStub = okStub();
+      const app = mountRoutesWithControllerStub({ create: createStub });
 
-      const response = await request(app).post("/cohorts");
+      const response = await request(app)
+        .post("/cohorts")
+        .send({ name: "a new cohort" });
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(createStub.calledOnce).to.equal(true);
     });
   });
 
   describe("GET /cohorts", () => {
-    it("should list cohorts", async () => {
-      const listStub = sinon.stub(createCohortController, "list");
-      // Replace with relevant implementation and expected response
+    it("should call list", async () => {
+      const listStub = okStub();
+      const app = mountRoutesWithControllerStub({ list: listStub });
 
       const response = await request(app).get("/cohorts");
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(listStub.calledOnce).to.equal(true);
     });
   });
 
   describe("GET /cohorts/summary", () => {
-    it("should list cohort summaries", async () => {
-      const listSummaryStub = sinon.stub(createCohortController, "listSummary");
-      // Replace with relevant implementation and expected response
+    it("should call listSummary", async () => {
+      const listSummaryStub = okStub();
+      const app = mountRoutesWithControllerStub({ listSummary: listSummaryStub });
 
       const response = await request(app).get("/cohorts/summary");
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(listSummaryStub.calledOnce).to.equal(true);
     });
   });
 
   describe("GET /cohorts/dashboard", () => {
-    it("should list cohort dashboard data", async () => {
-      const listDashboardStub = sinon.stub(
-        createCohortController,
-        "listDashboard"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call listDashboard", async () => {
+      const listDashboardStub = okStub();
+      const app = mountRoutesWithControllerStub({ listDashboard: listDashboardStub });
 
       const response = await request(app).get("/cohorts/dashboard");
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(listDashboardStub.calledOnce).to.equal(true);
+    });
+  });
+
+  describe("GET /cohorts/users", () => {
+    it("should call listUserCohorts", async () => {
+      const listUserCohortsStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listUserCohorts: listUserCohortsStub,
+      });
+
+      const response = await request(app).get("/cohorts/users");
+
+      expect(response.status).to.equal(200);
+      expect(listUserCohortsStub.calledOnce).to.equal(true);
     });
   });
 
   describe("PUT /cohorts/:cohort_id/assign-device/:device_id", () => {
-    it("should assign a device to a cohort", async () => {
-      const assignOneDeviceStub = sinon.stub(
-        createCohortController,
-        "assignOneDeviceToCohort"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call assignOneDeviceToCohort for valid ids", async () => {
+      const assignOneDeviceStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        assignOneDeviceToCohort: assignOneDeviceStub,
+      });
 
       const response = await request(app).put(
-        "/cohorts/:cohort_id/assign-device/:device_id"
+        `/cohorts/${VALID_COHORT_ID}/assign-device/${VALID_DEVICE_ID}`
       );
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(assignOneDeviceStub.calledOnce).to.equal(true);
     });
   });
 
   describe("GET /cohorts/:cohort_id/assigned-devices", () => {
-    it("should list assigned devices for a cohort", async () => {
-      const listAssignedDevicesStub = sinon.stub(
-        createCohortController,
-        "listAssignedDevices"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call listAssignedDevices for a valid cohort_id", async () => {
+      const listAssignedDevicesStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listAssignedDevices: listAssignedDevicesStub,
+      });
 
       const response = await request(app).get(
-        "/cohorts/:cohort_id/assigned-devices"
+        `/cohorts/${VALID_COHORT_ID}/assigned-devices`
       );
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(listAssignedDevicesStub.calledOnce).to.equal(true);
     });
   });
 
   describe("GET /cohorts/:cohort_id/available-devices", () => {
-    it("should list available devices for a cohort", async () => {
-      const listAvailableDevicesStub = sinon.stub(
-        createCohortController,
-        "listAvailableDevices"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call listAvailableDevices for a valid cohort_id", async () => {
+      const listAvailableDevicesStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listAvailableDevices: listAvailableDevicesStub,
+      });
 
       const response = await request(app).get(
-        "/cohorts/:cohort_id/available-devices"
+        `/cohorts/${VALID_COHORT_ID}/available-devices`
       );
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(listAvailableDevicesStub.calledOnce).to.equal(true);
     });
   });
 
   describe("POST /cohorts/:cohort_id/assign-devices", () => {
-    it("should assign multiple devices to a cohort", async () => {
-      const assignManyDevicesStub = sinon.stub(
-        createCohortController,
-        "assignManyDevicesToCohort"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call assignManyDevicesToCohort for a valid device_ids array", async () => {
+      const assignManyDevicesStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        assignManyDevicesToCohort: assignManyDevicesStub,
+      });
 
-      const response = await request(app).post(
-        "/cohorts/:cohort_id/assign-devices"
-      );
+      const response = await request(app)
+        .post(`/cohorts/${VALID_COHORT_ID}/assign-devices`)
+        .send({ device_ids: [VALID_DEVICE_ID] });
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(assignManyDevicesStub.calledOnce).to.equal(true);
     });
   });
 
   describe("DELETE /cohorts/:cohort_id/unassign-many-devices", () => {
-    it("should unassign multiple devices from a cohort", async () => {
-      const unassignManyDevicesStub = sinon.stub(
-        createCohortController,
-        "unAssignManyDevicesFromCohort"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call unAssignManyDevicesFromCohort for a valid device_ids array", async () => {
+      const unassignManyDevicesStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        unAssignManyDevicesFromCohort: unassignManyDevicesStub,
+      });
 
-      const response = await request(app).delete(
-        "/cohorts/:cohort_id/unassign-many-devices"
-      );
+      const response = await request(app)
+        .delete(`/cohorts/${VALID_COHORT_ID}/unassign-many-devices`)
+        .send({ device_ids: [VALID_DEVICE_ID] });
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(unassignManyDevicesStub.calledOnce).to.equal(true);
     });
   });
 
   describe("DELETE /cohorts/:cohort_id/unassign-device/:device_id", () => {
-    it("should unassign a device from a cohort", async () => {
-      const unassignOneDeviceStub = sinon.stub(
-        createCohortController,
-        "unAssignOneDeviceFromCohort"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call unAssignOneDeviceFromCohort for valid ids", async () => {
+      const unassignOneDeviceStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        unAssignOneDeviceFromCohort: unassignOneDeviceStub,
+      });
 
       const response = await request(app).delete(
-        "/cohorts/:cohort_id/unassign-device/:device_id"
+        `/cohorts/${VALID_COHORT_ID}/unassign-device/${VALID_DEVICE_ID}`
       );
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(unassignOneDeviceStub.calledOnce).to.equal(true);
     });
   });
 
   describe("POST /cohorts/networks", () => {
-    it("should create a new network", async () => {
-      const createNetworkStub = sinon.stub(
-        createCohortController,
-        "createNetwork"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call createNetwork for a valid network payload", async () => {
+      const createNetworkStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        createNetwork: createNetworkStub,
+      });
 
-      const response = await request(app).post("/cohorts/networks");
+      const response = await request(app)
+        .post("/cohorts/networks")
+        .send({
+          admin_secret: "test-secret",
+          net_name: "test-network",
+          net_email: "network@example.com",
+        });
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(createNetworkStub.calledOnce).to.equal(true);
     });
   });
 
   describe("PUT /cohorts/networks/:net_id", () => {
-    it("should update a network", async () => {
-      const updateNetworkStub = sinon.stub(
-        createCohortController,
-        "updateNetwork"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call updateNetwork for a valid net_id", async () => {
+      const updateNetworkStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        updateNetwork: updateNetworkStub,
+      });
 
-      const response = await request(app).put("/cohorts/networks/:net_id");
+      const response = await request(app).put(`/cohorts/networks/${VALID_NET_ID}`);
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(updateNetworkStub.calledOnce).to.equal(true);
     });
   });
 
   describe("DELETE /cohorts/networks/:net_id", () => {
-    it("should delete a network", async () => {
-      const deleteNetworkStub = sinon.stub(
-        createCohortController,
-        "deleteNetwork"
+    it("should call deleteNetwork for a valid net_id", async () => {
+      const deleteNetworkStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        deleteNetwork: deleteNetworkStub,
+      });
+
+      const response = await request(app).delete(
+        `/cohorts/networks/${VALID_NET_ID}`
       );
-      // Replace with relevant implementation and expected response
 
-      const response = await request(app).delete("/cohorts/networks/:net_id");
-
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(deleteNetworkStub.calledOnce).to.equal(true);
     });
   });
 
   describe("GET /cohorts/networks", () => {
-    it("should list networks", async () => {
-      const listNetworksStub = sinon.stub(
-        createCohortController,
-        "listNetworks"
-      );
-      // Replace with relevant implementation and expected response
+    it("should call listNetworks", async () => {
+      const listNetworksStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listNetworks: listNetworksStub,
+      });
 
       const response = await request(app).get("/cohorts/networks");
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(listNetworksStub.calledOnce).to.equal(true);
     });
   });
 
   describe("GET /cohorts/networks/:net_id", () => {
-    it("should get a specific network", async () => {
-      const getNetworkStub = sinon.stub(createCohortController, "listNetworks");
-      // Replace with relevant implementation and expected response
+    it("should call listNetworks for a specific net_id", async () => {
+      const listNetworksStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listNetworks: listNetworksStub,
+      });
 
-      const response = await request(app).get("/cohorts/networks/:net_id");
+      const response = await request(app).get(
+        `/cohorts/networks/${VALID_NET_ID}`
+      );
 
-      // Add assertions based on expected response and function calls
       expect(response.status).to.equal(200);
+      expect(listNetworksStub.calledOnce).to.equal(true);
+    });
+  });
+
+  describe("GET /cohorts/verify/:cohort_id", () => {
+    it("should call verify for a valid cohort_id", async () => {
+      const verifyStub = okStub();
+      const app = mountRoutesWithControllerStub({ verify: verifyStub });
+
+      const response = await request(app).get(
+        `/cohorts/verify/${VALID_COHORT_ID}`
+      );
+
+      expect(response.status).to.equal(200);
+      expect(verifyStub.calledOnce).to.equal(true);
+    });
+  });
+
+  describe("POST /cohorts/from-cohorts", () => {
+    it("should call createFromCohorts for a valid payload", async () => {
+      const createFromCohortsStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        createFromCohorts: createFromCohortsStub,
+      });
+
+      const response = await request(app)
+        .post("/cohorts/from-cohorts")
+        .send({ name: "merged-cohort", cohort_ids: [VALID_COHORT_ID] });
+
+      expect(response.status).to.equal(200);
+      expect(createFromCohortsStub.calledOnce).to.equal(true);
+    });
+  });
+
+  describe("POST /cohorts/sites", () => {
+    it("should call listSitesByCohort for a valid cohort_ids array", async () => {
+      const listSitesByCohortStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listSitesByCohort: listSitesByCohortStub,
+      });
+
+      const response = await request(app)
+        .post("/cohorts/sites")
+        .send({ cohort_ids: [VALID_COHORT_ID] });
+
+      expect(response.status).to.equal(200);
+      expect(listSitesByCohortStub.calledOnce).to.equal(true);
+    });
+  });
+
+  describe("POST /cohorts/devices", () => {
+    it("should call listDevicesByCohort for a valid cohort_ids array", async () => {
+      const listDevicesByCohortStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listDevicesByCohort: listDevicesByCohortStub,
+      });
+
+      const response = await request(app)
+        .post("/cohorts/devices")
+        .send({ cohort_ids: [VALID_COHORT_ID] });
+
+      expect(response.status).to.equal(200);
+      expect(listDevicesByCohortStub.calledOnce).to.equal(true);
+    });
+  });
+
+  describe("POST /cohorts/cached-sites", () => {
+    it("should call listCachedSitesByCohort for a valid cohort_ids array", async () => {
+      const listCachedSitesByCohortStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listCachedSitesByCohort: listCachedSitesByCohortStub,
+      });
+
+      const response = await request(app)
+        .post("/cohorts/cached-sites")
+        .send({ cohort_ids: [VALID_COHORT_ID] });
+
+      expect(response.status).to.equal(200);
+      expect(listCachedSitesByCohortStub.calledOnce).to.equal(true);
+    });
+  });
+
+  describe("POST /cohorts/cached-devices", () => {
+    it("should call listCachedDevicesByCohort for a valid cohort_ids array", async () => {
+      const listCachedDevicesByCohortStub = okStub();
+      const app = mountRoutesWithControllerStub({
+        listCachedDevicesByCohort: listCachedDevicesByCohortStub,
+      });
+
+      const response = await request(app)
+        .post("/cohorts/cached-devices")
+        .send({ cohort_ids: [VALID_COHORT_ID] });
+
+      expect(response.status).to.equal(200);
+      expect(listCachedDevicesByCohortStub.calledOnce).to.equal(true);
+    });
+  });
+
+  describe("GET /cohorts/:cohort_id", () => {
+    it("should call list (the catch-all handler) for a valid cohort_id", async () => {
+      const listStub = okStub();
+      const app = mountRoutesWithControllerStub({ list: listStub });
+
+      const response = await request(app).get(`/cohorts/${VALID_COHORT_ID}`);
+
+      expect(response.status).to.equal(200);
+      expect(listStub.calledOnce).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a new shared `@airqo-packages/rbac-middleware` package and pilots real server-side permission enforcement on a brand-new device-registry endpoint (`POST /api/v2/devices/cohorts/:cohort_id/devices`), gated by `requirePermission("DEVICE_UPDATE")`. Extends auth-service's token-verify response to additionally return the token owner's permissions (additive, non-breaking), which the new middleware relies on. Also fixes a pre-existing, unrelated broken test file (`ut_cohorts.routes.js`) discovered along the way.

### Why is this change needed?
device-registry currently has no server-side RBAC enforcement anywhere — authorization is enforced only in the Vertex frontend (disabled buttons based on permission checks), meaning any authenticated user can currently call mutation endpoints directly regardless of role. Since the existing `assign-devices` endpoint is already live in production and actively used by Vertex, this PR deliberately does **not** touch it — instead it pilots the new enforcement pattern on a brand-new, currently-unused endpoint first, so it can be validated safely before other endpoints are migrated with proper frontend coordination.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [x] Related to #6986

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` — new pilot route, new `RBAC_ENFORCEMENT_ENABLED` config flag, new dependency on `@airqo-packages/rbac-middleware`, new/fixed route tests
- `auth-service` — additive `permissions` field on the token-verify response
- `packages/airqo-rbac-middleware` — new shared package (not yet published to npm — see Additional Notes)

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added 8 tests for the new `requirePermission` middleware (covers every fail-closed path: missing token, unreachable auth-service, malformed response, permission denied, kill switch). Added 2 tests in auth-service confirming the new `permissions` field appears on a successful token verify and fails safe (empty array) if the lookup errors. Added 4 tests for the new pilot route (permission granted → controller called, permission denied → 403 and controller never called, malformed body rejected before the permission check, and the pre-existing `assign-devices` route confirmed still ungated/untouched). Also rewrote `ut_cohorts.routes.js`, which was previously broken (referenced a nonexistent module and never mounted the real router) — it now exercises all 23 routes against the real router with valid inputs. Full combined run: 62/62 device-registry cohort-related tests passing, 0 regressions. Manual end-to-end testing is blocked pending the npm publish and k8s env var steps noted below.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- **Blocking dependency:** `@airqo-packages/rbac-middleware` must be published to npm before this branch can build in CI/Docker — device-registry's `package.json` references it as `^0.1.0`. The Docker build context for device-registry is scoped to `src/device-registry/` only, so a local `file:` reference (used during development) will not resolve in the real build.
- `AUTH_SERVICE_URL` / `SERVICE_JWT_TOKEN` are not yet configured in `k8s/device-registry/` — until they're added to the deployment config, the new route will fail closed (403 for everyone, including admins). Nothing else is affected since no other route depends on these.
- `RBAC_ENFORCEMENT_ENABLED` (default `true`) is included as an emergency kill switch for the new middleware, independent of the two variables above.
- Fully additive change: the existing `assign-devices` route, the existing token-verify response shape, and all other device-registry routes are untouched.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added reusable RBAC middleware for token verification and permission-based access control.
- Token validation responses now include the owner’s permissions.
- Added a protected cohort device-assignment endpoint requiring `DEVICE_UPDATE`.
- Added a configuration switch to enable or disable RBAC enforcement.

## Bug Fixes
- Authorization failures now fail closed with clear 401/403 responses.
- Unavailable authorization services are handled safely.

## Tests
- Added coverage for middleware, token permissions, protected routes, authorization failures, and cohort route behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->