### PR TITLE
Fix duplicate cron job execution across pod replicas

### DIFF
--- a/src/auth-service/bin/jobs/active-status-job.js
+++ b/src/auth-service/bin/jobs/active-status-job.js
@@ -16,8 +16,12 @@ const {
   generateFilter,
   handleResponse,
 } = require("@utils/common");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const checkStatus = async () => {
+  const gotLock = await acquireCronLock("airqo", jobName);
+  if (!gotLock) return;
+
   try {
     const thresholdDate = new Date(Date.now() - inactiveThreshold);
     const batchSize = 100;

--- a/src/auth-service/bin/jobs/air-quality-alerts-job.js
+++ b/src/auth-service/bin/jobs/air-quality-alerts-job.js
@@ -17,6 +17,7 @@ const {
 } = require("@utils/common");
 const isEmpty = require("is-empty");
 const log4js = require("log4js");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/air-quality-alerts-job -- ops-alerts`,
 );
@@ -173,6 +174,9 @@ const isTimeInRange = (current, start, end) => {
 };
 
 const checkAirQualityAndAlert = async () => {
+  const gotLock = await acquireCronLock("airqo", jobName);
+  if (!gotLock) return;
+
   try {
     let skip = 0;
     let alertsToSend = [];

--- a/src/auth-service/bin/jobs/bypass-expiry-job.js
+++ b/src/auth-service/bin/jobs/bypass-expiry-job.js
@@ -11,6 +11,7 @@ const UserModel = require("@models/User");
 const tokenUtil = require("@utils/token.util");
 const { mailer } = require("@utils/common");
 const { logText } = require("@utils/shared");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const TIMEZONE = constants.TIMEZONE || "Africa/Kampala";
 const DAILY_SCHEDULE = "0 9 * * *"; // 9:00 AM every day
@@ -168,6 +169,8 @@ const sendWeeklyBypassDigest = async (tenant = "airqo") => {
 const runDailyBypassMaintenance = async (tenant = "airqo") => {
   try {
     if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") return;
+    const gotLock = await acquireCronLock(tenant, "bypass-expiry-job-daily");
+    if (!gotLock) return;
     await revokeExpiredBypasses(tenant);
     await sendUpcomingExpiryReminders(tenant);
   } catch (error) {
@@ -178,6 +181,8 @@ const runDailyBypassMaintenance = async (tenant = "airqo") => {
 const runWeeklyBypassDigest = async (tenant = "airqo") => {
   try {
     if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") return;
+    const gotLock = await acquireCronLock(tenant, "bypass-expiry-job-weekly");
+    if (!gotLock) return;
     await sendWeeklyBypassDigest(tenant);
   } catch (error) {
     logger.error(`bypass-expiry-job weekly digest failed: ${error.message}`);

--- a/src/auth-service/bin/jobs/check-subscription-status.js
+++ b/src/auth-service/bin/jobs/check-subscription-status.js
@@ -7,6 +7,7 @@ const log4js = require("log4js");
 const { mailer, stringify } = require("@utils/common");
 const httpStatus = require("http-status");
 const cron = require("node-cron");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/check-subscription-status -- ops-alerts`,
@@ -17,6 +18,10 @@ const checkSubscriptionStatuses = async () => {
     logger.warn("Paddle not configured — skipping subscription status check job");
     return;
   }
+
+  const gotLock = await acquireCronLock("airqo", jobName);
+  if (!gotLock) return;
+
   try {
     const batchSize = 100;
     let skip = 0;

--- a/src/auth-service/bin/jobs/daily-compromise-summary-job.js
+++ b/src/auth-service/bin/jobs/daily-compromise-summary-job.js
@@ -10,6 +10,7 @@ const UserModel = require("@models/User"); // Import UserModel
 const { mailer } = require("@utils/common");
 const moment = require("moment-timezone");
 const { logObject, logText } = require("@utils/shared");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const TIMEZONE = constants.TIMEZONE || "Africa/Kampala";
 const JOB_NAME = "daily-compromise-summary-job";
@@ -20,6 +21,9 @@ const generateAndSendSummaries = async (tenant = "airqo") => {
     if (constants.ENVIRONMENT !== "PRODUCTION ENVIRONMENT") {
       return;
     }
+
+    const gotLock = await acquireCronLock(tenant, JOB_NAME);
+    if (!gotLock) return;
 
     const yesterday = moment().subtract(1, "day").toDate();
 

--- a/src/auth-service/bin/jobs/dashboard-analytics-job.js
+++ b/src/auth-service/bin/jobs/dashboard-analytics-job.js
@@ -7,10 +7,16 @@ const logger = log4js.getLogger(
 );
 const { stringify } = require("@utils/common");
 const DashboardAnalyticsModel = require("@models/DashboardAnalytics");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
+
+const jobName = "dashboard-analytics-job";
 
 const calculateAndCacheAnalytics = async () => {
   try {
     const tenant = constants.DEFAULT_TENANT || "airqo";
+
+    const gotLock = await acquireCronLock(tenant, jobName);
+    if (!gotLock) return;
 
     const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
     const twoMonthsAgo = new Date();

--- a/src/auth-service/bin/jobs/feedback-reminder-job.js
+++ b/src/auth-service/bin/jobs/feedback-reminder-job.js
@@ -1,6 +1,7 @@
 const cron = require("node-cron");
 const constants = require("@config/constants");
 const mailer = require("@utils/common/mailer.util");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 const log4js = require("log4js");
 
 const logger = log4js.getLogger(
@@ -13,6 +14,8 @@ const STALE_THRESHOLD_DAYS = constants.FEEDBACK_REMINDER_THRESHOLD_DAYS;
 // Cap the digest at this many items to keep the email readable.
 const MAX_ITEMS_PER_DIGEST = 50;
 
+const jobName = "feedback-reminder-job";
+
 const sendFeedbackReminderDigest = async () => {
   // Require the model here (not at module load) so the DB connection is ready.
   const FeedbackModel = require("@models/Feedback");
@@ -20,6 +23,14 @@ const sendFeedbackReminderDigest = async () => {
 
   if (!constants.SUPPORT_EMAIL) {
     logger.warn("SUPPORT_EMAIL not configured — skipping feedback reminder job");
+    return;
+  }
+
+  const gotLock = await acquireCronLock(tenant, jobName);
+  if (!gotLock) {
+    logger.info(
+      "Feedback reminder job: another pod already handled this week's digest — skipping",
+    );
     return;
   }
 
@@ -72,7 +83,6 @@ const sendFeedbackReminderDigest = async () => {
 global.cronJobs = global.cronJobs || {};
 // Every Monday at 8 AM Nairobi time
 const schedule = "0 8 * * 1";
-const jobName = "feedback-reminder-job";
 global.cronJobs[jobName] = cron.schedule(
   schedule,
   sendFeedbackReminderDigest,

--- a/src/auth-service/bin/jobs/feedback-screenshot-cleanup-job.js
+++ b/src/auth-service/bin/jobs/feedback-screenshot-cleanup-job.js
@@ -2,6 +2,7 @@ const cron = require("node-cron");
 const cloudinary = require("@config/cloudinary");
 const constants = require("@config/constants");
 const log4js = require("log4js");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/feedback-screenshot-cleanup-job`,
@@ -23,6 +24,9 @@ const cleanupOldFeedbackScreenshots = async () => {
     );
     return;
   }
+
+  const gotLock = await acquireCronLock("airqo", jobName);
+  if (!gotLock) return;
 
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - RETENTION_DAYS);

--- a/src/auth-service/bin/jobs/inactive-users-job.js
+++ b/src/auth-service/bin/jobs/inactive-users-job.js
@@ -3,6 +3,7 @@ const UserModel = require("@models/User");
 const constants = require("@config/constants");
 const { mailer, stringify } = require("@utils/common");
 const log4js = require("log4js");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/inactive-users-job script -- ops-alerts`,
 );
@@ -11,10 +12,15 @@ const inactiveThresholdInDays = 45;
 const reminderCooldownInDays = 90; // Don't send reminders more than once every 90 days
 const BATCH_SIZE = 100;
 const CONCURRENCY_LIMIT = 10; // Number of emails to send in parallel
+const jobName = "inactive-users-job";
 
 const sendInactivityReminders = async () => {
   try {
     const tenant = (constants.DEFAULT_TENANT || "airqo").toLowerCase();
+
+    const gotLock = await acquireCronLock(tenant, jobName);
+    if (!gotLock) return;
+
     const now = new Date();
 
     const inactiveThresholdDate = new Date();

--- a/src/auth-service/bin/jobs/incomplete-profile-job.js
+++ b/src/auth-service/bin/jobs/incomplete-profile-job.js
@@ -16,6 +16,7 @@ const {
   handleResponse,
 } = require("@utils/common");
 const { logObject, logText } = require("@utils/shared");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 // Job identification
 const JOB_NAME = "incomplete-profile-job";
@@ -29,6 +30,12 @@ const checkStatus = async () => {
   // Prevent overlapping executions
   if (isJobRunning) {
     logger.warn(`${JOB_NAME} is already running, skipping this execution`);
+    return;
+  }
+
+  const gotLock = await acquireCronLock("airqo", JOB_NAME);
+  if (!gotLock) {
+    logger.info(`${JOB_NAME}: another pod already handled this run — skipping`);
     return;
   }
 

--- a/src/auth-service/bin/jobs/preferences-log-job.js
+++ b/src/auth-service/bin/jobs/preferences-log-job.js
@@ -19,9 +19,13 @@ const {
   handleResponse,
 } = require("@utils/common");
 const isEmpty = require("is-empty");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const logUserPreferences = async () => {
   try {
+    const gotLock = await acquireCronLock("airqo", jobName);
+    if (!gotLock) return;
+
     logText("Starting user preferences logging job...");
     const defaultGroupId = mongoose.Types.ObjectId(constants.DEFAULT_GROUP);
 

--- a/src/auth-service/bin/jobs/preferences-update-job.js
+++ b/src/auth-service/bin/jobs/preferences-update-job.js
@@ -11,11 +11,13 @@ const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/preference-update-job`
 );
 const { stringify } = require("@utils/common");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const isEmpty = require("is-empty");
 const BATCH_SIZE = 100;
 const NUMBER_OF_SITES_PER_USER = 2; // Number of sites to select for each user
 const SELECTION_POOL_SIZE = 20; // Size of the pool to select from
+const jobName = "preferences-update-job";
 
 // Function to validate critical default values
 const validateDefaultValues = () => {
@@ -127,6 +129,9 @@ const updatePreferences = async (siteSelectionMethod = "featured") => {
   }
 
   try {
+    const gotLock = await acquireCronLock("airqo", jobName);
+    if (!gotLock) return;
+
     const batchSize = BATCH_SIZE;
     let skip = 0;
 
@@ -257,7 +262,6 @@ const updatePreferences = async (siteSelectionMethod = "featured") => {
 
 global.cronJobs = global.cronJobs || {};
 const schedule = "30 * * * *"; // At minute 30 of every hour
-const jobName = "preferences-update-job";
 global.cronJobs[jobName] = cron.schedule(
   schedule,
   () => updatePreferences("featured"),

--- a/src/auth-service/bin/jobs/profile-picture-update-job.js
+++ b/src/auth-service/bin/jobs/profile-picture-update-job.js
@@ -10,12 +10,14 @@ const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/profile-picture-update-job`
 );
 const { stringify } = require("@utils/common");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 const isEmpty = require("is-empty");
 
 // Configuration
 const BATCH_SIZE = 100;
 const DEFAULT_PROFILE_PICTURE = constants.DEFAULT_ORGANISATION_PROFILE_PICTURE;
 const MAX_CONCURRENT_OPERATIONS = 5; // Limit concurrent operations
+const jobName = "profile-picture-update-job";
 
 // Function to validate URL
 const isValidUrl = (url) => {
@@ -104,6 +106,9 @@ async function updateProfilePictures() {
     return;
   }
 
+  const gotLock = await acquireCronLock("airqo", jobName);
+  if (!gotLock) return;
+
   const stats = {
     networks: { processed: 0, success: 0, error: 0 },
     groups: { processed: 0, success: 0, error: 0 },
@@ -187,7 +192,6 @@ async function updateProfilePictures() {
 global.cronJobs = global.cronJobs || {};
 // // Schedule the job to run daily at midnight
 const schedule = "0 0 * * *";
-const jobName = "profile-picture-update-job";
 global.cronJobs[jobName] = cron.schedule(schedule, updateProfilePictures, {
   scheduled: true,
   timezone: "Africa/Nairobi",

--- a/src/auth-service/bin/jobs/role-cleanup-job.js
+++ b/src/auth-service/bin/jobs/role-cleanup-job.js
@@ -5,6 +5,7 @@ const cron = require("node-cron");
 const moment = require("moment-timezone");
 const UserModel = require("@models/User");
 const userUtil = require("@utils/user.util");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const TIMEZONE = "Africa/Nairobi";
 const JOB_NAME = "role-cleanup-job";
@@ -100,6 +101,9 @@ class NonBlockingJobProcessor {
 const cleanupUserRolesJob = async () => {
   const processor = new NonBlockingJobProcessor(JOB_NAME);
   const tenant = constants.DEFAULT_TENANT || "airqo";
+
+  const gotLock = await acquireCronLock(tenant, JOB_NAME);
+  if (!gotLock) return;
 
   try {
     processor.start();

--- a/src/auth-service/bin/jobs/role-init-job.js
+++ b/src/auth-service/bin/jobs/role-init-job.js
@@ -3,6 +3,7 @@ const constants = require("@config/constants");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- role-init-job`);
 const nodeCron = require("node-cron");
 const mongoose = require("mongoose");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 // Track initialization status for diagnostics
 let initializationComplete = false;
@@ -123,6 +124,8 @@ function scheduleRoleVerification() {
     if (nodeCron.validate(cronSchedule)) {
       nodeCron.schedule(cronSchedule, async () => {
         try {
+          const gotLock = await acquireCronLock("airqo", "role-init-job");
+          if (!gotLock) return;
           await runRoleInitialization();
         } catch (error) {
           logger.error(`Scheduled role verification error: ${error.message}`);

--- a/src/auth-service/bin/jobs/selfie-cleanup-job.js
+++ b/src/auth-service/bin/jobs/selfie-cleanup-job.js
@@ -3,6 +3,7 @@ const cloudinary = require("@config/cloudinary");
 const constants = require("@config/constants");
 const SelfieModel = require("@models/Selfie");
 const log4js = require("log4js");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/selfie-cleanup-job`
@@ -18,6 +19,9 @@ const isCloudinaryConfigured =
   !!constants.CLOUDINARY_API_SECRET;
 
 const cleanupOldSelfies = async () => {
+  const gotLock = await acquireCronLock("airqo", jobName);
+  if (!gotLock) return;
+
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - RETENTION_DAYS);
 

--- a/src/auth-service/bin/jobs/stale-accounts-job.js
+++ b/src/auth-service/bin/jobs/stale-accounts-job.js
@@ -5,6 +5,7 @@ const AccessTokenModel = require("@models/AccessToken");
 const constants = require("@config/constants");
 const { mailer, stringify } = require("@utils/common");
 const log4js = require("log4js");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/stale-accounts-job script -- ops-alerts`,
 );
@@ -18,6 +19,10 @@ const BATCH_SIZE = 100;
 const processStaleAccounts = async () => {
   try {
     const tenant = (constants.DEFAULT_TENANT || "airqo").toLowerCase();
+
+    const gotLock = await acquireCronLock(tenant, jobName);
+    if (!gotLock) return;
+
     const now = new Date();
 
     const staleThresholdDate = new Date();

--- a/src/auth-service/bin/jobs/subscription-renewal-job.js
+++ b/src/auth-service/bin/jobs/subscription-renewal-job.js
@@ -8,6 +8,7 @@ const log4js = require("log4js");
 const httpStatus = require("http-status");
 const cron = require("node-cron");
 const { mailer, stringify } = require("@utils/common");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- subscription-renewal-utils -- ops-alerts`,
@@ -22,6 +23,10 @@ const subscriptionRenewalUtils = {
       logger.warn("Paddle not configured — skipping automatic renewal job");
       return;
     }
+
+    const gotLock = await acquireCronLock("airqo", "subscription-renewal-job");
+    if (!gotLock) return;
+
     try {
       const batchSize = 100;
       let skip = 0;
@@ -140,6 +145,12 @@ const subscriptionRenewalUtils = {
    */
   sendUpcomingRenewalNotifications: async () => {
     try {
+      const gotLock = await acquireCronLock(
+        "airqo",
+        "subscription-renewal-notification-job",
+      );
+      if (!gotLock) return;
+
       const batchSize = 100;
       let skip = 0;
 

--- a/src/auth-service/bin/jobs/token-expiration-job.js
+++ b/src/auth-service/bin/jobs/token-expiration-job.js
@@ -3,6 +3,7 @@ const cron = require("node-cron");
 const constants = require("@config/constants");
 const { logObject, logText } = require("@utils/shared");
 const { mailer, stringify } = require("@utils/common");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- bin/jobs/token-expiration-job -- ops-alerts`,
@@ -104,6 +105,9 @@ async function fetchTokensExpiringWithinDays(days) {
 }
 
 const sendAlertsForExpiringTokens = async () => {
+  const gotLock = await acquireCronLock("airqo", jobName);
+  if (!gotLock) return;
+
   for (const days of REMINDER_DAY_THRESHOLDS) {
     try {
       const tokens = await fetchTokensExpiringWithinDays(days);

--- a/src/auth-service/bin/jobs/token-strategy-migration-job.js
+++ b/src/auth-service/bin/jobs/token-strategy-migration-job.js
@@ -4,12 +4,14 @@ const constants = require("@config/constants");
 const log4js = require("log4js");
 const { stringify } = require("@utils/common");
 const RoleModel = require("@models/Role");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- token-strategy-migration-job`
 );
 
 const BATCH_SIZE = 100;
+const JOB_NAME = "token-strategy-migration-job";
 
 let isJobRunning = false;
 
@@ -24,6 +26,9 @@ const migrateTokenStrategiesToDefault = async (tenant) => {
 
   const tenantId = tenant || constants.DEFAULT_TENANT || "airqo";
   try {
+    const gotLock = await acquireCronLock(tenantId, JOB_NAME);
+    if (!gotLock) return;
+
     logger.info(
       "🚀 Starting data migration job (token strategy, legacy fields & roles)..."
     );

--- a/src/auth-service/bin/jobs/transaction-amount-fix-job.js
+++ b/src/auth-service/bin/jobs/transaction-amount-fix-job.js
@@ -3,6 +3,7 @@ const TransactionModel = require("@models/Transaction");
 const constants = require("@config/constants");
 const log4js = require("log4js");
 const { stringify } = require("@utils/common");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- transaction-amount-fix-job`
@@ -31,6 +32,9 @@ const fixTransactionAmounts = async () => {
   isJobRunning = true;
 
   try {
+    const gotLock = await acquireCronLock(TENANT, jobName);
+    if (!gotLock) return;
+
     // Fast pre-check: exit immediately if there is nothing to fix.
     const dirtyCount = await TransactionModel(TENANT).countDocuments(
       DIRTY_FILTER

--- a/src/auth-service/bin/jobs/unknown-ip-cleanup-job.js
+++ b/src/auth-service/bin/jobs/unknown-ip-cleanup-job.js
@@ -5,6 +5,7 @@ const logger = log4js.getLogger(
 );
 const cron = require("node-cron");
 const UnknownIPModel = require("@models/UnknownIP");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const JOB_NAME = "unknown-ip-cleanup-job";
 // Run every Sunday at 02:00 AM — low-traffic window
@@ -26,6 +27,9 @@ const cleanupUnknownIPs = async () => {
   }
 
   const tenant = constants.DEFAULT_TENANT || "airqo";
+
+  const gotLock = await acquireCronLock(tenant, JOB_NAME);
+  if (!gotLock) return;
 
   try {
     logger.info(`${JOB_NAME}: starting cleanup (retention = ${RETENTION_DAYS} days)`);

--- a/src/auth-service/bin/jobs/update-user-activities-job.js
+++ b/src/auth-service/bin/jobs/update-user-activities-job.js
@@ -8,6 +8,7 @@ const { logObject, logText } = require("@utils/shared");
 
 const { LogModel } = require("@models/log");
 const ActivityModel = require("@models/Activity");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
 
 const BATCH_SIZE = 500;
 const MAX_RETRIES = 3;
@@ -310,6 +311,9 @@ async function updateUserActivities({ tenant = "airqo" } = {}, retryCount = 0) {
 
 async function runUpdateUserActivities() {
   try {
+    const gotLock = await acquireCronLock("airqo", jobName);
+    if (!gotLock) return;
+
     const result = await updateUserActivities({ tenant: "airqo" });
     logObject("Run result", result);
   } catch (error) {

--- a/src/auth-service/models/CronLock.js
+++ b/src/auth-service/models/CronLock.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+
+/**
+ * Distributed lock for cron jobs that run independently on every pod replica
+ * (this deployment has no leader election). A unique index on `lockKey`
+ * enforces first-writer-wins: the pod whose insert succeeds got the lock,
+ * every other pod's insert fails with E11000. See utils/common/cron-lock.util.js
+ * for the acquire helper.
+ */
+const CronLockSchema = new mongoose.Schema(
+  {
+    lockKey: {
+      type: String,
+      required: true,
+    },
+  },
+  { timestamps: true },
+);
+
+CronLockSchema.index({ lockKey: 1 }, { unique: true });
+
+// TTL: locks expire after 24h so a crashed/never-run job can't wedge future
+// runs. Legitimate locks are always superseded by the next minute's bucket
+// long before this fires.
+CronLockSchema.index({ createdAt: 1 }, { expireAfterSeconds: 60 * 60 * 24 });
+
+const CronLockModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+
+  return getModelByTenant(dbTenant, "cron_lock", CronLockSchema);
+};
+
+module.exports = CronLockModel;

--- a/src/auth-service/utils/common/cron-lock.util.js
+++ b/src/auth-service/utils/common/cron-lock.util.js
@@ -1,0 +1,46 @@
+const moment = require("moment-timezone");
+const CronLockModel = require("@models/CronLock");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- cron-lock-util`);
+
+/**
+ * First-writer-wins distributed lock for cron jobs. This deployment runs
+ * multiple pod replicas and every pod registers its own node-cron schedule
+ * independently (no leader election), so without this gate every scheduled
+ * tick runs once per pod instead of once total.
+ *
+ * The lock bucket is minute-granularity rather than tied to each job's own
+ * cadence: node-cron's finest resolution is one minute, so all pods
+ * triggered by the same scheduled tick always compute the same bucket,
+ * regardless of whether the job itself runs hourly, daily, or weekly.
+ *
+ * Fails CLOSED on unexpected DB errors (e.g. connection issues) — skipping
+ * one run is safer than letting every pod run unguarded, and jobs recur.
+ *
+ * @param {string} tenant  - DB tenant; falls back to the default tenant.
+ * @param {string} jobName - Unique identifier for the job (its `jobName`
+ *   constant/global.cronJobs key is a good choice).
+ * @returns {Promise<boolean>} true if this pod acquired the lock and should run.
+ */
+const acquireCronLock = async (tenant, jobName) => {
+  const CronLock = CronLockModel(tenant);
+  const minuteBucket = moment().utc().format("YYYY-MM-DDTHH:mm");
+  const lockKey = `${jobName}:${minuteBucket}`;
+
+  try {
+    await CronLock.create({ lockKey });
+    return true;
+  } catch (err) {
+    if (err.code === 11000) {
+      return false;
+    }
+    logger.warn(
+      `acquireCronLock(${jobName}) failed, failing closed: ${err.message}`,
+    );
+    return false;
+  }
+};
+
+module.exports = { acquireCronLock };

--- a/src/auth-service/utils/common/test/ut_cron-lock.util.js
+++ b/src/auth-service/utils/common/test/ut_cron-lock.util.js
@@ -1,0 +1,62 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+// .noCallThru() so the @models/CronLock fake below stays a pure fake -- see
+// ut_mailer.util.js for the rationale (getModelByTenant throws synchronously
+// without a live DB connection, so the real model can't be obtained and then
+// stubbed with sinon).
+const proxyquire = require("proxyquire").noCallThru();
+
+describe("acquireCronLock", () => {
+  let createStub;
+  let CronLockModelStub;
+  let warnStub;
+  let acquireCronLock;
+
+  beforeEach(() => {
+    createStub = sinon.stub();
+    CronLockModelStub = sinon.stub().returns({ create: createStub });
+    warnStub = sinon.stub();
+
+    ({ acquireCronLock } = proxyquire("../cron-lock.util", {
+      "@models/CronLock": CronLockModelStub,
+      log4js: { getLogger: () => ({ warn: warnStub }) },
+    }));
+  });
+
+  it("returns true when the lock insert succeeds", async () => {
+    createStub.resolves({});
+
+    const result = await acquireCronLock("airqo", "some-job");
+
+    expect(result).to.equal(true);
+    expect(CronLockModelStub.calledOnceWith("airqo")).to.be.true;
+    expect(createStub.calledOnce).to.be.true;
+    const [{ lockKey }] = createStub.firstCall.args;
+    expect(lockKey).to.match(/^some-job:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  });
+
+  it("returns false without warning when another pod already holds the lock (E11000)", async () => {
+    const duplicateKeyError = Object.assign(new Error("E11000 duplicate key"), {
+      code: 11000,
+    });
+    createStub.rejects(duplicateKeyError);
+
+    const result = await acquireCronLock("airqo", "some-job");
+
+    expect(result).to.equal(false);
+    expect(warnStub.called).to.be.false;
+  });
+
+  it("fails closed and logs a warning on an unexpected DB error", async () => {
+    const dbError = new Error("connection timed out");
+    createStub.rejects(dbError);
+
+    const result = await acquireCronLock("airqo", "some-job");
+
+    expect(result).to.equal(false);
+    expect(warnStub.calledOnce).to.be.true;
+    expect(warnStub.firstCall.args[0]).to.include("some-job");
+    expect(warnStub.firstCall.args[0]).to.include("connection timed out");
+  });
+});


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a distributed, MongoDB-based lock (`acquireCronLock`) and applies it to all 22 recurring cron jobs in `src/auth-service/bin/jobs/`. Each job now checks the lock as the first step of its handler and skips the run if another pod already claimed it for that scheduled tick.

### Why is this change needed?
`auth-service` runs 3 pod replicas in production, and every pod independently registers the same `node-cron` schedules with no leader election. This meant every scheduled job ran once per pod instead of once total — most visibly, the weekly feedback digest email was sent 3x to support. The same gap also risked tripling Paddle renewal transactions (`subscription-renewal-job`) and triple-counting user activity stats (`update-user-activities-job`). The new lock (first-writer-wins via a unique index on `CronLock.lockKey`, minute-granularity bucket) closes this for every job in the directory.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `auth-service` (cron jobs in `bin/jobs/`, new `models/CronLock.js`, new `utils/common/cron-lock.util.js`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
All 22 modified job files verified with `node --check`. Module alias resolution for `@models/CronLock` and `@utils/common/cron-lock.util` confirmed via direct `require.resolve`. `autoIndex: true` in `config/database.js` confirmed, so the unique index on `CronLock.lockKey` is created automatically at startup — no manual migration needed. Not yet verified against a live 3-pod deployment.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
Adds one new MongoDB collection (`cron_lock`) with a 24h TTL index, so a crashed run can't wedge future ticks. `feedback-reminder-job.js` was refactored to use this same shared lock utility instead of its previous bespoke `EmailLog`-based implementation, for consistency across all jobs.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented scheduled maintenance, notifications, cleanup, analytics, and account-processing tasks from running concurrently.
  - Improved reliability by ensuring only one instance processes each scheduled task at a time.
  - Added automatic handling for overlapping executions, allowing duplicate runs to exit safely without affecting the active task.
  - Applied protection across subscription, user, role, profile, token, alert, and data-processing workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->