### PR TITLE
Return token owner's permissions from the token-verify endpoint

### DIFF
--- a/src/auth-service/services/rbac.service.js
+++ b/src/auth-service/services/rbac.service.js
@@ -160,7 +160,7 @@ class RBACService {
     }
   }
 
-  async getUserPermissions(userId) {
+  async getUserPermissions(userId, { strict = false } = {}) {
     try {
       const cacheKey = userId.toString();
       const now = Date.now();
@@ -241,6 +241,9 @@ class RBACService {
     } catch (error) {
       console.error("❌ Enhanced RBAC ERROR in getUserPermissions:", error);
       logger.error(`Error getting user permissions: ${error.message}`);
+      if (strict) {
+        throw error;
+      }
       return this.getDefaultPermissionsByUserType("user");
     }
   }

--- a/src/auth-service/utils/test/ut_token.util.js
+++ b/src/auth-service/utils/test/ut_token.util.js
@@ -820,4 +820,96 @@ describe("token util", () => {
       expect(threw).to.equal(false);
     });
   });
+
+  describe("verifyToken() - permissions in response", () => {
+    let origIsIPBlacklisted, origRBACService;
+
+    const stubHappyPathDeps = () => {
+      rewireToken.__set__("AccessTokenModel", () => ({
+        findOne: () => ({
+          select: sinon.stub().resolves({
+            client_id: "client-1",
+            token: "raw-token-123",
+            allowed_grids: [],
+            allowed_cohorts: [],
+            scopes: [],
+          }),
+        }),
+      }));
+
+      rewireToken.__set__("ClientModel", () => ({
+        findById: () => ({
+          select: sinon.stub().resolves({
+            isActive: true,
+            user_id: "user-1",
+            enforce_origin: false,
+          }),
+        }),
+      }));
+
+      rewireToken.__set__("UserModel", () => ({
+        updateOne: sinon.stub().resolves({}),
+      }));
+
+      rewireToken.__set__("isIPBlacklisted", sinon.stub().resolves(false));
+    };
+
+    beforeEach(() => {
+      origIsIPBlacklisted = rewireToken.__get__("isIPBlacklisted");
+      origRBACService = rewireToken.__get__("RBACService");
+    });
+
+    afterEach(() => {
+      rewireToken.__set__("isIPBlacklisted", origIsIPBlacklisted);
+      rewireToken.__set__("RBACService", origRBACService);
+    });
+
+    it("includes the token owner's permissions in a successful verify response", async () => {
+      stubHappyPathDeps();
+      rewireToken.__set__("RBACService", {
+        getInstance: sinon.stub().returns({
+          getUserPermissions: sinon
+            .stub()
+            .resolves(["DEVICE_VIEW", "DEVICE_UPDATE"]),
+        }),
+      });
+
+      const request = {
+        headers: { "x-client-ip": "1.2.3.4" },
+        params: { token: "raw-token-123" },
+      };
+
+      const result = await rewireToken.verifyToken(request, next);
+
+      expect(result.success).to.equal(true);
+      expect(result.data.permissions).to.deep.equal([
+        "DEVICE_VIEW",
+        "DEVICE_UPDATE",
+      ]);
+      // Existing fields must be preserved — this must be an additive change.
+      expect(result.data).to.have.property("allowed_grids");
+      expect(result.data).to.have.property("allowed_cohorts");
+    });
+
+    it("returns an empty permissions array (so callers fail closed) if permission lookup throws", async () => {
+      stubHappyPathDeps();
+      rewireToken.__set__("RBACService", {
+        getInstance: sinon.stub().returns({
+          getUserPermissions: sinon
+            .stub()
+            .rejects(new Error("RBAC lookup failed")),
+        }),
+      });
+
+      const request = {
+        headers: { "x-client-ip": "1.2.3.4" },
+        params: { token: "raw-token-123" },
+      };
+
+      const result = await rewireToken.verifyToken(request, next);
+
+      expect(result.success).to.equal(true);
+      expect(result.data.permissions).to.deep.equal([]);
+    });
+  });
 });

--- a/src/auth-service/utils/test/ut_token.util.js
+++ b/src/auth-service/utils/test/ut_token.util.js
@@ -911,5 +911,31 @@ describe("token util", () => {
       expect(result.success).to.equal(true);
       expect(result.data.permissions).to.deep.equal([]);
     });
