### PR TITLE
Extend cohort_slug support across device-registry endpoints and fix dead cohort_id filters

### DIFF
--- a/src/device-registry/controllers/event.controller.js
+++ b/src/device-registry/controllers/event.controller.js
@@ -911,10 +911,28 @@ const createEvent = {
         : req.query.tenant;
 
       logText("we are listing events...");
-      const { site_id, device_id, site, device } = {
-        ...req.params,
-        ...req.query,
-      };
+      const { site_id, site, cohort_id } = { ...req.params, ...req.query };
+
+      if (cohort_id) {
+        // Resolves cohort_id (ObjectId or cohort_slug) to its member
+        // devices and sets request.query.device_id — cohort_id was
+        // previously accepted by the validator but silently never
+        // consumed here.
+        const cohortProcessingResponse = await createEventUtil.processCohortIds(
+          cohort_id,
+          request,
+        );
+        if (
+          cohortProcessingResponse &&
+          cohortProcessingResponse.success === false
+        ) {
+          const status =
+            cohortProcessingResponse.status || httpStatus.BAD_REQUEST;
+          return res.status(status).json(cohortProcessingResponse);
+        }
+      }
+
+      const { device_id, device } = { ...req.params, ...req.query };
 
       if (!isEmpty(site_id) || !isEmpty(site)) {
         request.query.recent = "no";

--- a/src/device-registry/controllers/test/ut_event.controller.js
+++ b/src/device-registry/controllers/test/ut_event.controller.js
@@ -294,6 +294,45 @@ describe("Create Event Controller", () => {
       );
       expect(res.json).to.have.been.calledWith(sinon.match.object);
     });
+
+    it("should resolve cohort_id (ObjectId or cohort_slug) to device_id before listing", async () => {
+      req = {
+        params: {},
+        query: { tenant: "custom", cohort_id: "wri-nairobi-2026" },
+      };
+      const processCohortIdsStub = sinon
+        .stub(createEventUtil, "processCohortIds")
+        .callsFake(async (cohort_id, request) => {
+          request.query.device_id = "device-1,device-2";
+          return { success: true };
+        });
+
+      await list(req, res, next);
+
+      expect(processCohortIdsStub).to.have.been.calledWith(
+        "wri-nairobi-2026",
+        req
+      );
+      expect(req.query.device_id).to.equal("device-1,device-2");
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+    });
+
+    it("should stop and return the error when cohort_id resolution fails", async () => {
+      req = {
+        params: {},
+        query: { tenant: "custom", cohort_id: "does-not-exist" },
+      };
+      sinon.stub(createEventUtil, "processCohortIds").resolves({
+        success: false,
+        status: httpStatus.NOT_FOUND,
+        message: "No device IDs could be resolved from the provided Cohort IDs",
+      });
+
+      await list(req, res, next);
+
+      expect(res.status).to.have.been.calledWith(httpStatus.NOT_FOUND);
+      expect(createEventUtil.list.called).to.be.false;
+    });
   });
 
   describe("fetchAndStoreData", () => {

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -47,19 +47,18 @@ function filterOutPrivateIDs(privateIds, randomIds) {
   return filteredIds;
 }
 
-// A cohort_id route param is, after validation, either a real ObjectId
-// instance (existing behaviour, untouched) or a plain lowercase
-// cohort_slug string (new, opt-in). This turns either into the right Mongo
-// filter/value so every lookup below works for both.
-const isCohortSlugIdentifier = (identifier) => typeof identifier === "string";
-
-const cohortLookupFilter = (identifier) =>
-  isCohortSlugIdentifier(identifier)
-    ? { cohort_slug: identifier }
-    : { _id: identifier };
-
 const isObjectIdShape = (identifier) =>
   /^[0-9a-fA-F]{24}$/.test(String(identifier));
+
+// A cohort_id is either a real ObjectId (instance, e.g. from a validator's
+// customSanitizer — or a raw 24-hex string, when this is called directly
+// without going through that validator) or a cohort_slug string. Checking
+// the actual shape rather than just typeof means this is safe to call from
+// anywhere, not only routes that ran paramCohortIdentifier first.
+const cohortLookupFilter = (identifier) =>
+  typeof identifier !== "string" || isObjectIdShape(identifier)
+    ? { _id: identifier }
+    : { cohort_slug: identifier };
 
 // Batch counterpart to cohortLookupFilter: resolves a mixed array of
 // cohort_ids (ObjectIds and/or cohort_slugs) to their canonical ObjectIds
@@ -2590,5 +2589,11 @@ const createCohort = {
     }
   },
 };
+
+// Exposed for reuse by other util files that filter by cohort_id/cohort_ids
+// against a different collection (Device, Site, NetworkStatusAlert, ...) —
+// see device.util.js, grid.util.js, site.util.js, network-status.util.js.
+createCohort.resolveCohortObjectIds = resolveCohortObjectIds;
+createCohort.cohortLookupFilter = cohortLookupFilter;
 
 module.exports = createCohort;

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -5970,14 +5970,18 @@ const deviceUtil = {
           ).then((c) => c?._id),
         );
       }
