### PR TITLE
Fix missing period causing 500s on chart update and copy

### DIFF
--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -211,6 +211,25 @@ const findStaleMetadataEntry = (entries, idField, allowedIds) => {
   );
 };
 
+// Legacy preference docs created via the upsert()/replace() findOneAndUpdate
+// paths (no runValidators, no period default there) can exist without a
+// `period` even though it's required on the schema — invisible until
+// something calls preference.save(), which (unlike a findOneAndUpdate)
+// always validates every required path on the whole document, so a chart
+// change having nothing to do with `period` fails with "period: period is
+// required!". Backfilling here (the same default preference.register() and
+// createChart use) unblocks those pre-existing docs without a migration.
+const ensurePeriodDefault = (preference) => {
+  if (isEmpty(preference.period)) {
+    preference.period = {
+      value: "Last 7 days",
+      label: "Last 7 days",
+      unitValue: 7,
+      unit: "day",
+    };
+  }
+};
+
 // Define allowed properties for chart updates
 const allowedChartProperties = [
   "fieldId",
@@ -1074,6 +1093,7 @@ const preferences = {
         };
       }
 
+      ensurePeriodDefault(preference);
       await preference.save();
 
       return {
@@ -1291,6 +1311,7 @@ const preferences = {
 
       // Add the new chart to the preference
       preference.chartConfigurations.push(chartCopy);
+      ensurePeriodDefault(preference);
       await preference.save();
 
       return {
@@ -1302,6 +1323,9 @@ const preferences = {
         status: httpStatus.OK,
       };
     } catch (error) {
+      if (error.name === "ValidationError") {
+        return chartValidationErrorResponse(error);
+      }
       logger.error(`Error copying chart configuration: ${error.message}`);
       return {
         success: false,

--- a/src/auth-service/utils/test/ut_preference.util.js
+++ b/src/auth-service/utils/test/ut_preference.util.js
@@ -875,6 +875,33 @@ describe("preference chart UTIL", function() {
       expect(saveStub.calledOnce).to.equal(true);
       expect(chart.sites).to.deep.equal([{ site_id: siteId, name: "Site A" }]);
     });
+
+    it("backfills a missing period before saving — legacy preference docs created via upsert()/replace() (no runValidators there) can lack it, and save() always validates the whole document", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = {
+        _id: { toString: () => chartId },
+        title: "Old title",
+        device_ids: [deviceId],
+        site_ids: [],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: { tenant: "airqo", title: "New title" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(doc.period).to.deep.equal({
+        value: "Last 7 days",
+        label: "Last 7 days",
+        unitValue: 7,
+        unit: "day",
+      });
+      expect(result.success).to.equal(true);
+    });
   });
 
   describe("deleteChart", function() {
@@ -1138,6 +1165,82 @@ describe("preference chart UTIL", function() {
         { id: deviceId, color: "#FF0000" },
       ]);
       expect(result.data._id).to.equal(undefined);
+    });
+
+    it("backfills a missing period before saving — legacy preference docs created via upsert()/replace() (no runValidators there) can lack it, and save() always validates the whole document", async function() {
+      const saveStub = sinon.stub().resolves();
+      const sourceChart = {
+        _id: { toString: () => chartId },
+        toObject: () => ({ _id: chartId, title: "PM2.5", device_ids: [deviceId] }),
+      };
+      const doc = { chartConfigurations: [sourceChart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.copyChartConfiguration(
+        request
+      );
+
+      expect(doc.period).to.deep.equal({
+        value: "Last 7 days",
+        label: "Last 7 days",
+        unitValue: 7,
+        unit: "day",
+      });
+      expect(result.success).to.equal(true);
+    });
+
+    it("leaves an existing period untouched", async function() {
+      const saveStub = sinon.stub().resolves();
+      const existingPeriod = { value: "Last 30 days", label: "Last 30 days", unitValue: 30, unit: "day" };
+      const sourceChart = {
+        _id: { toString: () => chartId },
+        toObject: () => ({ _id: chartId, title: "PM2.5", device_ids: [deviceId] }),
+      };
+      const doc = {
+        chartConfigurations: [sourceChart],
+        period: existingPeriod,
+        save: saveStub,
+      };
+      findOneStub.resolves(doc);
+      const request = {
+        body: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      await rewirePreferenceUtil.copyChartConfiguration(request);
+
+      expect(doc.period).to.equal(existingPeriod);
+    });
+
+    it("returns 400 (not 500) when save() rejects with a schema ValidationError", async function() {
+      const validationError = new Error("preference validation failed: period: period is required!");
+      validationError.name = "ValidationError";
+      const saveStub = sinon.stub().rejects(validationError);
+      const sourceChart = {
+        _id: { toString: () => chartId },
+        toObject: () => ({ _id: chartId, title: "PM2.5", device_ids: [deviceId] }),
+      };
+      const doc = { chartConfigurations: [sourceChart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: { tenant: "airqo" },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.copyChartConfiguration(
+        request
+      );
+
+      expect(result.success).to.equal(false);
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(result.errors.message).to.equal(validationError.message);
     });
   });
 });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Backfills a missing `period` field on legacy preference documents before the `updateChart` and `copyChart` saves, and fixes `copyChart`'s error handling so a schema validation failure returns a clean 400 instead of a raw 500.

### Why is this change needed?
Staging and production logs showed a real user (`pochieng@airqo.net`) repeatedly hitting `500` on `POST /users/preferences/charts/:chartId/copy`, with the underlying error `preference validation failed: period: period is required!` — a field with nothing to do with charts. Root cause: the `upsert`/`replace` preference-update paths use `findOneAndUpdate({ upsert: true })` without `runValidators: true` and without setting `period`, so they can silently create a preference document with no `period` at all. That's invisible until something calls `.save()` on the fetched document — unlike `findOneAndUpdate`, `.save()` always validates every required field on the whole document — which is exactly what `updateChart` and `copyChartConfiguration` do. `createChart` never hit this because it only uses `findOneAndUpdate`.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `auth-service` (`utils/preference.util.js` — `updateChart` and `copyChartConfiguration`)

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added regression tests asserting the `period` default is backfilled (and an existing `period` is left untouched) before `updateChart`/`copyChartConfiguration` save, plus a test confirming `copyChart` now returns 400 (not 500) on a schema `ValidationError`. Ran the full chart-config test suites: 2181 passing; only a pre-existing, unrelated flaky date-util test fails.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely defensive — no schema or API contract change; existing well-formed documents and requests are unaffected.

---

## :memo: Additional Notes

This fixes the symptom for documents that are already missing `period`, unblocking the affected users immediately without a data migration. The root cause — `upsert`/`replace` creating preference documents without a `period` in the first place — was intentionally left untouched here, since fixing it means changing a shared update-building helper (`prepareUpdate`) used by four endpoints, which carries more risk than this narrow fix. Flagging as a follow-up if closing the root cause (vs. its symptom) is wanted.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chart updates and copies now automatically apply a default period when one is missing.
  - Existing preference periods are preserved during chart operations.
  - Invalid chart-copy requests now return a clear `400 Bad Request` response with error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->