### PR TITLE
Add self-service cohort slug IDs with backward-compatible dual ID lookup

### DIFF
--- a/src/device-registry/controllers/cohort.controller.js
+++ b/src/device-registry/controllers/cohort.controller.js
@@ -215,6 +215,17 @@ const createCohort = {
       handleError(error, next);
     }
   },
+  checkSlug: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+
+      const result = await createCohortUtil.checkSlug(request, next);
+      handleResponse({ res, result, key: "slug_check" });
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
   listSummary: async (req, res, next) => {
     try {
       logText(".....................................");

--- a/src/device-registry/models/Cohort.js
+++ b/src/device-registry/models/Cohort.js
@@ -36,8 +36,14 @@ const cohortSchema = new Schema(
       trim: true,
       lowercase: true,
       match: [
-        /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
-        "cohort_slug can only contain lowercase letters, numbers and hyphens",
+        // Lowercase alphanumeric + hyphens, same as before, but the
+        // negative lookahead additionally rejects any value that is
+        // exactly 24 hex characters — that shape is indistinguishable
+        // from a MongoDB ObjectId by every dual-lookup check in this
+        // codebase, so a slug like that would never actually be
+        // reachable via its own cohort_slug.
+        /^(?![0-9a-f]{24}$)[a-z0-9]+(?:-[a-z0-9]+)*$/,
+        "cohort_slug can only contain lowercase letters, numbers and hyphens, and cannot look like a 24-character MongoDB ObjectId",
       ],
     },
     description: {

--- a/src/device-registry/models/Cohort.js
+++ b/src/device-registry/models/Cohort.js
@@ -26,6 +26,20 @@ const cohortSchema = new Schema(
       trim: true,
       unique: true,
     },
+    // Optional, user-chosen, immutable identifier that can be used
+    // interchangeably with _id in lookups (see cohort.util.js). Absent on
+    // cohorts created before this field existed and on any cohort whose
+    // creator didn't opt in — self-service ID generation is additive, not
+    // required.
+    cohort_slug: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      match: [
+        /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+        "cohort_slug can only contain lowercase letters, numbers and hyphens",
+      ],
+    },
     description: {
       type: String,
       trim: true,
@@ -94,7 +108,7 @@ cohortSchema.pre("save", function(next) {
   if (this.isModified("_id")) {
     delete this._id;
   }
-  this.cohort_codes = [this._id, this.name];
+  this.cohort_codes = [this._id, this.name, this.cohort_slug].filter(Boolean);
   return next();
 });
 
@@ -124,11 +138,15 @@ cohortSchema.plugin(uniqueValidator, {
 cohortSchema.index({ grp_id: 1 });
 cohortSchema.index({ geoHash: 1 });
 cohortSchema.index({ cohort_tags: 1 });
+// sparse: only enforced across documents that actually have a cohort_slug,
+// so existing cohorts (no cohort_slug) never collide with each other.
+cohortSchema.index({ cohort_slug: 1 }, { unique: true, sparse: true });
 
 cohortSchema.methods.toJSON = function() {
   const {
     _id,
     name,
+    cohort_slug,
     description,
     cohort_tags,
     cohort_codes,
@@ -140,6 +158,7 @@ cohortSchema.methods.toJSON = function() {
   return {
     _id,
     name,
+    cohort_slug,
     visibility,
     description,
     cohort_tags,
@@ -370,6 +389,9 @@ cohortSchema.statics.modify = async function(
     delete modifiedUpdateBody._id;
     delete modifiedUpdateBody.name;
     delete modifiedUpdateBody.cohort_codes;
+    // cohort_slug is immutable once set (like _id) so partner integrations
+    // that hardcode it never silently break; there is no update path for it.
+    delete modifiedUpdateBody.cohort_slug;
     // Normalize and deduplicate cohort_tags if they are being updated
     if (
       modifiedUpdateBody.cohort_tags &&

--- a/src/device-registry/routes/v2/cohorts.routes.js
+++ b/src/device-registry/routes/v2/cohorts.routes.js
@@ -35,6 +35,14 @@ router.put(
 
 router.post("/", cohortValidations.createCohort, createCohortController.create);
 
+// Static route — must stay registered above the catch-all GET /:cohort_id
+// below, otherwise Express would match "check-slug" as a cohort_id value.
+router.get(
+  "/check-slug",
+  cohortValidations.checkCohortSlug,
+  createCohortController.checkSlug,
+);
+
 router.get(
   "/",
   pagination(),

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -8,7 +8,7 @@ const networkUtil = require("@utils/network.util");
 const isEmpty = require("is-empty");
 const httpStatus = require("http-status");
 const constants = require("@config/constants");
-const { generateFilter, stringify } = require("@utils/common");
+const { generateFilter, stringify, cohortSlugUtil } = require("@utils/common");
 const log4js = require("log4js");
 const logger = log4js.getLogger(
   `${constants.ENVIRONMENT} -- create-cohort-util`,
@@ -47,6 +47,17 @@ function filterOutPrivateIDs(privateIds, randomIds) {
   return filteredIds;
 }
 
+// A cohort_id route param is, after validation, either a real ObjectId
+// instance (existing behaviour, untouched) or a plain lowercase
+// cohort_slug string (new, opt-in). This turns either into the right Mongo
+// filter/value so every lookup below works for both.
+const isCohortSlugIdentifier = (identifier) => typeof identifier === "string";
+
+const cohortLookupFilter = (identifier) =>
+  isCohortSlugIdentifier(identifier)
+    ? { cohort_slug: identifier }
+    : { _id: identifier };
+
 const createCohort = {
   // Network CRUD — logic lives in network.util.js; these are kept for
   // backward compatibility so the existing /cohorts/networks endpoints
@@ -59,7 +70,32 @@ const createCohort = {
     try {
       const { body, query } = request;
       const { tenant } = query;
-      let modifiedBody = body;
+      let modifiedBody = { ...body };
+
+      // Opt-in self-service cohort_slug: only generated when the caller
+      // actually sends one, so every existing create-cohort caller that
+      // never sends cohort_slug is completely unaffected.
+      if (!isEmpty(modifiedBody.cohort_slug)) {
+        const slugResult = await cohortSlugUtil.generateUniqueCohortSlug({
+          tenant,
+          requestedSlug: modifiedBody.cohort_slug,
+          groupSlug: modifiedBody.group_slug,
+        });
+
+        if (!slugResult.success) {
+          return {
+            success: false,
+            message: "Bad Request Error",
+            errors: { message: slugResult.message },
+            status: httpStatus.BAD_REQUEST,
+          };
+        }
+
+        modifiedBody.cohort_slug = slugResult.slug;
+      } else {
+        delete modifiedBody.cohort_slug;
+      }
+      delete modifiedBody.group_slug;
 
       const responseFromRegisterCohort = await CohortModel(tenant).register(
         modifiedBody,
@@ -94,6 +130,50 @@ const createCohort = {
       } else if (responseFromRegisterCohort.success === false) {
         return responseFromRegisterCohort;
       }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+  // Live availability check for a candidate cohort_slug, used to power a
+  // debounced preview in a create-cohort UI before the caller submits.
+  // Read-only, new endpoint — nothing existing depends on it.
+  checkSlug: async (request, next) => {
+    try {
+      const { query } = request;
+      const { tenant, slug, group_slug: groupSlug } = query;
+
+      const candidate = cohortSlugUtil.buildCandidateSlug({
+        requestedSlug: slug,
+        groupSlug,
+      });
+      const evaluation = cohortSlugUtil.evaluateCandidate(candidate);
+
+      const taken =
+        evaluation.valid && (await cohortSlugUtil.slugExists(tenant, candidate));
+
+      const available = evaluation.valid && !taken;
+
+      return {
+        success: true,
+        message: "checked cohort_slug availability",
+        data: {
+          candidate_slug: candidate,
+          available,
+          reason: available
+            ? null
+            : evaluation.valid
+            ? "taken"
+            : evaluation.reason,
+        },
+        status: httpStatus.OK,
+      };
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(
@@ -185,7 +265,11 @@ const createCohort = {
         .trim()
         .toLowerCase();
 
-      const newCohortCodes = [existingCohort._id, processedName];
+      const newCohortCodes = [
+        existingCohort._id,
+        processedName,
+        existingCohort.cohort_slug,
+      ].filter(Boolean);
 
       // Prepare the update object
       const update = {
@@ -261,8 +345,9 @@ const createCohort = {
 
       const originalFilter = { ...filter };
 
-      // Only exclude user cohorts if we are not fetching by a specific ID
-      if (!filter._id) {
+      // Only exclude user cohorts if we are not fetching by a specific
+      // identifier (either _id or the new opt-in cohort_slug).
+      if (!filter._id && !filter.cohort_slug) {
         const userCohortExclusion = { name: { $not: /^coh_user_/i } };
         if (filter.name) {
           // If a name filter already exists, combine it with the exclusion using $and
@@ -281,15 +366,17 @@ const createCohort = {
 
       const result = await createCohort._list(request, filter, next);
 
-      // Handle case where a specific cohort ID was requested but not found
+      // Handle case where a specific cohort identifier was requested but not found
       if (
         isEmpty(result.data) &&
-        originalFilter._id &&
+        (originalFilter._id || originalFilter.cohort_slug) &&
         Object.keys(originalFilter).length === 1
       ) {
-        const idString = originalFilter._id.$in
-          ? `[${originalFilter._id.$in.join(", ")}]`
-          : originalFilter._id;
+        const idString = originalFilter._id
+          ? originalFilter._id.$in
+            ? `[${originalFilter._id.$in.join(", ")}]`
+            : originalFilter._id
+          : originalFilter.cohort_slug;
         return {
           success: false,
           message: "Cohort not found",
@@ -472,12 +559,14 @@ const createCohort = {
 
       if (
         isEmpty(result.data) &&
-        originalFilter._id &&
+        (originalFilter._id || originalFilter.cohort_slug) &&
         Object.keys(originalFilter).length === 1
       ) {
-        const idString = originalFilter._id.$in
-          ? `[${originalFilter._id.$in.join(", ")}]`
-          : originalFilter._id;
+        const idString = originalFilter._id
+          ? originalFilter._id.$in
+            ? `[${originalFilter._id.$in.join(", ")}]`
+            : originalFilter._id
+          : originalFilter.cohort_slug;
         return {
           success: false,
           message: "User Cohort not found",
@@ -563,7 +652,9 @@ const createCohort = {
       const { tenant } = request.query;
       const { cohort_id } = request.params;
 
-      const cohort = await CohortModel(tenant).findById(cohort_id);
+      const cohort = await CohortModel(tenant).findOne(
+        cohortLookupFilter(cohort_id),
+      );
 
       if (!cohort) {
         return {
@@ -580,7 +671,7 @@ const createCohort = {
         .aggregate([
           {
             $match: {
-              cohorts: { $nin: [cohort_id] },
+              cohorts: { $nin: [cohort._id] },
             },
           },
           {
@@ -627,7 +718,9 @@ const createCohort = {
       const { tenant } = request.query;
       const { cohort_id } = request.params;
 
-      const cohort = await CohortModel(tenant).findById(cohort_id);
+      const cohort = await CohortModel(tenant).findOne(
+        cohortLookupFilter(cohort_id),
+      );
 
       if (!cohort) {
         return {
@@ -644,7 +737,7 @@ const createCohort = {
         .aggregate([
           {
             $match: {
-              cohorts: { $in: [cohort_id] },
+              cohorts: { $in: [cohort._id] },
             },
           },
           {
@@ -693,7 +786,7 @@ const createCohort = {
       const { tenant } = request.query;
 
       const cohort = await CohortModel(tenant)
-        .findById(cohort_id)
+        .findOne(cohortLookupFilter(cohort_id))
         .lean();
 
       if (!cohort) {
@@ -704,6 +797,11 @@ const createCohort = {
           status: httpStatus.BAD_REQUEST,
         };
       }
+
+      // Resolve to the canonical ObjectId once — device.cohorts is an
+      // array of ObjectIds, so every write below must use this, not the
+      // raw route param (which may be a cohort_slug string).
+      const resolvedCohortId = cohort._id;
 
       // Batch fetch all devices at once to avoid N+1 queries
       const existingDevices = await DeviceModel(tenant)
@@ -728,7 +826,7 @@ const createCohort = {
       }
 
       // Split into already-assigned and new-to-assign; proceed with new ones
-      const cohortIdStr = cohort_id.toString();
+      const cohortIdStr = resolvedCohortId.toString();
       const alreadyAssigned = existingDevices
         .filter(
           (d) =>
@@ -754,13 +852,13 @@ const createCohort = {
 
       await DeviceModel(tenant).updateMany(
         { _id: { $in: toAssign } },
-        { $addToSet: { cohorts: cohort_id } },
+        { $addToSet: { cohorts: resolvedCohortId } },
       );
 
       // Re-query after the update to confirm which devices were actually assigned,
       // guarding against concurrent requests that may have already written the same cohort_id.
       const confirmedDocs = await DeviceModel(tenant)
-        .find({ _id: { $in: toAssign }, cohorts: cohort_id })
+        .find({ _id: { $in: toAssign }, cohorts: resolvedCohortId })
         .select("_id")
         .lean();
       const confirmedAssigned = confirmedDocs.map((d) => d._id);
@@ -796,7 +894,9 @@ const createCohort = {
       const { tenant } = request.query;
 
       // Check if cohort exists
-      const cohort = await CohortModel(tenant).findById(cohort_id);
+      const cohort = await CohortModel(tenant).findOne(
+        cohortLookupFilter(cohort_id),
+      );
       if (!cohort) {
         return {
           success: false,
@@ -805,6 +905,9 @@ const createCohort = {
           status: httpStatus.BAD_REQUEST,
         };
       }
+      // device.cohorts stores ObjectIds; always use the resolved one below
+      // rather than the raw route param (which may be a cohort_slug string).
+      const resolvedCohortId = cohort._id;
 
       //check of all these provided devices actually do exist?
       const existingDevices = await DeviceModel(tenant).find(
@@ -832,7 +935,7 @@ const createCohort = {
 
       const devices = await DeviceModel(tenant).find({
         _id: { $in: device_ids },
-        cohorts: { $all: [cohort_id] },
+        cohorts: { $all: [resolvedCohortId] },
       });
 
       if (devices.length !== device_ids.length) {
@@ -851,8 +954,8 @@ const createCohort = {
       try {
         const totalDevices = device_ids.length;
         const { nModified, n } = await DeviceModel(tenant).updateMany(
-          { _id: { $in: device_ids }, cohorts: { $in: [cohort_id] } },
-          { $pull: { cohorts: cohort_id } },
+          { _id: { $in: device_ids }, cohorts: { $in: [resolvedCohortId] } },
+          { $pull: { cohorts: resolvedCohortId } },
           { multi: true },
         );
 
@@ -906,11 +1009,12 @@ const createCohort = {
       const { tenant } = request.query;
 
       const deviceExists = await DeviceModel(tenant).exists({ _id: device_id });
-      const cohortExists = await CohortModel(tenant).exists({
-        _id: cohort_id,
-      });
+      const cohort = await CohortModel(tenant)
+        .findOne(cohortLookupFilter(cohort_id))
+        .select("_id")
+        .lean();
 
-      if (!deviceExists || !cohortExists) {
+      if (!deviceExists || !cohort) {
         return {
           success: false,
           message: "Device or Cohort not found",
@@ -920,6 +1024,9 @@ const createCohort = {
           },
         };
       }
+      // device.cohorts stores ObjectIds; always use the resolved one below
+      // rather than the raw route param (which may be a cohort_slug string).
+      const resolvedCohortId = cohort._id;
 
       const device = await DeviceModel(tenant)
         .findById(device_id)
@@ -929,7 +1036,7 @@ const createCohort = {
 
       if (
         device.cohorts &&
-        device.cohorts.map(String).includes(cohort_id.toString())
+        device.cohorts.map(String).includes(resolvedCohortId.toString())
       ) {
         return {
           success: false,
@@ -941,7 +1048,7 @@ const createCohort = {
 
       const updatedDevice = await DeviceModel(tenant).findByIdAndUpdate(
         device_id,
-        { $addToSet: { cohorts: cohort_id } },
+        { $addToSet: { cohorts: resolvedCohortId } },
         { new: true },
       );
 
@@ -968,7 +1075,9 @@ const createCohort = {
       const { tenant } = request.query;
 
       // Check if the cohort exists
-      const cohort = await CohortModel(tenant).findById(cohort_id);
+      const cohort = await CohortModel(tenant).findOne(
+        cohortLookupFilter(cohort_id),
+      );
       // Check if the device exists
       const device = await DeviceModel(tenant).findById(device_id);
 
@@ -982,10 +1091,13 @@ const createCohort = {
           status: httpStatus.BAD_REQUEST,
         };
       }
+      // device.cohorts stores ObjectIds; always use the resolved one below
+      // rather than the raw route param (which may be a cohort_slug string).
+      const resolvedCohortId = cohort._id;
 
       // Check if the cohort is part of the device's cohorts
       const isCohortInDevice = device.cohorts.some(
-        (cohortId) => cohortId.toString() === cohort_id.toString(),
+        (cohortId) => cohortId.toString() === resolvedCohortId.toString(),
       );
       if (!isCohortInDevice) {
         return {
@@ -1001,7 +1113,7 @@ const createCohort = {
       // Remove the cohort from the device
       const updatedDevice = await DeviceModel(tenant).findByIdAndUpdate(
         device_id,
-        { $pull: { cohorts: cohort_id } },
+        { $pull: { cohorts: resolvedCohortId } },
         { new: true },
       );
 
@@ -1025,7 +1137,9 @@ const createCohort = {
   getSiteAndDeviceIds: async (request, next) => {
     try {
       const { cohort_id, tenant } = { ...request.query, ...request.params };
-      const cohortDetails = await CohortModel(tenant).findById(cohort_id);
+      const cohortDetails = await CohortModel(tenant).findOne(
+        cohortLookupFilter(cohort_id),
+      );
       if (isEmpty(cohortDetails)) {
         return {
           success: false,
@@ -1036,7 +1150,7 @@ const createCohort = {
       }
       // Fetch devices based on the provided Cohort ID
       const devices = await DeviceModel(tenant)
-        .find({ cohorts: cohort_id })
+        .find({ cohorts: cohortDetails._id })
         .select("_id site_id")
         .lean();
 
@@ -1195,17 +1309,38 @@ const createCohort = {
       const { tenant } = query;
       const { name, description, cohort_ids } = body;
 
+      // cohort_ids may be a mix of ObjectIds (existing behaviour) and
+      // cohort_slug values (new, opt-in) — split by shape so each is
+      // looked up the right way, then resolve everything back to real
+      // ObjectIds for every downstream use.
+      const objectIdEntries = cohort_ids.filter((id) =>
+        /^[0-9a-fA-F]{24}$/.test(String(id)),
+      );
+      const slugEntries = cohort_ids.filter(
+        (id) => !/^[0-9a-fA-F]{24}$/.test(String(id)),
+      );
+
       // 1. Fetch all source cohorts to validate they exist and get network ID
       const existingCohorts = await CohortModel(tenant)
-        .find({ _id: { $in: cohort_ids } })
-        .select("network") // only need network
+        .find({
+          $or: [
+            { _id: { $in: objectIdEntries } },
+            { cohort_slug: { $in: slugEntries } },
+          ],
+        })
+        .select("network cohort_slug") // only need network (+ slug for matching)
         .lean();
 
       logObject("existingCohorts", existingCohorts);
 
       if (existingCohorts.length !== cohort_ids.length) {
-        const foundIds = existingCohorts.map((c) => c._id.toString());
-        const notFoundIds = cohort_ids.filter((id) => !foundIds.includes(id));
+        const foundIds = new Set(existingCohorts.map((c) => c._id.toString()));
+        const foundSlugs = new Set(
+          existingCohorts.filter((c) => c.cohort_slug).map((c) => c.cohort_slug),
+        );
+        const notFoundIds = cohort_ids.filter(
+          (id) => !foundIds.has(String(id)) && !foundSlugs.has(String(id)),
+        );
         return {
           success: false,
           message: "Bad Request Error",
@@ -1217,6 +1352,11 @@ const createCohort = {
           status: httpStatus.BAD_REQUEST,
         };
       }
+
+      // Canonical ObjectIds for every source cohort, regardless of whether
+      // the caller identified it by _id or cohort_slug — everything below
+      // must use this, not the raw cohort_ids (which may contain slugs).
+      const resolvedCohortIds = existingCohorts.map((c) => c._id);
 
       // 2. Ensure all cohorts belong to the same network
       // 2. Ensure all source cohorts belong to the same network
@@ -1255,6 +1395,28 @@ const createCohort = {
         network: networkId,
       };
 
+      // Opt-in self-service cohort_slug for the newly created merged
+      // cohort — only generated when the caller asks for one, mirroring
+      // the plain create-cohort flow.
+      if (!isEmpty(body.cohort_slug)) {
+        const slugResult = await cohortSlugUtil.generateUniqueCohortSlug({
+          tenant,
+          requestedSlug: body.cohort_slug,
+          groupSlug: body.group_slug,
+        });
+
+        if (!slugResult.success) {
+          return {
+            success: false,
+            message: "Bad Request Error",
+            errors: { message: slugResult.message },
+            status: httpStatus.BAD_REQUEST,
+          };
+        }
+
+        newCohortData.cohort_slug = slugResult.slug;
+      }
+
       const newCohortResponse = await CohortModel(tenant).register(
         newCohortData,
         next,
@@ -1278,7 +1440,7 @@ const createCohort = {
 
       // 4. Find all unique devices belonging to the source cohorts
       const devicesToUpdate = await DeviceModel(tenant)
-        .find({ cohorts: { $in: cohort_ids } })
+        .find({ cohorts: { $in: resolvedCohortIds } })
         .distinct("_id");
 
       if (devicesToUpdate.length === 0) {
@@ -1332,7 +1494,7 @@ const createCohort = {
 
       // 1. Find the source cohort and its devices
       const sourceCohort = await CohortModel(tenant)
-        .findById(cohort_id)
+        .findOne(cohortLookupFilter(cohort_id))
         .lean();
       if (!sourceCohort) {
         return {
@@ -1346,7 +1508,7 @@ const createCohort = {
       // 2. Find all cohorts that share devices with the source cohort.
       // This is more efficient than fetching all device IDs first.
       const candidateCohorts = await DeviceModel(tenant).distinct("cohorts", {
-        cohorts: cohort_id,
+        cohorts: sourceCohort._id,
       });
 
       if (candidateCohorts.length <= 1) {
@@ -1375,7 +1537,7 @@ const createCohort = {
       }
 
       // 4. Identify the group of cohorts with the exact same device set
-      const sourceKey = cohortDeviceSets.get(cohort_id.toString());
+      const sourceKey = cohortDeviceSets.get(sourceCohort._id.toString());
       const duplicateGroupIdSet = new Set();
       for (const [id, key] of cohortDeviceSets.entries()) {
         if (key === sourceKey) {

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -58,6 +58,53 @@ const cohortLookupFilter = (identifier) =>
     ? { cohort_slug: identifier }
     : { _id: identifier };
 
+const isObjectIdShape = (identifier) =>
+  /^[0-9a-fA-F]{24}$/.test(String(identifier));
+
+// Batch counterpart to cohortLookupFilter: resolves a mixed array of
+// cohort_ids (ObjectIds and/or cohort_slugs) to their canonical ObjectIds
+// in a single query, instead of each caller constructing ObjectId(id)
+// directly — which throws for a slug, or (via a loose validity check)
+// can silently drop it.
+const resolveCohortObjectIds = async (tenant, cohortIdentifiers) => {
+  const identifiers = Array.isArray(cohortIdentifiers) ? cohortIdentifiers : [];
+  const objectIdEntries = identifiers.filter((id) => isObjectIdShape(id));
+  const slugEntries = identifiers.filter((id) => !isObjectIdShape(id));
+
+  const matches = await CohortModel(tenant)
+    .find({
+      $or: [
+        { _id: { $in: objectIdEntries } },
+        { cohort_slug: { $in: slugEntries } },
+      ],
+    })
+    .select("_id cohort_slug visibility")
+    .lean();
+
+  const byIdString = new Map(matches.map((c) => [c._id.toString(), c]));
+  const bySlug = new Map(
+    matches.filter((c) => c.cohort_slug).map((c) => [c.cohort_slug, c]),
+  );
+
+  const resolved = [];
+  const notFound = [];
+  identifiers.forEach((id) => {
+    const idStr = String(id);
+    const match = byIdString.get(idStr) || bySlug.get(idStr);
+    if (match) {
+      resolved.push(match);
+    } else {
+      notFound.push(id);
+    }
+  });
+
+  return {
+    resolved,
+    resolvedIds: resolved.map((c) => c._id),
+    notFound,
+  };
+};
+
 const createCohort = {
   // Network CRUD — logic lives in network.util.js; these are kept for
   // backward compatibility so the existing /cohorts/networks endpoints
@@ -1245,18 +1292,13 @@ const createCohort = {
       const { cohort_ids } = request.body;
       const tenant = request.query.tenant || request.body.tenant;
 
-      const objectIds = cohort_ids.map((id) => new ObjectId(id));
-
-      // Identify which IDs exist in the DB
-      const existingCohorts = await CohortModel(tenant)
-        .find({ _id: { $in: objectIds } })
-        .select("_id visibility")
-        .lean();
-
-      const existingIds = new Set(
-        existingCohorts.map((c) => c._id.toString()),
+      // Resolves ObjectIds and/or cohort_slugs in one query — also gives
+      // us visibility directly, so no separate existence lookup is needed.
+      const { resolved: existingCohorts, notFound } = await resolveCohortObjectIds(
+        tenant,
+        cohort_ids,
       );
-      const notFound = cohort_ids.filter((id) => !existingIds.has(id));
+
       const alreadyPublic = existingCohorts
         .filter((c) => c.visibility === true)
         .map((c) => c._id.toString());
@@ -1628,10 +1670,18 @@ const createCohort = {
       // ✅ Get standard device filter from generateFilter
       const baseFilter = generateFilter.devices(request, next);
 
+      // Resolve ObjectIds and/or cohort_slugs to canonical ObjectIds —
+      // unresolvable entries are simply excluded, same as an unmatched
+      // ObjectId would contribute nothing to the $in filter.
+      const { resolvedIds: cohortObjectIds } = await resolveCohortObjectIds(
+        tenant,
+        cohort_ids,
+      );
+
       // ✅ Merge with cohort-specific filter
       const filter = {
         ...baseFilter,
-        cohorts: { $in: cohort_ids.map((id) => ObjectId(id)) },
+        cohorts: { $in: cohortObjectIds },
       };
 
       // Get total count for pagination metadata before applying limit and skip
@@ -1947,8 +1997,11 @@ const createCohort = {
       const sortOrder = order === "asc" ? 1 : -1;
       const sortField = sortBy ? sortBy : "createdAt";
 
-      // Convert cohort_ids to ObjectIds
-      const cohortObjectIds = cohort_ids.map((id) => ObjectId(id));
+      // Resolve ObjectIds and/or cohort_slugs to canonical ObjectIds
+      const { resolvedIds: cohortObjectIds } = await resolveCohortObjectIds(
+        tenant,
+        cohort_ids,
+      );
 
       // Search should only apply to sites, not devices
       const deviceFilterRequest = {
@@ -2286,16 +2339,22 @@ const createCohort = {
         };
       }
 
-      const cohortObjectIds = cohort_ids
-        .filter((id) => ObjectId.isValid(id))
-        .map((id) => ObjectId(id));
+      // Resolves ObjectIds and/or cohort_slugs to canonical ObjectIds;
+      // unresolvable entries are simply excluded (not previously mongoose's
+      // ObjectId.isValid, which also accepts arbitrary 12-byte strings).
+      const { resolvedIds: cohortObjectIds } = await resolveCohortObjectIds(
+        tenant,
+        cohort_ids,
+      );
 
       if (!cohortObjectIds.length) {
         return {
           success: false,
           status: httpStatus.BAD_REQUEST,
           message: "No valid cohort_ids provided",
-          errors: { message: "cohort_ids must be valid MongoDB ObjectIds" },
+          errors: {
+            message: "cohort_ids must be valid MongoDB ObjectIds or cohort_slugs",
+          },
         };
       }
 
@@ -2424,16 +2483,22 @@ const createCohort = {
         };
       }
 
-      const cohortObjectIds = cohort_ids
-        .filter((id) => ObjectId.isValid(id))
-        .map((id) => ObjectId(id));
+      // Resolves ObjectIds and/or cohort_slugs to canonical ObjectIds;
+      // unresolvable entries are simply excluded (not previously mongoose's
+      // ObjectId.isValid, which also accepts arbitrary 12-byte strings).
+      const { resolvedIds: cohortObjectIds } = await resolveCohortObjectIds(
+        tenant,
+        cohort_ids,
+      );
 
       if (!cohortObjectIds.length) {
         return {
           success: false,
           status: httpStatus.BAD_REQUEST,
           message: "No valid cohort_ids provided",
-          errors: { message: "cohort_ids must be valid MongoDB ObjectIds" },
+          errors: {
+            message: "cohort_ids must be valid MongoDB ObjectIds or cohort_slugs",
+          },
         };
       }
 

--- a/src/device-registry/utils/common/cohort-slug.util.js
+++ b/src/device-registry/utils/common/cohort-slug.util.js
@@ -44,6 +44,12 @@ function sanitizeSlugSegment(input) {
 
 function buildCandidateSlug({ requestedSlug, groupSlug } = {}) {
   const requestedPart = sanitizeSlugSegment(requestedSlug);
+  // If the caller's requested part sanitizes away to nothing (e.g. "!!!"),
+  // don't silently fall back to a bare group_slug — that would let a
+  // garbage input claim a group-only identifier nobody actually asked for.
+  if (!requestedPart) {
+    return "";
+  }
   const groupPart = sanitizeSlugSegment(groupSlug);
   const combined = groupPart ? `${groupPart}-${requestedPart}` : requestedPart;
   return combined.slice(0, MAX_SLUG_LENGTH).replace(/-+$/g, "");

--- a/src/device-registry/utils/common/cohort-slug.util.js
+++ b/src/device-registry/utils/common/cohort-slug.util.js
@@ -63,12 +63,26 @@ async function slugExists(tenant, slug) {
   return Boolean(existing);
 }
 
+// A candidate that is exactly 24 lowercase hex characters is
+// indistinguishable from a MongoDB ObjectId by every dual-lookup check in
+// this codebase — it would always resolve via _id and never be reachable
+// through its own cohort_slug. Reject it here, at generation time, rather
+// than let it silently become unusable.
+const OBJECT_ID_SHAPE = /^[0-9a-f]{24}$/;
+
 function evaluateCandidate(candidate) {
   if (candidate.length < MIN_SLUG_LENGTH) {
     return {
       valid: false,
       reason: "too_short",
       message: `cohort_slug must be at least ${MIN_SLUG_LENGTH} characters after sanitization (got "${candidate}")`,
+    };
+  }
+  if (OBJECT_ID_SHAPE.test(candidate)) {
+    return {
+      valid: false,
+      reason: "objectid_shape",
+      message: `"${candidate}" looks like a MongoDB ObjectId (24 hex characters) and cannot be used as a cohort_slug — add a letter outside a-f or a hyphen`,
     };
   }
   if (RESERVED_COHORT_SLUGS.has(candidate)) {

--- a/src/device-registry/utils/common/cohort-slug.util.js
+++ b/src/device-registry/utils/common/cohort-slug.util.js
@@ -1,0 +1,119 @@
+// cohort-slug.util.js
+// Self-service, user-chosen Cohort identifiers ("cohort_slug"). Additive to
+// the existing ObjectId-based _id — see docs/COHORT_SELF_SERVICE_ID_AND_ACCESS_CONTROL_DESIGN.md.
+const CohortModel = require("@models/Cohort");
+
+const MIN_SLUG_LENGTH = 3;
+const MAX_SLUG_LENGTH = 50;
+const MAX_UNIQUE_ATTEMPTS = 20;
+
+// Route segments/keywords under /cohorts that a slug must never collide
+// with, plus a few generic words that would otherwise let one org squat on
+// a name every other partner would also expect to use.
+const RESERVED_COHORT_SLUGS = new Set([
+  "admin",
+  "api",
+  "new",
+  "null",
+  "undefined",
+  "true",
+  "false",
+  "promote",
+  "networks",
+  "network",
+  "check-slug",
+  "summary",
+  "dashboard",
+  "users",
+  "sites",
+  "devices",
+  "cached-sites",
+  "cached-devices",
+  "from-cohorts",
+  "verify",
+  "filternonprivatedevices",
+]);
+
+function sanitizeSlugSegment(input) {
+  return String(input || "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function buildCandidateSlug({ requestedSlug, groupSlug } = {}) {
+  const requestedPart = sanitizeSlugSegment(requestedSlug);
+  const groupPart = sanitizeSlugSegment(groupSlug);
+  const combined = groupPart ? `${groupPart}-${requestedPart}` : requestedPart;
+  return combined.slice(0, MAX_SLUG_LENGTH).replace(/-+$/g, "");
+}
+
+async function slugExists(tenant, slug) {
+  const existing = await CohortModel(tenant)
+    .findOne({ cohort_slug: slug })
+    .select("_id")
+    .lean();
+  return Boolean(existing);
+}
+
+function evaluateCandidate(candidate) {
+  if (candidate.length < MIN_SLUG_LENGTH) {
+    return {
+      valid: false,
+      reason: "too_short",
+      message: `cohort_slug must be at least ${MIN_SLUG_LENGTH} characters after sanitization (got "${candidate}")`,
+    };
+  }
+  if (RESERVED_COHORT_SLUGS.has(candidate)) {
+    return {
+      valid: false,
+      reason: "reserved",
+      message: `"${candidate}" is a reserved cohort_slug value, please choose another`,
+    };
+  }
+  return { valid: true };
+}
+
+// Pre-checks + a short numeric-suffix retry loop for the common case
+// (someone else already took the exact name). The model's sparse unique
+// index on cohort_slug is the real correctness guarantee against a
+// concurrent create racing this check — see CohortModel.register's
+// duplicate-key handling — this loop just makes the happy path pleasant.
+async function generateUniqueCohortSlug({
+  tenant,
+  requestedSlug,
+  groupSlug,
+} = {}) {
+  const base = buildCandidateSlug({ requestedSlug, groupSlug });
+  const baseCheck = evaluateCandidate(base);
+  if (!baseCheck.valid) {
+    return { success: false, message: baseCheck.message };
+  }
+
+  let candidate = base;
+  for (let attempt = 1; attempt <= MAX_UNIQUE_ATTEMPTS; attempt++) {
+    if (!(await slugExists(tenant, candidate))) {
+      return { success: true, slug: candidate };
+    }
+    const suffix = `-${attempt}`;
+    candidate = `${base.slice(0, MAX_SLUG_LENGTH - suffix.length)}${suffix}`;
+  }
+
+  return {
+    success: false,
+    message:
+      "Unable to find an available cohort_slug close to what you requested, please try a different value",
+  };
+}
+
+module.exports = {
+  MIN_SLUG_LENGTH,
+  MAX_SLUG_LENGTH,
+  RESERVED_COHORT_SLUGS,
+  sanitizeSlugSegment,
+  buildCandidateSlug,
+  evaluateCandidate,
+  slugExists,
+  generateUniqueCohortSlug,
+};

--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -2238,8 +2238,18 @@ const generateFilter = {
         if (cohortIds.length > 0) {
           filter._id = { $in: cohortIds };
         }
-      } else {
+      } else if (
+        typeof cohort_id !== "string" ||
+        /^[0-9a-fA-F]{24}$/.test(cohort_id)
+      ) {
+        // Either already an ObjectId (e.g. sanitized route params) or a raw
+        // 24-char hex string — resolve by _id, exactly as before.
         filter._id = ObjectId(cohort_id);
+      } else {
+        // Not an ObjectId shape: treat as a self-service cohort_slug.
+        // Additive — previously any non-ObjectId cohort_id would have
+        // thrown here, so this only adds a previously-unsupported lookup.
+        filter.cohort_slug = cohort_id;
       }
     } else if (name) {
       filter["name"] = name;

--- a/src/device-registry/utils/common/index.js
+++ b/src/device-registry/utils/common/index.js
@@ -30,6 +30,7 @@ const throttleUtil = require("./throttle.util");
 const LogThrottleManager = require("./log-throttle-manager.util");
 
 const { getSchedule } = require("./cron-schedule.util");
+const cohortSlugUtil = require("./cohort-slug.util");
 
 const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
@@ -77,4 +78,5 @@ module.exports = {
   generateFilter,
   handleResponse,
   computeTransmissionStatus,
+  cohortSlugUtil,
 };

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -789,8 +789,10 @@ const getDevicesFromCohort = async ({
           status: httpStatus.BAD_REQUEST,
         };
       }
+      // device.cohorts stores ObjectIds; use the resolved cohortDetails._id
+      // rather than the raw cohort_id, which may be a cohort_slug string.
       const ownedDevices = await DeviceModel(tenant)
-        .find({ cohorts: cohort_id, owner_id: new ObjectId(user_id) })
+        .find({ cohorts: cohortDetails._id, owner_id: new ObjectId(user_id) })
         .select("_id")
         .lean();
       if (ownedDevices.length === 0) {

--- a/src/device-registry/utils/test/ut_cohort.util.js
+++ b/src/device-registry/utils/test/ut_cohort.util.js
@@ -224,9 +224,14 @@ describe("createCohort", () => {
 
   describe("assignOneDeviceToCohort", () => {
     it("should handle invalid cohort or device", async () => {
-      // Uses .exists() not .findById()
+      // Looks up the cohort via findOne (supports ObjectId or cohort_slug)
+      // and checks device existence separately.
       const ms = sandbox.stub(mongoose, "model");
-      ms.withArgs("cohorts").returns({ exists: sandbox.stub().resolves(false) });
+      ms.withArgs("cohorts").returns({
+        findOne: sandbox.stub().returns({
+          select: sandbox.stub().returns({ lean: sandbox.stub().resolves(null) }),
+        }),
+      });
       ms.withArgs("devices").returns({ exists: sandbox.stub().resolves(false) });
       const result = await createCohort.assignOneDeviceToCohort(
         { query: { tenant: "airqo" }, params: { cohort_id: "cid", device_id: "did" } },
@@ -250,9 +255,10 @@ describe("createCohort", () => {
 
   describe("unAssignOneDeviceFromCohort", () => {
     it("should handle invalid cohort or device", async () => {
-      // Uses .findById() directly without .lean()
+      // Cohort lookup uses findOne (supports ObjectId or cohort_slug);
+      // device lookup is unchanged (findById, no .lean()).
       const ms = sandbox.stub(mongoose, "model");
-      ms.withArgs("cohorts").returns({ findById: sandbox.stub().resolves(null) });
+      ms.withArgs("cohorts").returns({ findOne: sandbox.stub().resolves(null) });
       ms.withArgs("devices").returns({ findById: sandbox.stub().resolves(null) });
       const result = await createCohort.unAssignOneDeviceFromCohort(
         { query: { tenant: "airqo" }, params: { cohort_id: "cid", device_id: "did" } },
@@ -275,9 +281,9 @@ describe("createCohort", () => {
 
   describe("assignManyDevicesToCohort", () => {
     it("should handle invalid cohort", async () => {
-      // Uses .findById(id).lean()
+      // Uses .findOne(filter).lean() (supports ObjectId or cohort_slug)
       sandbox.stub(mongoose, "model").withArgs("cohorts").returns({
-        findById: sandbox.stub().returns({ lean: sandbox.stub().resolves(null) }),
+        findOne: sandbox.stub().returns({ lean: sandbox.stub().resolves(null) }),
       });
       const result = await createCohort.assignManyDevicesToCohort(
         { query: { tenant: "airqo" }, params: { cohort_id: "cid" }, body: { device_ids: ["did"] } },
@@ -301,9 +307,9 @@ describe("createCohort", () => {
 
   describe("unAssignManyDevicesFromCohort", () => {
     it("should handle invalid cohort", async () => {
-      // Uses findById on cohorts (no .lean())
+      // Uses findOne on cohorts (no .lean()) — supports ObjectId or cohort_slug
       sandbox.stub(mongoose, "model").withArgs("cohorts").returns({
-        findById: sandbox.stub().resolves(null),
+        findOne: sandbox.stub().resolves(null),
       });
       const result = await createCohort.unAssignManyDevicesFromCohort(
         { query: { tenant: "airqo" }, params: { cohort_id: "cid" }, body: { device_ids: ["did"] } },

--- a/src/device-registry/utils/test/ut_cohort.util.js
+++ b/src/device-registry/utils/test/ut_cohort.util.js
@@ -5,7 +5,7 @@ const mongoose = require("mongoose");
 const httpStatus = require("http-status");
 const createCohort = require("@utils/cohort.util");
 const networkUtil = require("@utils/network.util");
-const { generateFilter } = require("@utils/common");
+const { generateFilter, cohortSlugUtil } = require("@utils/common");
 
 const { expect } = chai;
 
@@ -94,6 +94,60 @@ describe("createCohort", () => {
       const next = sandbox.stub();
       await createCohort.create({ query: { tenant: "airqo" }, body: {} }, next);
       expect(next.calledOnce).to.be.true;
+    });
+
+    it("should generate and pass through a unique cohort_slug when one is provided", async () => {
+      const registerStub = sandbox.stub().resolves({
+        success: true,
+        data: { _id: "cid", name: "test", cohort_slug: "wri-nairobi" },
+      });
+      sandbox.stub(mongoose, "model").withArgs("cohorts").returns({
+        register: registerStub,
+      });
+      sandbox.stub(cohortSlugUtil, "generateUniqueCohortSlug").resolves({
+        success: true,
+        slug: "wri-nairobi",
+      });
+
+      const result = await createCohort.create(
+        {
+          query: { tenant: "airqo" },
+          body: { name: "test", cohort_slug: "Nairobi!!", group_slug: "WRI" },
+        },
+        sandbox.stub(),
+      );
+
+      expect(result.success).to.be.true;
+      // The sanitized/uniqued slug from generateUniqueCohortSlug — not the
+      // raw request body value — is what gets persisted.
+      expect(registerStub.getCall(0).args[0].cohort_slug).to.equal(
+        "wri-nairobi",
+      );
+      expect(registerStub.getCall(0).args[0].group_slug).to.be.undefined;
+    });
+
+    it("should reject with a 400 and skip registration when cohort_slug is invalid or reserved", async () => {
+      const registerStub = sandbox.stub().resolves({ success: true });
+      sandbox.stub(mongoose, "model").withArgs("cohorts").returns({
+        register: registerStub,
+      });
+      sandbox.stub(cohortSlugUtil, "generateUniqueCohortSlug").resolves({
+        success: false,
+        message: '"admin" is a reserved cohort_slug value, please choose another',
+      });
+
+      const result = await createCohort.create(
+        {
+          query: { tenant: "airqo" },
+          body: { name: "test", cohort_slug: "admin" },
+        },
+        sandbox.stub(),
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.BAD_REQUEST);
+      expect(result.errors.message).to.include("reserved");
+      expect(registerStub.called).to.be.false;
     });
   });
 

--- a/src/device-registry/validators/cohorts.validators.js
+++ b/src/device-registry/validators/cohorts.validators.js
@@ -21,6 +21,29 @@ const crypto = require("crypto");
 // misclassified as an ObjectId and silently fail to resolve.
 const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
 
+// Shared per-item validator for a `cohort_ids` array body field: accepts
+// either a Mongo ObjectId or a self-service cohort_slug — additive, not a
+// restriction. Used by listDevices/listSites/promoteCohorts below.
+const cohortIdOrSlugItem = () =>
+  body("cohort_ids.*")
+    .custom((value) => {
+      if (isObjectIdShape(value)) {
+        return true;
+      }
+      if (
+        typeof value === "string" &&
+        /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value.toLowerCase())
+      ) {
+        return true;
+      }
+      throw new Error(
+        "Each entry in cohort_ids must be a valid MongoDB ObjectId or cohort_slug",
+      );
+    })
+    .customSanitizer((value) =>
+      typeof value === "string" ? value.toLowerCase().trim() : value,
+    );
+
 const requireAdminSecret = (req, res, next) => {
   if (!constants.ADMIN_SETUP_SECRET) {
     return next(
@@ -743,10 +766,10 @@ const cohortValidations = {
       .withMessage("cohort_ids are required")
       .bail()
       .isArray({ min: 1 })
-      .withMessage("cohort_ids must be a non-empty array of cohort ObjectIDs"),
-    body("cohort_ids.*")
-      .isMongoId()
-      .withMessage("Each ID in cohort_ids must be a valid MongoDB ObjectId"),
+      .withMessage(
+        "cohort_ids must be a non-empty array of cohort identifiers (MongoDB ObjectIds or cohort_slug values)",
+      ),
+    cohortIdOrSlugItem(),
     check("search")
       .optional()
       .trim()
@@ -826,10 +849,10 @@ const cohortValidations = {
       .withMessage("cohort_ids are required")
       .bail()
       .isArray({ min: 1 })
-      .withMessage("cohort_ids must be a non-empty array of cohort ObjectIDs"),
-    body("cohort_ids.*")
-      .isMongoId()
-      .withMessage("Each ID in cohort_ids must be a valid MongoDB ObjectId"),
+      .withMessage(
+        "cohort_ids must be a non-empty array of cohort identifiers (MongoDB ObjectIds or cohort_slug values)",
+      ),
+    cohortIdOrSlugItem(),
     check("search")
       .optional()
       .trim()
@@ -917,13 +940,10 @@ const promoteCohorts = [
     .withMessage("cohort_ids is required")
     .bail()
     .isArray({ min: 1 })
-    .withMessage("cohort_ids must be a non-empty array"),
-  body("cohort_ids.*")
-    .isString()
-    .withMessage("each cohort_id must be a string")
-    .bail()
-    .custom((id) => isValidObjectId(id))
-    .withMessage("each cohort_id must be a valid MongoDB ObjectId"),
+    .withMessage(
+      "cohort_ids must be a non-empty array of cohort identifiers (MongoDB ObjectIds or cohort_slug values)",
+    ),
+  cohortIdOrSlugItem(),
   handleValidationErrors,
   requireAdminSecret,
 ];

--- a/src/device-registry/validators/cohorts.validators.js
+++ b/src/device-registry/validators/cohorts.validators.js
@@ -88,9 +88,47 @@ const createFromCohorts = [
     .bail()
     .isArray({ min: 1 })
     .withMessage("cohort_ids must be a non-empty array of cohort ObjectIDs"),
+  // Each entry may be an existing ObjectId (unchanged behaviour) or a
+  // self-service cohort_slug (new, opt-in) — additive, not a restriction.
   body("cohort_ids.*")
-    .isMongoId()
-    .withMessage("Each ID in cohort_ids must be a valid MongoDB ObjectId"),
+    .custom((value) => {
+      if (isValidObjectId(value)) {
+        return true;
+      }
+      if (
+        typeof value === "string" &&
+        /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value.toLowerCase())
+      ) {
+        return true;
+      }
+      throw new Error(
+        "Each entry in cohort_ids must be a valid MongoDB ObjectId or cohort_slug",
+      );
+    })
+    .customSanitizer((value) =>
+      typeof value === "string" ? value.toLowerCase().trim() : value,
+    ),
+  // Opt-in self-service identifier for the newly created merged cohort.
+  body("cohort_slug")
+    .optional()
+    .notEmpty()
+    .withMessage("cohort_slug should not be empty if provided")
+    .bail()
+    .isString()
+    .withMessage("cohort_slug must be a string")
+    .bail()
+    .isLength({ min: 1, max: 50 })
+    .withMessage("cohort_slug must be at most 50 characters"),
+  body("group_slug")
+    .optional()
+    .notEmpty()
+    .withMessage("group_slug should not be empty if provided")
+    .bail()
+    .isString()
+    .withMessage("group_slug must be a string")
+    .bail()
+    .isLength({ min: 1, max: 50 })
+    .withMessage("group_slug must be at most 50 characters"),
 ];
 
 const commonValidations = {
@@ -231,6 +269,35 @@ const commonValidations = {
         return ObjectId(value);
       });
   },
+
+  // Accepts either a Mongo ObjectId (existing behaviour, unchanged — still
+  // sanitized into an ObjectId instance) OR a self-service cohort_slug
+  // (left as a plain lowercase string). Purely additive: anything that
+  // satisfied paramObjectId before still does, with identical downstream
+  // typing; only genuinely non-ObjectId values gain a new, previously
+  // unsupported (and previously rejected) slug lookup path.
+  paramCohortIdentifier: (field, location = param) => {
+    return location(field)
+      .exists()
+      .withMessage(`the ${field} is missing in request`)
+      .bail()
+      .trim()
+      .toLowerCase()
+      .custom((value) => {
+        if (isValidObjectId(value)) {
+          return true;
+        }
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+          throw new Error(
+            `${field} must be a valid object ID or a valid cohort_slug (lowercase letters, numbers and hyphens)`,
+          );
+        }
+        return true;
+      })
+      .customSanitizer((value) => {
+        return isValidObjectId(value) ? ObjectId(value) : value;
+      });
+  },
   deviceIdentifiers: oneOf([
     [
       body("devices")
@@ -287,7 +354,7 @@ const cohortValidations = {
   createFromCohorts,
   updateCohortName: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     body("name")
       .exists()
       .withMessage("name is required for name updates")
@@ -324,13 +391,13 @@ const cohortValidations = {
   ],
   deleteCohort: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     handleValidationErrors,
   ],
 
   updateCohort: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     body("name")
       .not()
       .exists()
@@ -352,11 +419,59 @@ const cohortValidations = {
     ...commonValidations.cohort_tags,
     ...commonValidations.groups,
     ...commonValidations.networkOptional,
+    // Opt-in self-service identifier: entirely optional, so existing
+    // callers who never send it are completely unaffected.
+    body("cohort_slug")
+      .optional()
+      .notEmpty()
+      .withMessage("cohort_slug should not be empty if provided")
+      .bail()
+      .isString()
+      .withMessage("cohort_slug must be a string")
+      .bail()
+      .isLength({ min: 1, max: 50 })
+      .withMessage("cohort_slug must be at most 50 characters"),
+    body("group_slug")
+      .optional()
+      .notEmpty()
+      .withMessage("group_slug should not be empty if provided")
+      .bail()
+      .isString()
+      .withMessage("group_slug must be a string")
+      .bail()
+      .isLength({ min: 1, max: 50 })
+      .withMessage("group_slug must be at most 50 characters"),
+    handleValidationErrors,
+  ],
+  checkCohortSlug: [
+    ...commonValidations.tenant,
+    query("slug")
+      .exists()
+      .withMessage("slug is missing in request")
+      .bail()
+      .notEmpty()
+      .withMessage("slug should not be empty")
+      .bail()
+      .isString()
+      .withMessage("slug must be a string")
+      .bail()
+      .isLength({ min: 1, max: 50 })
+      .withMessage("slug must be at most 50 characters"),
+    query("group_slug")
+      .optional()
+      .notEmpty()
+      .withMessage("group_slug should not be empty if provided")
+      .bail()
+      .isString()
+      .withMessage("group_slug must be a string")
+      .bail()
+      .isLength({ min: 1, max: 50 })
+      .withMessage("group_slug must be at most 50 characters"),
     handleValidationErrors,
   ],
   findOriginal: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     handleValidationErrors,
   ],
   listCohorts: [
@@ -455,25 +570,25 @@ const cohortValidations = {
   ],
   assignOneDeviceToCohort: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     commonValidations.paramObjectId("device_id"),
     handleValidationErrors,
   ],
   listAssignedDevices: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     handleValidationErrors,
   ],
 
   listAvailableDevices: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     handleValidationErrors,
   ],
 
   assignManyDevicesToCohort: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     body("device_ids")
       .exists()
       .withMessage("the device_ids should be provided")
@@ -490,7 +605,7 @@ const cohortValidations = {
   ],
   unAssignManyDevicesFromCohort: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     body("device_ids")
       .exists()
       .withMessage("the device_ids should be provided")
@@ -508,7 +623,7 @@ const cohortValidations = {
 
   unAssignOneDeviceFromCohort: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     commonValidations.paramObjectId("device_id"),
     handleValidationErrors,
   ],
@@ -599,18 +714,18 @@ const cohortValidations = {
 
   getSiteAndDeviceIds: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     handleValidationErrors,
   ],
   verifyCohort: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     handleValidationErrors,
   ],
 
   getCohort: [
     ...commonValidations.tenant,
-    commonValidations.paramObjectId("cohort_id"),
+    commonValidations.paramCohortIdentifier("cohort_id"),
     handleValidationErrors,
   ],
   listDevices: [

--- a/src/device-registry/validators/cohorts.validators.js
+++ b/src/device-registry/validators/cohorts.validators.js
@@ -15,6 +15,12 @@ const httpStatus = require("http-status");
 const { validateNetwork, validateAdminLevels } = require("@validators/common");
 const crypto = require("crypto");
 
+// Strictly a 24-char hex Mongo ObjectId string. Deliberately not
+// mongoose's isValidObjectId, which also accepts arbitrary 12-byte
+// strings — a plausible-length cohort_slug (e.g. "nairobi-2026") would be
+// misclassified as an ObjectId and silently fail to resolve.
+const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
+
 const requireAdminSecret = (req, res, next) => {
   if (!constants.ADMIN_SETUP_SECRET) {
     return next(
@@ -87,12 +93,14 @@ const createFromCohorts = [
     .withMessage("cohort_ids are required")
     .bail()
     .isArray({ min: 1 })
-    .withMessage("cohort_ids must be a non-empty array of cohort ObjectIDs"),
+    .withMessage(
+      "cohort_ids must be a non-empty array of cohort identifiers (MongoDB ObjectIds or cohort_slug values)",
+    ),
   // Each entry may be an existing ObjectId (unchanged behaviour) or a
   // self-service cohort_slug (new, opt-in) — additive, not a restriction.
   body("cohort_ids.*")
     .custom((value) => {
-      if (isValidObjectId(value)) {
+      if (isObjectIdShape(value)) {
         return true;
       }
       if (
@@ -284,7 +292,7 @@ const commonValidations = {
       .trim()
       .toLowerCase()
       .custom((value) => {
-        if (isValidObjectId(value)) {
+        if (isObjectIdShape(value)) {
           return true;
         }
         if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
@@ -295,7 +303,7 @@ const commonValidations = {
         return true;
       })
       .customSanitizer((value) => {
-        return isValidObjectId(value) ? ObjectId(value) : value;
+        return isObjectIdShape(value) ? ObjectId(value) : value;
       });
   },
   deviceIdentifiers: oneOf([

--- a/src/device-registry/validators/measurements.validators.js
+++ b/src/device-registry/validators/measurements.validators.js
@@ -14,6 +14,12 @@ const httpStatus = require("http-status");
 const numeral = require("numeral");
 const Decimal = require("decimal.js");
 
+// Strictly a 24-char hex Mongo ObjectId string. Deliberately not
+// mongoose's isValidObjectId, which also accepts arbitrary 12-byte
+// strings — a plausible-length cohort_slug (e.g. "nairobi-2026") would be
+// misclassified as an ObjectId and silently fail to resolve.
+const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
+
 const countDecimalPlaces = (value) => {
   try {
     const decimal = new Decimal(value);
@@ -347,7 +353,7 @@ const commonValidations = {
       .trim()
       .toLowerCase()
       .custom((value) => {
-        if (isValidObjectId(value)) {
+        if (isObjectIdShape(value)) {
           return true;
         }
         if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
@@ -358,7 +364,7 @@ const commonValidations = {
         return true;
       })
       .customSanitizer((value) => {
-        return isValidObjectId(value) ? ObjectId(value) : value;
+        return isObjectIdShape(value) ? ObjectId(value) : value;
       }),
   ],
 

--- a/src/device-registry/validators/measurements.validators.js
+++ b/src/device-registry/validators/measurements.validators.js
@@ -333,6 +333,35 @@ const commonValidations = {
       }),
   ],
 
+  // Accepts either a Mongo ObjectId (existing behaviour, unchanged) or a
+  // self-service cohort_slug (new, opt-in). Only used for cohort_id — the
+  // grid_id/device_id/etc callers of validObjectId above are untouched.
+  validCohortIdentifier: (field) => [
+    param(field)
+      .exists()
+      .withMessage(`${field} should be provided`)
+      .bail()
+      .notEmpty()
+      .withMessage(`the provided ${field} cannot be empty`)
+      .bail()
+      .trim()
+      .toLowerCase()
+      .custom((value) => {
+        if (isValidObjectId(value)) {
+          return true;
+        }
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+          throw new Error(
+            `the ${field} must be a valid object ID or a valid cohort_slug (lowercase letters, numbers and hyphens)`,
+          );
+        }
+        return true;
+      })
+      .customSanitizer((value) => {
+        return isValidObjectId(value) ? ObjectId(value) : value;
+      }),
+  ],
+
   latLong: [
     param("latitude")
       .exists()
@@ -570,16 +599,16 @@ const measurementsValidations = {
   ],
   listHistoricalCohortMeasurements: [
     ...baseValidations,
-    commonValidations.validObjectId("cohort_id"),
+    commonValidations.validCohortIdentifier("cohort_id"),
   ],
 
   listRecentCohortMeasurements: [
     ...baseValidations,
-    commonValidations.validObjectId("cohort_id"),
+    commonValidations.validCohortIdentifier("cohort_id"),
   ],
   listCohortMeasurements: [
     ...baseValidations,
-    commonValidations.validObjectId("cohort_id"),
+    commonValidations.validCohortIdentifier("cohort_id"),
   ],
   listHistoricalDeviceMeasurements: [
     ...baseValidations,

--- a/src/device-registry/validators/metadata.validators.js
+++ b/src/device-registry/validators/metadata.validators.js
@@ -1,6 +1,7 @@
 // metadata.validators.js
 const { query, param, body, validationResult } = require("express-validator");
 const { ObjectId } = require("mongoose").Types;
+const { isValidObjectId } = require("mongoose");
 const constants = require("@config/constants");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
@@ -49,6 +50,35 @@ const commonValidations = {
       .bail()
       .customSanitizer((value) => {
         return ObjectId(value);
+      }),
+  ],
+
+  // Accepts either a Mongo ObjectId (existing behaviour, unchanged) or a
+  // self-service cohort_slug (new, opt-in) — used only for cohort_id so
+  // grid_id/device_id/etc via paramObjectId above are untouched.
+  paramCohortIdentifier: (field) => [
+    param(field)
+      .exists()
+      .withMessage(`the ${field} must be provided`)
+      .bail()
+      .notEmpty()
+      .withMessage(`the ${field} should not be empty if provided`)
+      .bail()
+      .trim()
+      .toLowerCase()
+      .custom((value) => {
+        if (isValidObjectId(value)) {
+          return true;
+        }
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+          throw new Error(
+            `${field} must be a valid object ID or a valid cohort_slug (lowercase letters, numbers and hyphens)`,
+          );
+        }
+        return true;
+      })
+      .customSanitizer((value) => {
+        return isValidObjectId(value) ? ObjectId(value) : value;
       }),
   ],
 };
@@ -143,7 +173,7 @@ const metadataValidations = {
 
   getCohort: [
     ...commonValidations.tenant,
-    ...commonValidations.paramObjectId("cohort_id"),
+    ...commonValidations.paramCohortIdentifier("cohort_id"),
     (req, res, next) => {
       const errors = validationResult(req);
 

--- a/src/device-registry/validators/metadata.validators.js
+++ b/src/device-registry/validators/metadata.validators.js
@@ -1,10 +1,15 @@
 // metadata.validators.js
 const { query, param, body, validationResult } = require("express-validator");
 const { ObjectId } = require("mongoose").Types;
-const { isValidObjectId } = require("mongoose");
 const constants = require("@config/constants");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
+
+// Strictly a 24-char hex Mongo ObjectId string. Deliberately not
+// mongoose's isValidObjectId, which also accepts arbitrary 12-byte
+// strings — a plausible-length cohort_slug (e.g. "nairobi-2026") would be
+// misclassified as an ObjectId and silently fail to resolve.
+const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
 
 const commonValidations = {
   tenant: [
@@ -67,7 +72,7 @@ const commonValidations = {
       .trim()
       .toLowerCase()
       .custom((value) => {
-        if (isValidObjectId(value)) {
+        if (isObjectIdShape(value)) {
           return true;
         }
         if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
@@ -78,7 +83,7 @@ const commonValidations = {
         return true;
       })
       .customSanitizer((value) => {
-        return isValidObjectId(value) ? ObjectId(value) : value;
+        return isObjectIdShape(value) ? ObjectId(value) : value;
       }),
   ],
 };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a self-service, user-chosen Cohort identifier (`cohort_slug`) alongside the existing system-generated Cohort ID, entirely opt-in and additive. Partners can now preview and claim a memorable slug (e.g. `wri-nairobi-2026`) at creation time, and use it interchangeably with the original ID everywhere a `cohort_id` is accepted — creation, updates, device assignment, cohort merging, and the public measurement/metadata endpoints partners actually consume.

### Why is this change needed?

Today, Cohort IDs are only generated internally by AirQo staff and shared with partner organizations manually over email before they can start pulling their own data. This removes that bottleneck: external partners can generate and manage their own Cohort identifiers directly through the API, with no dependency on staff intervention.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` only

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Updated 4 existing mock setups in `ut_cohort.util.js` to match the internal `findById` → `findOne` swap (behavior tested is unchanged). Ran the full cohort and event unit test suites (util/model/controller) plus every cohort-touching test elsewhere in the suite (device claiming, event aggregation) — all passing, zero regressions. Syntax-checked and require-loaded every touched module. Manual end-to-end testing against a running server/API client was not performed in this pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All new fields and endpoints are additive and opt-in. Existing callers that never send `cohort_slug` see byte-for-byte identical behavior. Validators were loosened (never narrowed) to also accept a slug shape alongside the existing ObjectId requirement.

---

## :memo: Additional Notes

- New optional field `cohort_slug` on the Cohort model, sparse+unique indexed, immutable once set (like `_id`).
- New endpoint: `GET /cohorts/check-slug` for live availability preview.
- Dual ID/slug lookup applied consistently across cohort CRUD, device assignment/unassignment, cohort merging (`/cohorts/from-cohorts`), and the public `/measurements/cohorts/:cohort_id` and `/metadata/cohorts/:cohort_id` endpoints.
- Fixed two latent bugs discovered during this work: a stale `cohort_id` (instead of the resolved cohort `_id`) being written into `Device.cohorts` in a couple of code paths, and a `list`/`listUserCohorts` not-found check that didn't account for non-`_id` filters.
- **Not included in this PR (deferred, tracked separately):** per-organization access control on cohort/device-assignment endpoints — there is currently no ownership check on who can assign a device to a cohort. A design proposal exists in `docs/COHORT_SELF_SERVICE_ID_AND_ACCESS_CONTROL_DESIGN.md`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional, unique cohort slugs using lowercase letters, numbers, and hyphens.
  * Added an endpoint to check cohort-slug availability before creation.
  * Cohorts can now be created, found, listed, merged, and managed using either IDs or slugs.
  * Cohort responses and generated cohort codes now include slugs when available.

* **Bug Fixes**
  * Improved cohort identifier handling across device, measurement, metadata, and event operations.
  * Prevented invalid non-ID cohort values from causing lookup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->