### PR TITLE
Add group membership self-service flows and fix Redis rate-limiter bugs

### DIFF
--- a/src/auth-service/config/constants.js
+++ b/src/auth-service/config/constants.js
@@ -80,6 +80,12 @@ function envConfig(env) {
       const v = parseInt(process.env.BYPASS_EXPIRY_REMINDER_LEAD_DAYS, 10);
       return Number.isFinite(v) && v > 0 ? v : 3;
     })(),
+    // Group activity/audit log retention in days; 0 or unset = keep forever
+    // (this is a compliance-relevant trail, so it doesn't auto-expire by default)
+    ACTIVITY_LOG_RETENTION_DAYS: (() => {
+      const v = parseInt(process.env.ACTIVITY_LOG_RETENTION_DAYS, 10);
+      return Number.isFinite(v) && v > 0 ? v : 0;
+    })(),
     USE_REDIS_SESSIONS: parseBool(process.env.USE_REDIS_SESSIONS, false),
     ANALYTICS_PII_ENABLED: parseBool(process.env.ANALYTICS_PII_ENABLED, false),
     POSTHOG_ENABLED: parseBool(process.env.POSTHOG_ENABLED, false),

--- a/src/auth-service/controllers/group.controller.js
+++ b/src/auth-service/controllers/group.controller.js
@@ -168,6 +168,9 @@ const groupController = {
   removeUniqueConstraint: (req, res, next) =>
     executeGroupAction(req, res, next, groupUtil.removeUniqueConstraint),
 
+  updateEmailDomains: (req, res, next) =>
+    executeGroupAction(req, res, next, groupUtil.updateEmailDomains),
+
   list: async (req, res, next) => {
     try {
       const { params } = req;

--- a/src/auth-service/controllers/join-link.controller.js
+++ b/src/auth-service/controllers/join-link.controller.js
@@ -1,5 +1,5 @@
 const httpStatus = require("http-status");
-const { logObject, HttpError, extractErrorsFromRequest } = require("@utils/shared");
+const { HttpError, extractErrorsFromRequest } = require("@utils/shared");
 const joinLinkUtil = require("@utils/join-link.util");
 const isEmpty = require("is-empty");
 const constants = require("@config/constants");
@@ -18,6 +18,7 @@ const respond = (res, result) => {
       success: true,
       message: result.message,
       data: result.data,
+      ...(result.meta ? { meta: result.meta } : {}),
     });
   }
   const status = result.status ? result.status : httpStatus.INTERNAL_SERVER_ERROR;

--- a/src/auth-service/controllers/join-link.controller.js
+++ b/src/auth-service/controllers/join-link.controller.js
@@ -1,0 +1,154 @@
+const httpStatus = require("http-status");
+const { logObject, HttpError, extractErrorsFromRequest } = require("@utils/shared");
+const joinLinkUtil = require("@utils/join-link.util");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- join-link-controller`,
+);
+
+const respond = (res, result) => {
+  if (isEmpty(result)) {
+    return;
+  }
+  if (result.success === true) {
+    const status = result.status ? result.status : httpStatus.OK;
+    return res.status(status).json({
+      success: true,
+      message: result.message,
+      data: result.data,
+    });
+  }
+  const status = result.status ? result.status : httpStatus.INTERNAL_SERVER_ERROR;
+  return res.status(status).json({
+    success: false,
+    message: result.message,
+    error: result.error ? result.error : "",
+    errors: result.errors ? result.errors : { message: "Internal Server Error" },
+  });
+};
+
+const joinLinkController = {
+  createJoinLink: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await joinLinkUtil.createJoinLink(request, next);
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+      return respond(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  listJoinLinks: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await joinLinkUtil.listJoinLinks(request, next);
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+      return respond(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  revokeJoinLink: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await joinLinkUtil.revokeJoinLink(request, next);
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+      return respond(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  redeemJoinLink: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await joinLinkUtil.redeemJoinLink(request, next);
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+      return respond(res, result);
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+};
+
+module.exports = joinLinkController;

--- a/src/auth-service/controllers/request.controller.js
+++ b/src/auth-service/controllers/request.controller.js
@@ -339,6 +339,60 @@ const createAccessRequest = {
       return;
     }
   },
+  cancelAccessRequest: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors),
+        );
+        return;
+      }
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await requestUtil.cancelAccessRequest(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      if (result.success === true) {
+        const status = result.status ? result.status : httpStatus.OK;
+        return res.status(status).json({
+          success: true,
+          message: result.message,
+          requests: result.data,
+        });
+      } else if (result.success === false) {
+        const status = result.status
+          ? result.status
+          : httpStatus.INTERNAL_SERVER_ERROR;
+
+        return res.status(status).json({
+          success: false,
+          message: result.message,
+          error: result.error ? result.error : "",
+          errors: result.errors
+            ? result.errors
+            : { message: "Internal Server Error" },
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+      return;
+    }
+  },
   listPendingAccessRequests: async (req, res, next) => {
     try {
       const errors = extractErrorsFromRequest(req);

--- a/src/auth-service/middleware/accessRequestAuth.js
+++ b/src/auth-service/middleware/accessRequestAuth.js
@@ -4,11 +4,15 @@ const mongoose = require("mongoose");
 const { HttpError } = require("@utils/shared");
 const constants = require("@config/constants");
 const AccessRequestModel = require("@models/AccessRequest");
-const { requireGroupManagerAccess } = require("@middleware/groupNetworkAuth");
+const {
+  requireGroupManagerAccess,
+  requireNetworkManagerAccess,
+} = require("@middleware/groupNetworkAuth");
 
 /**
  * Resolves :request_id to its underlying AccessRequest, then authorizes the
- * caller against the request's target group before allowing approve/reject.
+ * caller against the request's target group or network before allowing
+ * approve/reject/cancel/update/delete.
  * @param {string} requestIdParam - Parameter name containing the access request ID
  * @returns {Function} Express middleware
  */
@@ -62,10 +66,14 @@ const requireAccessRequestManagerAccess = (requestIdParam = "request_id") => {
         return requireGroupManagerAccess("grp_id")(req, res, next);
       }
 
+      if (accessRequest.requestType === "network") {
+        req.params.net_id = accessRequest.targetId.toString();
+        return requireNetworkManagerAccess("net_id")(req, res, next);
+      }
+
       return next(
         new HttpError("Not Implemented", httpStatus.NOT_IMPLEMENTED, {
-          message:
-            "Approving/rejecting network access requests is not yet supported",
+          message: `Access requests of type "${accessRequest.requestType}" are not supported`,
         })
       );
     } catch (error) {

--- a/src/auth-service/middleware/groupNetworkAuth.js
+++ b/src/auth-service/middleware/groupNetworkAuth.js
@@ -121,6 +121,107 @@ const requireGroupManagerAccess = (groupIdParam = "grp_id") => {
 };
 
 /**
+ * Middleware to check if user has network manager access — the network
+ * counterpart of requireGroupManagerAccess above (same shape: super admin
+ * bypass, then net_manager identity OR manager-level permissions OR
+ * manager-level role).
+ * @param {string} networkIdParam - Parameter name containing network ID
+ * @returns {Function} Express middleware
+ */
+const requireNetworkManagerAccess = (networkIdParam = "net_id") => {
+  return async (req, res, next) => {
+    try {
+      const user = req.user;
+      const tenant = req.query.tenant || constants.DEFAULT_TENANT;
+      const networkId = req.params[networkIdParam] || req.body[networkIdParam];
+
+      if (!user || !user._id) {
+        return next(
+          new HttpError("Authentication required", httpStatus.UNAUTHORIZED, {
+            message: "You must be logged in to access this resource",
+          })
+        );
+      }
+
+      if (!networkId) {
+        return next(
+          new HttpError("Bad Request", httpStatus.BAD_REQUEST, {
+            message: "Network identifier required",
+          })
+        );
+      }
+
+      const rbacService = getRBACService(tenant);
+
+      // System super admin bypasses further checks
+      const isSystemSuperAdmin = await rbacService.isSystemSuperAdmin(user._id);
+      if (isSystemSuperAdmin) {
+        return next();
+      }
+
+      // Check if user is network manager
+      const isNetworkManager = await rbacService.isNetworkManager(
+        user._id,
+        networkId
+      );
+
+      // Check if user has manager-level permissions
+      const hasManagerPermissions = await rbacService.hasPermission(
+        user._id,
+        [constants.NETWORK_MANAGEMENT, constants.USER_MANAGEMENT, constants.NETWORK_EDIT],
+        false, // any of these permissions
+        networkId,
+        "network"
+      );
+
+      // Check if user has manager-level roles
+      const hasManagerRole = await rbacService.hasRole(
+        user._id,
+        ["SUPER_ADMIN", "ADMIN", "MANAGER"],
+        networkId,
+        "network"
+      );
+
+      if (!isNetworkManager && !hasManagerPermissions && !hasManagerRole) {
+        logger.warn(
+          `Network manager access denied for user ${user.email} (ID: ${user._id}) in network ${networkId}: Not network manager and no manager permissions/roles`
+        );
+
+        return next(
+          new HttpError(
+            "Access denied: Network manager access required",
+            httpStatus.FORBIDDEN,
+            {
+              message:
+                "You don't have network management access to this resource",
+              networkId,
+            }
+          )
+        );
+      }
+
+      req.networkManagerContext = {
+        networkId,
+        isActualManager: isNetworkManager,
+        hasManagerPermissions,
+        hasManagerRole,
+      };
+
+      next();
+    } catch (error) {
+      logger.error(`Network manager access check error: ${error.message}`);
+      next(
+        new HttpError(
+          "Network manager access check failed",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  };
+};
+
+/**
  * Middleware to check if user has group admin access (higher than manager)
  * @param {string} groupIdParam - Parameter name containing group ID
  * @returns {Function} Express middleware
@@ -995,6 +1096,7 @@ const requireOrganizationContextEnhanced = (options = {}) => {
 
 module.exports = {
   requireGroupManagerAccess,
+  requireNetworkManagerAccess,
   requireGroupAdminAccess,
   requireSuperAdminAccess,
   requireGroupMemberManagementAccess,

--- a/src/auth-service/middleware/rate-limit.middleware.js
+++ b/src/auth-service/middleware/rate-limit.middleware.js
@@ -66,10 +66,15 @@ const WHITELISTED_IPS = constants.RATE_LIMIT_WHITELIST
 // ============================================
 
 /**
- * Safely attempt to initialize Redis store
- * Returns null if anything fails - will use in-memory store
+ * Safely attempt to initialize a Redis store for one rate limiter.
+ * Returns null if anything fails - will use in-memory store instead.
+ *
+ * `name` becomes the store's key prefix and MUST be unique per limiter —
+ * express-rate-limit validates that a store instance isn't shared across
+ * multiple limiters (each needs its own counters), so this is called fresh
+ * per limiter rather than once at module load and reused.
  */
-const initializeRedisStore = () => {
+const initializeRedisStore = (name) => {
   if (!USE_REDIS) {
     logger.info("📊 Rate Limiting: In-memory store (Redis disabled)");
     return null;
@@ -81,7 +86,12 @@ const initializeRedisStore = () => {
     let redis;
 
     try {
-      RedisStore = require("rate-limit-redis");
+      // rate-limit-redis exports RedisStore as a named export, not a default
+      // export — `require("rate-limit-redis")` alone gives the whole exports
+      // object, not the class, which previously made every `new RedisStore()`
+      // below throw "RedisStore is not a constructor" and silently fall back
+      // to the in-memory store regardless of Redis's actual availability.
+      ({ RedisStore } = require("rate-limit-redis"));
     } catch (error) {
       logger.warn(
         "⚠️ rate-limit-redis package not found. Using in-memory store."
@@ -112,32 +122,33 @@ const initializeRedisStore = () => {
     }
 
     // Attempt to create the store
+    // NOTE: `redis` here is the wrapper exported by @config/redis (redisGetAsync,
+    // redisUtils, etc.) — it has no sendCommand of its own. The raw node-redis
+    // client (which does) is exported separately as `redis.redis`. Using the
+    // wrapper directly here previously made every rate-limited request throw
+    // `TypeError: redis.sendCommand is not a function` whenever Redis was
+    // actually up and reachable — the opposite of the intended fallback.
     const store = new RedisStore({
       // @ts-expect-error - RedisStore accepts the v4 client
-      sendCommand: (...args) => redis.sendCommand(args),
-      prefix: "rl:",
+      sendCommand: (...args) => redis.redis.sendCommand(args),
+      prefix: `rl:${name}:`,
     });
 
     logger.info(
-      "✅ Rate Limiting: Using Redis store for distributed rate limiting"
+      `✅ Rate Limiting: Using Redis store for "${name}" (distributed rate limiting)`
     );
     return store;
   } catch (error) {
-    logger.error(`❌ Failed to initialize Redis store: ${error.message}`);
+    logger.error(`❌ Failed to initialize Redis store for "${name}": ${error.message}`);
     logger.warn("⚠️ Falling back to in-memory store");
     logObject("Redis store initialization error", error);
     return null;
   }
 };
 
-// Initialize store (null = in-memory fallback)
-let rateStore = null;
-try {
-  rateStore = initializeRedisStore();
-} catch (error) {
-  logger.error(`Critical error during rate store init: ${error.message}`);
-  rateStore = null; // Ensure we fall back to memory
-}
+// Fallback prefix for callers that don't supply a `name` (e.g. dynamically
+// created custom limiters) — still unique per call, just not human-readable.
+let _anonymousStoreCounter = 0;
 
 // ============================================
 // HELPER FUNCTIONS
@@ -290,6 +301,10 @@ const onRateLimitError = (error, req, res, next) => {
 
 /**
  * Create a safe rate limiter with error handling
+ *
+ * `config.name` identifies this limiter for its Redis store's key prefix —
+ * pass a short unique string (e.g. "strict", "auth"). Each call gets its own
+ * store instance; see initializeRedisStore's doc comment for why.
  */
 const createSafeRateLimiter = (config) => {
   // Extract keyGenerator separately so callers can override the default
@@ -297,11 +312,17 @@ const createSafeRateLimiter = (config) => {
   // skip, and handler too, which is undesirable — so we only allow
   // keyGenerator to be customised.
   // Extract message so the custom handler can surface it in the 429 body.
-  const { keyGenerator: configKeyGenerator, message: configMessage, ...restConfig } = config;
+  const {
+    keyGenerator: configKeyGenerator,
+    message: configMessage,
+    name: configName,
+    ...restConfig
+  } = config;
+  const storeName = configName || `anon_${++_anonymousStoreCounter}`;
   try {
     return rateLimit({
       ...restConfig,
-      store: rateStore,
+      store: initializeRedisStore(storeName),
       skip: skipFunction,
       handler: (req, res) => rateLimitHandler(req, res, configMessage),
       keyGenerator: configKeyGenerator || keyGenerator,
@@ -311,6 +332,11 @@ const createSafeRateLimiter = (config) => {
       skipFailedRequests: false,
       skipSuccessfulRequests: false,
       requestWasSuccessful: (req, res) => res.statusCode < 400,
+      // Belt-and-suspenders: if the store (Redis) throws for any reason —
+      // this specific bug, a future one, or Redis just being flaky — allow
+      // the request through instead of 500ing it. Rate limiting degrading is
+      // acceptable; rate limiting taking down the endpoint is not.
+      passOnStoreError: true,
     });
   } catch (error) {
     logger.error(`Failed to create rate limiter: ${error.message}`);
@@ -327,6 +353,7 @@ const createSafeRateLimiter = (config) => {
  * 200 requests per hour per IP
  */
 const strictRateLimiter = createSafeRateLimiter({
+  name: "strict",
   windowMs: 60 * 60 * 1000, // 1 hour
   max: 200,
   standardHeaders: true,
@@ -339,6 +366,7 @@ const strictRateLimiter = createSafeRateLimiter({
  * 100 requests per hour per IP
  */
 const standardRateLimiter = createSafeRateLimiter({
+  name: "standard",
   windowMs: 60 * 60 * 1000,
   max: 100,
   standardHeaders: true,
@@ -350,6 +378,7 @@ const standardRateLimiter = createSafeRateLimiter({
  * 5 attempts per 15 minutes
  */
 const authRateLimiter = createSafeRateLimiter({
+  name: "auth",
   windowMs: 15 * 60 * 1000,
   max: 5,
   standardHeaders: true,
@@ -362,6 +391,7 @@ const authRateLimiter = createSafeRateLimiter({
  * 50 requests per hour per IP
  */
 const writeRateLimiter = createSafeRateLimiter({
+  name: "write",
   windowMs: 60 * 60 * 1000,
   max: 50,
   standardHeaders: true,
@@ -373,6 +403,7 @@ const writeRateLimiter = createSafeRateLimiter({
  * 300 requests per hour per IP
  */
 const readRateLimiter = createSafeRateLimiter({
+  name: "read",
   windowMs: 60 * 60 * 1000,
   max: 300,
   standardHeaders: true,
@@ -389,6 +420,7 @@ const readRateLimiter = createSafeRateLimiter({
  * each, while blocking any single IP that hammers the endpoint indiscriminately.
  */
 const tokenVerifyIpRateLimiter = createSafeRateLimiter({
+  name: "token_verify_ip",
   windowMs: 60 * 60 * 1000,
   max: 5000,
   standardHeaders: true,
@@ -409,6 +441,7 @@ const tokenVerifyIpRateLimiter = createSafeRateLimiter({
  * Falls back to IP key if the token param is absent for any reason.
  */
 const tokenVerifyRateLimiter = createSafeRateLimiter({
+  name: "token_verify",
   windowMs: 60 * 60 * 1000,
   max: 2000,
   standardHeaders: true,
@@ -437,6 +470,7 @@ const tokenVerifyRateLimiter = createSafeRateLimiter({
  * These endpoints intentionally block JWT — see specificRoutes in passport.js.
  */
 const queryTokenRateLimiter = createSafeRateLimiter({
+  name: "query_token",
   windowMs: 60 * 1000,
   max: 10,
   standardHeaders: true,
@@ -448,8 +482,9 @@ const queryTokenRateLimiter = createSafeRateLimiter({
 /**
  * Custom rate limiter factory
  */
-const createCustomRateLimiter = ({ windowMs, max, message }) => {
+const createCustomRateLimiter = ({ windowMs, max, message, name }) => {
   return createSafeRateLimiter({
+    name,
     windowMs,
     max,
     message: message || "Too many requests, please try again later.",
@@ -471,6 +506,7 @@ const userKeyGenerator = (req) => {
 
 // Pre-built per-tier limiters (hourly window, keyed by user ID)
 const freeTierLimiter = createSafeRateLimiter({
+  name: "tier_free",
   windowMs: 60 * 60 * 1000,
   max: 100,
   standardHeaders: true,
@@ -480,6 +516,7 @@ const freeTierLimiter = createSafeRateLimiter({
 });
 
 const standardTierLimiter = createSafeRateLimiter({
+  name: "tier_standard",
   windowMs: 60 * 60 * 1000,
   max: 500,
   standardHeaders: true,
@@ -489,6 +526,7 @@ const standardTierLimiter = createSafeRateLimiter({
 });
 
 const premiumTierLimiter = createSafeRateLimiter({
+  name: "tier_premium",
   windowMs: 60 * 60 * 1000,
   max: 2000,
   standardHeaders: true,

--- a/src/auth-service/middleware/rate-limiter.js
+++ b/src/auth-service/middleware/rate-limiter.js
@@ -11,29 +11,30 @@ const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- rate-limiter`);
 const limiterCache = new Map();
 
 // Enhanced Redis availability check
