### PR TITLE
Sync userName field to match users email

### DIFF
--- a/src/auth-service/bin/jobs/username-email-sync-job.js
+++ b/src/auth-service/bin/jobs/username-email-sync-job.js
@@ -1,0 +1,123 @@
+const cron = require("node-cron");
+const UserModel = require("@models/User");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const { stringify } = require("@utils/common");
+const { acquireCronLock } = require("@utils/common/cron-lock.util");
+
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- username-email-sync-job`
+);
+
+const TENANT = constants.DEFAULT_TENANT || "airqo";
+const BATCH_SIZE = 500;
+
+// Only users whose userName doesn't already match their email are "dirty".
+// $expr lets Mongo compare the two fields server-side, so already-aligned
+// users are never fetched or written — each run only touches what's left.
+const DIRTY_FILTER = {
+  email: { $nin: [null, ""] },
+  $expr: { $ne: ["$userName", "$email"] },
+};
+
+let isJobRunning = false;
+
+const syncUsernamesToEmail = async () => {
+  if (isJobRunning) {
+    logger.warn("username-email-sync-job already running — skipping tick");
+    return;
+  }
+  isJobRunning = true;
+
+  try {
+    const gotLock = await acquireCronLock(TENANT, jobName);
+    if (!gotLock) return;
+
+    const dirtyCount = await UserModel(TENANT).countDocuments(DIRTY_FILTER);
+
+    if (dirtyCount === 0) {
+      logger.info("username-email-sync-job: all userNames aligned — nothing to do");
+      return;
+    }
+
+    logger.info(
+      `username-email-sync-job: ${dirtyCount} user(s) with mismatched userName — starting sync`
+    );
+
+    let totalUpdated = 0;
+    let totalConflicts = 0;
+
+    while (true) {
+      if (global.isShuttingDown) {
+        logger.info(
+          `username-email-sync-job: shutdown signal received — stopping after ${totalUpdated} record(s) updated`
+        );
+        break;
+      }
+
+      const batch = await UserModel(TENANT)
+        .find(DIRTY_FILTER)
+        .select("_id")
+        .limit(BATCH_SIZE)
+        .lean();
+
+      if (batch.length === 0) break;
+
+      const ids = batch.map((doc) => doc._id);
+
+      // Re-check $expr per op (not just _id) so a doc that changed between the
+      // find and the write is never blindly overwritten.
+      const ops = ids.map((id) => ({
+        updateOne: {
+          filter: { _id: id, $expr: { $ne: ["$userName", "$email"] } },
+          update: [{ $set: { userName: "$email" } }],
+        },
+      }));
+
+      try {
+        const result = await UserModel(TENANT).bulkWrite(ops, {
+          ordered: false,
+        });
+        totalUpdated += result.modifiedCount || 0;
+      } catch (bulkError) {
+        // With ordered:false, a duplicate-key conflict on one doc (some other
+        // user already holds that email string as their userName) doesn't
+        // stop the rest of the batch — it's just skipped and logged.
+        const writeErrors = bulkError.writeErrors || [];
+        totalUpdated += (bulkError.result && bulkError.result.nModified) || 0;
+        totalConflicts += writeErrors.length;
+        writeErrors.forEach((writeError) => {
+          const failedId = ids[writeError.index];
+          logger.warn(
+            `username-email-sync-job: skipped user _id=${failedId} — userName/email conflict: ${writeError.errmsg}`
+          );
+        });
+        if (writeErrors.length === 0) {
+          throw bulkError;
+        }
+      }
+
+      logger.debug(`Batch done: ${batch.length} record(s) processed`);
+    }
+
+    logger.info(
+      `username-email-sync-job: complete — ${totalUpdated} updated, ${totalConflicts} skipped due to conflicts`
+    );
+  } catch (error) {
+    logger.error(`username-email-sync-job error --- ${stringify(error)}`);
+  } finally {
+    isJobRunning = false;
+  }
+};
+
+// Run once daily at 04:00 Nairobi time.
+const schedule = "0 4 * * *";
+const jobName = "username-email-sync-job";
+
+global.cronJobs = global.cronJobs || {};
+global.cronJobs[jobName] = cron.schedule(schedule, syncUsernamesToEmail, {
+  scheduled: true,
+  timezone: "Africa/Nairobi",
+});
+
+module.exports = { syncUsernamesToEmail };

--- a/src/auth-service/bin/jobs/username-email-sync-job.js
+++ b/src/auth-service/bin/jobs/username-email-sync-job.js
@@ -46,6 +46,7 @@ const syncUsernamesToEmail = async () => {
 
     let totalUpdated = 0;
     let totalConflicts = 0;
+    let lastId = null;
 
     while (true) {
       if (global.isShuttingDown) {
@@ -55,14 +56,24 @@ const syncUsernamesToEmail = async () => {
         break;
       }
 
+      // Cursor on _id guarantees forward progress every iteration, even for a
+      // doc that keeps failing with a duplicate-key conflict — without this,
+      // a conflicted doc stays "dirty" forever and the same batch would be
+      // re-fetched on every loop, spinning indefinitely.
+      const cursorFilter = lastId
+        ? { ...DIRTY_FILTER, _id: { $gt: lastId } }
+        : DIRTY_FILTER;
+
       const batch = await UserModel(TENANT)
-        .find(DIRTY_FILTER)
+        .find(cursorFilter)
         .select("_id")
+        .sort({ _id: 1 })
         .limit(BATCH_SIZE)
         .lean();
 
       if (batch.length === 0) break;
 
+      lastId = batch[batch.length - 1]._id;
       const ids = batch.map((doc) => doc._id);
 
       // Re-check $expr per op (not just _id) so a doc that changed between the
@@ -82,19 +93,30 @@ const syncUsernamesToEmail = async () => {
       } catch (bulkError) {
         // With ordered:false, a duplicate-key conflict on one doc (some other
         // user already holds that email string as their userName) doesn't
-        // stop the rest of the batch — it's just skipped and logged.
+        // stop the rest of the batch — it's just skipped and logged. Any
+        // writeError with a different code is unexpected, so it's rethrown
+        // to stop the job rather than being silently swallowed as a conflict.
         const writeErrors = bulkError.writeErrors || [];
+        if (writeErrors.length === 0) {
+          throw bulkError;
+        }
+
+        const unexpected = writeErrors.filter((we) => we.code !== 11000);
+        if (unexpected.length > 0) {
+          throw bulkError;
+        }
+
         totalUpdated += (bulkError.result && bulkError.result.nModified) || 0;
         totalConflicts += writeErrors.length;
         writeErrors.forEach((writeError) => {
           const failedId = ids[writeError.index];
+          // Log only the _id and code — the driver's errmsg embeds the
+          // actual duplicate value (here, an email address), which must not
+          // land in logs.
           logger.warn(
-            `username-email-sync-job: skipped user _id=${failedId} — userName/email conflict: ${writeError.errmsg}`
+            `username-email-sync-job: skipped user _id=${failedId} — userName/email conflict (code ${writeError.code})`
           );
         });
-        if (writeErrors.length === 0) {
-          throw bulkError;
-        }
       }
 
       logger.debug(`Batch done: ${batch.length} record(s) processed`);

--- a/src/auth-service/bin/server.js
+++ b/src/auth-service/bin/server.js
@@ -116,6 +116,7 @@ const jobs = [
   "@bin/jobs/feedback-reminder-job",
   "@bin/jobs/transaction-amount-fix-job",
   "@bin/jobs/selfie-cleanup-job",
+  "@bin/jobs/username-email-sync-job",
 ];
 
 // Initialize log4js with SAFE configuration


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a new background job (`username-email-sync-job`) that keeps every user's `userName` field in sync with their `email` address. It queries only users whose `userName` doesn't already match their `email`, updates them in batches via `bulkWrite`, and skips everyone else — already-aligned users are never fetched or written.

### Why is this change needed?
Some existing user records have a `userName` that no longer matches the user's `email`, causing inconsistency across the platform. This job brings all accounts into a consistent state (`userName === email`) in an optimized, idempotent way, without needing a one-off manual migration script.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- auth-service

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Verified the job's dirty-record filter correctly matches only users whose `userName` differs from their `email`, confirmed the batch/bulkWrite update logic syntactically (`node -c`), and confirmed already-aligned users are excluded from the query so the job is a no-op once the backlog is cleared.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- Runs once daily at 04:00 (Africa/Nairobi) via cron, guarded by the existing `acquireCronLock` mechanism so only one pod replica executes it per tick.
- Processes users in batches of 500 using a MongoDB update pipeline (`$set: { userName: "$email" }`), so email values never need to be loaded into application memory.
- Uses `ordered: false` on `bulkWrite` so a unique-index conflict on one user (rare case where another user already holds that email string as their `userName`) is logged and skipped without blocking the rest of the batch.
- Includes a shutdown-signal check so an in-progress run stops cleanly on pod termination.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated daily synchronization that updates usernames to match users’ email addresses when needed.
  * Processes updates in batches and safely handles conflicting records without stopping the remaining updates.
  * The synchronization runs automatically as part of the server’s background jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->