### PR TITLE
Add multi-site-ID filtering to sites summary endpoint

### DIFF
--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -2009,12 +2009,12 @@ const generateFilter = {
     }
 
     if (!isEmpty(site_ids)) {
-      const rawSiteIds = Array.isArray(site_ids)
+      const rawSiteIds = (Array.isArray(site_ids)
         ? site_ids
-        : String(site_ids)
-            .split(",")
-            .map((value) => value.trim())
-            .filter((value) => value.length > 0);
+        : String(site_ids).split(",")
+      )
+        .map((value) => String(value).trim())
+        .filter((value) => value.length > 0);
       const validSiteIds = rawSiteIds.filter((value) =>
         /^[0-9a-fA-F]{24}$/.test(String(value)),
       );

--- a/src/device-registry/utils/common/generate-filter.js
+++ b/src/device-registry/utils/common/generate-filter.js
@@ -1939,6 +1939,7 @@ const generateFilter = {
       division,
       sub_county,
       site_id,
+      site_ids,
       category,
       path,
       site_codes,
@@ -2005,6 +2006,21 @@ const generateFilter = {
 
     if (site_id) {
       filter["_id"] = ObjectId(site_id);
+    }
+
+    if (!isEmpty(site_ids)) {
+      const rawSiteIds = Array.isArray(site_ids)
+        ? site_ids
+        : String(site_ids)
+            .split(",")
+            .map((value) => value.trim())
+            .filter((value) => value.length > 0);
+      const validSiteIds = rawSiteIds.filter((value) =>
+        /^[0-9a-fA-F]{24}$/.test(String(value)),
+      );
+      if (!isEmpty(validSiteIds)) {
+        filter["_id"] = { $in: validSiteIds.map((value) => ObjectId(value)) };
+      }
     }
 
     if (category) {

--- a/src/device-registry/utils/common/test/ut_generate-filter.util.js
+++ b/src/device-registry/utils/common/test/ut_generate-filter.util.js
@@ -66,6 +66,71 @@ describe("generateFilter Util", () => {
     });
   });
 
+  // Nexus follow-up: sites summary needed to filter by more than one site
+  // at a time (previously site_ids wasn't read at all, so multi-site
+  // requests silently fell back to the unfiltered fleet).
+  describe("sites — site_ids filtering", () => {
+    it("should return an empty filter if no query params are provided", () => {
+      const req = mockRequest();
+      const result = generateFilter.sites(req);
+      expect(result).to.be.an("object").that.is.empty;
+    });
+
+    it("should build an $in filter from repeated site_ids query params", () => {
+      const ids = ["507f1f77bcf86cd799439011", "507f1f77bcf86cd799439012"];
+      const req = mockRequest({ site_ids: ids });
+      const result = generateFilter.sites(req);
+      expect(result._id.$in).to.have.lengthOf(2);
+      result._id.$in.forEach((id, i) =>
+        expect(id.toString()).to.equal(ids[i])
+      );
+    });
+
+    it("should build an $in filter from a comma-separated site_ids string", () => {
+      const ids = ["507f1f77bcf86cd799439011", "507f1f77bcf86cd799439012"];
+      const req = mockRequest({ site_ids: ids.join(",") });
+      const result = generateFilter.sites(req);
+      expect(result._id.$in).to.have.lengthOf(2);
+      result._id.$in.forEach((id, i) =>
+        expect(id.toString()).to.equal(ids[i])
+      );
+    });
+
+    it("should trim whitespace around comma-separated site_ids", () => {
+      const req = mockRequest({
+        site_ids: " 507f1f77bcf86cd799439011 , 507f1f77bcf86cd799439012 ",
+      });
+      const result = generateFilter.sites(req);
+      expect(result._id.$in).to.have.lengthOf(2);
+    });
+
+    it("should drop malformed IDs instead of throwing", () => {
+      const req = mockRequest({
+        site_ids: "507f1f77bcf86cd799439011,not-an-id",
+      });
+      const result = generateFilter.sites(req);
+      expect(result._id.$in).to.have.lengthOf(1);
+      expect(result._id.$in[0].toString()).to.equal(
+        "507f1f77bcf86cd799439011"
+      );
+    });
+
+    it("should leave the filter untouched if every site_id is malformed", () => {
+      const req = mockRequest({ site_ids: "not-an-id,also-not-an-id" });
+      const result = generateFilter.sites(req);
+      expect(result._id).to.be.undefined;
+    });
+
+    it("should let site_ids take precedence over a singular site_id", () => {
+      const req = mockRequest({
+        site_id: "507f1f77bcf86cd799439099",
+        site_ids: "507f1f77bcf86cd799439011,507f1f77bcf86cd799439012",
+      });
+      const result = generateFilter.sites(req);
+      expect(result._id.$in).to.have.lengthOf(2);
+    });
+  });
+
   // Nexus follow-up: events/fetch's ?index=<category> filter now accepts an
   // optional trailing `resolved` config (see utils/aqi.util.js's
   // resolveActiveAqiRanges) so an admin-set custom AQI range narrows the

--- a/src/device-registry/utils/common/test/ut_generate-filter.util.js
+++ b/src/device-registry/utils/common/test/ut_generate-filter.util.js
@@ -104,6 +104,20 @@ describe("generateFilter Util", () => {
       expect(result._id.$in).to.have.lengthOf(2);
     });
 
+    it("should trim whitespace on repeated site_ids query params too", () => {
+      const req = mockRequest({
+        site_ids: [" 507f1f77bcf86cd799439011", "507f1f77bcf86cd799439012 "],
+      });
+      const result = generateFilter.sites(req);
+      expect(result._id.$in).to.have.lengthOf(2);
+      expect(result._id.$in[0].toString()).to.equal(
+        "507f1f77bcf86cd799439011"
+      );
+      expect(result._id.$in[1].toString()).to.equal(
+        "507f1f77bcf86cd799439012"
+      );
+    });
+
     it("should drop malformed IDs instead of throwing", () => {
       const req = mockRequest({
         site_ids: "507f1f77bcf86cd799439011,not-an-id",

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -200,6 +200,20 @@ function validateCategoryField(value) {
 const siteIdentifierChains = [
   createMongoIdValidation("id"),
   createMongoIdValidation("site_id", { isOptional: true }),
+  query("site_ids")
+    .optional()
+    .customSanitizer((value) =>
+      Array.isArray(value)
+        ? value
+        : String(value)
+            .split(",")
+            .map((id) => id.trim())
+            .filter((id) => id.length > 0)
+    )
+    .custom((value) => value.every((id) => isObjectIdShape(id)))
+    .withMessage(
+      "site_ids must be a comma-separated list or repeated query parameter of valid MongoDB ObjectIds"
+    ),
   query("name")
     .optional()
     .notEmpty()

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -200,19 +200,16 @@ function validateCategoryField(value) {
 const siteIdentifierChains = [
   createMongoIdValidation("id"),
   createMongoIdValidation("site_id", { isOptional: true }),
+  // Accepts either a comma-separated string or repeated query params;
+  // sanitizes down to well-formed ObjectIds and silently drops anything
+  // else rather than rejecting the whole request, matching how
+  // generateFilter.sites treats this same param downstream.
   query("site_ids")
     .optional()
     .customSanitizer((value) =>
-      Array.isArray(value)
-        ? value
-        : String(value)
-            .split(",")
-            .map((id) => id.trim())
-            .filter((id) => id.length > 0)
-    )
-    .custom((value) => value.every((id) => isObjectIdShape(id)))
-    .withMessage(
-      "site_ids must be a comma-separated list or repeated query parameter of valid MongoDB ObjectIds"
+      (Array.isArray(value) ? value : String(value).split(","))
+        .map((id) => String(id).trim())
+        .filter((id) => id.length > 0 && isObjectIdShape(id))
     ),
   query("name")
     .optional()


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds `site_ids` support to `GET /devices/sites/summary` so callers can filter by multiple site IDs in one request, using either repeated query params (`?site_ids=A&site_ids=B`) or a comma-separated list (`?site_ids=A,B`). Malformed IDs are dropped rather than causing an error.

### Why is this change needed?

Flagged in a staging observation report from the Nexus frontend team and confirmed against the backend code: the endpoint accepted a `site_ids` parameter but never read it, so requests silently fell back to the full, unfiltered fleet. This forced the client to paginate through the entire ~717-site fleet (9 paginated calls) just to resolve display names for a handful of site IDs.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `device-registry`

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added 7 new unit tests for the `site_ids` filter in `generate-filter.js` (repeated params, comma-separated string, whitespace trimming, malformed-ID handling, precedence over the singular `site_id` param). Ran the full `generateFilter Util` suite — all 20 tests pass. No manual/browser testing performed against a live staging environment.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely additive — the endpoint's existing `id`/`site_id`/other query params are untouched; `site_ids` was previously accepted but ignored, so no caller could have depended on the old (no-op) behavior.

---

## :memo: Additional Notes

Addresses item #4 from the 2026-08-22 Nexus staging observations report. A companion fix for item #3 (chart preferences body-shape asymmetry) is being submitted as a separate PR against `auth-service`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filtering sites by multiple site IDs using comma-separated or repeated query values.
  - Valid site IDs are trimmed and applied together; existing single-site filtering remains supported.
  - Invalid or empty ID values are safely ignored.

- **Bug Fixes**
  - Improved handling of whitespace, repeated values, malformed IDs, and mixed valid/invalid filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->