### PR TITLE
Fix chart preferences body-shape asymmetry between create/update

### DIFF
--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -1042,10 +1042,19 @@ const preferences = {
       // values untouched.
       const updates = { ...request.body };
       const nestedChartConfig = request.body.chartConfig || {};
-      if (isEmpty(updates.sites) && !isEmpty(nestedChartConfig.sites)) {
+      // isEmpty() would also treat an explicit `sites: []` (a deliberate
+      // clear) as "absent" and wrongly backfill it from chartConfig — check
+      // for a genuinely missing key instead.
+      if (
+        typeof updates.sites === "undefined" &&
+        !isEmpty(nestedChartConfig.sites)
+      ) {
         updates.sites = nestedChartConfig.sites;
       }
-      if (isEmpty(updates.devices) && !isEmpty(nestedChartConfig.devices)) {
+      if (
+        typeof updates.devices === "undefined" &&
+        !isEmpty(nestedChartConfig.devices)
+      ) {
         updates.devices = nestedChartConfig.devices;
       }
 

--- a/src/auth-service/utils/preference.util.js
+++ b/src/auth-service/utils/preference.util.js
@@ -930,11 +930,19 @@ const preferences = {
         };
       }
 
-      const staleSite = findStaleMetadataEntry(
-        chartConfig.sites,
-        "site_id",
-        siteIds
-      );
+      // updateChart expects sites/devices at the request body's top level;
+      // accept that shape here too (falling back to it when chartConfig
+      // doesn't carry its own sites/devices) so create and update behave
+      // the same way instead of one silently dropping data the other
+      // would have accepted.
+      const chartSites = !isEmpty(chartConfig.sites)
+        ? chartConfig.sites
+        : request.body.sites;
+      const chartDevices = !isEmpty(chartConfig.devices)
+        ? chartConfig.devices
+        : request.body.devices;
+
+      const staleSite = findStaleMetadataEntry(chartSites, "site_id", siteIds);
       if (staleSite) {
         return {
           success: false,
@@ -943,7 +951,7 @@ const preferences = {
         };
       }
       const staleDevice = findStaleMetadataEntry(
-        chartConfig.devices,
+        chartDevices,
         "device_id",
         deviceIds
       );
@@ -965,6 +973,15 @@ const preferences = {
         device_ids: deviceIds,
         site_ids: siteIds,
       };
+      // Only set sites/devices when a value was actually resolved, so a
+      // request with neither the nested nor the top-level shape doesn't add
+      // stray `sites: undefined` / `devices: undefined` keys.
+      if (!isEmpty(chartSites)) {
+        chartToInsert.sites = chartSites;
+      }
+      if (!isEmpty(chartDevices)) {
+        chartToInsert.devices = chartDevices;
+      }
 
       // Atomically add this chart to the user's preference doc for this
       // group, creating the doc if it doesn't exist yet.
@@ -1014,8 +1031,23 @@ const preferences = {
       // isn't the convention this API validates against.
       const tenant = (request.query || {}).tenant || request.body.tenant;
       const { chartId } = request.params;
-      const updates = request.body;
       const userId = request.user._id;
+
+      // createChart accepts sites/devices nested inside a chartConfig
+      // wrapper; fall back to that shape here too when the top-level
+      // sites/devices aren't present, so create and update behave the same
+      // way instead of one silently dropping data the other would accept.
+      // Only fills in the field when it's genuinely absent, so a request
+      // that omits sites/devices entirely still leaves the chart's existing
+      // values untouched.
+      const updates = { ...request.body };
+      const nestedChartConfig = request.body.chartConfig || {};
+      if (isEmpty(updates.sites) && !isEmpty(nestedChartConfig.sites)) {
+        updates.sites = nestedChartConfig.sites;
+      }
+      if (isEmpty(updates.devices) && !isEmpty(nestedChartConfig.devices)) {
+        updates.devices = nestedChartConfig.devices;
+      }
 
       // chartId (a subdocument _id) is globally unique on its own, so the
       // chart's parent preference doc can be found by user_id + chartId

--- a/src/auth-service/utils/test/ut_preference.util.js
+++ b/src/auth-service/utils/test/ut_preference.util.js
@@ -876,6 +876,59 @@ describe("preference chart UTIL", function() {
       expect(chart.sites).to.deep.equal([{ site_id: siteId, name: "Site A" }]);
     });
 
+    it("clears sites via an explicit empty array even when chartConfig.sites is also present in the body — an explicit [] must not be treated as \"absent\" and backfilled", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = {
+        _id: { toString: () => chartId },
+        device_ids: [deviceId],
+        site_ids: [siteId],
+        sites: [{ site_id: siteId, name: "Site A" }],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: {
+          tenant: "airqo",
+          device_ids: [deviceId],
+          sites: [],
+          chartConfig: { sites: [{ site_id: siteId, name: "Leftover" }] },
+        },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(true);
+      expect(saveStub.calledOnce).to.equal(true);
+      expect(chart.sites).to.deep.equal([]);
+    });
+
+    it("falls back to chartConfig.sites when sites is genuinely absent from the request body", async function() {
+      const saveStub = sinon.stub().resolves();
+      const chart = {
+        _id: { toString: () => chartId },
+        device_ids: [],
+        site_ids: [siteId],
+        sites: [],
+      };
+      const doc = { chartConfigurations: [chart], save: saveStub };
+      findOneStub.resolves(doc);
+      const request = {
+        body: {
+          tenant: "airqo",
+          chartConfig: { sites: [{ site_id: siteId, name: "Site A" }] },
+        },
+        params: { chartId },
+        user: { _id: userId },
+      };
+
+      const result = await rewirePreferenceUtil.updateChart(request);
+
+      expect(result.success).to.equal(true);
+      expect(chart.sites).to.deep.equal([{ site_id: siteId, name: "Site A" }]);
+    });
+
     it("backfills a missing period before saving — legacy preference docs created via upsert()/replace() (no runValidators there) can lack it, and save() always validates the whole document", async function() {
       const saveStub = sinon.stub().resolves();
       const chart = {

--- a/src/auth-service/validators/preferences.validators.js
+++ b/src/auth-service/validators/preferences.validators.js
@@ -1546,6 +1546,48 @@ const preferenceValidations = {
       .isInt({ min: 1, max: 8 })
       .withMessage("fieldId must be an integer between 1 and 8"),
     ...createNestedValidations("chartConfig"),
+    // updateChart accepts sites/devices at the request body's top level;
+    // accept that shape here too (as a fallback to chartConfig.sites/
+    // chartConfig.devices) so create and update behave the same way.
+    body("sites").optional().isArray().withMessage("sites must be an array"),
+    body("sites.*.site_id")
+      .exists()
+      .withMessage("sites[].site_id is required")
+      .bail()
+      .isMongoId()
+      .withMessage("sites[].site_id must be a valid ObjectId"),
+    body("sites.*.name")
+      .exists()
+      .withMessage("sites[].name is required")
+      .bail()
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage("sites[].name must be a non-empty string")
+      .bail()
+      .isLength({ max: 200 })
+      .withMessage("sites[].name must not exceed 200 characters"),
+    body("devices")
+      .optional()
+      .isArray()
+      .withMessage("devices must be an array"),
+    body("devices.*.device_id")
+      .exists()
+      .withMessage("devices[].device_id is required")
+      .bail()
+      .isMongoId()
+      .withMessage("devices[].device_id must be a valid ObjectId"),
+    body("devices.*.name")
+      .exists()
+      .withMessage("devices[].name is required")
+      .bail()
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage("devices[].name must be a non-empty string")
+      .bail()
+      .isLength({ max: 200 })
+      .withMessage("devices[].name must not exceed 200 characters"),
   ],
   updateChart: [
     ...commonValidations.tenant,
@@ -1558,6 +1600,57 @@ const preferenceValidations = {
     chartScopeNotBothClearedOnUpdate,
     // Use all validations from chartConfigValidation
     ...chartConfigValidation,
+    // createChart accepts sites/devices nested inside a chartConfig wrapper;
+    // accept that shape here too (as a fallback to the top-level sites/
+    // devices above) so create and update behave the same way.
+    body("chartConfig")
+      .optional()
+      .isObject()
+      .withMessage("chartConfig must be an object"),
+    body("chartConfig.sites")
+      .optional()
+      .isArray()
+      .withMessage("chartConfig.sites must be an array"),
+    body("chartConfig.sites.*.site_id")
+      .exists()
+      .withMessage("chartConfig.sites[].site_id is required")
+      .bail()
+      .isMongoId()
+      .withMessage("chartConfig.sites[].site_id must be a valid ObjectId"),
+    body("chartConfig.sites.*.name")
+      .exists()
+      .withMessage("chartConfig.sites[].name is required")
+      .bail()
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage("chartConfig.sites[].name must be a non-empty string")
+      .bail()
+      .isLength({ max: 200 })
+      .withMessage("chartConfig.sites[].name must not exceed 200 characters"),
+    body("chartConfig.devices")
+      .optional()
+      .isArray()
+      .withMessage("chartConfig.devices must be an array"),
+    body("chartConfig.devices.*.device_id")
+      .exists()
+      .withMessage("chartConfig.devices[].device_id is required")
+      .bail()
+      .isMongoId()
+      .withMessage("chartConfig.devices[].device_id must be a valid ObjectId"),
+    body("chartConfig.devices.*.name")
+      .exists()
+      .withMessage("chartConfig.devices[].name is required")
+      .bail()
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage("chartConfig.devices[].name must be a non-empty string")
+      .bail()
+      .isLength({ max: 200 })
+      .withMessage(
+        "chartConfig.devices[].name must not exceed 200 characters"
+      ),
   ],
   deleteChart: [
     ...commonValidations.tenant,

--- a/src/auth-service/validators/test/ut_preferences-chart.validators.js
+++ b/src/auth-service/validators/test/ut_preferences-chart.validators.js
@@ -194,6 +194,35 @@ describe("personal chart validators", () => {
       expect(res.status).to.equal(200);
     });
 
+    it("accepts sites/devices sent at the top level instead of nested in chartConfig — the updateChart shape, accepted here as a fallback", async () => {
+      const siteId = validId();
+      const deviceId = validId();
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: { fieldId: 1 },
+          sites: [{ site_id: siteId, name: "Site A" }],
+          devices: [{ device_id: deviceId, name: "Device A" }],
+          site_ids: [siteId],
+          device_ids: [deviceId],
+        });
+      expect(res.status).to.equal(200);
+    });
+
+    it("rejects a top-level sites entry with an invalid site_id", async () => {
+      const res = await request(app)
+        .post("/test/charts")
+        .send({
+          chartConfig: { fieldId: 1 },
+          sites: [{ site_id: "not-an-id", name: "Site A" }],
+          site_ids: [validId()],
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "sites[].site_id must be a valid ObjectId"
+      );
+    });
+
     it("rejects a chartConfig.sites entry with an invalid site_id", async () => {
       const res = await request(app)
         .post("/test/charts")
@@ -346,6 +375,29 @@ describe("personal chart validators", () => {
           sites: [{ site_id: siteId, name: "Site A" }],
         });
       expect(res.status).to.equal(200);
+    });
+
+    it("accepts sites/devices nested inside chartConfig instead of at the top level — the createChart shape, accepted here as a fallback", async () => {
+      const siteId = validId();
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({
+          site_ids: [siteId],
+          chartConfig: { sites: [{ site_id: siteId, name: "Site A" }] },
+        });
+      expect(res.status).to.equal(200);
+    });
+
+    it("rejects a chartConfig.sites entry with an invalid site_id on update", async () => {
+      const res = await request(app)
+        .put(`/test/charts/${validId()}`)
+        .send({
+          chartConfig: { sites: [{ site_id: "not-an-id", name: "Site A" }] },
+        });
+      expect(res.status).to.equal(422);
+      expect(JSON.stringify(res.body)).to.include(
+        "chartConfig.sites[].site_id must be a valid ObjectId"
+      );
     });
 
     it("rejects a sites entry with an invalid site_id", async () => {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes the request-body mismatch between the chart-preferences create (`POST /users/preferences/charts`) and update (`PUT /users/preferences/charts/:chartId`) endpoints. Both now accept `sites`/`devices` at either the nested `chartConfig.*` shape or the flat top-level shape, falling back to whichever one the caller didn't use.

### Why is this change needed?

Flagged in a staging observation report from the Nexus frontend team and confirmed against the backend code: `POST` expected `sites`/`devices` nested inside `chartConfig`, while `PUT` expected them at the top level of the body. Sending either field at the "wrong" level for a given verb caused it to be silently dropped — the request still returned HTTP 200, but the data never made it into the stored chart.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `auth-service`

---

## :test_tube: Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran the full `preference chart UTIL` and `personal chart validators` suites — all `createChart`/`updateChart` cases pass, including the existing stale-entry and body-shape assertions. A handful of pre-existing, unrelated failures elsewhere in the suite (date-utility and tenant-list tests) were confirmed present on the base branch as well. No manual/browser testing performed against a live staging environment.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Additive fallback only — existing callers using either endpoint's current body shape continue to work exactly as before; the change only adds acceptance of the other shape as well.

---

## :memo: Additional Notes

Addresses item #3 from the 2026-08-22 Nexus staging observations report. A companion fix for item #4 (sites-summary multi-ID filter) is being submitted as a separate PR against `device-registry`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart creation and updates now accept site and device details from supported request formats.
  * Explicitly clearing sites or devices with empty arrays is supported.
  * Only provided metadata is saved, preserving omitted fields.

* **Bug Fixes**
  * Improved validation for site and device identifiers and display names.
  * Invalid metadata now returns clear validation errors instead of being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->