+
+    it("calls getUserPermissions with { strict: true }, so a real RBAC lookup failure cannot silently fall back to default 'user' permissions", async () => {
+      stubHappyPathDeps();
+      const getUserPermissionsStub = sinon
+        .stub()
+        .rejects(new Error("RBAC lookup failed"));
+      rewireToken.__set__("RBACService", {
+        getInstance: sinon.stub().returns({
+          getUserPermissions: getUserPermissionsStub,
+        }),
+      });
+
+      const request = {
+        headers: { "x-client-ip": "1.2.3.4" },
+        params: { token: "raw-token-123" },
+      };
+
+      const result = await rewireToken.verifyToken(request, next);
+
+      expect(
+        getUserPermissionsStub.calledWithMatch(sinon.match.any, {
+          strict: true,
+        }),
+      ).to.equal(true);
+      expect(result.data.permissions).to.deep.equal([]);
+    });
   });
 });

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1949,15 +1949,17 @@ const token = {
 
           // Resolve the token owner's permissions so downstream services
           // (e.g. device-registry) can enforce RBAC without direct DB access
-          // to auth-service. Non-critical: if this lookup fails, permissions
-          // stays empty and callers relying on it correctly fail closed
-          // rather than silently granting access.
+          // to auth-service. { strict: true } is required here: by default
+          // getUserPermissions() swallows lookup errors and falls back to
+          // default "user" permissions, which would defeat the fail-closed
+          // guarantee callers rely on — strict mode makes it rethrow instead,
+          // so the catch below can force permissions back to [].
           let permissions = [];
           if (client.user_id) {
             try {
               permissions = await RBACService.getInstance(
                 "airqo"
-              ).getUserPermissions(client.user_id);
+              ).getUserPermissions(client.user_id, { strict: true });
             } catch (permErr) {
               logger.error(
                 `Non-critical: permission resolution failed for verify response: ${permErr.message}`

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -16,6 +16,7 @@ const BlockedDomainModel = require("@models/BlockedDomain");
 const BlockedASNModel = require("@models/BlockedASN");
 const FlaggedTokenModel = require("@models/FlaggedToken");
 const { AbstractTokenFactory } = require("@services/atf.service");
+const RBACService = require("@services/rbac.service");
 const {
   redisGetAsync,
   redisSetAsync,
@@ -1946,12 +1947,31 @@ const token = {
             endpoint: endpoint ? endpoint : "unknown",
           });
 
+          // Resolve the token owner's permissions so downstream services
+          // (e.g. device-registry) can enforce RBAC without direct DB access
+          // to auth-service. Non-critical: if this lookup fails, permissions
+          // stays empty and callers relying on it correctly fail closed
+          // rather than silently granting access.
+          let permissions = [];
+          if (client.user_id) {
+            try {
+              permissions = await RBACService.getInstance(
+                "airqo"
+              ).getUserPermissions(client.user_id);
+            } catch (permErr) {
+              logger.error(
+                `Non-critical: permission resolution failed for verify response: ${permErr.message}`
+              );
+            }
+          }
+
           // Return resource-binding data so downstream services (e.g.
           // device-registry) can enforce grid/cohort restrictions without a
           // second DB call.
           return createValidTokenResponse({
             allowed_grids:   accessToken.allowed_grids   || [],
             allowed_cohorts: accessToken.allowed_cohorts || [],
+            permissions,
           });
         }
       }


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a `permissions` field to the existing `GET /api/v2/tokens/:token/verify` success response, resolved via the existing `RBACService` for the token's owning user. Purely additive — no existing field is changed or removed.

### Why is this change needed?
device-registry (and potentially other services) currently has no way to check a caller's permissions without direct database access to auth-service, which is intentionally not allowed (each service runs its own DB). This field lets downstream services enforce RBAC by reading permissions off the same token-verify call they may already be making, without a second round trip or any new coupling. It's the prerequisite for a separate, currently-blocked PR (`rbac-pilot` branch) that pilots real permission enforcement in device-registry using this field.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [x] Related to #6986

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` only

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added 2 tests covering the new behavior: confirms `data.permissions` is populated on a successful verify, and confirms it safely defaults to an empty array (rather than failing the whole request) if the permission lookup itself errors. Ran the full `ut_token.util.js` suite plus a scoped run — no regressions; the only failures present in the wider suite are pre-existing and unrelated (in `utils/shared/test/ut_log.js` / `ut_errors.js`).

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely additive field on an existing 200 response — any current consumer of this endpoint that doesn't know about `permissions` simply ignores it.

---

## :memo: Additional Notes
- This PR is safe to merge and deploy independently — it does not depend on, or get depended on by, anything else in this repo's build/deploy pipeline.
- It exists to unblock a separate, currently-held PR (`rbac-pilot` branch) that adds real permission enforcement to device-registry using this new field. That PR should not be deployed until this one is live.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Successful token verification now includes the token owner’s RBAC permissions.
  * Verification continues successfully with an empty permissions list when permission lookup fails.

* **Tests**
  * Added coverage for permission inclusion, preservation of existing token details, and lookup failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->