### PR TITLE
Fix ThingSpeak error handling, status codes, and tag format bug

### DIFF
--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2330,7 +2330,14 @@ const deviceUtil = {
       // expects "tags" as a comma-separated string, not a JSON array --
       // sending an array causes the provider to fail with an HTTP 500
       if (Array.isArray(transformedBody.tags)) {
-        transformedBody.tags = transformedBody.tags.join(",");
+        const normalizedTags = transformedBody.tags
+          .map((tag) => (typeof tag === "string" ? tag.trim() : ""))
+          .filter(Boolean);
+        if (normalizedTags.length > 0) {
+          transformedBody.tags = normalizedTags.join(",");
+        } else {
+          delete transformedBody.tags;
+        }
       }
 
       return await axios

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -2325,6 +2325,14 @@ const deviceUtil = {
           },
         };
       }
+
+      // the external device-channel provider's channel-creation endpoint
+      // expects "tags" as a comma-separated string, not a JSON array --
+      // sending an array causes the provider to fail with an HTTP 500
+      if (Array.isArray(transformedBody.tags)) {
+        transformedBody.tags = transformedBody.tags.join(",");
+      }
+
       return await axios
         .post(baseURL, transformedBody)
         .then(async (response) => {

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -1916,8 +1916,74 @@ describe("Device Util", () => {
         const result = await deviceUtil.createOnThingSpeak({ body: {} });
 
         expect(result.success).to.be.false;
-        expect(result.errors.message).to.equal("Bad Request");
+        expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+        expect(result.errors.message).to.include("Bad Request");
         expect(axios.post.calledOnce).to.be.true;
+      });
+
+      it("should send array tags to the external provider as a comma-separated string", async () => {
+        const responseFromPost = {
+          data: {
+            api_keys: [
+              { write_flag: true, api_key: "WRITE_KEY" },
+              { write_flag: false, api_key: "READ_KEY" },
+            ],
+            id: "DEVICE_ID",
+          },
+        };
+        sinon.stub(axios, "post").resolves(responseFromPost);
+
+        const request = { body: { name: "aq_001", tags: ["pm2.5", "humidity"] } };
+        const result = await deviceUtil.createOnThingSpeak(request);
+
+        expect(result.success).to.be.true;
+        expect(axios.post.calledOnce).to.be.true;
+        const outboundBody = axios.post.firstCall.args[1];
+        expect(outboundBody.tags).to.equal("pm2.5,humidity");
+        // the original request body must be untouched -- tags are stored
+        // as an array in our own database independently of this call
+        expect(request.body.tags).to.deep.equal(["pm2.5", "humidity"]);
+      });
+
+      it("should trim tags and drop blank entries before sending to the external provider", async () => {
+        const responseFromPost = {
+          data: {
+            api_keys: [
+              { write_flag: true, api_key: "WRITE_KEY" },
+              { write_flag: false, api_key: "READ_KEY" },
+            ],
+            id: "DEVICE_ID",
+          },
+        };
+        sinon.stub(axios, "post").resolves(responseFromPost);
+
+        const request = {
+          body: { name: "aq_001", tags: [" inlab ", "", "  ", "industrial"] },
+        };
+        const result = await deviceUtil.createOnThingSpeak(request);
+
+        expect(result.success).to.be.true;
+        const outboundBody = axios.post.firstCall.args[1];
+        expect(outboundBody.tags).to.equal("inlab,industrial");
+      });
+
+      it("should omit tags entirely when only blank entries are provided", async () => {
+        const responseFromPost = {
+          data: {
+            api_keys: [
+              { write_flag: true, api_key: "WRITE_KEY" },
+              { write_flag: false, api_key: "READ_KEY" },
+            ],
+            id: "DEVICE_ID",
+          },
+        };
+        sinon.stub(axios, "post").resolves(responseFromPost);
+
+        const request = { body: { name: "aq_001", tags: ["", "  "] } };
+        await deviceUtil.createOnThingSpeak(request);
+
+        const outboundBody = axios.post.firstCall.args[1];
+        expect(outboundBody).to.not.have.property("tags");
       });
 
       it("should handle axios.post failure without response and return failure status", async () => {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes device creation failures on the external device-channel provider integration and makes provider-side failures diagnosable:

1. **Root cause fix:** device `tags` submitted as a JSON array were forwarded unmodified to the provider's channel-creation endpoint, which requires tags as a comma-separated string. This caused device creation to fail with an HTTP 500 every time a tag was selected, regardless of which tag. Tags are now joined into a comma-separated string only for the outbound provider payload — tag storage in our own database is unaffected.
2. Enhanced provider-failure error responses to carry real diagnostic detail (HTTP status + provider error text, normalized to a readable string) instead of collapsing to a blank/generic `"Internal Server Error"` message.
3. Fixed two failure paths that could return a missing or non-numeric (`""`/`NaN`) `status` code, so callers always receive a valid numeric status.
4. Fixed write/read API key selection to match the provider's `write_flag` field instead of assuming fixed array position — a reordered response previously could silently create a device with blank channel keys instead of failing.
5. Fixed misleading rollback messaging: cleanup of a partially-created channel is now actually checked and reported (success vs. failure), and cleanup exceptions no longer leak into the unrelated network-failure error branch.

### Why is this change needed?
Production logs were repeatedly showing `unable to generate enrichment data for the device -- {"message":"Internal Server Error"}` with no diagnostic value. Investigation traced this through several layers in `createOnThingSpeak`/`deviceUtil.create`, and a team member separately reproduced it live: any device created with a tag selected in the Vertex UI deterministically failed, while devices with no tags succeeded. Tracing the request payload confirmed tags are sent as a JSON array to the provider's channel-creation endpoint, which expects a comma-separated string — causing a provider-side 500 on every tagged device creation. Along the way, several related gaps (blank status codes, positional key-selection bug, unreliable rollback reporting) were found and fixed to make this failure mode fully diagnosable going forward.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` (`utils/device.util.js` — `createOnThingSpeak`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified the file compiles cleanly (`node --check utils/device.util.js`) after each change. Traced the tags array through `config/definitions/mappings.js` and `node-json-transform`'s `iterator()` to confirm it reaches the provider payload unmodified prior to this fix. Full automated test suite has not been run in this session — recommend running it and confirming in staging that creating a device with a tag via Vertex now succeeds end-to-end before merge.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Response shape (`success`, `status`, `errors`) is unchanged. Tags remain stored as an array in our own database; only the outbound provider payload format changed.

---

## :memo: Additional Notes
- The word "ThingSpeak" is deliberately avoided in all user/API-facing error messages (generic "external device-channel provider" wording used instead); it's named directly here only for internal reviewer context.
- Confirmed during investigation that there is no tag-value whitelist anywhere in `device-registry` — the failure is triggered by tag array *format*, not by specific tag values like `inlab`/`industrial`, ruling out an earlier theory that particular tag choices were the cause.

---

## :white_check_mark: Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel creation requests so device tags are submitted in the expected comma-separated format.
  * Improved compatibility with the external provider when creating channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->