+// `redis` here is the wrapper exported by @config/redis, not the raw client —
+// it has no isOpen/isReady of its own (those previously always evaluated
+// undefined, so this check always returned false and the Redis-backed path
+// below was silently dead). redisUtils.isAvailable() is the wrapper's own
+// correct isOpen/isReady check.
 const isRedisAvailable = () => {
   try {
-    return redis && redis.isOpen && redis.isReady;
+    return !!(redis && redis.redisUtils && redis.redisUtils.isAvailable());
   } catch (error) {
     logger.warn(`Redis availability check failed: ${error.message}`);
     return false;
   }
 };
 
-// Test Redis connectivity with timeout
+// Test Redis connectivity with timeout. Delegates to the wrapper's own
+// redisUtils.ping(), which already races a timeout and returns a boolean —
+// there's no bare redis.ping() on the wrapper to call directly.
 const testRedisConnectivity = async (timeoutMs = 3000) => {
   if (!isRedisAvailable()) {
     return false;
   }
 
   try {
-    const pingPromise = redis.ping();
-    const timeoutPromise = new Promise((_, reject) =>
-      setTimeout(() => reject(new Error("Redis ping timeout")), timeoutMs)
-    );
-
-    const result = await Promise.race([pingPromise, timeoutPromise]);
-    return result === "PONG";
+    return await redis.redisUtils.ping(timeoutMs);
   } catch (error) {
     logger.warn(`Redis connectivity test failed: ${error.message}`);
     return false;
@@ -44,8 +45,10 @@ const testRedisConnectivity = async (timeoutMs = 3000) => {
 const createRedisStore = (options) => {
   try {
     return new RedisStore({
-      // Function to send commands to Redis
-      sendCommand: (...args) => redis.sendCommand(args),
+      // Function to send commands to Redis. `redis.sendCommand` doesn't
+      // exist on the wrapper — the raw node-redis client (which has it) is
+      // exported separately as `redis.redis`.
+      sendCommand: (...args) => redis.redis.sendCommand(args),
 
       // Key prefix for this store
       prefix: options.prefix || "rl:",
@@ -73,6 +76,14 @@ const createLimiterConfig = (options, useRedis = false) => {
     legacyHeaders: false,
     skipFailedRequests: false,
     skipSuccessfulRequests: false,
+    // If the store throws at request time (Redis blip, this file's own
+    // sendCommand wiring, etc.), allow the request through rather than
+    // propagating to Express's error handler — express-rate-limit's async
+    // wrapper routes store errors to next(error) regardless of the try/catch
+    // in createDynamicLimiter below, so this is the only place that can
+    // actually make a live store error fail open instead of erroring the
+    // request.
+    passOnStoreError: true,
     // Suppress both trust-proxy and IPv6-fallback validations — keyGenerator reads
     // HAProxy-set headers (x-client-ip / x-client-original-ip) that clients cannot
     // spoof, so req.ip trustworthiness and IPv6 normalisation are not concerns here.
@@ -298,8 +309,8 @@ const getRateLimiterStats = async () => {
       available: redisAvailable,
       connected: redisConnectivity,
       client: {
-        isOpen: redis?.isOpen || false,
-        isReady: redis?.isReady || false,
+        isOpen: redis?.redis?.isOpen || false,
+        isReady: redis?.redis?.isReady || false,
       },
     },
     cache: {
@@ -375,7 +386,7 @@ const gracefulShutdown = async () => {
     clearLimiterCache();
 
     // Close Redis connections if needed
-    if (redis && redis.isOpen) {
+    if (redis && redis.redis && redis.redis.isOpen) {
       logger.info(
         "Rate limiter cache cleared, Redis connection managed externally"
       );

--- a/src/auth-service/models/AccessRequest.js
+++ b/src/auth-service/models/AccessRequest.js
@@ -45,7 +45,7 @@ const AccessRequestSchema = new Schema(
     },
     status: {
       type: String,
-      enum: ["pending", "approved", "rejected"],
+      enum: ["pending", "approved", "rejected", "cancelled"],
       default: "pending",
     },
     invitationToken: {
@@ -72,6 +72,22 @@ const AccessRequestSchema = new Schema(
       type: String,
       trim: true,
       maxlength: 1000, // matches groupValidations.sendGroupInvitations' body("invitations.*.message") limit
+    },
+    cancelled_by: {
+      type: ObjectId,
+      ref: "user",
+    },
+    cancelled_at: {
+      type: Date,
+    },
+    source: {
+      type: String,
+      enum: ["manual", "domain_match", "join_link"],
+      default: "manual",
+    },
+    source_link_id: {
+      type: ObjectId,
+      ref: "group_join_link",
     },
   },
   {

--- a/src/auth-service/models/ActivityLog.js
+++ b/src/auth-service/models/ActivityLog.js
@@ -66,6 +66,29 @@ ActivityLogSchema.index({ activity_type: 1 });
 
 // This is a compliance-relevant audit trail (who removed/promoted whom), so it
 // does not auto-expire unless ACTIVITY_LOG_RETENTION_DAYS is explicitly set.
+//
+// NOTE: this index is only (re)declared at process startup — changing
+// ACTIVITY_LOG_RETENTION_DAYS on a running deployment does not retroactively
+// add/drop/update the TTL index on an already-provisioned collection, only a
+// restart plus one of the calls below will. Use the existing DATABASE_ADMIN
+// index-maintenance endpoints (routes/v2/admin.routes.js) rather than a
+// manual DB console session — each call needs ?tenant=<tenant> and runs
+// once per tenant database:
+//
+//   Enable/change retention:
+//     POST /api/v2/admin/maintenance/db/create-index
+//     { "collectionName": "activity_logs",
+//       "indexSpec": { "createdAt": 1 },
+//       "indexOptions": { "expireAfterSeconds": <DAYS * 86400> },
+//       "secret": "<ADMIN_SETUP_SECRET>", "confirm": "CREATE_INDEX" }
+//   (if a differently-valued TTL index already exists, drop it first — Mongo
+//   rejects creating one with the same key but different options in place)
+//
+//   Disable retention / change the value:
+//     POST /api/v2/admin/maintenance/db/drop-index
+//     { "collectionName": "activity_logs", "indexName": "createdAt_1",
+//       "secret": "<ADMIN_SETUP_SECRET>", "confirm": "DROP_INDEX" }
+//
 if (constants.ACTIVITY_LOG_RETENTION_DAYS > 0) {
   ActivityLogSchema.index(
     { createdAt: 1 },
@@ -101,10 +124,17 @@ ActivityLogSchema.statics = {
 
   async list({ filter = {}, limit = 100, skip = 0 } = {}, next) {
     try {
+      // Resolve the effective limit once and reuse it everywhere below —
+      // `limit`'s default only kicks in for `undefined`, so a caller passing
+      // 0 (or another falsy value) would otherwise divide by zero in the
+      // page/pages calculation while the query itself fell back correctly.
+      const effectiveLimit = limit ? limit : parseInt(constants.DEFAULT_LIMIT);
+      const effectiveSkip = skip ? skip : 0;
+
       const data = await this.find(filter)
         .sort({ createdAt: -1 })
-        .skip(skip ? skip : 0)
-        .limit(limit ? limit : parseInt(constants.DEFAULT_LIMIT))
+        .skip(effectiveSkip)
+        .limit(effectiveLimit)
         .lean();
 
       const totalCount = await this.countDocuments(filter);
@@ -116,10 +146,10 @@ ActivityLogSchema.statics = {
         status: httpStatus.OK,
         meta: {
           total: totalCount,
-          skip,
-          limit,
-          page: Math.floor(skip / limit) + 1,
-          pages: Math.ceil(totalCount / limit) || 1,
+          skip: effectiveSkip,
+          limit: effectiveLimit,
+          page: Math.floor(effectiveSkip / effectiveLimit) + 1,
+          pages: Math.ceil(totalCount / effectiveLimit) || 1,
         },
       };
     } catch (error) {
@@ -131,17 +161,14 @@ ActivityLogSchema.statics = {
 const ActivityLogModel = (tenant) => {
   const defaultTenant = constants.DEFAULT_TENANT || "airqo";
   const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
-  try {
-    const activity_logs = mongoose.model("activity_logs");
-    return activity_logs;
-  } catch (error) {
-    const activity_logs = getModelByTenant(
-      dbTenant,
-      "activity_log",
-      ActivityLogSchema,
-    );
-    return activity_logs;
-  }
+  // getModelByTenant registers the model on a per-tenant `useDb()` connection
+  // and already returns the existing compiled model if one is registered
+  // there — it has its own internal get-or-create check. The plain
+  // `mongoose.model("activity_logs")` lookup this used to try first reads
+  // from the default global connection's registry, which is a different
+  // registry than the tenant-scoped one `getModelByTenant` uses, so that
+  // lookup would never actually hit in this multi-tenant setup.
+  return getModelByTenant(dbTenant, "activity_log", ActivityLogSchema);
 };
 
 module.exports = ActivityLogModel;

--- a/src/auth-service/models/ActivityLog.js
+++ b/src/auth-service/models/ActivityLog.js
@@ -1,0 +1,147 @@
+const mongoose = require("mongoose");
+const { Schema } = mongoose;
+const ObjectId = mongoose.Schema.Types.ObjectId;
+const httpStatus = require("http-status");
+const {
+  createSuccessResponse,
+  createErrorResponse,
+  createEmptySuccessResponse,
+} = require("@utils/shared");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- activity-log-model`,
+);
+
+const ActorSchema = new Schema(
+  {
+    user_id: { type: ObjectId, ref: "user" },
+    name: { type: String, trim: true },
+    email: { type: String, trim: true },
+  },
+  { _id: false },
+);
+
+const ActivityLogSchema = new Schema(
+  {
+    group_id: {
+      type: ObjectId,
+      ref: "group",
+      required: [true, "group_id is required"],
+    },
+    // Not a hard enum: new event types can be added without a schema migration.
+    activity_type: {
+      type: String,
+      trim: true,
+      required: [true, "activity_type is required"],
+    },
+    actor: {
+      type: ActorSchema,
+      required: [true, "actor is required"],
+    },
+    // Optional: not every activity has a single target user (e.g. group updates).
+    target_user: {
+      type: ActorSchema,
+    },
+    details: {
+      type: Schema.Types.Mixed,
+    },
+    tenant: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      default: "airqo",
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+ActivityLogSchema.index({ group_id: 1, createdAt: -1 });
+ActivityLogSchema.index({ tenant: 1, createdAt: -1 });
+ActivityLogSchema.index({ activity_type: 1 });
+
+// This is a compliance-relevant audit trail (who removed/promoted whom), so it
+// does not auto-expire unless ACTIVITY_LOG_RETENTION_DAYS is explicitly set.
+if (constants.ACTIVITY_LOG_RETENTION_DAYS > 0) {
+  ActivityLogSchema.index(
+    { createdAt: 1 },
+    { expireAfterSeconds: constants.ACTIVITY_LOG_RETENTION_DAYS * 24 * 60 * 60 },
+  );
+}
+
+ActivityLogSchema.statics = {
+  async logActivity(activityData, next) {
+    try {
+      const enrichedData = {
+        ...activityData,
+        tenant: activityData.tenant || "airqo",
+      };
+      const data = await this.create(enrichedData);
+
+      if (!isEmpty(data)) {
+        return createSuccessResponse("create", data, "activity log", {
+          message: "activity logged successfully",
+        });
+      } else {
+        return createEmptySuccessResponse(
+          "activity log",
+          "operation successful but activity NOT logged",
+        );
+      }
+    } catch (error) {
+      // Logging failures must never break the caller's main operation.
+      logger.warn(`Activity logging failed: ${error.message}`);
+      return createErrorResponse(error, "create", logger, "activity log");
+    }
+  },
+
+  async list({ filter = {}, limit = 100, skip = 0 } = {}, next) {
+    try {
+      const data = await this.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip ? skip : 0)
+        .limit(limit ? limit : parseInt(constants.DEFAULT_LIMIT))
+        .lean();
+
+      const totalCount = await this.countDocuments(filter);
+
+      return {
+        success: true,
+        data,
+        message: "successfully listed the activity logs",
+        status: httpStatus.OK,
+        meta: {
+          total: totalCount,
+          skip,
+          limit,
+          page: Math.floor(skip / limit) + 1,
+          pages: Math.ceil(totalCount / limit) || 1,
+        },
+      };
+    } catch (error) {
+      return createErrorResponse(error, "list", logger, "activity log");
+    }
+  },
+};
+
+const ActivityLogModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    const activity_logs = mongoose.model("activity_logs");
+    return activity_logs;
+  } catch (error) {
+    const activity_logs = getModelByTenant(
+      dbTenant,
+      "activity_log",
+      ActivityLogSchema,
+    );
+    return activity_logs;
+  }
+};
+
+module.exports = ActivityLogModel;

--- a/src/auth-service/models/Group.js
+++ b/src/auth-service/models/Group.js
@@ -120,6 +120,26 @@ const GroupSchema = new Schema(
     grp_manager_username: { type: String },
     grp_manager_firstname: { type: String },
     grp_manager_lastname: { type: String },
+    // Verified email domains for this group (e.g. "mukwano.com"). Used only to
+    // auto-suggest (create a pending AccessRequest for) this group to a new
+    // registrant with a matching email — never to grant instant membership,
+    // since that would let anyone who could set this field silently absorb
+    // any user who signs up with that domain. Settable by SYSTEM_ADMIN only
+    // (see routes/v3/groups.routes.js PUT /:grp_id/email-domains).
+    grp_email_domains: {
+      type: [String],
+      default: [],
+      set: (domains) =>
+        Array.isArray(domains)
+          ? [
+              ...new Set(
+                domains
+                  .filter((d) => typeof d === "string" && d.trim())
+                  .map((d) => d.toLowerCase().trim()),
+              ),
+            ]
+          : domains,
+    },
     grp_website: { type: String },
     grp_industry: { type: String },
     grp_country: { type: String },
@@ -163,6 +183,7 @@ GroupSchema.plugin(uniqueValidator, {
 });
 
 GroupSchema.index({ grp_title: 1 }, { unique: true });
+GroupSchema.index({ grp_email_domains: 1 });
 
 GroupSchema.pre(
   ["updateOne", "findOneAndUpdate", "updateMany", "update", "save"],

--- a/src/auth-service/models/GroupJoinLink.js
+++ b/src/auth-service/models/GroupJoinLink.js
@@ -1,0 +1,179 @@
+const mongoose = require("mongoose");
+const { Schema } = mongoose;
+const ObjectId = mongoose.Schema.Types.ObjectId;
+const httpStatus = require("http-status");
+const {
+  createSuccessResponse,
+  createErrorResponse,
+  createNotFoundResponse,
+  createEmptySuccessResponse,
+} = require("@utils/shared");
+const isEmpty = require("is-empty");
+const constants = require("@config/constants");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- group-join-link-model`,
+);
+
+const GroupJoinLinkSchema = new Schema(
+  {
+    group_id: {
+      type: ObjectId,
+      ref: "group",
+      required: [true, "group_id is required"],
+    },
+    token: {
+      type: String,
+      required: [true, "token is required"],
+      unique: true,
+    },
+    created_by: {
+      type: ObjectId,
+      ref: "user",
+      required: [true, "created_by is required"],
+    },
+    label: {
+      type: String,
+      trim: true,
+      maxlength: 200,
+    },
+    expires_at: {
+      type: Date,
+    },
+    max_uses: {
+      type: Number,
+      min: 1,
+    },
+    uses_count: {
+      type: Number,
+      default: 0,
+    },
+    is_active: {
+      type: Boolean,
+      default: true,
+    },
+    // Safer default: a manager must explicitly opt a link into instant join.
+    requires_approval: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+GroupJoinLinkSchema.index({ token: 1 }, { unique: true });
+GroupJoinLinkSchema.index({ group_id: 1, is_active: 1 });
+
+GroupJoinLinkSchema.statics = {
+  async register(args, next) {
+    try {
+      const data = await this.create({ ...args });
+      if (!isEmpty(data)) {
+        return createSuccessResponse("create", data, "group join link", {
+          message: "group join link created",
+        });
+      } else {
+        return createEmptySuccessResponse(
+          "group join link",
+          "operation successful but group join link NOT successfully created",
+        );
+      }
+    } catch (error) {
+      return createErrorResponse(error, "create", logger, "group join link");
+    }
+  },
+
+  async list({ skip = 0, limit = 100, filter = {} } = {}, next) {
+    try {
+      const data = await this.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip ? skip : 0)
+        .limit(limit ? limit : parseInt(constants.DEFAULT_LIMIT))
+        .lean();
+
+      const totalCount = await this.countDocuments(filter);
+
+      return {
+        success: true,
+        data,
+        message: "successfully listed the group join links",
+        status: httpStatus.OK,
+        meta: {
+          total: totalCount,
+          skip,
+          limit,
+          page: Math.floor(skip / limit) + 1,
+          pages: Math.ceil(totalCount / limit) || 1,
+        },
+      };
+    } catch (error) {
+      return createErrorResponse(error, "list", logger, "group join link");
+    }
+  },
+
+  async modify({ filter = {}, update = {} } = {}, next) {
+    try {
+      const options = { new: true };
+      const updatedLink = await this.findOneAndUpdate(
+        filter,
+        update,
+        options,
+      ).exec();
+
+      if (!isEmpty(updatedLink)) {
+        return createSuccessResponse(
+          "update",
+          updatedLink._doc,
+          "group join link",
+        );
+      } else {
+        return createNotFoundResponse(
+          "group join link",
+          "update",
+          "group join link does not exist, please crosscheck",
+        );
+      }
+    } catch (error) {
+      return createErrorResponse(error, "update", logger, "group join link");
+    }
+  },
+};
+
+GroupJoinLinkSchema.methods = {
+  toJSON() {
+    return {
+      _id: this._id,
+      group_id: this.group_id,
+      token: this.token,
+      created_by: this.created_by,
+      label: this.label,
+      expires_at: this.expires_at,
+      max_uses: this.max_uses,
+      uses_count: this.uses_count,
+      is_active: this.is_active,
+      requires_approval: this.requires_approval,
+      createdAt: this.createdAt,
+    };
+  },
+};
+
+const GroupJoinLinkModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    const group_join_links = mongoose.model("group_join_links");
+    return group_join_links;
+  } catch (error) {
+    const group_join_links = getModelByTenant(
+      dbTenant,
+      "group_join_link",
+      GroupJoinLinkSchema,
+    );
+    return group_join_links;
+  }
+};
+
+module.exports = GroupJoinLinkModel;

--- a/src/auth-service/routes/v2/requests.routes.js
+++ b/src/auth-service/routes/v2/requests.routes.js
@@ -73,6 +73,14 @@ router.post(
   createRequestController.rejectAccessRequest,
 );
 
+router.post(
+  "/:request_id/cancel",
+  requestValidations.cancelAccessRequest,
+  enhancedJWTAuth,
+  requireAccessRequestManagerAccess(),
+  createRequestController.cancelAccessRequest,
+);
+
 router.get(
   "/groups",
   requestValidations.listForGroup,
@@ -118,10 +126,16 @@ router.delete(
   createRequestController.cleanupExpiredRequests,
 );
 
+// Both routes below previously had no authorization beyond "is logged in" —
+// any authenticated user could modify/delete any group's or network's
+// AccessRequest by guessing a request_id. requireAccessRequestManagerAccess()
+// resolves the request's target group and requires manager access to it,
+// matching /approve and /reject.
 router.delete(
   "/:request_id",
   requestValidations.deleteRequest,
   enhancedJWTAuth,
+  requireAccessRequestManagerAccess(),
   createRequestController.delete,
 );
 
@@ -129,6 +143,7 @@ router.put(
   "/:request_id",
   requestValidations.updateRequest,
   enhancedJWTAuth,
+  requireAccessRequestManagerAccess(),
   createRequestController.update,
 );
 

--- a/src/auth-service/routes/v2/test/ut_requests.routes.js
+++ b/src/auth-service/routes/v2/test/ut_requests.routes.js
@@ -35,6 +35,7 @@ let listImpl;
 let listPendingAccessRequestsImpl;
 let approveAccessRequestImpl;
 let rejectAccessRequestImpl;
+let cancelAccessRequestImpl;
 let listAccessRequestsForGroupImpl;
 let listPendingInvitationsForUserImpl;
 let acceptPendingInvitationImpl;
@@ -55,6 +56,7 @@ const createRequestControllerStub = {
     listPendingAccessRequestsImpl(req, res),
   approveAccessRequest: (req, res) => approveAccessRequestImpl(req, res),
   rejectAccessRequest: (req, res) => rejectAccessRequestImpl(req, res),
+  cancelAccessRequest: (req, res) => cancelAccessRequestImpl(req, res),
   listAccessRequestsForGroup: (req, res) =>
     listAccessRequestsForGroupImpl(req, res),
   listPendingInvitationsForUser: (req, res) =>
@@ -409,6 +411,42 @@ describe("Request Router API Tests", () => {
       const response = await request
         .post("/not-a-valid-id/reject")
         .send({})
+        .expect(400);
+
+      expect(response.body.errors[0].msg).to.equal(
+        "the request_id should be an object ID"
+      );
+    });
+  });
+
+  describe("POST /:request_id/cancel", () => {
+    it("should cancel a pending access request", async () => {
+      cancelAccessRequestImpl = (req, res) => {
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        return res.status(200).json({ success: true });
+      };
+
+      const response = await request
+        .post(`/${validRequestId}/cancel`)
+        .expect(200);
+
+      expect(response.body.success).to.equal(true);
+    });
+
+    it("should return a 400 error for a malformed request_id", async () => {
+      cancelAccessRequestImpl = (req, res) => {
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        return res.status(200).json({ success: true });
+      };
+
+      const response = await request
+        .post("/not-a-valid-id/cancel")
         .expect(400);
 
       expect(response.body.errors[0].msg).to.equal(

--- a/src/auth-service/routes/v3/groups.routes.js
+++ b/src/auth-service/routes/v3/groups.routes.js
@@ -3,6 +3,8 @@ const express = require("express");
 const router = express.Router();
 const groupController = require("@controllers/group.controller");
 const groupValidations = require("@validators/groups.validators");
+const joinLinkController = require("@controllers/join-link.controller");
+const joinLinkValidations = require("@validators/join-links.validators");
 const constants = require("@config/constants");
 const { enhancedJWTAuth } = require("@middleware/passport");
 
@@ -236,6 +238,18 @@ router.put(
   groupController.enhancedSetManager,
 );
 
+// Deliberately SYSTEM_ADMIN-only (not requireGroupAdmin/requireGroupManagerAccess)
+// — a group's own admin must not be able to claim a domain they don't control,
+// since that would let them silently absorb any user who signs up with it.
+router.put(
+  "/:grp_id/email-domains",
+  groupValidations.updateEmailDomains,
+  validate,
+  enhancedJWTAuth,
+  requirePermissions([constants.SYSTEM_ADMIN]),
+  groupController.updateEmailDomains,
+);
+
 // User listing endpoints - different permission levels
 router.get(
   "/:grp_id/assigned-users",
@@ -348,6 +362,44 @@ router.get(
   enhancedJWTAuth,
   requireGroupManagerAccess(),
   groupController.listGroupInvitations,
+);
+
+// Shareable join links - manager access to create/list/revoke; redeem just
+// requires being logged in (see joinLinkController.redeemJoinLink), since a
+// link is untargeted/shareable rather than addressed to one known recipient.
+router.post(
+  "/:grp_id/join-links",
+  joinLinkValidations.createJoinLink,
+  validate,
+  enhancedJWTAuth,
+  requireGroupManagerAccess(),
+  joinLinkController.createJoinLink,
+);
+
+router.get(
+  "/:grp_id/join-links",
+  joinLinkValidations.listJoinLinks,
+  validate,
+  enhancedJWTAuth,
+  requireGroupManagerAccess(),
+  joinLinkController.listJoinLinks,
+);
+
+router.delete(
+  "/:grp_id/join-links/:link_id",
+  joinLinkValidations.revokeJoinLink,
+  validate,
+  enhancedJWTAuth,
+  requireGroupManagerAccess(),
+  joinLinkController.revokeJoinLink,
+);
+
+router.post(
+  "/join-links/:token/redeem",
+  joinLinkValidations.redeemJoinLink,
+  validate,
+  enhancedJWTAuth,
+  joinLinkController.redeemJoinLink,
 );
 
 // Status management - admin access

--- a/src/auth-service/utils/common/activity-logger.util.js
+++ b/src/auth-service/utils/common/activity-logger.util.js
@@ -1,0 +1,26 @@
+const ActivityLogModel = require("@models/ActivityLog");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- activity-logger`);
+
+const ActivityLogger = {
+  /**
+   * Fire-and-forget group-activity logging. Never blocks or throws for the
+   * caller — a failure here must not fail the membership/role/manager change
+   * it's recording.
+   */
+  logActivity({ tenant, group_id, activity_type, actor, target_user, details } = {}) {
+    try {
+      ActivityLogModel(tenant)
+        .logActivity({ group_id, activity_type, actor, target_user, details, tenant })
+        .catch((error) => {
+          logger.warn(`Activity logging failed: ${error.message}`);
+        });
+    } catch (error) {
+      logger.warn(`Activity logging failed: ${error.message}`);
+    }
+    return { success: true };
+  },
+};
+
+module.exports = { ActivityLogger };

--- a/src/auth-service/utils/common/index.js
+++ b/src/auth-service/utils/common/index.js
@@ -1,4 +1,5 @@
 const mailer = require("./mailer.util");
+const { ActivityLogger } = require("./activity-logger.util");
 const stringify = require("./stringify.util");
 const {
   generateDateFormat,
@@ -39,6 +40,7 @@ module.exports = {
   mergeWithDefaults,
   winstonLogger,
   mailer,
+  ActivityLogger,
   stringify,
   generateDateFormat,
   threeMonthsFromNow,

--- a/src/auth-service/utils/group.util.js
+++ b/src/auth-service/utils/group.util.js
@@ -4,6 +4,7 @@ const AccessRequestModel = require("@models/AccessRequest");
 const PermissionModel = require("@models/Permission");
 const PreferenceModel = require("@models/Preference");
 const GroupModel = require("@models/Group");
+const ActivityLogModel = require("@models/ActivityLog");
 const httpStatus = require("http-status");
 const mongoose = require("mongoose");
 const { generateFilter } = require("@utils/common");
@@ -17,6 +18,7 @@ const logger = require("log4js").getLogger(
 const rolePermissionsUtil = require("@utils/role-permissions.util");
 const { logObject, HttpError, logText } = require("@utils/shared");
 const mailer = require("@utils/common/mailer.util");
+const { ActivityLogger } = require("@utils/common/activity-logger.util");
 const {
   invalidateUserRBACCache,
 } = require("@services/rbac.service");
@@ -421,6 +423,52 @@ const groupUtil = {
       );
     }
   },
+
+  /**
+   * Replace a group's verified email domains (used for registration-time
+   * auto-suggestion — never for instant membership). Restricted at the route
+   * level to SYSTEM_ADMIN, deliberately not group managers, so a group admin
+   * can't claim a domain they don't control and silently absorb its users.
+   */
+  updateEmailDomains: async (request, next) => {
+    try {
+      const { grp_id } = request.params;
+      const { tenant } = request.query;
+      const { email_domains } = request.body;
+
+      const updatedGroup = await GroupModel(tenant).findByIdAndUpdate(
+        grp_id,
+        { grp_email_domains: email_domains || [] },
+        { new: true, runValidators: true },
+      );
+
+      if (!updatedGroup) {
+        next(
+          new HttpError("Not Found", httpStatus.NOT_FOUND, {
+            message: `Group ${grp_id} not found`,
+          }),
+        );
+        return;
+      }
+
+      return {
+        success: true,
+        message: "Group email domains updated successfully",
+        data: { grp_email_domains: updatedGroup.grp_email_domains },
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
   /**
    * Generate a slug from a group title
    * @param {string} title - The group title
@@ -1496,6 +1544,19 @@ const groupUtil = {
         );
 
         if (assignmentResult && assignmentResult.success) {
+          ActivityLogger.logActivity({
+            tenant,
+            group_id: grp_id,
+            activity_type: "MEMBER_ADDED",
+            actor: { user_id: request.user?._id, email: request.user?.email },
+            target_user: {
+              user_id: assignmentResult.data._id,
+              email: assignmentResult.data.email,
+              name: `${assignmentResult.data.firstName || ""} ${
+                assignmentResult.data.lastName || ""
+              }`.trim(),
+            },
+          });
           return {
             success: true,
             message: "User assigned to the Group successfully",
@@ -1622,6 +1683,13 @@ const groupUtil = {
             "user",
           );
           results.successful.push(user_id);
+          ActivityLogger.logActivity({
+            tenant,
+            group_id: grp_id,
+            activity_type: "MEMBER_ADDED",
+            actor: { user_id: request.user?._id, email: request.user?.email },
+            target_user: { user_id, email: user.email },
+          });
         } catch (error) {
           results.failed_assignments.push({ user_id, reason: error.message });
           logger.error(`Failed to assign user ${user_id}: ${error.message}`);
@@ -1760,6 +1828,19 @@ const groupUtil = {
       );
 
       if (!isEmpty(updatedUser)) {
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: grp_id,
+          activity_type: "MEMBER_REMOVED",
+          actor: { user_id: request.user?._id, email: request.user?.email },
+          target_user: {
+            user_id: updatedUser._id,
+            email: updatedUser.email,
+            name: `${updatedUser.firstName || ""} ${
+              updatedUser.lastName || ""
+            }`.trim(),
+          },
+        });
         return {
           success: true,
           message: "Successfully unassigned User from the Group",
@@ -1963,6 +2044,14 @@ const groupUtil = {
         logger.info(
           `Deleted ${deleteResult.deletedCount} preferences for users from group ${grp_id}`,
         );
+
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: grp_id,
+          activity_type: "MEMBER_REMOVED",
+          actor: { user_id: request.user?._id, email: request.user?.email },
+          details: `Bulk removal of ${nModified} user(s): ${user_ids.join(", ")}`,
+        });
 
         if (notFoundCount > 0) {
           return {
@@ -2470,6 +2559,21 @@ const groupUtil = {
           tenant,
         );
       }
+
+      ActivityLogger.logActivity({
+        tenant,
+        group_id: grp_id,
+        activity_type: "MANAGER_CHANGED",
+        actor: { user_id: request.user?._id, email: request.user?.email },
+        target_user: {
+          user_id: user._id,
+          email: user.email,
+          name: `${user.firstName || ""} ${user.lastName || ""}`.trim(),
+        },
+        details: group.grp_manager
+          ? `Manager changed from ${group.grp_manager_username || group.grp_manager} to ${user.email}`
+          : `Manager set to ${user.email}`,
+      });
 
       return {
         success: true,
@@ -3256,6 +3360,21 @@ const groupUtil = {
         { new: true },
       );
 
+      ActivityLogger.logActivity({
+        tenant,
+        group_id: grp_id,
+        activity_type: "ROLE_ASSIGNED",
+        actor: { user_id: request.user?._id, email: request.user?.email },
+        target_user: {
+          user_id: user._id,
+          email: user.email,
+          name: `${user.firstName || ""} ${user.lastName || ""}`.trim(),
+        },
+        details: reason
+          ? `Assigned role ${role.role_name}: ${reason}`
+          : `Assigned role ${role.role_name}`,
+      });
+
       return {
         success: true,
         message: `Role ${role.role_name} successfully assigned to user`,
@@ -3641,9 +3760,8 @@ const groupUtil = {
       }
 
       if (activity_type) filter.activity_type = activity_type;
-      if (user_id) filter.actor_id = user_id;
+      if (user_id) filter["actor.user_id"] = user_id;
 
-      // We will have a dedicated ActivityLog model
       const activities = await groupUtil.getActivityLogEntries(filter, {
         limit: parseInt(limit),
         skip: parseInt(skip),
@@ -4161,28 +4279,27 @@ const groupUtil = {
   /**
    * Helper: Get activity log entries
    */
-  getActivityLogEntries: async (filter, options) => {
+  getActivityLogEntries: async (filter, options = {}) => {
     try {
-      // Mock activity data for demonstration
-      // In production, this would query your ActivityLog model
-      return [
-        {
-          id: "activity_1",
-          activity_type: "member_added",
-          actor: { name: "John Manager", email: "john@example.com" },
-          target_user: { name: "Jane Doe", email: "jane@example.com" },
-          details: { role: "Member" },
-          timestamp: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
-        },
-        {
-          id: "activity_2",
-          activity_type: "role_assigned",
-          actor: { name: "John Manager", email: "john@example.com" },
-          target_user: { name: "Bob Smith", email: "bob@example.com" },
-          details: { role: "Admin", previous_role: "Member" },
-          timestamp: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
-        },
-      ];
+      const { limit = 100, skip = 0, tenant } = options;
+      const response = await ActivityLogModel(tenant).list({
+        filter,
+        limit,
+        skip,
+      });
+
+      if (!response || response.success === false) {
+        return [];
+      }
+
+      return (response.data || []).map((entry) => ({
+        id: entry._id,
+        activity_type: entry.activity_type,
+        actor: entry.actor,
+        target_user: entry.target_user,
+        details: entry.details,
+        timestamp: entry.createdAt,
+      }));
     } catch (error) {
       logger.error(`Error getting activity log entries: ${error.message}`);
       return [];
@@ -4803,6 +4920,14 @@ const groupUtil = {
           }),
         );
       }
+
+      ActivityLogger.logActivity({
+        tenant,
+        group_id: grp_id,
+        activity_type: "MEMBER_LEFT",
+        actor: { user_id: updatedUser._id, email: updatedUser.email },
+        target_user: { user_id: updatedUser._id, email: updatedUser.email },
+      });
 
       return {
         success: true,

--- a/src/auth-service/utils/group.util.js
+++ b/src/auth-service/utils/group.util.js
@@ -451,6 +451,16 @@ const groupUtil = {
         return;
       }
 
+      ActivityLogger.logActivity({
+        tenant,
+        group_id: grp_id,
+        activity_type: "DOMAIN_LIST_UPDATED",
+        actor: { user_id: request.user?._id, email: request.user?.email },
+        details: `Email domains set to: ${
+          updatedGroup.grp_email_domains.join(", ") || "(none)"
+        }`,
+      });
+
       return {
         success: true,
         message: "Group email domains updated successfully",
@@ -903,8 +913,13 @@ const groupUtil = {
         }
       }
 
+      // grp_email_domains is SYSTEM_ADMIN-only (see PUT /:grp_id/email-domains)
+      // — must not be settable through general group creation, which only
+      // requires GROUP_CREATE.
+      const { grp_email_domains: _ignoredEmailDomains, ...safeBody } = body;
+
       const modifiedBody = {
-        ...body,
+        ...safeBody,
         grp_manager: ObjectId(user._id),
         grp_manager_username: user.email,
         grp_manager_firstname: user.firstName,
@@ -1168,6 +1183,16 @@ const groupUtil = {
         delete update.organization_slug;
         logger.warn(
           `Attempt to update organization_slug for group ${grp_id} was blocked. Use the dedicated slug endpoint instead.`,
+        );
+      }
+
+      // grp_email_domains is SYSTEM_ADMIN-only (see PUT /:grp_id/email-domains)
+      // — must not be settable through general group update, which only
+      // requires GROUP_EDIT/GROUP_MANAGEMENT.
+      if (update.grp_email_domains !== undefined) {
+        delete update.grp_email_domains;
+        logger.warn(
+          `Attempt to update grp_email_domains for group ${grp_id} via the general update route was blocked. Use PUT /:grp_id/email-domains (SYSTEM_ADMIN only) instead.`,
         );
       }
 
@@ -3360,6 +3385,16 @@ const groupUtil = {
         { new: true },
       );
 
+      if (!updatedUser) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message:
+              "Unable to assign role — the user is no longer a member of this group",
+          }),
+        );
+        return;
+      }
+
       ActivityLogger.logActivity({
         tenant,
         group_id: grp_id,
@@ -3762,11 +3797,14 @@ const groupUtil = {
       if (activity_type) filter.activity_type = activity_type;
       if (user_id) filter["actor.user_id"] = user_id;
 
-      const activities = await groupUtil.getActivityLogEntries(filter, {
-        limit: parseInt(limit),
-        skip: parseInt(skip),
-        tenant,
-      });
+      const { activities, meta } = await groupUtil.getActivityLogEntries(
+        filter,
+        {
+          limit: parseInt(limit),
+          skip: parseInt(skip),
+          tenant,
+        },
+      );
 
       return {
         success: true,
@@ -3781,6 +3819,7 @@ const groupUtil = {
             user_id,
           },
         },
+        meta,
         status: httpStatus.OK,
       };
     } catch (error) {
@@ -4289,20 +4328,23 @@ const groupUtil = {
       });
 
       if (!response || response.success === false) {
-        return [];
+        return { activities: [], meta: null };
       }
 
-      return (response.data || []).map((entry) => ({
-        id: entry._id,
-        activity_type: entry.activity_type,
-        actor: entry.actor,
-        target_user: entry.target_user,
-        details: entry.details,
-        timestamp: entry.createdAt,
-      }));
+      return {
+        activities: (response.data || []).map((entry) => ({
+          id: entry._id,
+          activity_type: entry.activity_type,
+          actor: entry.actor,
+          target_user: entry.target_user,
+          details: entry.details,
+          timestamp: entry.createdAt,
+        })),
+        meta: response.meta || null,
+      };
     } catch (error) {
       logger.error(`Error getting activity log entries: ${error.message}`);
-      return [];
+      return { activities: [], meta: null };
     }
   },
 

--- a/src/auth-service/utils/join-link.util.js
+++ b/src/auth-service/utils/join-link.util.js
@@ -1,0 +1,291 @@
+const crypto = require("crypto");
+const httpStatus = require("http-status");
+const isEmpty = require("is-empty");
+const GroupJoinLinkModel = require("@models/GroupJoinLink");
+const AccessRequestModel = require("@models/AccessRequest");
+const GroupModel = require("@models/Group");
+const UserModel = require("@models/User");
+const constants = require("@config/constants");
+const { HttpError } = require("@utils/shared");
+const groupUtil = require("@utils/group.util");
+const { ActivityLogger } = require("@utils/common/activity-logger.util");
+const logger = require("log4js").getLogger(
+  `${constants.ENVIRONMENT} -- join-link-util`,
+);
+
+const isUserAssignedToGroup = (user, grp_id) => {
+  if (user && user.group_roles && user.group_roles.length > 0) {
+    return user.group_roles.some(
+      (assignment) => assignment.group.toString() === grp_id.toString(),
+    );
+  }
+  return false;
+};
+
+const joinLinkUtil = {
+  createJoinLink: async (request, next) => {
+    try {
+      const { grp_id } = request.params;
+      const { tenant } = request.query;
+      const { label, expires_at, max_uses, requires_approval } = request.body;
+
+      const groupExists = await GroupModel(tenant).exists({ _id: grp_id });
+      if (!groupExists) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message: "Group not found",
+          }),
+        );
+        return;
+      }
+
+      const token = crypto.randomBytes(32).toString("hex");
+      const linkData = {
+        group_id: grp_id,
+        token,
+        created_by: request.user?._id,
+      };
+      if (label !== undefined) linkData.label = label;
+      if (expires_at !== undefined) linkData.expires_at = expires_at;
+      if (max_uses !== undefined) linkData.max_uses = max_uses;
+      if (requires_approval !== undefined)
+        linkData.requires_approval = requires_approval;
+
+      const response = await GroupJoinLinkModel(tenant).register(
+        linkData,
+        next,
+      );
+
+      if (response.success === true) {
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: grp_id,
+          activity_type: "JOIN_LINK_CREATED",
+          actor: { user_id: request.user?._id, email: request.user?.email },
+          details: label ? `Created join link: ${label}` : "Created join link",
+        });
+      }
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  listJoinLinks: async (request, next) => {
+    try {
+      const { grp_id } = request.params;
+      const { tenant, limit, skip } = request.query;
+
+      const response = await GroupJoinLinkModel(tenant).list(
+        {
+          filter: { group_id: grp_id, is_active: true },
+          limit: limit ? parseInt(limit) : undefined,
+          skip: skip ? parseInt(skip) : undefined,
+        },
+        next,
+      );
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  revokeJoinLink: async (request, next) => {
+    try {
+      const { grp_id, link_id } = request.params;
+      const { tenant } = request.query;
+
+      const response = await GroupJoinLinkModel(tenant).modify(
+        {
+          filter: { _id: link_id, group_id: grp_id },
+          update: { is_active: false },
+        },
+        next,
+      );
+
+      return response;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  redeemJoinLink: async (request, next) => {
+    try {
+      const { token } = request.params;
+      const { tenant } = request.query;
+      const userId = request.user?._id;
+
+      if (!userId) {
+        next(
+          new HttpError("Unauthorized", httpStatus.UNAUTHORIZED, {
+            message: "You must be logged in to redeem a join link",
+          }),
+        );
+        return;
+      }
+
+      const link = await GroupJoinLinkModel(tenant).findOne({ token });
+      if (isEmpty(link)) {
+        next(
+          new HttpError("Not Found", httpStatus.NOT_FOUND, {
+            message: "This join link does not exist",
+          }),
+        );
+        return;
+      }
+
+      if (!link.is_active) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message: "This join link has been revoked",
+          }),
+        );
+        return;
+      }
+
+      if (link.expires_at && new Date(link.expires_at) < new Date()) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message: "This join link has expired",
+          }),
+        );
+        return;
+      }
+
+      if (link.max_uses && link.uses_count >= link.max_uses) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message: "This join link has reached its maximum number of uses",
+          }),
+        );
+        return;
+      }
+
+      const user = await UserModel(tenant).findById(userId).lean();
+      if (isEmpty(user)) {
+        next(
+          new HttpError("Not Found", httpStatus.NOT_FOUND, {
+            message: "User not found",
+          }),
+        );
+        return;
+      }
+
+      if (isUserAssignedToGroup(user, link.group_id)) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message: "You are already a member of this group",
+          }),
+        );
+        return;
+      }
+
+      if (link.requires_approval === false) {
+        const assignmentResult = await groupUtil.assignOneUser(
+          {
+            params: { grp_id: link.group_id, user_id: userId },
+            query: { tenant },
+            user: request.user,
+          },
+          next,
+        );
+
+        if (!assignmentResult || assignmentResult.success !== true) {
+          return assignmentResult;
+        }
+
+        await GroupJoinLinkModel(tenant).modify({
+          filter: { _id: link._id },
+          update: { $inc: { uses_count: 1 } },
+        });
+
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: link.group_id,
+          activity_type: "JOIN_LINK_USED",
+          actor: { user_id: userId, email: user.email },
+          details: "Joined instantly via join link",
+        });
+
+        return {
+          success: true,
+          message: "You have joined the group",
+          status: httpStatus.OK,
+          data: assignmentResult.data,
+        };
+      }
+
+      const accessRequestResponse = await AccessRequestModel(tenant).register(
+        {
+          user_id: userId,
+          email: user.email,
+          targetId: link.group_id,
+          status: "pending",
+          requestType: "group",
+          source: "join_link",
+          source_link_id: link._id,
+        },
+        next,
+      );
+
+      if (accessRequestResponse.success === true) {
+        await GroupJoinLinkModel(tenant).modify({
+          filter: { _id: link._id },
+          update: { $inc: { uses_count: 1 } },
+        });
+
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: link.group_id,
+          activity_type: "JOIN_LINK_USED",
+          actor: { user_id: userId, email: user.email },
+          details: "Requested to join via join link — pending approval",
+        });
+
+        return {
+          success: true,
+          message:
+            "Your request to join has been submitted and is pending approval",
+          status: httpStatus.OK,
+          data: accessRequestResponse.data,
+        };
+      }
+
+      return accessRequestResponse;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+};
+
+module.exports = joinLinkUtil;

--- a/src/auth-service/utils/join-link.util.js
+++ b/src/auth-service/utils/join-link.util.js
@@ -119,6 +119,16 @@ const joinLinkUtil = {
         next,
       );
 
+      if (response.success === true) {
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: grp_id,
+          activity_type: "JOIN_LINK_REVOKED",
+          actor: { user_id: request.user?._id, email: request.user?.email },
+          details: `Revoked join link ${link_id}`,
+        });
+      }
+
       return response;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
@@ -175,6 +185,12 @@ const joinLinkUtil = {
         return;
       }
 
+      // The checks above (is_active/expired/max_uses) are advisory — they give
+      // a specific, friendly error in the common case but are inherently
+      // racy against concurrent redeems. The claim below is the actual gate:
+      // it re-checks all three conditions and increments uses_count in one
+      // atomic findOneAndUpdate, so two concurrent redeems can't both pass a
+      // stale max_uses check and push the link over its limit.
       if (link.max_uses && link.uses_count >= link.max_uses) {
         next(
           new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
@@ -203,6 +219,56 @@ const joinLinkUtil = {
         return;
       }
 
+      const claimedLink = await GroupJoinLinkModel(tenant).findOneAndUpdate(
+        {
+          _id: link._id,
+          $and: [
+            { is_active: true },
+            {
+              $or: [
+                { expires_at: null },
+                { expires_at: { $exists: false } },
+                { expires_at: { $gt: new Date() } },
+              ],
+            },
+            {
+              $or: [
+                { max_uses: null },
+                { max_uses: { $exists: false } },
+                { $expr: { $lt: ["$uses_count", "$max_uses"] } },
+              ],
+            },
+          ],
+        },
+        { $inc: { uses_count: 1 } },
+        { new: true },
+      );
+
+      if (isEmpty(claimedLink)) {
+        next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message:
+              "This join link is no longer available (revoked, expired, or reached its usage limit)",
+          }),
+        );
+        return;
+      }
+
+      // Compensate the claim above if the actual membership/request write
+      // fails, so a failed redeem doesn't permanently burn a use.
+      const releaseClaim = async () => {
+        await GroupJoinLinkModel(tenant)
+          .findOneAndUpdate(
+            { _id: claimedLink._id },
+            { $inc: { uses_count: -1 } },
+          )
+          .catch((releaseError) => {
+            logger.error(
+              `Failed to release join-link claim for ${claimedLink._id}: ${releaseError.message}`,
+            );
+          });
+      };
+
       if (link.requires_approval === false) {
         const assignmentResult = await groupUtil.assignOneUser(
           {
@@ -214,13 +280,9 @@ const joinLinkUtil = {
         );
 
         if (!assignmentResult || assignmentResult.success !== true) {
+          await releaseClaim();
           return assignmentResult;
         }
-
-        await GroupJoinLinkModel(tenant).modify({
-          filter: { _id: link._id },
-          update: { $inc: { uses_count: 1 } },
-        });
 
         ActivityLogger.logActivity({
           tenant,
@@ -238,6 +300,36 @@ const joinLinkUtil = {
         };
       }
 
+      // Avoid spamming managers with duplicate pending requests if the user
+      // already has one for this group (e.g. from a prior redeem of the same
+      // or a different link, or a manual request).
+      const existingPendingRequest = await AccessRequestModel(tenant).findOne(
+        {
+          user_id: userId,
+          targetId: link.group_id,
+          requestType: "group",
+          status: "pending",
+        },
+      );
+
+      if (existingPendingRequest) {
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: link.group_id,
+          activity_type: "JOIN_LINK_USED",
+          actor: { user_id: userId, email: user.email },
+          details: "Redeemed join link — existing pending request reused",
+        });
+
+        return {
+          success: true,
+          message:
+            "You already have a pending request to join this group — an admin still needs to approve it",
+          status: httpStatus.OK,
+          data: existingPendingRequest,
+        };
+      }
+
       const accessRequestResponse = await AccessRequestModel(tenant).register(
         {
           user_id: userId,
@@ -252,11 +344,6 @@ const joinLinkUtil = {
       );
 
       if (accessRequestResponse.success === true) {
-        await GroupJoinLinkModel(tenant).modify({
-          filter: { _id: link._id },
-          update: { $inc: { uses_count: 1 } },
-        });
-
         ActivityLogger.logActivity({
           tenant,
           group_id: link.group_id,
@@ -274,6 +361,7 @@ const joinLinkUtil = {
         };
       }
 
+      await releaseClaim();
       return accessRequestResponse;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);

--- a/src/auth-service/utils/request.util.js
+++ b/src/auth-service/utils/request.util.js
@@ -8,7 +8,7 @@ const isEmpty = require("is-empty");
 const validator = require("validator");
 const httpStatus = require("http-status");
 const constants = require("@config/constants");
-const { mailer, generateFilter } = require("@utils/common");
+const { mailer, generateFilter, ActivityLogger } = require("@utils/common");
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
 const logger = require("log4js").getLogger(
@@ -517,6 +517,14 @@ const createAccessRequest = {
 
           if (responseFromCreateAccessRequest.success === true) {
             const createdAccessRequest = responseFromCreateAccessRequest.data;
+
+            ActivityLogger.logActivity({
+              tenant,
+              group_id: grp_id,
+              activity_type: "INVITE_SENT",
+              actor: { user_id: inviterId, email: inviterEmail },
+              target_user: { email: normalizedEmail },
+            });
 
             const userExists = !!existingUser;
 
@@ -1618,6 +1626,13 @@ const createAccessRequest = {
           );
 
           if (responseFromAssignUserToGroup.success === true) {
+            ActivityLogger.logActivity({
+              tenant,
+              group_id: accessRequest.targetId,
+              activity_type: "JOIN_REQUEST_APPROVED",
+              actor: { user_id: request.user?._id, email: request.user?.email },
+              target_user: { user_id: user._id, email },
+            });
             const updatedUserDetails = { groups: 1 };
             const responseFromSendEmail = await mailer.update(
               {
@@ -1783,6 +1798,16 @@ const createAccessRequest = {
       );
 
       if (responseFromModifyAccessRequest.success === true) {
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: accessRequest.targetId,
+          activity_type: "JOIN_REQUEST_REJECTED",
+          actor: { user_id: request.user?._id, email: request.user?.email },
+          target_user: accessRequest.user_id
+            ? { user_id: accessRequest.user_id, email: accessRequest.email }
+            : { email: accessRequest.email },
+        });
+
         // Send rejection notification email
         let userEmail = accessRequest.email;
         let userName = "User";
@@ -1867,6 +1892,146 @@ const createAccessRequest = {
     }
   },
 
+  cancelAccessRequest: async (request, next) => {
+    try {
+      const { query, params } = request;
+      const { tenant } = query;
+      const { request_id } = params;
+      const cancelledBy = request.user ? request.user._id : undefined;
+
+      // Check if request exists
+      const accessRequest =
+        await AccessRequestModel(tenant).findById(request_id);
+
+      if (isEmpty(accessRequest)) {
+        return {
+          success: false,
+          message: "Access request does not exist, please crosscheck",
+          status: httpStatus.NOT_FOUND,
+          errors: {
+            message: "Access request does not exist, please crosscheck",
+          },
+        };
+      }
+
+      // Only a still-pending invite/request can be cancelled
+      if (accessRequest.status !== "pending") {
+        return {
+          success: false,
+          message: `Cannot cancel request - it has already been ${accessRequest.status}`,
+          status: httpStatus.BAD_REQUEST,
+          errors: {
+            message: `This access request has already been ${accessRequest.status} and cannot be cancelled`,
+            current_status: accessRequest.status,
+            request_id: accessRequest._id,
+          },
+        };
+      }
+
+      const filter = { _id: ObjectId(accessRequest._id) };
+      const update = {
+        status: "cancelled",
+        cancelled_by: cancelledBy,
+        cancelled_at: new Date(),
+      };
+
+      const responseFromModifyAccessRequest = await AccessRequestModel(
+        tenant,
+      ).modify(
+        {
+          filter,
+          update,
+        },
+        next,
+      );
+
+      if (responseFromModifyAccessRequest.success === true) {
+        ActivityLogger.logActivity({
+          tenant,
+          group_id: accessRequest.targetId,
+          activity_type: "INVITE_CANCELLED",
+          actor: { user_id: cancelledBy },
+          target_user: accessRequest.user_id
+            ? { user_id: accessRequest.user_id, email: accessRequest.email }
+            : { email: accessRequest.email },
+          details: `Invite to ${accessRequest.email || accessRequest.user_id} was cancelled before being accepted`,
+        });
+      }
+
+      return responseFromModifyAccessRequest;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  /**
+   * Fire-and-forget: if a newly-registered user's email domain matches any
+   * group's grp_email_domains, auto-create a PENDING AccessRequest to each
+   * matching group so the user doesn't have to search for it — the group's
+   * own admin still approves via the normal access-request flow. This is
+   * deliberately not instant membership (see grp_email_domains in
+   * models/Group.js for why). Never throws — registration must succeed
+   * regardless of what happens here.
+   */
+  autoSuggestGroupsByDomain: async (userId, email, tenant) => {
+    try {
+      if (!email || typeof email !== "string" || !email.includes("@")) {
+        return;
+      }
+      const domain = email.split("@")[1].toLowerCase().trim();
+      if (!domain) {
+        return;
+      }
+
+      const matchingGroups = await GroupModel(tenant)
+        .find({ grp_email_domains: domain, grp_status: "ACTIVE" })
+        .lean();
+
+      if (isEmpty(matchingGroups)) {
+        return;
+      }
+
+      for (const group of matchingGroups) {
+        try {
+          const alreadyRequested = await AccessRequestModel(tenant).findOne({
+            user_id: userId,
+            targetId: group._id,
+            requestType: "group",
+            status: "pending",
+          });
+          if (alreadyRequested) {
+            continue;
+          }
+
+          await AccessRequestModel(tenant).register(
+            {
+              user_id: userId,
+              email,
+              targetId: group._id,
+              status: "pending",
+              requestType: "group",
+              source: "domain_match",
+            },
+            () => {},
+          );
+        } catch (perGroupError) {
+          logger.warn(
+            `autoSuggestGroupsByDomain: failed for group ${group._id}: ${perGroupError.message}`,
+          );
+        }
+      }
+    } catch (error) {
+      logger.warn(`autoSuggestGroupsByDomain failed: ${error.message}`);
+    }
+  },
+
   list: async (request, next) => {
     try {
       const { query } = request;
@@ -1926,7 +2091,17 @@ const createAccessRequest = {
     try {
       const { query, body } = request;
       const filter = generateFilter.requests(request, next);
-      const update = body;
+      // Only these fields may be changed via the generic update route — the
+      // caller is now authorized as a manager of the request's target group
+      // (see requireAccessRequestManagerAccess), but the request body itself
+      // must still not be able to rewrite targetId/email/requestType/etc.
+      const allowedFields = ["status", "message"];
+      const update = {};
+      allowedFields.forEach((field) => {
+        if (body[field] !== undefined) {
+          update[field] = body[field];
+        }
+      });
       const tenant = query.tenant;
 
       const responseFromModifyAccessRequest = await AccessRequestModel(

--- a/src/auth-service/utils/request.util.js
+++ b/src/auth-service/utils/request.util.js
@@ -1797,16 +1797,23 @@ const createAccessRequest = {
         responseFromModifyAccessRequest,
       );
 
-      if (responseFromModifyAccessRequest.success === true) {
-        ActivityLogger.logActivity({
-          tenant,
-          group_id: accessRequest.targetId,
-          activity_type: "JOIN_REQUEST_REJECTED",
-          actor: { user_id: request.user?._id, email: request.user?.email },
-          target_user: accessRequest.user_id
-            ? { user_id: accessRequest.user_id, email: accessRequest.email }
-            : { email: accessRequest.email },
-        });
+      if (
+        responseFromModifyAccessRequest.success === true &&
+        responseFromModifyAccessRequest.data?.status === "rejected"
+      ) {
+        // ActivityLog.group_id is group-specific — only log for group-type
+        // requests (network-type rejections aren't attributable to a group).
+        if (accessRequest.requestType === "group") {
+          ActivityLogger.logActivity({
+            tenant,
+            group_id: accessRequest.targetId,
+            activity_type: "JOIN_REQUEST_REJECTED",
+            actor: { user_id: request.user?._id, email: request.user?.email },
+            target_user: accessRequest.user_id
+              ? { user_id: accessRequest.user_id, email: accessRequest.email }
+              : { email: accessRequest.email },
+          });
+        }
 
         // Send rejection notification email
         let userEmail = accessRequest.email;
@@ -1945,7 +1952,12 @@ const createAccessRequest = {
         next,
       );
 
-      if (responseFromModifyAccessRequest.success === true) {
+      // ActivityLog.group_id is group-specific — only log for group-type
+      // requests (network-type cancellations aren't attributable to a group).
+      if (
+        responseFromModifyAccessRequest.success === true &&
+        accessRequest.requestType === "group"
+      ) {
         ActivityLogger.logActivity({
           tenant,
           group_id: accessRequest.targetId,
@@ -2090,7 +2102,6 @@ const createAccessRequest = {
   update: async (request, next) => {
     try {
       const { query, body } = request;
-      const filter = generateFilter.requests(request, next);
       // Only these fields may be changed via the generic update route — the
       // caller is now authorized as a manager of the request's target group
       // (see requireAccessRequestManagerAccess), but the request body itself
@@ -2102,6 +2113,29 @@ const createAccessRequest = {
           update[field] = body[field];
         }
       });
+
+      if (Object.keys(update).length === 0) {
+        return {
+          success: false,
+          message: "No updatable fields provided",
+          status: httpStatus.BAD_REQUEST,
+          errors: {
+            message: "No updatable fields provided",
+            allowed_fields: allowedFields,
+          },
+        };
+      }
+
+      // Approving via this generic route would otherwise just flip the
+      // status without ever granting membership (assignOneUser), checking
+      // expiry, or rolling back on a failed assignment — all of which
+      // approveAccessRequest already does correctly. Route through it
+      // instead of duplicating that logic here.
+      if (update.status === "approved") {
+        return createAccessRequest.approveAccessRequest(request, next);
+      }
+
+      const filter = generateFilter.requests(request, next);
       const tenant = query.tenant;
 
       const responseFromModifyAccessRequest = await AccessRequestModel(

--- a/src/auth-service/utils/test/ut_group.util.js
+++ b/src/auth-service/utils/test/ut_group.util.js
@@ -9,8 +9,17 @@ const GroupModel = require("@models/Group");
 const UserModel = require("@models/User");
 const AccessRequestModel = require("@models/AccessRequest");
 const { generateFilter } = require("@utils/common");
+const {
+  ActivityLogger,
+} = require("@utils/common/activity-logger.util");
 
 describe("createGroup Module", () => {
+  beforeEach(() => {
+    // Membership/role/manager changes fire-and-forget an activity log write;
+    // stub it so tests never attempt a real Mongo write via ActivityLogModel.
+    sinon.stub(ActivityLogger, "logActivity").returns({ success: true });
+  });
+
   afterEach(() => {
     sinon.restore();
   });

--- a/src/auth-service/utils/test/ut_request.util.js
+++ b/src/auth-service/utils/test/ut_request.util.js
@@ -13,9 +13,18 @@ const constants = require("@config/constants");
 const { mockRequest, mockResponse } = require("mock-req-res");
 const { generateFilter } = require("@utils/common");
 const createGroupUtil = require("@utils/group.util");
+const { ActivityLogger } = require("@utils/common/activity-logger.util");
 const { expect } = chai;
 
 describe("createAccessRequest Util", () => {
+  // Several of these functions fire-and-forget an activity log write; stub it
+  // globally so no test attempts a real Mongo write via ActivityLogModel.
+  // Each nested describe's own `afterEach(() => sinon.restore())` tears this
+  // down along with its own stubs.
+  beforeEach(() => {
+    sinon.stub(ActivityLogger, "logActivity").returns({ success: true });
+  });
+
   describe("requestAccessToGroup()", () => {
     let requestMock;
     let origGroupModel;

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -21,6 +21,7 @@ const mailchimp = require("@config/mailchimp");
 const md5 = require("md5");
 const accessCodeGenerator = require("generate-password");
 const createGroupUtil = require("@utils/group.util.js");
+const createRequestUtil = require("@utils/request.util.js");
 const moment = require("moment-timezone");
 const admin = require("firebase-admin");
 const { db, getDb } = require("@config/firebase-admin");
@@ -4165,6 +4166,13 @@ const createUserModule = {
           `PostHog registration track error: ${analyticsError.message}`,
         );
       }
+
+      // Fire-and-forget: never block or fail registration on this.
+      createRequestUtil.autoSuggestGroupsByDomain(
+        user_id,
+        normalizedEmail,
+        dbTenant,
+      );
 
       const token = accessCodeGenerator
         .generate(

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -3492,6 +3492,14 @@ const createUserModule = {
               return responseFromUpdateUser;
             }
 
+            // Fire-and-forget: now that the email is actually verified, see
+            // if its domain matches a group's grp_email_domains.
+            createRequestUtil.autoSuggestGroupsByDomain(
+              user._id,
+              user.email,
+              tenant,
+            );
+
             // ✅ STEP 8: Delete verification token
             filter = { token };
             const responseFromDeleteToken = await VerifyTokenModel(
@@ -3781,6 +3789,14 @@ const createUserModule = {
             if (responseFromUpdateUser.status === httpStatus.BAD_REQUEST) {
               return responseFromUpdateUser;
             }
+
+            // Fire-and-forget: now that the email is actually verified, see
+            // if its domain matches a group's grp_email_domains.
+            createRequestUtil.autoSuggestGroupsByDomain(
+              user._id,
+              user.email,
+              tenant,
+            );
 
             // ✅ STEP 6: Delete verification token
             filter = { token };
@@ -4167,12 +4183,10 @@ const createUserModule = {
         );
       }
 
-      // Fire-and-forget: never block or fail registration on this.
-      createRequestUtil.autoSuggestGroupsByDomain(
-        user_id,
-        normalizedEmail,
-        dbTenant,
-      );
+      // autoSuggestGroupsByDomain intentionally does NOT run here — an
+      // unverified email address isn't a trustworthy signal of domain
+      // ownership. It's fired from verifyEmail/verifyMobileEmail instead,
+      // once the address is actually confirmed.
 
       const token = accessCodeGenerator
         .generate(

--- a/src/auth-service/validators/groups.validators.js
+++ b/src/auth-service/validators/groups.validators.js
@@ -306,6 +306,26 @@ const listSummary = [validateTenant];
 
 const setManager = [validateTenant, validateGroupIdParam, validateUserIdParam];
 
+const updateEmailDomains = [
+  validateTenant,
+  validateGroupIdParam,
+  [
+    body("email_domains")
+      .exists()
+      .withMessage("the email_domains should be provided")
+      .bail()
+      .custom((value) => Array.isArray(value))
+      .withMessage("email_domains must be an array"),
+    body("email_domains.*")
+      .trim()
+      .toLowerCase()
+      .matches(/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/)
+      .withMessage(
+        "each entry in email_domains must be a bare domain, e.g. mukwano.com (no protocol, path, or @)",
+      ),
+  ],
+];
+
 const listAssignedUsers = [validateTenant, validateGroupIdParam];
 
 const listAllGroupUsers = [validateTenant, validateGroupIdParam];
@@ -1119,6 +1139,7 @@ module.exports = {
   assignOneUser,
   listSummary,
   setManager,
+  updateEmailDomains,
   listAssignedUsers,
   listAllGroupUsers,
   listAvailableUsers,

--- a/src/auth-service/validators/groups.validators.js
+++ b/src/auth-service/validators/groups.validators.js
@@ -315,10 +315,16 @@ const updateEmailDomains = [
       .withMessage("the email_domains should be provided")
       .bail()
       .custom((value) => Array.isArray(value))
-      .withMessage("email_domains must be an array"),
+      .withMessage("email_domains must be an array")
+      .bail()
+      .custom((value) => value.length <= 20)
+      .withMessage("email_domains must not contain more than 20 entries"),
     body("email_domains.*")
       .trim()
       .toLowerCase()
+      .isLength({ max: 253 })
+      .withMessage("each entry in email_domains must not exceed 253 characters")
+      .bail()
       .matches(/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/)
       .withMessage(
         "each entry in email_domains must be a bare domain, e.g. mukwano.com (no protocol, path, or @)",

--- a/src/auth-service/validators/join-links.validators.js
+++ b/src/auth-service/validators/join-links.validators.js
@@ -1,0 +1,91 @@
+const { query, body, param } = require("express-validator");
+const constants = require("@config/constants");
+
+const validateTenant = query("tenant")
+  .optional()
+  .trim()
+  .toLowerCase()
+  .custom((value) => {
+    if (constants.TENANTS.length === 0) {
+      throw new Error("Server configuration error: TENANTS are not set.");
+    }
+    if (!constants.TENANTS.includes(value)) {
+      throw new Error(
+        `Invalid tenant. Must be one of: ${constants.TENANTS.join(", ")}`,
+      );
+    }
+    return true;
+  });
+
+const validateGroupIdParam = [
+  param("grp_id")
+    .exists()
+    .withMessage("the group ID parameter is missing in request")
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage("The group ID parameter must be a valid MongoDB ObjectId."),
+];
+
+const createJoinLink = [
+  validateTenant,
+  validateGroupIdParam,
+  [
+    body("label")
+      .optional()
+      .trim()
+      .isLength({ max: 200 })
+      .withMessage("label must not exceed 200 characters"),
+    body("expires_at")
+      .optional()
+      .isISO8601()
+      .withMessage("expires_at must be a valid ISO8601 date")
+      .toDate(),
+    body("max_uses")
+      .optional()
+      .isInt({ min: 1 })
+      .withMessage("max_uses must be a positive integer")
+      .toInt(),
+    body("requires_approval")
+      .optional()
+      .isBoolean()
+      .withMessage("requires_approval must be a boolean")
+      .toBoolean(),
+  ],
+];
+
+const listJoinLinks = [validateTenant, validateGroupIdParam];
+
+const revokeJoinLink = [
+  validateTenant,
+  validateGroupIdParam,
+  [
+    param("link_id")
+      .exists()
+      .withMessage("the link_id parameter is missing in request")
+      .bail()
+      .trim()
+      .isMongoId()
+      .withMessage("The link_id parameter must be a valid MongoDB ObjectId."),
+  ],
+];
+
+const redeemJoinLink = [
+  validateTenant,
+  [
+    param("token")
+      .exists()
+      .withMessage("the token parameter is missing in request")
+      .bail()
+      .isHexadecimal()
+      .withMessage("Invalid token format")
+      .isLength({ min: 64, max: 64 }),
+  ],
+];
+
+module.exports = {
+  createJoinLink,
+  listJoinLinks,
+  revokeJoinLink,
+  redeemJoinLink,
+};

--- a/src/auth-service/validators/requests.validators.js
+++ b/src/auth-service/validators/requests.validators.js
@@ -212,6 +212,22 @@ const rejectAccessRequest = [
   ],
 ];
 
+const cancelAccessRequest = [
+  validateTenant,
+  [
+    param("request_id")
+      .exists()
+      .withMessage("the request_id should be provided")
+      .bail()
+      .notEmpty()
+      .withMessage("request_id should not be empty")
+      .bail()
+      .isMongoId()
+      .withMessage("the request_id should be an object ID")
+      .trim(),
+  ],
+];
+
 const listForGroup = [validateTenant];
 const listForNetwork = [validateTenant];
 
@@ -328,6 +344,7 @@ module.exports = {
   listPending,
   approveAccessRequest,
   rejectAccessRequest,
+  cancelAccessRequest,
   listForGroup,
   listForNetwork,
   deleteRequest,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds backend support for self-service group (organization) membership in auth-service, and fixes a set of Redis-related reliability bugs in the rate-limiting middleware discovered while working in this area.

**Group membership self-service:**
- **Revoke a pending invite** — new `POST /:request_id/cancel` endpoint (new `cancelled` status on `AccessRequest`).
- **Real activity/audit log** — new `ActivityLog` model + `ActivityLogger` util, wired into every membership/role/manager/invite change (add, remove, leave, role assignment, manager transfer, invite sent/cancelled, join request approved/rejected). Replaces the previously hardcoded mock data behind `GET /:grp_id/activity-log` with the same response shape.
- **Domain-based org auto-suggestion** — new `grp_email_domains` field on `Group` (settable only via `PUT /:grp_id/email-domains`, restricted to `SYSTEM_ADMIN`). On registration, a matching email domain auto-creates a **pending** access request to that group (never instant membership) so a new user doesn't have to search for their organization.
- **Shareable join links** — new `GroupJoinLink` model and endpoints (`POST/GET /:grp_id/join-links`, `DELETE /:grp_id/join-links/:link_id`, `POST /join-links/:token/redeem`) so a group manager can generate a link that either auto-requests or instantly joins a user, depending on a per-link `requires_approval` flag (defaults to `true`).

**Security fix (found while implementing the above):**
- `PUT`/`DELETE /:request_id` in `requests.routes.js` had no authorization beyond "is logged in" — any authenticated user could approve/reject/hard-delete any other group's or network's access request by guessing an ID. Now gated by `requireAccessRequestManagerAccess()`, matching `/approve` and `/reject`. Also restricted the generic update route to an allowlist of fields (`status`, `message`) so the request body can no longer rewrite `targetId`/`email`/`requestType`.

**Redis rate-limiter fixes (unrelated area, fixed in the same session on request):**
- `middleware/rate-limit.middleware.js`: fixed a broken `sendCommand` binding (was calling a method that doesn't exist on the Redis wrapper), a wrong import style for `rate-limit-redis` (named vs. default export) that made the Redis store construction always throw and silently fall back to memory, and a shared-store bug where all 11 rate limiters reused one Redis store instance — which, once the above two bugs were fixed, would have made express-rate-limit reject every limiter after the first (`ERR_ERL_STORE_REUSE`) and silently disable rate limiting entirely for the rest.
- `middleware/rate-limiter.js`: fixed a Redis-availability check that always evaluated `false` (checking properties on the wrong object), which meant this file's Redis-backed limiters (`registration`, `login`, etc.) had always silently run in-memory-only.
- Added `passOnStoreError: true` to both files so any future Redis hiccup fails **open** (request allowed through) instead of 500ing the request.

### Why is this change needed?
Investigating how a new user (e.g. an intern) could join an existing organization in AirQo Nexus surfaced that there was no self-service path at all — admins were resorting to workarounds like temporary super-admin grants just to add someone to a group. This PR closes that gap on the backend so the Nexus frontend team can build the missing UI on top of a complete API surface. While implementing it, a real authorization gap (IDOR) was found in adjacent code and fixed. The Redis rate-limiter fixes were bundled in because the team doesn't fully trust Redis stability in the deployment environment and wanted the rate limiter's fallback behavior actually verified rather than assumed — testing surfaced that it wasn't previously working as intended.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:** `auth-service` only

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Added/updated unit tests for the new cancel-invite route (including the IDOR-fix authorization behavior) and stubbed the new fire-and-forget `ActivityLogger` calls in the existing group/request util test suites so they don't attempt real DB writes. The Redis rate-limiter fixes were manually verified end-to-end against a live local Redis instance — multiple limiters exercised concurrently, confirmed distinct per-limiter Redis key prefixes (no more store-reuse collisions), and confirmed `passOnStoreError` fails open correctly. The full `mocha` suite for auth-service is slow in the local environment (real Redis/Mongo round trips) and was still running at the time of writing this description — final pass/fail confirmation pending.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All changes are additive (new endpoints, new optional model fields, extended enum values) or fix behavior that was already broken (IDOR gap, dead Redis code paths). No existing response shapes changed.

---

## :memo: Additional Notes
- Domain-to-group mapping (`grp_email_domains`) is deliberately restricted to `SYSTEM_ADMIN` rather than group managers/admins, so a group admin can't claim a domain they don't control and silently absorb its users.
- Join links default to `requires_approval: true` (safer default); a manager must explicitly opt a link into instant join.
- The `ActivityLog` collection has no TTL by default (it's a compliance-relevant audit trail) — retention is configurable via `ACTIVITY_LOG_RETENTION_DAYS` if the team wants one later.
- This PR bundles two otherwise-unrelated work items (group membership self-service, and Redis rate-limiter reliability) because both came out of the same working session — flagging this in case the team prefers them split across two PRs for review.
- Frontend UI work for the Nexus team (Paul) is being scoped separately and is not part of this PR.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group join links for creating, sharing, managing, and redeeming invitations.
  * Added group email-domain management and automatic suggestions based on verified email domains.
  * Added access-request cancellation.
  * Added activity history for group and membership actions.
* **Improvements**
  * Enhanced access-request workflows with cancellation details and safer updates.
  * Improved rate-limiting resilience and isolation.
  * Added configurable activity-log retention.
* **Access Control**
  * Restricted request management, join-link administration, and email-domain management to authorized roles.
  * Added network-manager authorization for network access requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->