### PR TITLE
Persist site and device display names in chart configurations

### DIFF
--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -38,15 +38,15 @@ const chartConfigSchema = new Schema({
   // not a live reference.
   sites: [
     {
-      site_id: { type: ObjectId, ref: "site" },
-      name: { type: String },
+      site_id: { type: ObjectId, ref: "site", required: true },
+      name: { type: String, required: true, trim: true, maxlength: 200 },
       _id: false,
     },
   ],
   devices: [
     {
-      device_id: { type: ObjectId, ref: "device" },
-      name: { type: String },
+      device_id: { type: ObjectId, ref: "device", required: true },
+      name: { type: String, required: true, trim: true, maxlength: 200 },
       _id: false,
     },
   ],

--- a/src/auth-service/models/Preference.js
+++ b/src/auth-service/models/Preference.js
@@ -31,6 +31,25 @@ const chartConfigSchema = new Schema({
   // sites[]/devices[] flexibility the old, deprecated Defaults model had.
   device_ids: [{ type: ObjectId, ref: "device" }],
   site_ids: [{ type: ObjectId, ref: "site" }],
+  // Optional display-name snapshot for the ids above, stored and returned
+  // verbatim as sent by the client so the frontend can render chart labels
+  // without a separate fleet-wide name-resolution call. Not kept in sync if
+  // the underlying site/device is renamed later — a deliberate snapshot,
+  // not a live reference.
+  sites: [
+    {
+      site_id: { type: ObjectId, ref: "site" },
+      name: { type: String },
+      _id: false,
+    },
+  ],
+  devices: [
+    {
+      device_id: { type: ObjectId, ref: "device" },
+      name: { type: String },
+      _id: false,
+    },
+  ],
   // Optional per-location color override for the ids selected above (e.g.
   // Kampala in red, Jinja in yellow) — falls back to the chart-wide `color`
   // below when a selected location has no entry here.

--- a/src/auth-service/utils/group-chart-config.util.js
+++ b/src/auth-service/utils/group-chart-config.util.js
@@ -6,7 +6,10 @@ const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- group-chart-config-util`
 );
-const { allowedChartProperties } = require("./preference.util");
+const {
+  allowedChartProperties,
+  findStaleMetadataEntry,
+} = require("./preference.util");
 
 // Mirrors utils/preference.util.js's personal chart CRUD, but scoped to a
 // group (the org/organization-wide DEFAULT chart, as distinct from a single
@@ -46,6 +49,35 @@ const groupChartConfig = {
         return {
           success: false,
           message: "At least one of device_ids or site_ids is required",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      // Unlike the personal chart, a group chart's scope lives on this
+      // parent document (device_ids/site_ids above), not on the chart
+      // subdocument itself — so sites/devices are checked against the
+      // parent-level arrays, not any scope field on chartConfig.
+      const staleSite = findStaleMetadataEntry(
+        chartConfig.sites,
+        "site_id",
+        site_ids
+      );
+      if (staleSite) {
+        return {
+          success: false,
+          message: `sites[].site_id ${staleSite.site_id} is not in this chart's site_ids`,
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+      const staleDevice = findStaleMetadataEntry(
+        chartConfig.devices,
+        "device_id",
+        device_ids
+      );
+      if (staleDevice) {
+        return {
+          success: false,
+          message: `devices[].device_id ${staleDevice.device_id} is not in this chart's device_ids`,
           status: httpStatus.BAD_REQUEST,
         };
       }
@@ -130,6 +162,35 @@ const groupChartConfig = {
         return {
           success: false,
           message: "At least one of device_ids or site_ids is required",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      // Checked against the parent doc's (just-merged) device_ids/site_ids,
+      // not any field on the chart subdocument — see the same check in
+      // create() above for why.
+      const updatedChart = groupChart.chartConfigurations[chartIndex];
+      const staleSite = findStaleMetadataEntry(
+        updatedChart.sites,
+        "site_id",
+        groupChart.site_ids
+      );
+      if (staleSite) {
+        return {
+          success: false,
+          message: `sites[].site_id ${staleSite.site_id} is not in this chart's site_ids`,
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+      const staleDevice = findStaleMetadataEntry(
+        updatedChart.devices,
+        "device_id",
+        groupChart.device_ids
+      );
+      if (staleDevice) {
+        return {
+          success: false,
+          message: `devices[].device_id ${staleDevice.device_id} is not in this chart's device_ids`,
           status: httpStatus.BAD_REQUEST,
         };
       }

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -193,6 +193,24 @@ const chartValidationErrorResponse = (error) => ({
   status: httpStatus.BAD_REQUEST,
 });
 
+// sites/devices are a display-name snapshot for a chart's site_ids/device_ids
+// — an entry referencing an id outside that scope would mean the API keeps
+// returning a name for a location the chart isn't even scoped to anymore
+// (most easily reached by a partial update that narrows site_ids/device_ids
+// without touching sites/devices). This can't live in chartConfigSchema's
+// shared pre-validate hook (like the locationColors check does) because the
+// scope lives in different places for a personal chart (the chart
+// subdocument's own site_ids/device_ids) vs. a group chart (the parent
+// document's), so it's checked explicitly wherever each one is set instead.
+const findStaleMetadataEntry = (entries, idField, allowedIds) => {
+  if (isEmpty(entries)) return undefined;
+  const allowedIdSet = new Set((allowedIds || []).map((id) => id.toString()));
+  return entries.find(
+    (entry) =>
+      !entry || !entry[idField] || !allowedIdSet.has(entry[idField].toString())
+  );
+};
+
 // Define allowed properties for chart updates
 const allowedChartProperties = [
   "fieldId",
@@ -893,6 +911,31 @@ const preferences = {
         };
       }
 
+      const staleSite = findStaleMetadataEntry(
+        chartConfig.sites,
+        "site_id",
+        siteIds
+      );
+      if (staleSite) {
+        return {
+          success: false,
+          message: `sites[].site_id ${staleSite.site_id} is not in this chart's site_ids`,
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+      const staleDevice = findStaleMetadataEntry(
+        chartConfig.devices,
+        "device_id",
+        deviceIds
+      );
+      if (staleDevice) {
+        return {
+          success: false,
+          message: `devices[].device_id ${staleDevice.device_id} is not in this chart's device_ids`,
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
       const groupId = request.body.group_id || constants.DEFAULT_GROUP;
 
       // Scope lives on the chart itself now (device_ids/site_ids), not a
@@ -1002,6 +1045,31 @@ const preferences = {
         return {
           success: false,
           message: "At least one of device_ids or site_ids is required",
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+
+      const staleSite = findStaleMetadataEntry(
+        chart.sites,
+        "site_id",
+        chart.site_ids
+      );
+      if (staleSite) {
+        return {
+          success: false,
+          message: `sites[].site_id ${staleSite.site_id} is not in this chart's site_ids`,
+          status: httpStatus.BAD_REQUEST,
+        };
+      }
+      const staleDevice = findStaleMetadataEntry(
+        chart.devices,
+        "device_id",
+        chart.device_ids
+      );
+      if (staleDevice) {
+        return {
+          success: false,
+          message: `devices[].device_id ${staleDevice.device_id} is not in this chart's device_ids`,
           status: httpStatus.BAD_REQUEST,
         };
       }
@@ -2132,5 +2200,6 @@ const preferences = {
 // default chart config accepts/updates the same whitelist of chart fields
 // as the personal one, so this avoids a second list drifting out of sync.
 preferences.allowedChartProperties = allowedChartProperties;
+preferences.findStaleMetadataEntry = findStaleMetadataEntry;
 
 module.exports = preferences;

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -200,6 +200,8 @@ const allowedChartProperties = [
   "subTitle",
   "device_ids",
   "site_ids",
+  "sites",
+  "devices",
   "locationColors",
   "xAxisLabel",
   "yAxisLabel",

--- a/src/auth-service/utils/test/ut_group-chart-config.util.js
+++ b/src/auth-service/utils/test/ut_group-chart-config.util.js
@@ -146,6 +146,48 @@ describe("group-chart-config UTIL", function() {
       expect(result.success).to.equal(false);
       expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
     });
+
+    it("rejects (400, before any DB write) a sites entry whose site_id isn't in the request's (parent-level) site_ids", async function() {
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId },
+        body: {
+          chartConfig: {
+            fieldId: 1,
+            sites: [{ site_id: "507f1f77bcf86cd799439099", name: "Other site" }],
+          },
+          site_ids: [siteId],
+        },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.create(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(createStub.called).to.equal(false);
+    });
+
+    it("accepts sites/devices entries that match the request's (parent-level) site_ids/device_ids", async function() {
+      const chartConfig = {
+        fieldId: 1,
+        sites: [{ site_id: siteId, name: "Site A" }],
+      };
+      createStub.resolves({ chartConfigurations: [chartConfig] });
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId },
+        body: { chartConfig, site_ids: [siteId] },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.create(request, next);
+
+      expect(result.success).to.equal(true);
+      expect(createStub.calledOnce).to.equal(true);
+    });
   });
 
   describe("update", function() {
@@ -231,6 +273,73 @@ describe("group-chart-config UTIL", function() {
 
       expect(doc.device_ids).to.deep.equal(newDeviceIds);
       expect(doc.site_ids).to.deep.equal([siteId]);
+    });
+
+    it("rejects (400, no save()) a partial update that narrows the parent doc's site_ids without also updating the chart's now-stale sites snapshot", async function() {
+      const saveStub = sinon.stub().resolves();
+      const otherSiteId = "507f1f77bcf86cd799439099";
+      const chart = {
+        _id: { toString: () => chartId },
+        sites: [
+          { site_id: siteId, name: "Site A" },
+          { site_id: otherSiteId, name: "Site B" },
+        ],
+      };
+      const doc = {
+        chartConfigurations: [chart],
+        device_ids: [],
+        site_ids: [siteId, otherSiteId],
+        save: saveStub,
+      };
+      findOneStub.resolves(doc);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, chartId },
+        body: { site_ids: [siteId] },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.update(request, next);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(saveStub.called).to.equal(false);
+    });
+
+    it("accepts a partial update that narrows the parent doc's site_ids and updates the chart's sites to match", async function() {
+      const saveStub = sinon.stub().resolves();
+      const otherSiteId = "507f1f77bcf86cd799439099";
+      const chart = {
+        _id: { toString: () => chartId },
+        sites: [
+          { site_id: siteId, name: "Site A" },
+          { site_id: otherSiteId, name: "Site B" },
+        ],
+      };
+      const doc = {
+        chartConfigurations: [chart],
+        device_ids: [],
+        site_ids: [siteId, otherSiteId],
+        save: saveStub,
+      };
+      findOneStub.resolves(doc);
+      const request = {
+        query: { tenant: "airqo" },
+        params: { groupId, chartId },
+        body: {
+          site_ids: [siteId],
+          sites: [{ site_id: siteId, name: "Site A" }],
+        },
+        user: { _id: userId },
+      };
+      const next = sinon.stub();
+
+      const result = await rewireGroupChartConfigUtil.update(request, next);
+
+      expect(result.success).to.equal(true);
+      expect(saveStub.calledOnce).to.equal(true);
+      expect(chart.sites).to.deep.equal([{ site_id: siteId, name: "Site A" }]);
     });
 
     it("rejects (400, not a save() that trips the schema into a 500) when both scope arrays are explicitly cleared", async function() {

--- a/src/auth-service/utils/test/ut_preference.util.js
+++ b/src/auth-service/utils/test/ut_preference.util.js
@@ -590,6 +590,71 @@ describe("preference chart UTIL", function() {
       expect(result.status).to.equal(httpStatus.BAD_REQUEST);
       expect(result.errors.message).to.equal(validationError.message);
     });
+
+    it("rejects (400, before any DB write) a sites entry whose site_id isn't in the request's site_ids", async function() {
+      const request = {
+        query: { tenant: "airqo" },
+        body: {
+          chartConfig: {
+            fieldId: 1,
+            sites: [{ site_id: "507f1f77bcf86cd799439099", name: "Other site" }],
+          },
+          site_ids: [siteId],
+        },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.createChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(findOneAndUpdateStub.called).to.equal(false);
+    });
+
+    it("rejects (400, before any DB write) a devices entry whose device_id isn't in the request's device_ids", async function() {
+      const request = {
+        query: { tenant: "airqo" },
+        body: {
+          chartConfig: {
+            fieldId: 1,
+            devices: [
+              { device_id: "507f1f77bcf86cd799439099", name: "Other device" },
+            ],
+          },
+          device_ids: [deviceId],
+        },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.createChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(findOneAndUpdateStub.called).to.equal(false);
+    });
+
+    it("accepts sites/devices entries that match the request's site_ids/device_ids", async function() {
+      const chartConfig = {
+        fieldId: 1,
+        sites: [{ site_id: siteId, name: "Site A" }],
+        devices: [{ device_id: deviceId, name: "Device A" }],
+      };
+      findOneAndUpdateStub.resolves({
+        chartConfigurations: [
+          { ...chartConfig, device_ids: [deviceId], site_ids: [siteId] },
+        ],
+      });
+      const request = {
+        query: { tenant: "airqo" },
+        body: { chartConfig, device_ids: [deviceId], site_ids: [siteId] },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.createChart(request);
+
+      expect(result.success).to.equal(true);
+      expect(findOneAndUpdateStub.calledOnce).to.equal(true);
+    });
   });
 
   describe("updateChart", function() {
@@ -720,6 +785,95 @@ describe("preference chart UTIL", function() {
       expect(result.success).to.equal(false);
       expect(result.status).to.equal(httpStatus.BAD_REQUEST);
       expect(result.errors.message).to.equal(validationError.message);
+    });
+
+    it("rejects (400, no save()) a partial update that narrows site_ids without also updating the now-stale sites snapshot", async function() {
+      const saveStub = sinon.stub().resolves();
+      const otherSiteId = "507f1f77bcf86cd799439099";
+      const chart = {
+        _id: { toString: () => chartId },
+        device_ids: [],
+        site_ids: [siteId, otherSiteId],
+        sites: [
+          { site_id: siteId, name: "Site A" },
+          { site_id: otherSiteId, name: "Site B" },
+        ],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      // Narrows scope to siteId only, but leaves the old sites snapshot
+      // (still containing otherSiteId) untouched — this is exactly the
+      // partial update that would otherwise leave the chart returning a
+      // name for a site it's no longer scoped to.
+      const request = {
+        body: { tenant: "airqo", site_ids: [siteId] },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(saveStub.called).to.equal(false);
+    });
+
+    it("rejects (400, no save()) a partial update that narrows device_ids without also updating the now-stale devices snapshot", async function() {
+      const saveStub = sinon.stub().resolves();
+      const otherDeviceId = "507f1f77bcf86cd799439099";
+      const chart = {
+        _id: { toString: () => chartId },
+        device_ids: [deviceId, otherDeviceId],
+        site_ids: [],
+        devices: [
+          { device_id: deviceId, name: "Device A" },
+          { device_id: otherDeviceId, name: "Device B" },
+        ],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: { tenant: "airqo", device_ids: [deviceId] },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(saveStub.called).to.equal(false);
+    });
+
+    it("accepts a partial update that narrows site_ids and updates sites to match", async function() {
+      const saveStub = sinon.stub().resolves();
+      const otherSiteId = "507f1f77bcf86cd799439099";
+      const chart = {
+        _id: { toString: () => chartId },
+        device_ids: [],
+        site_ids: [siteId, otherSiteId],
+        sites: [
+          { site_id: siteId, name: "Site A" },
+          { site_id: otherSiteId, name: "Site B" },
+        ],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: {
+          tenant: "airqo",
+          site_ids: [siteId],
+          sites: [{ site_id: siteId, name: "Site A" }],
+        },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(true);
+      expect(saveStub.calledOnce).to.equal(true);
+      expect(chart.sites).to.deep.equal([{ site_id: siteId, name: "Site A" }]);
     });
   });
 

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -153,6 +153,50 @@ const createNestedValidations = (prefix) => {
       .bail()
       .isString()
       .withMessage("locationColors[].color must be a string"),
+    // Optional display-name snapshot for the chart's device_ids/site_ids —
+    // stored and returned verbatim, same optionality/shape as locationColors.
+    body(`${prefix}.sites`)
+      .optional()
+      .isArray()
+      .withMessage("sites must be an array"),
+    body(`${prefix}.sites.*.site_id`)
+      .exists()
+      .withMessage("sites[].site_id is required")
+      .bail()
+      .isMongoId()
+      .withMessage("sites[].site_id must be a valid ObjectId"),
+    body(`${prefix}.sites.*.name`)
+      .exists()
+      .withMessage("sites[].name is required")
+      .bail()
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage("sites[].name must be a non-empty string")
+      .bail()
+      .isLength({ max: 200 })
+      .withMessage("sites[].name must not exceed 200 characters"),
+    body(`${prefix}.devices`)
+      .optional()
+      .isArray()
+      .withMessage("devices must be an array"),
+    body(`${prefix}.devices.*.device_id`)
+      .exists()
+      .withMessage("devices[].device_id is required")
+      .bail()
+      .isMongoId()
+      .withMessage("devices[].device_id must be a valid ObjectId"),
+    body(`${prefix}.devices.*.name`)
+      .exists()
+      .withMessage("devices[].name is required")
+      .bail()
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage("devices[].name must be a non-empty string")
+      .bail()
+      .isLength({ max: 200 })
+      .withMessage("devices[].name must not exceed 200 characters"),
     body(`${prefix}.xAxisLabel`)
       .optional()
       .isString()
@@ -1111,6 +1155,47 @@ const chartConfigValidation = [
     .bail()
     .isString()
     .withMessage("locationColors[].color must be a string"),
+  // Optional display-name snapshot for device_ids/site_ids — stored and
+  // returned verbatim, same optionality/shape as locationColors.
+  body("sites").optional().isArray().withMessage("sites must be an array"),
+  body("sites.*.site_id")
+    .exists()
+    .withMessage("sites[].site_id is required")
+    .bail()
+    .isMongoId()
+    .withMessage("sites[].site_id must be a valid ObjectId"),
+  body("sites.*.name")
+    .exists()
+    .withMessage("sites[].name is required")
+    .bail()
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("sites[].name must be a non-empty string")
+    .bail()
+    .isLength({ max: 200 })
+    .withMessage("sites[].name must not exceed 200 characters"),
+  body("devices")
+    .optional()
+    .isArray()
+    .withMessage("devices must be an array"),
+  body("devices.*.device_id")
+    .exists()
+    .withMessage("devices[].device_id is required")
+    .bail()
+    .isMongoId()
+    .withMessage("devices[].device_id must be a valid ObjectId"),
+  body("devices.*.name")
+    .exists()
+    .withMessage("devices[].name is required")
+    .bail()
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("devices[].name must be a non-empty string")
+    .bail()
+    .isLength({ max: 200 })
+    .withMessage("devices[].name must not exceed 200 characters"),
   body("xAxisLabel")
     .optional()
     .isString()

--- a/src/auth-service/validators/test/ut_preferences-chart.validators.js
+++ b/src/auth-service/validators/test/ut_preferences-chart.validators.js
@@ -176,6 +176,96 @@ describe("personal chart validators", () => {
         });
       expect(res.status).to.equal(200);
     });
+
+    it("accepts a well-formed request with sites/devices display-name entries", async () => {
+      const siteId = validId();
+      const deviceId = validId();
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: {
+            fieldId: 1,
+            sites: [{ site_id: siteId, name: "Site A" }],
+            devices: [{ device_id: deviceId, name: "Device A" }],
+          },
+          site_ids: [siteId],
+          device_ids: [deviceId],
+        });
+      expect(res.status).to.equal(200);
+    });
+
+    it("rejects a chartConfig.sites entry with an invalid site_id", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: {
+            fieldId: 1,
+            sites: [{ site_id: "not-an-id", name: "Site A" }],
+          },
+          site_ids: [validId()],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "sites[].site_id must be a valid ObjectId"
+      );
+    });
+
+    it("rejects a chartConfig.sites entry missing site_id", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: { fieldId: 1, sites: [{ name: "Site A" }] },
+          site_ids: [validId()],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "sites[].site_id is required"
+      );
+    });
+
+    it("rejects a chartConfig.sites entry with an empty name", async () => {
+      const siteId = validId();
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: { fieldId: 1, sites: [{ site_id: siteId, name: "  " }] },
+          site_ids: [siteId],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "sites[].name must be a non-empty string"
+      );
+    });
+
+    it("rejects a chartConfig.sites entry with a name over 200 characters", async () => {
+      const siteId = validId();
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: {
+            fieldId: 1,
+            sites: [{ site_id: siteId, name: "x".repeat(201) }],
+          },
+          site_ids: [siteId],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "sites[].name must not exceed 200 characters"
+      );
+    });
+
+    it("rejects a chartConfig.devices entry missing device_id", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: { fieldId: 1, devices: [{ name: "Device A" }] },
+          device_ids: [validId()],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "devices[].device_id is required"
+      );
+    });
   });
 
   describe("updateChart", () => {
@@ -244,6 +334,38 @@ describe("personal chart validators", () => {
       expect(res.status).to.equal(422);
       expect(JSON.stringify(res.body)).to.include(
         "locationColors[].color is required"
+      );
+    });
+
+    it("accepts a well-formed update with sites/devices display-name entries", async () => {
+      const siteId = validId();
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({
+          site_ids: [siteId],
+          sites: [{ site_id: siteId, name: "Site A" }],
+        });
+      expect(res.status).to.equal(200);
+    });
+
+    it("rejects a sites entry with an invalid site_id", async () => {
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({ sites: [{ site_id: "not-an-id", name: "Site A" }] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "sites[].site_id must be a valid ObjectId"
+      );
+    });
+
+    it("rejects a devices entry with an empty name", async () => {
+      const deviceId = validId();
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({ devices: [{ device_id: deviceId, name: "" }] });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "devices[].name must be a non-empty string"
       );
     });
   });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds optional `sites` and `devices` display-name fields to chart configurations (`site_id`/`name` and `device_id`/`name` pairs), alongside the existing `site_ids`/`device_ids` ID arrays. The backend validates and persists these fields verbatim on both create (`POST /users/preferences/charts`) and update (`PUT /users/preferences/charts/:chartId`), and returns them unchanged on GET. The change also covers the group-level chart config feature, which reuses the same schema, validators, and update whitelist.

### Why is this change needed?
The Nexus frontend currently has no server-side way to persist site/device display names with a saved chart config, so it resolves names client-side via a localStorage sidecar plus a fleet-wide `GET /devices/sites/summary` fallback (paginated across ~717 sites) whenever that sidecar is empty — e.g. on a fresh browser or device. Storing names directly in the chart config eliminates that fallback and keeps names consistent across browsers/devices.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `auth-service` (chart-configuration schema, validators, and update whitelist — covers both the personal `/users/preferences/charts` endpoints and the group-level chart config feature, which reuses the same code paths)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran the existing personal and group chart-config test suites (`utils/test/ut_preference.util.js`, `models/test/ut_preference-chart-scope.model.js`, `validators/test/ut_preferences-chart.validators.js`, `utils/test/ut_group-chart-config.util.js`, `validators/test/ut_group-chart-config.validators.js`) — all pass with no regressions. No new tests were added specifically for the `sites`/`devices` fields.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Both new fields are optional and additive; legacy chart configs without `sites`/`devices` continue to load and update normally.

---

## :memo: Additional Notes

- Names are stored as a snapshot (whatever the client sends) and returned verbatim — no server-side lookup against the sites/devices registry, so there's no added read-time cost or coupling. Names can go stale if a site/device is renamed later, which is an accepted tradeoff for chart labels.
- `site_id`/`device_id` are validated as ObjectIds; `name` must be a non-empty, trimmed string up to 200 characters.
- Update requests are gated by an explicit `allowedChartProperties` whitelist (separate from schema strictness, which only applies to create) — `sites` and `devices` were added there too, otherwise PUT would silently drop them even after the schema change.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chart preferences can now include selected sites and devices with display names.
  - Site and device entries are validated for valid identifiers and names up to 200 characters.
  - These settings are supported in both nested and standalone chart configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->