### PR TITLE
Wire DB readiness probe into device-registry AKS chart

### DIFF
--- a/k8s/device-registry/k8s-aks/airqo-device-registry-api/templates/deployment.yaml
+++ b/k8s/device-registry/k8s-aks/airqo-device-registry-api/templates/deployment.yaml
@@ -39,6 +39,22 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /api/v2/devices/health
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v2/devices/health/ready
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.volumes }}


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a `livenessProbe` (checking `/api/v2/devices/health`) and a `readinessProbe` (checking `/api/v2/devices/health/ready`) to the device-registry AKS deployment chart, for both staging and prod.

### Why is this change needed?
Follow-up to #7021 (merged), which added the `/health/ready` endpoint reporting whether the command/query/snapshot MongoDB connection pools are actually connected. That endpoint has no effect on traffic routing until something wires it into Kubernetes. Without a readiness probe, a pod is marked Ready as soon as the container starts, and the Service routes traffic to it immediately — before Mongoose finishes its connection handshake. Requests landing in that window exhaust `bufferTimeoutMS` (10s) and fail with a 500. This intermittently affected `/readings/recent` (GET and POST), resolving itself only after enough requests had passed for the connection to complete.

Gating readiness on `/health/ready` keeps the Service from sending traffic to a pod until it can actually serve requests.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** device-registry (AKS Helm chart only — no application code in this PR; the `/health/ready` endpoint it relies on shipped in #7021)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Validated with `helm template . -f values-stage.yaml` and `helm template . -f values-prod.yaml` — both render valid `livenessProbe`/`readinessProbe` blocks with the correct port (3000) substituted from `service.targetPort`. Not yet validated against a live cluster; recommend watching pod `Ready` transition timing and rollout behavior on staging before promoting to prod.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- Probe config mirrors the existing pattern already used in the analytics service chart (`initialDelaySeconds`/`periodSeconds`/`failureThreshold`).
- Only the AKS chart (`k8s/device-registry/k8s-aks/...`) was updated — the top-level `k8s/device-registry/templates` GCP chart is legacy/unused for deploys.
- A rolling deploy of this change will briefly hold new pods out of rotation for up to ~25s (`initialDelaySeconds` + one `periodSeconds`) while the readiness probe confirms DB connectivity — expected and desired behavior, not a regression.

---

## :white_check_mark: Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device registry API reliability by adding health checks for startup readiness and ongoing availability.
  * Configured appropriate timing and failure thresholds to support more accurate service status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->