### PR TITLE
Add DB connection readiness check endpoint to device-registry

### DIFF
--- a/src/device-registry/config/database.js
+++ b/src/device-registry/config/database.js
@@ -158,6 +158,31 @@ const connectToMongoDB = () => {
   }
 };
 
+/**
+ * Reports whether the command, query, and snapshot connection pools are all
+ * fully connected (readyState 1). Used by the /health/ready endpoint so the
+ * k8s readinessProbe can hold traffic back from a pod until Mongo is actually
+ * reachable, instead of routing requests into the bufferTimeoutMS window.
+ */
+function getConnectionStatus() {
+  const describe = (db) => {
+    if (!db) return "not_initialized";
+    const states = ["disconnected", "connected", "connecting", "disconnecting"];
+    return states[db.readyState] || "unknown";
+  };
+
+  const command = describe(commandDB);
+  const query = describe(queryDB);
+  const snapshot = describe(snapshotDB);
+
+  return {
+    ready: command === "connected" && query === "connected" && snapshot === "connected",
+    command,
+    query,
+    snapshot,
+  };
+}
+
 function ensureModel(db, modelName, schema) {
   try {
     db.model(modelName);
@@ -282,6 +307,7 @@ module.exports = {
   getModelByTenant,
   getTenantDB,
   connectToMongoDB,
+  getConnectionStatus,
   getCommandModelByTenant,
   getQueryModelByTenant,
   getSnapshotModelByTenant,

--- a/src/device-registry/controllers/health.controller.js
+++ b/src/device-registry/controllers/health.controller.js
@@ -31,15 +31,13 @@ const healthController = {
   ready: async (req, res, next) => {
     try {
       const result = await healthUtil.getReadiness(req, next);
-      if (result && result.success) {
-        return res.status(result.status).json(result.data);
+      // getReadiness calls next(err) itself on failure, so guard against
+      // acting on an undefined result and racing Express's error handler.
+      if (!result || res.headersSent) {
+        return;
       }
 
-      const status =
-        (result && result.status) || httpStatus.SERVICE_UNAVAILABLE;
-      return res.status(status).json(
-        (result && result.data) || { status: "not_ready" }
-      );
+      return res.status(result.status).json(result.data);
     } catch (error) {
       next(
         new HttpError(

--- a/src/device-registry/controllers/health.controller.js
+++ b/src/device-registry/controllers/health.controller.js
@@ -28,6 +28,29 @@ const healthController = {
     }
   },
 
+  ready: async (req, res, next) => {
+    try {
+      const result = await healthUtil.getReadiness(req, next);
+      if (result && result.success) {
+        return res.status(result.status).json(result.data);
+      }
+
+      const status =
+        (result && result.status) || httpStatus.SERVICE_UNAVAILABLE;
+      return res.status(status).json(
+        (result && result.data) || { status: "not_ready" }
+      );
+    } catch (error) {
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
   getJobMetrics: async (req, res, next) => {
     try {
       const result = await healthUtil.getJobMetrics(req, next);

--- a/src/device-registry/routes/v2/health.routes.js
+++ b/src/device-registry/routes/v2/health.routes.js
@@ -7,6 +7,7 @@ const { headers } = require("@validators/common");
 router.use(headers);
 
 router.get("/", check, healthController.check);
+router.get("/ready", healthController.ready);
 
 const isDev = process.env.NODE_ENV === "development";
 if (isDev) {

--- a/src/device-registry/routes/v2/test/ut_health.routes.js
+++ b/src/device-registry/routes/v2/test/ut_health.routes.js
@@ -1,0 +1,77 @@
+require("module-alias/register");
+process.env.NODE_ENV = "development";
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const { expect } = chai;
+const proxyquire = require("proxyquire");
+const express = require("express");
+const request = require("supertest");
+
+chai.use(sinonChai);
+
+// Exercises the real router (routes/v2/health.routes.js) mounted on a real
+// Express app — only the controller layer is stubbed, matching the approach
+// used for readings.routes.js so this stays valid across internal refactors.
+describe("health.routes.js (mounted at /api/v2/devices/health)", () => {
+  const BASE = "/api/v2/devices/health";
+
+  let healthController;
+
+  const buildApp = (controllerOverrides = {}) => {
+    healthController = {
+      check: sinon.stub().callsFake((req, res) => {
+        res.status(200).json({ success: true, calledWith: "check" });
+      }),
+      ready: sinon.stub().callsFake((req, res) => {
+        res.status(200).json({ success: true, calledWith: "ready" });
+      }),
+      getJobMetrics: sinon.stub().callsFake((req, res) => {
+        res.status(200).json({ success: true, calledWith: "getJobMetrics" });
+      }),
+    };
+    Object.assign(healthController, controllerOverrides);
+
+    const router = proxyquire("@routes/v2/health.routes", {
+      "@controllers/health.controller": healthController,
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use(BASE, router);
+    return app;
+  };
+
+  describe("GET /ready", () => {
+    it("reaches healthController.ready and returns 200 when the controller reports ready", async () => {
+      const app = buildApp();
+
+      const res = await request(app).get(`${BASE}/ready`);
+
+      expect(res.status).to.equal(200);
+      expect(healthController.ready).to.have.been.calledOnce;
+    });
+
+    it("returns 503 when the controller reports not ready", async () => {
+      const app = buildApp({
+        ready: sinon.stub().callsFake((req, res) => {
+          res.status(503).json({ success: false, status: "not_ready" });
+        }),
+      });
+
+      const res = await request(app).get(`${BASE}/ready`);
+
+      expect(res.status).to.equal(503);
+      expect(healthController.ready).to.have.been.calledOnce;
+    });
+
+    it("does not require any query params (no tenant validation on the readiness route)", async () => {
+      const app = buildApp();
+
+      const res = await request(app).get(`${BASE}/ready`).query({ foo: "bar" });
+
+      expect(res.status).to.equal(200);
+      expect(healthController.ready).to.have.been.calledOnce;
+    });
+  });
+});

--- a/src/device-registry/utils/health.util.js
+++ b/src/device-registry/utils/health.util.js
@@ -70,7 +70,7 @@ const healthUtil = {
         data: { status: "ready", database: dbStatus },
       };
     } catch (error) {
-      next(
+      return next(
         new HttpError(
           "Internal Server Error",
           httpStatus.INTERNAL_SERVER_ERROR,

--- a/src/device-registry/utils/health.util.js
+++ b/src/device-registry/utils/health.util.js
@@ -2,6 +2,7 @@ const mongoose = require("mongoose");
 const httpStatus = require("http-status");
 const { HttpError } = require("@utils/shared");
 const { redisUtils } = require("@config/redis");
+const { getConnectionStatus } = require("@config/database");
 
 const healthUtil = {
   getHealth: async (req, next) => {
@@ -31,6 +32,42 @@ const healthUtil = {
         message: "health check successful",
         data: healthStatus,
         status: httpStatus.OK,
+      };
+    } catch (error) {
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
+
+  /**
+   * Readiness check for the k8s readinessProbe. Unlike getHealth (liveness —
+   * only confirms the process is up), this gates on the command/query/snapshot
+   * Mongo connections actually being open, so the Service holds traffic back
+   * from a pod until it's past the cold-start buffering window.
+   */
+  getReadiness: async (req, next) => {
+    try {
+      const dbStatus = getConnectionStatus();
+
+      if (!dbStatus.ready) {
+        return {
+          success: false,
+          message: "not ready",
+          status: httpStatus.SERVICE_UNAVAILABLE,
+          data: { status: "not_ready", database: dbStatus },
+        };
+      }
+
+      return {
+        success: true,
+        message: "ready",
+        status: httpStatus.OK,
+        data: { status: "ready", database: dbStatus },
       };
     } catch (error) {
       next(

--- a/src/device-registry/utils/test/ut_health.util.js
+++ b/src/device-registry/utils/test/ut_health.util.js
@@ -1,0 +1,74 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const chai = require("chai");
+chai.use(sinonChai);
+const httpStatus = require("http-status");
+const proxyquire = require("proxyquire");
+
+describe("healthUtil.getReadiness", () => {
+  let healthUtil;
+  let getConnectionStatusStub;
+  let next;
+
+  beforeEach(() => {
+    getConnectionStatusStub = sinon.stub();
+    next = sinon.stub();
+
+    healthUtil = proxyquire("@utils/health.util", {
+      "@config/database": { getConnectionStatus: getConnectionStatusStub },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("returns 200 and success:true when all DB pools are connected", async () => {
+    const dbStatus = {
+      ready: true,
+      command: "connected",
+      query: "connected",
+      snapshot: "connected",
+    };
+    getConnectionStatusStub.returns(dbStatus);
+
+    const result = await healthUtil.getReadiness({}, next);
+
+    expect(result.success).to.be.true;
+    expect(result.status).to.equal(httpStatus.OK);
+    expect(result.data).to.deep.equal({ status: "ready", database: dbStatus });
+    expect(next).to.not.have.been.called;
+  });
+
+  it("returns 503 and success:false when a DB pool is not connected", async () => {
+    const dbStatus = {
+      ready: false,
+      command: "connected",
+      query: "connecting",
+      snapshot: "not_initialized",
+    };
+    getConnectionStatusStub.returns(dbStatus);
+
+    const result = await healthUtil.getReadiness({}, next);
+
+    expect(result.success).to.be.false;
+    expect(result.status).to.equal(httpStatus.SERVICE_UNAVAILABLE);
+    expect(result.data).to.deep.equal({
+      status: "not_ready",
+      database: dbStatus,
+    });
+    expect(next).to.not.have.been.called;
+  });
+
+  it("propagates via next(err) and returns undefined when getConnectionStatus throws", async () => {
+    getConnectionStatusStub.throws(new Error("boom"));
+
+    const result = await healthUtil.getReadiness({}, next);
+
+    expect(result).to.be.undefined;
+    expect(next).to.have.been.calledOnce;
+    expect(next.firstCall.args[0].message).to.equal("Internal Server Error");
+  });
+});


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a `/health/ready` endpoint to device-registry that reports whether the command, query, and snapshot MongoDB connection pools are actually connected (`getConnectionStatus()` in `config/database.js`, exposed via `utils/health.util.js` → `controllers/health.controller.js` → `routes/v2/health.routes.js`). Returns `200` when all three are connected, `503` otherwise.

### Why is this change needed?
Intermittent 500s were reported on `/readings/recent` (both GET and the new POST variant) that resolved after a handful of requests. Root cause: the deployment currently has no readiness probe, so Kubernetes marks a pod Ready as soon as the container starts and routes traffic to it immediately — before Mongoose finishes its connection handshake. Requests landing in that window exhaust the `bufferTimeoutMS` (10s) and fail.

This PR adds the endpoint the probe needs. Wiring it into the AKS deployment chart's `readinessProbe`/`livenessProbe` is split into a follow-up PR so this one stays scoped to device-registry application code.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** device-registry (application code only — no infra/chart changes in this PR)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified locally that the new modules load without errors and that `getConnectionStatus()` correctly reports `ready: false` / `not_initialized` before `connectToMongoDB()` runs. Not yet exercised against a live cluster — recommend validating actual probe behavior (pod stays `NotReady` until Mongo connects, then flips `Ready`) on staging before promoting to prod.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- New route is additive (`GET /api/v2/devices/health/ready`); existing `/health` behavior is unchanged and still used for liveness.
- **Follow-up PR needed:** this endpoint has no effect until the AKS deployment chart's `readinessProbe`/`livenessProbe` are pointed at it — that chart change is being submitted separately so it can be reviewed/rolled out independently of the app code.
- Does not address root-caused connection-pool sizing/timeouts — only gives infra a signal to hold traffic back from a pod that isn't ready yet.

---

## :white_check_mark: Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness health check endpoint.
  * Reports whether required database connections are available.
  * Returns a successful readiness response when systems are ready and a service-unavailable response otherwise.

* **Bug Fixes**
  * Improved handling of unexpected health-check errors with appropriate server error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->