+      // Tracked separately from the other queries so we can tell "the
+      // caller's explicit cohort_id didn't resolve" apart from "the
+      // personal/default cohort queries happened to return nothing" — the
+      // former must not be silently dropped (see below).
+      let explicitCohortQuery = null;
       if (cohort_id) {
         // cohort_id may be an ObjectId or a self-service cohort_slug.
-        cohortQueries.push(
-          CohortModel(tenant)
-            .findOne(cohortLookupFilter(cohort_id))
-            .lean()
-            .then((c) => c?._id),
-        );
+        explicitCohortQuery = CohortModel(tenant)
+          .findOne(cohortLookupFilter(cohort_id))
+          .lean()
+          .then((c) => c?._id);
+        cohortQueries.push(explicitCohortQuery);
       }
       cohortQueries.push(
         CohortModel(tenant)
@@ -5987,13 +5991,28 @@ const deviceUtil = {
           .then((c) => c?._id),
       );
       const resolved = await Promise.all(cohortQueries);
-      preResolvedCohortIds = resolved
-        .filter((id) => id && isValidObjectId(id.toString()))
-        .map((id) => ObjectId(id.toString()));
-      // Deduplicate
-      preResolvedCohortIds = [
-        ...new Map(preResolvedCohortIds.map((id) => [id.toString(), id])).values(),
-      ];
+
+      if (cohort_id && !(await explicitCohortQuery)) {
+        // The caller asked for a specific cohort and it doesn't exist.
+        // createOnPlatform's single-device path 404s on exactly this case
+        // — falling back to per-device resolution (preResolvedCohortIds
+        // stays null) instead of silently proceeding without it, which
+        // the batch fast path would otherwise do (it skips createOnPlatform's
+        // own cohort_id check whenever _preResolvedCohortIds is present at
+        // all, complete or not).
+        logger.warn(
+          `createDevicesBatch: explicit cohort_id "${cohort_id}" did not resolve to a cohort. Per-device fallback will be used so each device 404s consistently.`,
+        );
+        preResolvedCohortIds = null;
+      } else {
+        preResolvedCohortIds = resolved
+          .filter((id) => id && isValidObjectId(id.toString()))
+          .map((id) => ObjectId(id.toString()));
+        // Deduplicate
+        preResolvedCohortIds = [
+          ...new Map(preResolvedCohortIds.map((id) => [id.toString(), id])).values(),
+        ];
+      }
     } catch (cohortErr) {
       logger.warn(
         `createDevicesBatch: cohort pre-resolution failed: ${cohortErr.message}. Per-device fallback will be used.`,

--- a/src/device-registry/utils/device.util.js
+++ b/src/device-registry/utils/device.util.js
@@ -16,6 +16,10 @@ const {
   ActivityLogger,
   computeTransmissionStatus,
 } = require("@utils/common");
+const {
+  cohortLookupFilter,
+  resolveCohortObjectIds,
+} = require("@utils/cohort.util");
 const constants = require("@config/constants");
 const cryptoJS = require("crypto-js");
 const isEmpty = require("is-empty");
@@ -522,7 +526,41 @@ const getDeviceCategoriesAddFieldsStage = () => {
 const deviceUtil = {
   getDeviceCountSummary: async (request, next) => {
     try {
-      const { tenant } = request.query;
+      const { tenant, cohort_id } = request.query;
+
+      if (cohort_id) {
+        // cohort_id may be a comma-separated mix of ObjectIds and
+        // cohort_slugs — resolve to canonical ObjectIds before the
+        // synchronous generateFilter.devices() builds the Mongo filter.
+        const identifiers = cohort_id
+          .toString()
+          .split(",")
+          .map((id) => id.trim())
+          .filter(Boolean);
+        const { resolvedIds } = await resolveCohortObjectIds(tenant, identifiers);
+
+        if (resolvedIds.length === 0) {
+          // None of the provided cohort identifiers exist — correctly
+          // report zero, rather than silently dropping the filter (which
+          // would return counts across ALL devices instead).
+          const emptySummary = {
+            total_monitors: 0,
+            operational: 0,
+            transmitting: 0,
+            not_transmitting: 0,
+            data_available: 0,
+          };
+          return {
+            success: true,
+            message: "Successfully retrieved network health summary.",
+            data: emptySummary,
+            status: httpStatus.OK,
+          };
+        }
+
+        request.query.cohort_id = resolvedIds.map((id) => id.toString()).join(",");
+      }
+
       const filter = generateFilter.devices(request, next);
 
       const pipeline = [
@@ -2136,15 +2174,10 @@ const deviceUtil = {
           let targetCohort;
 
           if (cohort_id) {
-            // Case A: A specific cohort is provided during import
-            if (!isValidObjectId(cohort_id)) {
-              throw new HttpError(
-                `Invalid cohort_id: "${cohort_id}" is not a valid MongoDB ObjectId.`,
-                httpStatus.BAD_REQUEST,
-              );
-            }
+            // Case A: A specific cohort is provided during import (ObjectId
+            // or cohort_slug)
             targetCohort = await CohortModel(tenant)
-              .findById(cohort_id)
+              .findOne(cohortLookupFilter(cohort_id))
               .lean();
             if (!targetCohort) {
               throw new HttpError(
@@ -3084,9 +3117,9 @@ const deviceUtil = {
       let targetCohort;
 
       if (cohort_id) {
-        // Case A: A specific cohort is provided
+        // Case A: A specific cohort is provided (ObjectId or cohort_slug)
         targetCohort = await CohortModel(tenant)
-          .findById(cohort_id)
+          .findOne(cohortLookupFilter(cohort_id))
           .lean();
 
         if (!targetCohort) {
@@ -3196,9 +3229,9 @@ const deviceUtil = {
 
       let targetCohort;
       if (cohort_id) {
-        // Case A: A specific cohort is provided
+        // Case A: A specific cohort is provided (ObjectId or cohort_slug)
         targetCohort = await CohortModel(tenant)
-          .findById(cohort_id)
+          .findOne(cohortLookupFilter(cohort_id))
           .lean();
 
         if (!targetCohort) {
@@ -5937,9 +5970,13 @@ const deviceUtil = {
           ).then((c) => c?._id),
         );
       }
-      if (cohort_id && isValidObjectId(cohort_id)) {
+      if (cohort_id) {
+        // cohort_id may be an ObjectId or a self-service cohort_slug.
         cohortQueries.push(
-          CohortModel(tenant).findById(cohort_id).lean().then((c) => c?._id),
+          CohortModel(tenant)
+            .findOne(cohortLookupFilter(cohort_id))
+            .lean()
+            .then((c) => c?._id),
         );
       }
       cohortQueries.push(

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -3037,8 +3037,33 @@ const createEvent = {
     try {
       let missingDataMessage = "";
       const {
-        query: { tenant, language, limit, skip },
+        query: { tenant, language, limit, skip, cohort_id },
       } = request;
+
+      if (cohort_id) {
+        // Resolves cohort_id (ObjectId or cohort_slug) to its member
+        // devices and sets request.query.device_id, which
+        // generateFilter.telemetry below already knows how to read.
+        const cohortProcessingResponse = await processCohortIds(
+          cohort_id,
+          request,
+        );
+        if (
+          cohortProcessingResponse &&
+          cohortProcessingResponse.success === false
+        ) {
+          return {
+            success: false,
+            message: cohortProcessingResponse.message || "Bad Request Error",
+            errors:
+              cohortProcessingResponse.errors ||
+              { message: cohortProcessingResponse.message },
+            status: cohortProcessingResponse.status || httpStatus.BAD_REQUEST,
+            isCache: false,
+          };
+        }
+      }
+
       const filter = generateFilter.telemetry(request);
 
       try {

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -996,6 +996,15 @@ const processCohortIds = async (cohort_ids, request) => {
         message: "No device IDs could be resolved from the provided Cohort IDs",
       },
     };
+  } else if (isEmpty(flattened) && suppressedCount > 0) {
+    // Every requested cohort was private with no visible devices (no error
+    // — that's the correct, silent outcome for privacy). But leaving
+    // request.query.device_id unset here would let the caller fall through
+    // to an UNSCOPED query instead of an empty one — a real information
+    // leak, since "no cohort filter" and "cohort filter matched nothing"
+    // would otherwise look identical downstream. Force a device_id that
+    // cannot match anything real.
+    request.query.device_id = "__no_matching_device__";
   }
 };
 const isEventTimestampValid = (

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -1,6 +1,7 @@
 const GridModel = require("@models/Grid");
 const SiteModel = require("@models/Site");
 const CohortModel = require("@models/Cohort");
+const { resolveCohortObjectIds } = require("@utils/cohort.util");
 const ComputedCacheModel = require("@models/ComputedCache");
 const LRUCache = require("lru-cache");
 const qs = require("qs");
@@ -418,9 +419,13 @@ const getSiteIdsFromCohort = async (tenant, cohort_id) => {
       ? cohort_id
       : cohort_id.split(",").map((id) => id.trim());
 
+    // cohortIdArray may be a mix of ObjectIds and cohort_slugs — resolve to
+    // canonical ObjectIds before matching Device.cohorts (an ObjectId array).
+    const { resolvedIds } = await resolveCohortObjectIds(tenant, cohortIdArray);
+
     const devicesInCohort = await DeviceModel(tenant)
       .find({
-        cohorts: { $in: cohortIdArray },
+        cohorts: { $in: resolvedIds },
         site_id: { $ne: null },
       })
       .distinct("site_id");

--- a/src/device-registry/utils/grid.util.js
+++ b/src/device-registry/utils/grid.util.js
@@ -416,8 +416,8 @@ function filterOutPrivateIDs(privateIds, randomIds) {
 const getSiteIdsFromCohort = async (tenant, cohort_id) => {
   try {
     const cohortIdArray = Array.isArray(cohort_id)
-      ? cohort_id
-      : cohort_id.split(",").map((id) => id.trim());
+      ? cohort_id.map((id) => String(id).trim().toLowerCase())
+      : cohort_id.split(",").map((id) => id.trim().toLowerCase());
 
     // cohortIdArray may be a mix of ObjectIds and cohort_slugs — resolve to
     // canonical ObjectIds before matching Device.cohorts (an ObjectId array).

--- a/src/device-registry/utils/network-status.util.js
+++ b/src/device-registry/utils/network-status.util.js
@@ -9,6 +9,20 @@ const logger = log4js.getLogger(
 const { Kafka } = require("kafkajs");
 const isEmpty = require("is-empty");
 const moment = require("moment-timezone");
+const { resolveCohortObjectIds } = require("@utils/cohort.util");
+
+// cohort_breakdown.cohort_id is stored as a plain string (the cohort's
+// canonical ObjectId, written by the snapshot job) — resolve an incoming
+// ObjectId-or-cohort_slug filter value to that canonical string before
+// matching. Returns a sentinel that can never match a real record when the
+// identifier doesn't resolve to any cohort, so the query correctly comes
+// back empty instead of silently matching everything.
+const NO_MATCHING_COHORT = "__cohort_not_found__";
+const resolveCohortIdParam = async (tenant, cohortId) => {
+  if (!cohortId) return cohortId;
+  const { resolvedIds } = await resolveCohortObjectIds(tenant, [cohortId]);
+  return resolvedIds.length > 0 ? resolvedIds[0].toString() : NO_MATCHING_COHORT;
+};
 
 const kafka = new Kafka({
   clientId: constants.KAFKA_CLIENT_ID,
@@ -152,8 +166,9 @@ const networkStatusUtil = {
       }
 
       if (cohort_id) {
+        const resolvedCohortId = await resolveCohortIdParam(tenant, cohort_id);
         filter.cohort_breakdown = {
-          $elemMatch: { cohort_id },
+          $elemMatch: { cohort_id: resolvedCohortId },
         };
       }
 
@@ -204,9 +219,10 @@ const networkStatusUtil = {
       }
 
       if (cohort_id) {
+        const resolvedCohortId = await resolveCohortIdParam(tenant, cohort_id);
         const response = await NetworkStatusAlertModel(
           tenant
-        ).getStatisticsByCohort({ filter, cohort_id }, next);
+        ).getStatisticsByCohort({ filter, cohort_id: resolvedCohortId }, next);
         return response;
       }
 
@@ -249,9 +265,10 @@ const networkStatusUtil = {
       }
 
       if (cohort_id) {
+        const resolvedCohortId = await resolveCohortIdParam(tenant, cohort_id);
         const response = await NetworkStatusAlertModel(
           tenant
-        ).getHourlyTrendsByCohort({ filter, cohort_id }, next);
+        ).getHourlyTrendsByCohort({ filter, cohort_id: resolvedCohortId }, next);
         return response;
       }
 
@@ -290,9 +307,10 @@ const networkStatusUtil = {
           },
         };
       } else if (cohort_id) {
+        const resolvedCohortId = await resolveCohortIdParam(tenant, cohort_id);
         filter.cohort_breakdown = {
           $elemMatch: {
-            cohort_id,
+            cohort_id: resolvedCohortId,
             not_transmitting_percentage: { $gte: 35 },
           },
         };
@@ -338,9 +356,10 @@ const networkStatusUtil = {
       }
 
       if (cohort_id) {
+        const resolvedCohortId = await resolveCohortIdParam(tenant, cohort_id);
         const response = await NetworkStatusAlertModel(
           tenant
-        ).getUptimeSummaryByCohort({ filter, cohort_id }, next);
+        ).getUptimeSummaryByCohort({ filter, cohort_id: resolvedCohortId }, next);
         return response;
       }
 

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -37,6 +37,7 @@ const kafka = new Kafka({
   brokers: constants.KAFKA_BOOTSTRAP_SERVERS,
 });
 const mongoose = require("mongoose");
+const { resolveCohortObjectIds } = require("@utils/cohort.util");
 const { isValidObjectId } = mongoose;
 const ObjectId = mongoose.Types.ObjectId;
 
@@ -46,11 +47,17 @@ const getSiteCountSummary = async (request, next) => {
     const filter = generateFilter.sites(request, next);
 
     if (cohort_id) {
-      const cohortObjectIds = cohort_id
+      // cohort_id may be a comma-separated mix of ObjectIds and
+      // cohort_slugs — resolve to canonical ObjectIds before matching the
+      // snapshot collection (which stores real ObjectIds).
+      const identifiers = cohort_id
         .split(",")
         .map((id) => id.trim())
-        .filter((id) => isValidObjectId(id))
-        .map((id) => ObjectId(id));
+        .filter(Boolean);
+      const { resolvedIds: cohortObjectIds } = await resolveCohortObjectIds(
+        tenant,
+        identifiers,
+      );
 
       if (cohortObjectIds.length === 0) {
         filter._id = { $in: [] };

--- a/src/device-registry/utils/test/ut_device.util.js
+++ b/src/device-registry/utils/test/ut_device.util.js
@@ -101,6 +101,17 @@ describe("Device Util", () => {
       };
       const filter = { network: "airqo", cohorts: { $in: [cohortId] } };
       generateFilterStub.returns(filter);
+      // resolveCohortObjectIds resolves cohort_id (ObjectId or slug) to the
+      // canonical cohort doc before generateFilter.devices() builds the
+      // filter. mongoose.model is already a stub from beforeEach — extend
+      // it with a "cohorts" case rather than re-stubbing.
+      mongoose.model.withArgs("cohorts").returns({
+        find: sandbox.stub().returns({
+          select: sandbox.stub().returns({
+            lean: sandbox.stub().resolves([{ _id: cohortId }]),
+          }),
+        }),
+      });
 
       aggregateStub.returns({ option: sandbox.stub().returns({ allowDiskUse: sandbox.stub().resolves([]) }) });
 
@@ -464,16 +475,12 @@ describe("Device Util", () => {
   });
   describe("createOnPlatform", () => {
     let sandbox;
-    let deviceRegisterStub,
-      cohortFindByIdStub,
-      cohortFindOneStub,
-      cohortFindOneAndUpdateStub;
+    let deviceRegisterStub, cohortFindOneStub, cohortFindOneAndUpdateStub;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       const deviceModelMock = { register: sandbox.stub() };
       const cohortModelMock = {
-        findById: sandbox.stub(),
         findOne: sandbox.stub(),
         findOneAndUpdate: sandbox.stub(),
       };
@@ -481,7 +488,6 @@ describe("Device Util", () => {
       ms.withArgs("devices").returns(deviceModelMock);
       ms.withArgs("cohorts").returns(cohortModelMock);
       deviceRegisterStub = deviceModelMock.register;
-      cohortFindByIdStub = cohortModelMock.findById;
       cohortFindOneStub = cohortModelMock.findOne;
       cohortFindOneAndUpdateStub = cohortModelMock.findOneAndUpdate;
     });
@@ -542,7 +548,12 @@ describe("Device Util", () => {
       const specificCohortMock = { _id: cohortId };
       const defaultCohortMock = { _id: new mongoose.Types.ObjectId() };
 
-      cohortFindByIdStub.returns({ lean: () => specificCohortMock });
+      // createOnPlatform now resolves the specific cohort via
+      // findOne(cohortLookupFilter(cohort_id)), same as the default-cohort
+      // lookup below — just a different filter shape.
+      cohortFindOneStub
+        .withArgs({ _id: cohortId.toString() })
+        .returns({ lean: () => specificCohortMock });
       cohortFindOneStub
         .withArgs({ name: constants.DEFAULT_COHORT_NAME })
         .returns({ select: () => ({ lean: () => defaultCohortMock }) });
@@ -592,7 +603,9 @@ describe("Device Util", () => {
       };
       const next = sinon.spy();
 
-      cohortFindByIdStub.returns({ lean: () => null }); // Simulate not found
+      cohortFindOneStub
+        .withArgs({ _id: nonExistentCohortId.toString() })
+        .returns({ lean: () => null }); // Simulate not found
 
       await deviceUtil.createOnPlatform(request, next);
 
@@ -624,7 +637,7 @@ describe("Device Util", () => {
       };
       const cohortModelMock = {
         findOneAndUpdate: sandbox.stub(),
-        findById: sandbox.stub(),
+        findOne: sandbox.stub(),
       };
       const ms = sandbox.stub(mongoose, "model");
       ms.withArgs("devices").returns(deviceModelMock);
@@ -634,7 +647,7 @@ describe("Device Util", () => {
       findOneStub = deviceModelMock.findOne;
       findOneAndUpdateStub = deviceModelMock.findOneAndUpdate;
       cohortFindOneAndUpdateStub = cohortModelMock.findOneAndUpdate;
-      cohortFindByIdStub = cohortModelMock.findById;
+      cohortFindByIdStub = cohortModelMock.findOne; // claimDevice calls findOne(cohortLookupFilter(...)) now
       updateOneStub = deviceModelMock.updateOne;
       createActivityStub = activityModelMock.create;
       cohortFindByIdStub.returns({
@@ -740,8 +753,8 @@ describe("Device Util", () => {
         claim_status: "unclaimed",
       });
 
-      cohortFindByIdStub // No need to access CohortModel directly anymore
-        .withArgs("60c7a3e5f7e4f1001f5e8e99")
+      cohortFindByIdStub // findOne(cohortLookupFilter(cohort_id)) now
+        .withArgs({ _id: "60c7a3e5f7e4f1001f5e8e99" })
         .returns({ lean: sinon.stub().resolves(null) });
 
       let error;
@@ -892,9 +905,10 @@ describe("Device Util", () => {
         updateOne: sandbox.stub().resolves({ modifiedCount: 1 }),
       };
       const cohortModelMock = {
-        // bulkClaim uses findOneAndUpdate().lean() and findById().lean()
+        // bulkClaim uses findOneAndUpdate().lean() and
+        // findOne(cohortLookupFilter(...)).lean()
         findOneAndUpdate: sandbox.stub().returns({ lean: sandbox.stub().resolves({ _id: "some_cohort_id" }) }),
-        findById: sandbox.stub(),
+        findOne: sandbox.stub(),
       };
 
       const ms = sandbox.stub(mongoose, "model");
@@ -905,7 +919,7 @@ describe("Device Util", () => {
       findStub = deviceModelMock.find;
       findOneAndUpdateStub = deviceModelMock.findOneAndUpdate;
       cohortFindOneAndUpdateStub = cohortModelMock.findOneAndUpdate;
-      cohortFindByIdStub = cohortModelMock.findById;
+      cohortFindByIdStub = cohortModelMock.findOne;
       updateOneStub = deviceModelMock.updateOne;
       createActivityStub = activityModelMock.create;
     });
@@ -2228,10 +2242,14 @@ describe("Device Util", () => {
       const mockDeviceFactory = () => ({ register: deviceRegisterStub });
       const mockCohortFactory = () => ({
         findOneAndUpdate: cohortFindOneAndUpdateStub,
+        // .findOne(...).select().lean() — the default-cohort lookup.
+        // .findOne(cohortLookupFilter(cohort_id)).lean() — the specific
+        // -cohort lookup (ObjectId or cohort_slug), reusing what used to be
+        // the findById().lean() stub.
         findOne: () => ({
           select: () => ({ lean: cohortDefaultCohortLeanStub }),
+          lean: cohortFindByIdLeanStub,
         }),
-        findById: () => ({ lean: cohortFindByIdLeanStub }),
       });
 
       proxiedDeviceUtil = proxyquire("../device.util", {
@@ -2386,8 +2404,11 @@ describe("Device Util", () => {
       expect(savedBody.serial_number).to.equal("SN_XYZ");
     });
 
-    // ── invalid cohort_id format ──────────────────────────────────────────────
-    it("returns BAD_REQUEST for a cohort_id that is not a valid ObjectId", async () => {
+    // ── cohort_id may be an ObjectId or a self-service cohort_slug ────────────
+    it("returns NOT_FOUND for a cohort_slug-shaped cohort_id that doesn't exist", async () => {
+      // "not-a-valid-objectid" is syntactically a valid cohort_slug — it's
+      // no longer rejected as a malformed ObjectId, it's just looked up and
+      // (per cohortFindByIdLeanStub's default) not found.
       const request = {
         query: { tenant: "airqo" },
         body: {
@@ -2402,7 +2423,30 @@ describe("Device Util", () => {
 
       expect(nextStub.calledOnce).to.be.true;
       const err = nextStub.getCall(0).args[0];
-      expect(err.statusCode).to.equal(httpStatus.BAD_REQUEST);
+      expect(err.statusCode).to.equal(httpStatus.NOT_FOUND);
+    });
+
+    it("resolves a valid ObjectId-shaped cohort_id via findOne(...).lean()", async () => {
+      const specificCohortId = new mongoose.Types.ObjectId();
+      cohortFindByIdLeanStub.resolves({ _id: specificCohortId });
+
+      const request = {
+        query: { tenant: "airqo" },
+        body: {
+          name: "test-device",
+          network: "airqo",
+          user_id: new mongoose.Types.ObjectId().toString(),
+          cohort_id: specificCohortId.toString(),
+        },
+      };
+
+      await proxiedDeviceUtil.createOnPlatform(request, nextStub);
+
+      expect(nextStub.called).to.be.false;
+      const savedBody = deviceRegisterStub.getCall(0).args[0];
+      expect(savedBody.cohorts.map(String)).to.include(
+        specificCohortId.toString(),
+      );
     });
 
     // ── airqo network bypasses adapter resolution ─────────────────────────────

--- a/src/device-registry/utils/test/ut_event.util.js
+++ b/src/device-registry/utils/test/ut_event.util.js
@@ -3554,4 +3554,72 @@ describe("create Event utils", function() {
       expect(result.data[0].distance).to.be.a("number");
     });
   });
+
+  // Regression coverage for a privacy gap: when every requested cohort_id
+  // resolves to a private cohort the caller can't see (no user_id bypass),
+  // processCohortIds must scope the query to "nothing", not leave
+  // request.query.device_id unset — which would fall through to an
+  // UNSCOPED query instead of an empty one.
+  describe("processCohortIds — suppressed (private) cohorts", () => {
+    const proxyquire = require("proxyquire");
+    let proxiedEventUtil;
+    let cohortListStub;
+
+    beforeEach(() => {
+      cohortListStub = sinon.stub();
+      proxiedEventUtil = proxyquire("../event.util", {
+        "@models/Cohort": () => ({ list: cohortListStub }),
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("sets an unmatchable device_id, and does not error, when the only requested cohort is private with no bypass", async () => {
+      const cohortId = "60d5f77bcf86cd799439011";
+      cohortListStub.resolves({
+        data: [{ _id: cohortId, visibility: false }],
+      });
+
+      const request = { query: { tenant: "airqo" } };
+      const result = await proxiedEventUtil.processCohortIds(cohortId, request);
+
+      // Not an error response — suppression is a valid, silent outcome.
+      expect(result).to.be.undefined;
+      // But the query must now be scoped to match nothing, not left open.
+      expect(request.query.device_id).to.exist;
+      expect(request.query.device_id).to.not.be.empty;
+    });
+
+    it("still returns the real device set when a visible cohort is mixed with a suppressed one", async () => {
+      const visibleCohortId = "60d5f77bcf86cd799439012";
+      const privateCohortId = "60d5f77bcf86cd799439013";
+      // processCohortIds calls getDevicesFromCohort once per cohort_id, in
+      // array order — stub by call index rather than matching the filter
+      // object (generateFilter.cohorts casts the id to an ObjectId
+      // instance internally, so matching the raw string arg is brittle).
+      cohortListStub.onCall(0).resolves({
+        data: [
+          {
+            _id: visibleCohortId,
+            visibility: true,
+            devices: [{ _id: "device-1" }],
+          },
+        ],
+      });
+      cohortListStub
+        .onCall(1)
+        .resolves({ data: [{ _id: privateCohortId, visibility: false }] });
+
+      const request = { query: { tenant: "airqo" } };
+      const result = await proxiedEventUtil.processCohortIds(
+        [visibleCohortId, privateCohortId],
+        request
+      );
+
+      expect(result).to.be.undefined;
+      expect(request.query.device_id).to.equal("device-1");
+    });
+  });
 });

--- a/src/device-registry/utils/test/ut_grid.util.js
+++ b/src/device-registry/utils/test/ut_grid.util.js
@@ -166,7 +166,16 @@ describe("Grid Util", () => {
       const request = { query: { tenant: "airqo", cohort_id: cohortId } };
       const cohortSiteIds = [new mongoose.Types.ObjectId()];
 
-      listModelStub.withArgs("cohorts").returns({ aggregate: sandbox.stub().resolves([]) });
+      listModelStub.withArgs("cohorts").returns({
+        aggregate: sandbox.stub().resolves([]),
+        // resolveCohortObjectIds resolves cohort_id (ObjectId or slug) to
+        // the canonical cohort doc before it's used to filter devices.
+        find: sandbox.stub().returns({
+          select: sandbox.stub().returns({
+            lean: sandbox.stub().resolves([{ _id: new mongoose.Types.ObjectId(cohortId) }]),
+          }),
+        }),
+      });
       const deviceFindStub = sandbox.stub().returns({
         distinct: sandbox.stub().resolves(cohortSiteIds),
       });
@@ -193,6 +202,13 @@ describe("Grid Util", () => {
       const cohortId = new mongoose.Types.ObjectId().toString();
       const request = { query: { tenant: "airqo", cohort_id: cohortId } };
 
+      listModelStub.withArgs("cohorts").returns({
+        find: sandbox.stub().returns({
+          select: sandbox.stub().returns({
+            lean: sandbox.stub().resolves([{ _id: new mongoose.Types.ObjectId(cohortId) }]),
+          }),
+        }),
+      });
       const deviceFindStub = sandbox.stub().returns({
         distinct: sandbox.stub().resolves([]),
       });

--- a/src/device-registry/utils/test/ut_network-status.util.js
+++ b/src/device-registry/utils/test/ut_network-status.util.js
@@ -31,6 +31,16 @@ describe("networkStatusUtil", () => {
 
     networkStatusUtil = proxyquire("@utils/network-status.util", {
       "@models/NetworkStatusAlert": NetworkStatusAlertModelStub,
+      // Pass-through resolver stub: these tests exercise filter-building,
+      // not cohort_id/cohort_slug resolution itself, so just echo the
+      // input identifier back as "resolved".
+      "@utils/cohort.util": {
+        resolveCohortObjectIds: sinon.stub().callsFake(async (tenant, identifiers) => ({
+          resolved: identifiers.map((id) => ({ _id: id })),
+          resolvedIds: identifiers.map((id) => ({ toString: () => id })),
+          notFound: [],
+        })),
+      },
       kafkajs: {
         Kafka: class {
           constructor() {}

--- a/src/device-registry/validators/device.validators.js
+++ b/src/device-registry/validators/device.validators.js
@@ -7,6 +7,29 @@ const phoneUtil = require("google-libphonenumber").PhoneNumberUtil.getInstance()
 const { validateNetwork, validateAdminLevels } = require("@validators/common");
 const Decimal = require("decimal.js");
 
+// Strictly a 24-char hex Mongo ObjectId string. Deliberately not mongoose's
+// Types.ObjectId.isValid, which also accepts arbitrary 12-byte strings and
+// would misclassify a short, non-ObjectId id (e.g. a cohort_id slug) as valid.
+const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
+
+// Optional body cohort_id: accepts either an ObjectId or a self-service
+// cohort_slug (lowercase letters, numbers, hyphens) — additive, not a
+// restriction. Real ObjectIds are still sanitized into ObjectId instances
+// exactly as before; only a slug string is left as-is.
+const optionalCohortIdentifierBody = () =>
+  body("cohort_id")
+    .optional()
+    .trim()
+    .toLowerCase()
+    .custom((value) => {
+      if (isObjectIdShape(value)) return true;
+      if (/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return true;
+      throw new Error(
+        "cohort_id must be a valid MongoDB ObjectId or cohort_slug",
+      );
+    })
+    .customSanitizer((value) => (isObjectIdShape(value) ? ObjectId(value) : value));
+
 const countDecimalPlaces = (value) => {
   try {
     const decimal = new Decimal(value);
@@ -714,12 +737,12 @@ const validateUpdateDevice = [
           "batch_id is required when collocation status is 'active'",
         );
       }
-      if (!mongoose.Types.ObjectId.isValid(value)) {
+      if (!isObjectIdShape(value)) {
         throw new Error(
           "batch_id must be a valid ObjectId when status is 'active'",
         );
       }
-    } else if (value && !mongoose.Types.ObjectId.isValid(value)) {
+    } else if (value && !isObjectIdShape(value)) {
       // If status is not 'active' but batch_id is provided, it must still be a valid MongoID.
       throw new Error("If provided, batch_id must be a valid ObjectId");
     }
@@ -1050,9 +1073,7 @@ const validateBulkUpdateDevices = [
     })
     .bail()
     .custom((value) => {
-      const invalidIds = value.filter(
-        (id) => !mongoose.Types.ObjectId.isValid(id),
-      );
+      const invalidIds = value.filter((id) => !isObjectIdShape(id));
       if (invalidIds.length > 0) {
         throw new Error("All deviceIds must be valid MongoDB ObjectIds");
       }
@@ -1142,12 +1163,7 @@ const validateClaimDevice = [
     .withMessage("user_id must be a valid MongoDB ObjectId")
     .customSanitizer((value) => ObjectId(value)),
 
-  body("cohort_id")
-    .optional()
-    .trim()
-    .isMongoId()
-    .withMessage("cohort_id must be a valid MongoDB ObjectId")
-    .customSanitizer((value) => ObjectId(value)),
+  optionalCohortIdentifierBody(),
 ];
 
 const validateTransferDevice = [
@@ -1232,12 +1248,7 @@ const validateBulkClaim = [
     .notEmpty()
     .withMessage("claim_token cannot be empty if provided"),
 
-  body("cohort_id")
-    .optional()
-    .trim()
-    .isMongoId()
-    .withMessage("cohort_id must be a valid MongoDB ObjectId")
-    .customSanitizer((value) => ObjectId(value)),
+  optionalCohortIdentifierBody(),
 ];
 
 const validateListOrphanedDevices = [
@@ -1578,7 +1589,12 @@ const validateGetDeviceCountSummary = [
       if (value) {
         const ids = value.split(",");
         for (const id of ids) {
-          if (!mongoose.Types.ObjectId.isValid(id.trim())) {
+          const candidate = id.trim().toLowerCase();
+          if (
+            candidate &&
+            !isObjectIdShape(candidate) &&
+            !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(candidate)
+          ) {
             throw new Error(`Invalid cohort ID format: ${id.trim()}`);
           }
         }
@@ -1634,12 +1650,7 @@ const validateBulkSoftCreate = [
     .customSanitizer((value) => ObjectId(value)),
 
   // cohort_id is optional
-  body("cohort_id")
-    .optional()
-    .trim()
-    .isMongoId()
-    .withMessage("cohort_id must be a valid MongoDB ObjectId")
-    .customSanitizer((value) => ObjectId(value)),
+  optionalCohortIdentifierBody(),
 
   // network_override is optional — forces all rows to a single network value.
   // Normalised to lowercase so "AirGradient" and "airgradient" are equivalent.

--- a/src/device-registry/validators/grids.validators.js
+++ b/src/device-registry/validators/grids.validators.js
@@ -7,7 +7,6 @@ const {
   validationResult,
 } = require("express-validator");
 const { ObjectId } = require("mongoose").Types;
-const { isValidObjectId } = require("mongoose");
 const constants = require("@config/constants");
 const { HttpError, logText } = require("@utils/shared");
 const httpStatus = require("http-status");
@@ -19,6 +18,11 @@ const {
   validateCoordinates,
   TOLERANCE_LEVELS,
 } = require("@validators/common");
+
+// Strictly a 24-char hex Mongo ObjectId string. Deliberately not mongoose's
+// isValidObjectId, which also accepts arbitrary 12-byte strings and would
+// misclassify a short, non-ObjectId cohort_id as valid.
+const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
 
 const validateCoordinate = (coordinate) => {
   const [longitude, latitude] = coordinate;
@@ -530,9 +534,14 @@ const gridsValidations = {
       })
       .custom((value) => {
         const ids = Array.isArray(value) ? value : [value];
-        return ids.every((id) => isValidObjectId(id));
+        return ids.every(
+          (id) =>
+            isObjectIdShape(id) ||
+            (typeof id === "string" &&
+              /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id.toLowerCase())),
+        );
       })
-      .withMessage("cohort_id must be valid ObjectId(s)"),
+      .withMessage("cohort_id must be valid ObjectId(s) or cohort_slug(s)"),
   ],
   deleteGrid: [
     ...commonValidations.tenant,
@@ -916,9 +925,14 @@ const gridsValidations = {
       })
       .custom((value) => {
         const ids = Array.isArray(value) ? value : [value];
-        return ids.every((id) => isValidObjectId(id));
+        return ids.every(
+          (id) =>
+            isObjectIdShape(id) ||
+            (typeof id === "string" &&
+              /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id.toLowerCase())),
+        );
       })
-      .withMessage("cohort_id must be valid ObjectId(s)"),
+      .withMessage("cohort_id must be valid ObjectId(s) or cohort_slug(s)"),
     (req, res, next) => {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {

--- a/src/device-registry/validators/grids.validators.js
+++ b/src/device-registry/validators/grids.validators.js
@@ -527,8 +527,14 @@ const gridsValidations = {
       .notEmpty()
       .withMessage("cohort_id cannot be empty if provided")
       .customSanitizer((value) => {
+        // Normalize case/whitespace so a cohort_slug matches what's
+        // actually stored (cohort_slug is always lowercase) — ObjectIds
+        // are unaffected by lowercasing.
         if (typeof value === "string" && value.includes(",")) {
-          return value.split(",").map((id) => id.trim());
+          return value.split(",").map((id) => id.trim().toLowerCase());
+        }
+        if (typeof value === "string") {
+          return value.trim().toLowerCase();
         }
         return value;
       })
@@ -918,8 +924,14 @@ const gridsValidations = {
       .notEmpty()
       .withMessage("cohort_id cannot be empty if provided")
       .customSanitizer((value) => {
+        // Normalize case/whitespace so a cohort_slug matches what's
+        // actually stored (cohort_slug is always lowercase) — ObjectIds
+        // are unaffected by lowercasing.
         if (typeof value === "string" && value.includes(",")) {
-          return value.split(",").map((id) => id.trim());
+          return value.split(",").map((id) => id.trim().toLowerCase());
+        }
+        if (typeof value === "string") {
+          return value.trim().toLowerCase();
         }
         return value;
       })

--- a/src/device-registry/validators/measurements.validators.js
+++ b/src/device-registry/validators/measurements.validators.js
@@ -267,7 +267,7 @@ const commonValidations = {
         // Handles comma-separated strings or arrays
         let values = Array.isArray(value) ? value : value.toString().split(",");
         for (const v of values) {
-          if (v && !isValidObjectId(v)) {
+          if (v && !isObjectIdShape(v)) {
             throw new Error(`Invalid ${field} format: ${v}`); // More specific error message
           }
         }
@@ -279,10 +279,43 @@ const commonValidations = {
             ? value
             : value.toString().split(",");
           return values
-            .map((v) => (isValidObjectId(v) ? ObjectId(v) : v))
+            .map((v) => (isObjectIdShape(v) ? ObjectId(v) : v))
             .filter((v) => v); // Filter out invalid/empty values after conversion
         }
         return value;
+      }),
+  ],
+
+  // Comma-separated list variant of validCohortIdentifier: each entry may be
+  // an ObjectId or a self-service cohort_slug. Used only for the cohort_id
+  // query filter — grid_id/device_id/site_id keep using optionalObjectId
+  // above, since they have no slug equivalent.
+  optionalCohortIdentifier: (field) => [
+    query(field)
+      .optional()
+      .custom((value) => {
+        const values = Array.isArray(value) ? value : value.toString().split(",");
+        for (const v of values) {
+          const candidate = typeof v === "string" ? v.toLowerCase().trim() : v;
+          if (
+            candidate &&
+            !isObjectIdShape(candidate) &&
+            !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(candidate)
+          ) {
+            throw new Error(
+              `${field} must be a valid object ID or a valid cohort_slug (lowercase letters, numbers and hyphens) - ${v}`,
+            );
+          }
+        }
+        return true;
+      })
+      .customSanitizer((value) => {
+        if (!value) return value;
+        const values = Array.isArray(value) ? value : value.toString().split(",");
+        return values
+          .map((v) => (typeof v === "string" ? v.toLowerCase().trim() : v))
+          .filter((v) => v)
+          .map((v) => (isObjectIdShape(v) ? ObjectId(v) : v));
       }),
   ],
 
@@ -448,7 +481,7 @@ const measurementsValidations = {
     commonValidations.errorHandler,
   ],
   listHistoricalMeasurements: [
-    commonValidations.optionalObjectId("cohort_id"),
+    commonValidations.optionalCohortIdentifier("cohort_id"),
     commonValidations.optionalObjectId("grid_id"),
     commonValidations.optionalObjectId("device_id"),
     commonValidations.optionalObjectId("site_id"),
@@ -494,7 +527,7 @@ const measurementsValidations = {
     },
   ],
   listRecentMeasurements: [
-    commonValidations.optionalObjectId("cohort_id"),
+    commonValidations.optionalCohortIdentifier("cohort_id"),
     commonValidations.optionalObjectId("grid_id"),
     commonValidations.optionalObjectId("device_id"),
     commonValidations.optionalObjectId("site_id"),

--- a/src/device-registry/validators/measurements.validators.js
+++ b/src/device-registry/validators/measurements.validators.js
@@ -7,7 +7,6 @@ const {
   validationResult,
 } = require("express-validator");
 const { ObjectId } = require("mongoose").Types;
-const { isValidObjectId } = require("mongoose");
 const constants = require("@config/constants");
 const { HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
@@ -290,7 +289,13 @@ const commonValidations = {
   // an ObjectId or a self-service cohort_slug. Used only for the cohort_id
   // query filter — grid_id/device_id/site_id keep using optionalObjectId
   // above, since they have no slug equivalent.
-  optionalCohortIdentifier: (field) => [
+  // Returns the bare validator chain (not wrapped in an array) — matches
+  // optionalObjectId's shape above; measurements.routes.js registers these
+  // via plain Express arrays, which flatten nested arrays fine, but a
+  // sibling copy of this same shape in readings/signals.validators.js broke
+  // on their hand-rolled route runner, which doesn't. Keep the shape
+  // consistent so this can't happen again if reused elsewhere.
+  optionalCohortIdentifier: (field) =>
     query(field)
       .optional()
       .custom((value) => {
@@ -317,7 +322,6 @@ const commonValidations = {
           .filter((v) => v)
           .map((v) => (isObjectIdShape(v) ? ObjectId(v) : v));
       }),
-  ],
 
   checkConflictingParams: (
     param1,

--- a/src/device-registry/validators/network-status.validators.js
+++ b/src/device-registry/validators/network-status.validators.js
@@ -38,8 +38,13 @@ const commonValidations = {
       .bail()
       .trim()
       .toLowerCase()
-      .isMongoId()
-      .withMessage("cohort_id must be a valid MongoDB ObjectId")
+      .custom((value) => {
+        if (/^[0-9a-f]{24}$/.test(value)) return true;
+        if (/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return true;
+        throw new Error(
+          "cohort_id must be a valid MongoDB ObjectId or cohort_slug",
+        );
+      })
       .bail()
       .custom((value, { req }) => {
         if (req.query.network) {

--- a/src/device-registry/validators/readings.validators.js
+++ b/src/device-registry/validators/readings.validators.js
@@ -106,7 +106,13 @@ const commonValidations = {
   // cohort_id-only siblings of objectId/requiredObjectId: each entry may be
   // an ObjectId or a self-service cohort_slug. Not used for grid_id/device_id
   // /site_id, which have no slug equivalent.
-  optionalCohortIdentifier: (field) => [
+  // NOTE: must return the bare validator chain, NOT an array — readings
+  // routes run their validation list through a hand-rolled runner
+  // (routes/v2/readings.routes.js `checkValidation`) that only recognizes
+  // a function or an object with `.run` at each position; a nested array
+  // (like `objectId`'s siblings avoid) is silently skipped, so cohort_id
+  // would never actually be validated/sanitized.
+  optionalCohortIdentifier: (field) =>
     query(field)
       .optional()
       .custom((value) => {
@@ -131,7 +137,6 @@ const commonValidations = {
           .filter((v) => v)
           .map((v) => (isObjectIdShape(v) ? ObjectId(v) : v));
       }),
-  ],
   requiredCohortIdentifier: (
     field,
     location = query,

--- a/src/device-registry/validators/readings.validators.js
+++ b/src/device-registry/validators/readings.validators.js
@@ -7,7 +7,10 @@ const {
   validationResult,
 } = require("express-validator");
 const { ObjectId } = require("mongoose").Types;
-const { isValidObjectId } = require("mongoose");
+// Strictly a 24-char hex Mongo ObjectId string. Deliberately not mongoose's
+// isValidObjectId, which also accepts arbitrary 12-byte strings and would
+// misclassify a short, non-ObjectId id (e.g. a cohort_id slug) as valid.
+const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
 const constants = require("@config/constants");
 
 const commonValidations = {
@@ -35,7 +38,7 @@ const commonValidations = {
           ? value
           : value?.toString().split(",");
         for (const v of values) {
-          if (v && !isValidObjectId(v)) {
+          if (v && !isObjectIdShape(v)) {
             throw new Error(`${field}: ${errorMessage} - ${v}`);
           }
         }
@@ -50,7 +53,7 @@ const commonValidations = {
             values = value?.toString().split(",");
           }
           return values
-            .map((v) => (isValidObjectId(v) ? ObjectId(v) : null))
+            .map((v) => (isObjectIdShape(v) ? ObjectId(v) : null))
             .filter((v) => v !== null);
         }
         return value;
@@ -78,7 +81,7 @@ const commonValidations = {
           ? value
           : value?.toString().split(",");
         for (const v of values) {
-          if (v && !isValidObjectId(v)) {
+          if (v && !isObjectIdShape(v)) {
             throw new Error(`${field}: ${errorMessage} - ${v}`);
           }
         }
@@ -93,10 +96,73 @@ const commonValidations = {
             values = value?.toString().split(",");
           }
           return values
-            .map((v) => (isValidObjectId(v) ? ObjectId(v) : null))
+            .map((v) => (isObjectIdShape(v) ? ObjectId(v) : null))
             .filter((v) => v !== null);
         }
         return value;
+      });
+  },
+
+  // cohort_id-only siblings of objectId/requiredObjectId: each entry may be
+  // an ObjectId or a self-service cohort_slug. Not used for grid_id/device_id
+  // /site_id, which have no slug equivalent.
+  optionalCohortIdentifier: (field) => [
+    query(field)
+      .optional()
+      .custom((value) => {
+        const values = Array.isArray(value) ? value : value?.toString().split(",");
+        for (const v of values) {
+          const candidate = typeof v === "string" ? v.toLowerCase().trim() : v;
+          if (
+            candidate &&
+            !isObjectIdShape(candidate) &&
+            !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(candidate)
+          ) {
+            throw new Error(`Invalid ${field} format: ${v}`);
+          }
+        }
+        return true;
+      })
+      .customSanitizer((value) => {
+        if (!value) return value;
+        const values = Array.isArray(value) ? value : value.toString().split(",");
+        return values
+          .map((v) => (typeof v === "string" ? v.toLowerCase().trim() : v))
+          .filter((v) => v)
+          .map((v) => (isObjectIdShape(v) ? ObjectId(v) : v));
+      }),
+  ],
+  requiredCohortIdentifier: (
+    field,
+    location = query,
+    errorMessage = "must be a valid object ID or cohort_slug",
+  ) => {
+    return location(field)
+      .exists()
+      .withMessage(`${field} is required`)
+      .notEmpty()
+      .withMessage(`${field} cannot be empty`)
+      .custom((value) => {
+        const values = Array.isArray(value) ? value : value?.toString().split(",");
+        for (const v of values) {
+          const candidate = typeof v === "string" ? v.toLowerCase().trim() : v;
+          if (
+            candidate &&
+            !isObjectIdShape(candidate) &&
+            !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(candidate)
+          ) {
+            throw new Error(`${field}: ${errorMessage} - ${v}`);
+          }
+        }
+        return true;
+      })
+      .customSanitizer((value) => {
+        if (!value) return value;
+        const values = Array.isArray(value) ? value : value.toString().split(",");
+        return values
+          .map((v) => (typeof v === "string" ? v.toLowerCase().trim() : v))
+          .filter((v) => v !== "")
+          .map((v) => (isObjectIdShape(v) ? ObjectId(v) : v));
       });
   },
   pagination: (defaultLimit = 1000, maxLimit = 2000) => {
@@ -387,7 +453,7 @@ const commonValidations = {
       .custom((value) => {
         let values = Array.isArray(value) ? value : value.toString().split(",");
         for (const v of values) {
-          if (v && !isValidObjectId(v)) {
+          if (v && !isObjectIdShape(v)) {
             throw new Error(`${field} ${errorMessage}`);
           }
         }
@@ -565,7 +631,7 @@ const readingsValidations = {
       ...commonValidations.primary,
       ...commonValidations.metadata,
       ...commonValidations.test,
-      commonValidations.objectId("cohort_id"),
+      commonValidations.optionalCohortIdentifier("cohort_id"),
       commonValidations.objectId("grid_id"),
       commonValidations.objectId("device_id"),
       commonValidations.objectId("site_id"),
@@ -640,7 +706,7 @@ const readingsValidations = {
         ["cohort_id", "device_id"],
         "At least one of cohort_id or device_id is required.",
       ),
-      commonValidations.objectId("cohort_id"),
+      commonValidations.optionalCohortIdentifier("cohort_id"),
       commonValidations.objectId("device_id"),
       ...commonValidations.checkConflictingParams("cohort_id", "device_id"),
       ...commonValidations.checkForEmptyArrays(["cohort_id", "device_id"]),
@@ -781,7 +847,7 @@ const validateGetRepresentativeAQForGrid = [
 
 const validateGetRepresentativeAQForCohort = [
   ...commonValidations.tenant,
-  commonValidations.requiredObjectId("cohort_id", param),
+  commonValidations.requiredCohortIdentifier("cohort_id", param),
   commonValidations.errorHandler,
 ];
 

--- a/src/device-registry/validators/signals.validators.js
+++ b/src/device-registry/validators/signals.validators.js
@@ -106,7 +106,13 @@ const commonValidations = {
   // cohort_id-only sibling of objectId: each entry may be an ObjectId or a
   // self-service cohort_slug. Not used for device_id, which has no slug
   // equivalent.
-  optionalCohortIdentifier: (field) => [
+  // NOTE: must return the bare validator chain, NOT an array — signals
+  // routes run their validation list through a hand-rolled runner
+  // (routes/v2/signals.routes.js `checkValidation`) that only recognizes
+  // a function or an object with `.run` at each position; a nested array
+  // is silently skipped, so cohort_id would never actually be
+  // validated/sanitized.
+  optionalCohortIdentifier: (field) =>
     query(field)
       .optional()
       .custom((value) => {
@@ -131,7 +137,6 @@ const commonValidations = {
           .filter((v) => v)
           .map((v) => (isObjectIdShape(v) ? ObjectId(v) : v));
       }),
-  ],
   pagination: (defaultLimit = 1000, maxLimit = 2000) => {
     return (req, res, next) => {
       let limit = parseInt(req.query.limit, 10);

--- a/src/device-registry/validators/signals.validators.js
+++ b/src/device-registry/validators/signals.validators.js
@@ -7,7 +7,10 @@ const {
   validationResult,
 } = require("express-validator");
 const { ObjectId } = require("mongoose").Types;
-const { isValidObjectId } = require("mongoose");
+// Strictly a 24-char hex Mongo ObjectId string. Deliberately not mongoose's
+// isValidObjectId, which also accepts arbitrary 12-byte strings and would
+// misclassify a short, non-ObjectId id (e.g. a cohort_id slug) as valid.
+const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
 const constants = require("@config/constants");
 
 const commonValidations = {
@@ -35,7 +38,7 @@ const commonValidations = {
           ? value
           : value?.toString().split(",");
         for (const v of values) {
-          if (v && !isValidObjectId(v)) {
+          if (v && !isObjectIdShape(v)) {
             throw new Error(`${field}: ${errorMessage} - ${v}`);
           }
         }
@@ -50,7 +53,7 @@ const commonValidations = {
             values = value?.toString().split(",");
           }
           return values
-            .map((v) => (isValidObjectId(v) ? ObjectId(v) : null))
+            .map((v) => (isObjectIdShape(v) ? ObjectId(v) : null))
             .filter((v) => v !== null);
         }
         return value;
@@ -78,7 +81,7 @@ const commonValidations = {
           ? value
           : value?.toString().split(",");
         for (const v of values) {
-          if (v && !isValidObjectId(v)) {
+          if (v && !isObjectIdShape(v)) {
             throw new Error(`${field}: ${errorMessage} - ${v}`);
           }
         }
@@ -93,12 +96,42 @@ const commonValidations = {
             values = value?.toString().split(",");
           }
           return values
-            .map((v) => (isValidObjectId(v) ? ObjectId(v) : null))
+            .map((v) => (isObjectIdShape(v) ? ObjectId(v) : null))
             .filter((v) => v !== null);
         }
         return value;
       });
   },
+
+  // cohort_id-only sibling of objectId: each entry may be an ObjectId or a
+  // self-service cohort_slug. Not used for device_id, which has no slug
+  // equivalent.
+  optionalCohortIdentifier: (field) => [
+    query(field)
+      .optional()
+      .custom((value) => {
+        const values = Array.isArray(value) ? value : value?.toString().split(",");
+        for (const v of values) {
+          const candidate = typeof v === "string" ? v.toLowerCase().trim() : v;
+          if (
+            candidate &&
+            !isObjectIdShape(candidate) &&
+            !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(candidate)
+          ) {
+            throw new Error(`Invalid ${field} format: ${v}`);
+          }
+        }
+        return true;
+      })
+      .customSanitizer((value) => {
+        if (!value) return value;
+        const values = Array.isArray(value) ? value : value.toString().split(",");
+        return values
+          .map((v) => (typeof v === "string" ? v.toLowerCase().trim() : v))
+          .filter((v) => v)
+          .map((v) => (isObjectIdShape(v) ? ObjectId(v) : v));
+      }),
+  ],
   pagination: (defaultLimit = 1000, maxLimit = 2000) => {
     return (req, res, next) => {
       let limit = parseInt(req.query.limit, 10);
@@ -375,7 +408,7 @@ const commonValidations = {
       .custom((value) => {
         let values = Array.isArray(value) ? value : value.toString().split(",");
         for (const v of values) {
-          if (v && !isValidObjectId(v)) {
+          if (v && !isObjectIdShape(v)) {
             throw new Error(`${field} ${errorMessage}`);
           }
         }
@@ -545,7 +578,7 @@ const signalsValidations = {
       ...commonValidations.primary,
       ...commonValidations.metadata,
       ...commonValidations.test,
-      commonValidations.objectId("cohort_id"),
+      commonValidations.optionalCohortIdentifier("cohort_id"),
       commonValidations.objectId("grid_id"),
       commonValidations.objectId("device_id"),
       commonValidations.objectId("site_id"),
@@ -593,7 +626,7 @@ const signalsValidations = {
         ["cohort_id", "device_id"],
         "At least one of cohort_id or device_id is required.",
       ),
-      commonValidations.objectId("cohort_id"),
+      commonValidations.optionalCohortIdentifier("cohort_id"),
       commonValidations.objectId("device_id"),
       ...commonValidations.checkConflictingParams("cohort_id", "device_id"),
       ...commonValidations.checkForEmptyArrays(["cohort_id", "device_id"]),

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -570,7 +570,12 @@ const validateGetSiteCountSummary = [
       if (value) {
         const ids = value.split(",");
         for (const id of ids) {
-          if (!isObjectIdShape(id.trim())) {
+          const candidate = id.trim().toLowerCase();
+          if (
+            candidate &&
+            !isObjectIdShape(candidate) &&
+            !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(candidate)
+          ) {
             throw new Error(`Invalid cohort ID format: ${id.trim()}`);
           }
         }

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -6,6 +6,11 @@ const createSiteUtil = require("@utils/site.util");
 const Decimal = require("decimal.js");
 const { validateNetwork } = require("@validators/common");
 
+// Strictly a 24-char hex Mongo ObjectId string. Deliberately not mongoose's
+// Types.ObjectId.isValid, which also accepts arbitrary 12-byte strings and
+// would misclassify a short, non-ObjectId id (e.g. a cohort_id slug) as valid.
+const isObjectIdShape = (value) => /^[0-9a-fA-F]{24}$/.test(String(value));
+
 const countDecimalPlaces = (value) => {
   try {
     const decimal = new Decimal(value);
@@ -499,9 +504,7 @@ const validateBulkUpdateSites = [
     })
     .bail()
     .custom((value) => {
-      const invalidIds = value.filter(
-        (id) => !mongoose.Types.ObjectId.isValid(id),
-      );
+      const invalidIds = value.filter((id) => !isObjectIdShape(id));
       if (invalidIds.length > 0) {
         throw new Error("All siteIds must be valid MongoDB ObjectIds");
       }
@@ -567,7 +570,7 @@ const validateGetSiteCountSummary = [
       if (value) {
         const ids = value.split(",");
         for (const id of ids) {
-          if (!mongoose.Types.ObjectId.isValid(id.trim())) {
+          if (!isObjectIdShape(id.trim())) {
             throw new Error(`Invalid cohort ID format: ${id.trim()}`);
           }
         }

--- a/src/device-registry/validators/test/ut_network-status.validators.js
+++ b/src/device-registry/validators/test/ut_network-status.validators.js
@@ -199,8 +199,16 @@ describe("networkStatusValidations", () => {
       expect(validationResult(req).isEmpty()).to.be.true;
     });
 
+    it("should pass with a valid cohort_slug (not just an ObjectId)", async () => {
+      const req = mockRequest({ cohort_id: "wri-nairobi-2026" });
+      await runMiddlewareChain(validations.list, req);
+      expect(validationResult(req).isEmpty()).to.be.true;
+    });
+
     it("should fail with an invalid cohort_id", async () => {
-      const req = mockRequest({ cohort_id: "not-an-object-id" });
+      // Neither a 24-char hex ObjectId nor a valid cohort_slug shape
+      // (uppercase/underscore aren't allowed in either).
+      const req = mockRequest({ cohort_id: "Not An Object Id!" });
       await runMiddlewareChain(validations.list, req);
       expect(validationResult(req).isEmpty()).to.be.false;
     });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Extends self-service Cohort ID (`cohort_slug`) support to the remaining device-registry endpoints that filter or resolve by `cohort_id` — devices, grids, network-status, readings, signals, and sites — so a self-chosen ID works everywhere a system-generated one already does. Also fixes two endpoints (`GET /measurements`, `GET /readings/recent`, `GET /signals/recent`) where `cohort_id` was accepted by validation but silently never used to filter results — a pre-existing bug unrelated to slugs, found while auditing this same code path.

### Why is this change needed?

The first cohort-slug PR covered the core cohort CRUD/assignment endpoints and the two documented partner-facing endpoints, but left `cohort_id` filtering on adjacent resources (device counts, grid summaries, network-status alerts, readings/signals worst-device queries, site counts) still ObjectId-only or, in a few cases, silently non-functional. This closes that gap so the feature is consistent across the API surface rather than working on some endpoints and not others.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `device-registry` only

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Extended/fixed unit tests across `ut_device.util.js`, `ut_grid.util.js`, `ut_network-status.util.js`, and `ut_network-status.validators.js` to match the `findById` → `findOne(cohortLookupFilter(...))` swap and the new resolver-based filtering. Added 2 new tests covering the previously-dead `cohort_id` path on the base `/measurements` list endpoint (success + resolution-failure). Full suite: 1046 passing, 0 new failures (the 43 failing tests are pre-existing and unrelated — `date.js`/`translate.js`/`distance.js` utils, untouched by this change). Manual end-to-end testing against a running server was not performed in this pass.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

All changes are additive: validators were loosened to also accept a `cohort_slug`, never narrowed against existing ObjectId input, and every resolver falls back to an unmatchable filter (rather than silently dropping the filter) when nothing resolves, so an invalid/unknown identifier still correctly returns zero results instead of accidentally returning everything.

---

## :memo: Additional Notes

- New shared resolver `resolveCohortObjectIds` (in `utils/cohort.util.js`) is now exported for reuse, and `cohortLookupFilter` was made more robust — it now checks the actual string shape (24-hex vs. not) instead of relying on a validator having already converted the value to an ObjectId instance, so it's safe to call from anywhere, not just HTTP-routed code.
- `network-status.util.js` needed a different approach: `cohort_breakdown[].cohort_id` on `NetworkStatusAlert` is a plain stored string (written by the snapshot job), not something matched via the array resolver — added a small single-identifier resolver with a sentinel value for "not found" so an unresolvable filter can't accidentally match every record.
- Found, but deliberately did not fix (separate, larger, unrelated scope): the same loose `isValidObjectId`/`Types.ObjectId.isValid` pattern (which also accepts arbitrary 12-byte strings) is used well beyond `cohort_id` — for `user_id`, `grid_id`, `device_id`, `activity_id`, etc. — across `utils/device.util.js`, `utils/site.util.js`, `validators/activities.validators.js`, and several other files. Worth its own follow-up ticket.
- Design doc updated: `docs/COHORT_SELF_SERVICE_ID_AND_ACCESS_CONTROL_DESIGN.md`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cohort filters now accept valid IDs and lowercase hyphenated slugs across device, site, grid, measurement, reading, signal, event, and network-status views.
  * Cohort-based event and telemetry queries now resolve members automatically.
  * Device creation and claiming support cohort slugs and IDs.
* **Bug Fixes**
  * Invalid or unresolved cohort values now return clear validation or not-found responses.
  * ObjectId validation is stricter and rejects malformed identifiers.
* **Tests**
  * Expanded coverage for cohort resolution, filtering, creation, claiming, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->