### PR TITLE
Add total count metadata to clients list endpoint

### DIFF
--- a/src/auth-service/controllers/client.controller.js
+++ b/src/auth-service/controllers/client.controller.js
@@ -151,6 +151,7 @@ const createClient = {
           success: true,
           message: result.message ? result.message : "",
           clients: result.data ? result.data : [],
+          meta: result.meta ? result.meta : undefined,
         });
       } else if (result.success === false) {
         const status = result.status

--- a/src/auth-service/controllers/test/ut_client.controller.js
+++ b/src/auth-service/controllers/test/ut_client.controller.js
@@ -89,6 +89,36 @@ describe("createClient", () => {
       expect(res.json.calledWithMatch({ success: true, clients: sinon.match.array })).to.be.true;
     });
 
+    it("should forward pagination meta from the util layer", async () => {
+      const meta = { total: 192, skip: 0, limit: 100, page: 1, pages: 2 };
+      sinon.stub(clientUtil, "listClients").resolves({
+        success: true,
+        status: httpStatus.OK,
+        message: "Clients listed successfully",
+        data: [{ clientId: "client123" }],
+        meta,
+      });
+
+      await createClient.list(req, res, next);
+
+      expect(res.status.calledWith(httpStatus.OK)).to.be.true;
+      expect(res.json.calledWithMatch({ success: true, meta })).to.be.true;
+    });
+
+    it("should omit meta when the util layer doesn't provide it", async () => {
+      sinon.stub(clientUtil, "listClients").resolves({
+        success: true,
+        status: httpStatus.OK,
+        message: "Clients listed successfully",
+        data: [{ clientId: "client123" }],
+      });
+
+      await createClient.list(req, res, next);
+
+      const jsonArg = res.json.firstCall.args[0];
+      expect(jsonArg.meta).to.be.undefined;
+    });
+
     it("should handle client listing failure", async () => {
       sinon.stub(clientUtil, "listClients").resolves({
         success: false,

--- a/src/auth-service/models/Client.js
+++ b/src/auth-service/models/Client.js
@@ -124,6 +124,8 @@ ClientSchema.statics = {
         delete filter.category;
       }
 
+      const totalCount = await this.countDocuments(filter).exec();
+
       const response = await this.aggregate()
         .match(filter)
         .lookup({
@@ -145,10 +147,21 @@ ClientSchema.statics = {
         .limit(limit ? limit : 100)
         .allowDiskUse(true);
 
-      return createSuccessResponse("list", response, "client", {
+      const successResponse = createSuccessResponse("list", response, "client", {
         message: "successfully retrieved the client details",
         emptyMessage: "no clients exist",
       });
+
+      return {
+        ...successResponse,
+        meta: {
+          total: totalCount,
+          skip: skip ? skip : 0,
+          limit: limit ? limit : 100,
+          page: Math.floor((skip ? skip : 0) / (limit ? limit : 100)) + 1,
+          pages: Math.ceil(totalCount / (limit ? limit : 100)) || 1,
+        },
+      };
     } catch (error) {
       return createErrorResponse(error, "list", logger, "client");
     }


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a `meta` object (`total`, `skip`, `limit`, `page`, `pages`) to the clients list endpoint response, computed via `countDocuments` alongside the existing paginated query.

### Why is this change needed?
The clients list endpoint was paginated with a default `limit=100` but never returned a total count, so any consumer relying on the returned array length (instead of a real total) would see a number silently capped at the page size rather than the true count. This caused a mismatch between the "clients" figure shown on Nexus (100) and an unrelated, unpaginated "API users" stat (192), which are not directly comparable numbers to begin with.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** auth-service

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran the existing client controller unit test suite (`list()` cases) — all pass unchanged. Verified the additive `meta` field does not affect existing consumers of the list response, since no other code path relies on strict response shape.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

Frontend (Nexus) follow-up needed: switch the clients count display from `clients.length` to the new `meta.total` field, and update the response type to include the `meta` object.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination metadata to client listing responses, including total results, current page, page size, offset, and total pages.
  * Client list responses now consistently expose metadata when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->