### PR TITLE
Add known-devices/email-queue endpoints and notification retry fix

### DIFF
--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -1675,6 +1675,34 @@ const userController = {
     }
   },
 
+  /**
+   * Get the authenticated user's known sign-in devices
+   * @route GET /api/v2/users/known-devices
+   */
+  listKnownDevices: async (req, res, next) => {
+    try {
+      const userId = req.user && req.user._id;
+      if (!userId) {
+        return next(
+          new HttpError("Authentication required", httpStatus.UNAUTHORIZED, {
+            auth: "User must be authenticated to access known devices",
+          }),
+        );
+      }
+
+      const request = handleRequest(req, next);
+      if (!request) return;
+      const { tenant } = request.query;
+
+      const result = await userUtil.listKnownDevices({ userId, tenant }, next);
+
+      return sendResponse(res, result, "knownDevices");
+    } catch (error) {
+      logger.error(`🐛 List known devices controller error: ${error.message}`);
+      handleError(error, next);
+    }
+  },
+
   getEnhancedProfileForUser: async (req, res, next) => {
     try {
       logger.info("Enhanced profile for specific user endpoint called");

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -1703,6 +1703,37 @@ const userController = {
     }
   },
 
+  /**
+   * Admin diagnostic view of the email queue (pending/processing/failed jobs)
+   * @route GET /api/v2/users/email-queue
+   */
+  listEmailQueue: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+      const result = await userUtil.listEmailQueue(request, next);
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message,
+          emailQueue: result.data,
+          meta: result.meta,
+        });
+      }
+      return res
+        .status(result.status || httpStatus.INTERNAL_SERVER_ERROR)
+        .json({
+          success: false,
+          message: result.message,
+          errors: result.errors || { message: "Internal Server Error" },
+        });
+    } catch (error) {
+      logger.error(`🐛 List email queue controller error: ${error.message}`);
+      handleError(error, next);
+    }
+  },
+
   getEnhancedProfileForUser: async (req, res, next) => {
     try {
       logger.info("Enhanced profile for specific user endpoint called");

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -1678,6 +1678,7 @@ const userController = {
   /**
    * Get the authenticated user's known sign-in devices
    * @route GET /api/v2/users/known-devices
+   * @route GET /api/v3/users/known-devices
    */
   listKnownDevices: async (req, res, next) => {
     try {
@@ -1706,6 +1707,7 @@ const userController = {
   /**
    * Admin diagnostic view of the email queue (pending/processing/failed jobs)
    * @route GET /api/v2/users/email-queue
+   * @route GET /api/v3/users/email-queue
    */
   listEmailQueue: async (req, res, next) => {
     try {

--- a/src/auth-service/models/EmailQueue.js
+++ b/src/auth-service/models/EmailQueue.js
@@ -31,6 +31,15 @@ const EmailQueueSchema = new mongoose.Schema(
     errorMessage: {
       type: String,
     },
+    // Opt-in context a caller can attach when queuing (e.g. functionName,
+    // userId, fingerprint) so the queue processor can react to a permanent
+    // delivery failure — e.g. rolling back a security notification's side
+    // effect so it is retried on the next trigger instead of being silently
+    // dropped forever.
+    metadata: {
+      type: Object,
+      default: {},
+    },
   },
   { timestamps: true },
 );

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -122,6 +122,14 @@ router.get(
   userController.getEnhancedProfile,
 );
 
+router.get(
+  "/known-devices",
+  enhancedJWTAuth,
+  userValidations.tenant,
+  validate,
+  userController.listKnownDevices,
+);
+
 // ================================
 // GROUP-SPECIFIC ROUTES
 // ================================

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -130,6 +130,15 @@ router.get(
   userController.listKnownDevices,
 );
 
+router.get(
+  "/email-queue",
+  enhancedJWTAuth,
+  requirePermissions([constants.SYSTEM_ADMIN]),
+  userValidations.listEmailQueue,
+  validate,
+  userController.listEmailQueue,
+);
+
 // ================================
 // GROUP-SPECIFIC ROUTES
 // ================================

--- a/src/auth-service/routes/v3/users.routes.js
+++ b/src/auth-service/routes/v3/users.routes.js
@@ -196,6 +196,20 @@ router.get(
   userController.listKnownDevices
 );
 
+/**
+ * @route GET /api/v3/users/email-queue
+ * @desc Admin diagnostic view of the email queue (pending/processing/failed jobs)
+ * @access Private (SYSTEM_ADMIN)
+ */
+router.get(
+  "/email-queue",
+  enhancedJWTAuth,
+  requirePermissions([constants.SYSTEM_ADMIN]),
+  userValidations.listEmailQueue,
+  validate,
+  userController.listEmailQueue
+);
+
 // ================================
 // GROUP-SPECIFIC ROUTES
 // ================================

--- a/src/auth-service/routes/v3/users.routes.js
+++ b/src/auth-service/routes/v3/users.routes.js
@@ -183,6 +183,19 @@ router.get(
   userController.getEnhancedProfile
 );
 
+/**
+ * @route GET /api/v3/users/known-devices
+ * @desc Get the authenticated user's known sign-in devices
+ * @access Private
+ */
+router.get(
+  "/known-devices",
+  enhancedJWTAuth,
+  userValidations.tenant,
+  validate,
+  userController.listKnownDevices
+);
+
 // ================================
 // GROUP-SPECIFIC ROUTES
 // ================================

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -55,10 +55,10 @@ const MAX_ATTEMPTS = 3;
 let isProcessingQueue = false;
 let queueIntervalId = null;
 
-const addToEmailQueue = async (mailOptions, tenant = "airqo") => {
+const addToEmailQueue = async (mailOptions, tenant = "airqo", metadata = {}) => {
   try {
     const EmailQueue = EmailQueueModel(tenant);
-    await new EmailQueue({ mailOptions }).save();
+    await new EmailQueue({ mailOptions, metadata }).save();
     // The background processor will pick this up
     return { success: true, message: "Email queued successfully." };
   } catch (error) {
@@ -66,6 +66,34 @@ const addToEmailQueue = async (mailOptions, tenant = "airqo") => {
     // Even if queuing fails, we should probably still try to send for critical emails.
     // For now, we'll just log the error.
     return { success: false, error: error.message };
+  }
+};
+
+// When a queued email permanently fails, "queued successfully" earlier
+// deceived any caller that had already applied a side effect on the
+// assumption the notification would go out (e.g. recording a device as
+// known before the email confirming it to the user has actually sent).
+// A job can attach { rollbackKnownDevice: { userId, fingerprint } } as
+// metadata so that side effect is undone here, letting the next trigger
+// retry the notification instead of staying silently suppressed forever.
+const rollbackFailedJobSideEffect = async (emailJob, tenant) => {
+  const rollback = emailJob.metadata && emailJob.metadata.rollbackKnownDevice;
+  if (!rollback || !rollback.userId || !rollback.fingerprint) {
+    return;
+  }
+  try {
+    const UserModel = require("@models/User");
+    await UserModel(tenant).updateOne(
+      { _id: rollback.userId },
+      { $pull: { knownDevices: { fingerprint: rollback.fingerprint } } },
+    );
+    logger.info(
+      `Rolled back knownDevices fingerprint for user ${rollback.userId} after permanent email failure (job ${emailJob._id})`,
+    );
+  } catch (rollbackError) {
+    logger.error(
+      `Failed to roll back knownDevices fingerprint for user ${rollback.userId}: ${rollbackError.message}`,
+    );
   }
 };
 
@@ -142,6 +170,7 @@ const processEmailQueue = async () => {
           logger.warn(
             `Email job ${emailJob._id} failed permanently. Dedup key removed.`,
           );
+          await rollbackFailedJobSideEffect(emailJob, tenant);
         }
         await EmailQueueForTenant.findByIdAndUpdate(emailJob._id, {
           $set: { status: newStatus, errorMessage: error.message },
@@ -1034,7 +1063,18 @@ const createSecurityEmailFunction = (
     let tenant = "";
     try {
       let cooldownKey;
-      ({ email, tenant = "airqo", cooldownKey, ...otherParams } = params);
+      let rollbackKnownDevice;
+      ({
+        email,
+        tenant = "airqo",
+        cooldownKey,
+        rollbackKnownDevice,
+        ...otherParams
+      } = params);
+      const queueMetadata = {
+        functionName,
+        ...(rollbackKnownDevice ? { rollbackKnownDevice } : {}),
+      };
       // Optional per-call cooldown scoping. Without it, the cooldown/dedup
       // window is keyed only by (email, functionName) — fine for one-token
       // alerts, but for per-token notifications (e.g. bypass expiry) that
@@ -1158,7 +1198,11 @@ const createSecurityEmailFunction = (
           await emailDeduplicator.checkAndMarkEmail(baseMailOptions);
 
         if (shouldSend) {
-          const queueResult = await addToEmailQueue(baseMailOptions, tenant);
+          const queueResult = await addToEmailQueue(
+            baseMailOptions,
+            tenant,
+            queueMetadata,
+          );
           if (!queueResult.success) {
             throw new HttpError(
               "Internal Server Error",
@@ -1195,7 +1239,11 @@ const createSecurityEmailFunction = (
           `Email queue insertion failed after deduplication step: ${dbError.message}`,
           { email: baseMailOptions.to, subject: baseMailOptions.subject },
         );
-        const retryQueueResult = await addToEmailQueue(baseMailOptions, tenant);
+        const retryQueueResult = await addToEmailQueue(
+          baseMailOptions,
+          tenant,
+          queueMetadata,
+        );
         if (!retryQueueResult.success) {
           throw new HttpError(
             "Internal Server Error",

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -140,6 +140,98 @@ describe("create-user-util", function () {
       expect(err.message).to.equal("Internal Server Error");
     });
   });
+  describe("listKnownDevices", function () {
+    let origUserModel;
+    let findByIdStub;
+    let selectStub;
+    let leanStub;
+
+    beforeEach(function () {
+      leanStub = sinon.stub();
+      selectStub = sinon.stub().returns({ lean: leanStub });
+      findByIdStub = sinon.stub().returns({ select: selectStub });
+      origUserModel = rewireCreateUser.__get__("UserModel");
+      rewireCreateUser.__set__("UserModel", () => ({
+        findById: findByIdStub,
+      }));
+    });
+
+    afterEach(function () {
+      rewireCreateUser.__set__("UserModel", origUserModel);
+      sinon.restore();
+    });
+
+    it("should return known devices sorted by lastSeenAt, most recent first", async function () {
+      leanStub.resolves({
+        knownDevices: [
+          {
+            fingerprint: "older",
+            os: "Windows",
+            lastSeenAt: new Date("2026-01-01T00:00:00Z"),
+          },
+          {
+            fingerprint: "newer",
+            os: "macOS",
+            lastSeenAt: new Date("2026-06-01T00:00:00Z"),
+          },
+        ],
+      });
+
+      const result = await rewireCreateUser.listKnownDevices({
+        userId: "user_id",
+        tenant: "airqo",
+      });
+
+      expect(result.success).to.be.true;
+      expect(result.status).to.equal(httpStatus.OK);
+      expect(result.data).to.be.an("array").with.lengthOf(2);
+      expect(result.data[0].fingerprint).to.equal("newer");
+      expect(result.data[1].fingerprint).to.equal("older");
+      sinon.assert.calledWith(findByIdStub, "user_id");
+      sinon.assert.calledWith(selectStub, "knownDevices");
+    });
+
+    it("should return an empty array when the user has no known devices", async function () {
+      leanStub.resolves({ knownDevices: [] });
+
+      const result = await rewireCreateUser.listKnownDevices({
+        userId: "user_id",
+        tenant: "airqo",
+      });
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal([]);
+    });
+
+    it("should return a 404 when the user is not found", async function () {
+      leanStub.resolves(null);
+
+      const result = await rewireCreateUser.listKnownDevices({
+        userId: "missing_user",
+        tenant: "airqo",
+      });
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.NOT_FOUND);
+      expect(result.message).to.equal("User not found");
+    });
+
+    it("should return a generic error message without leaking the raw exception", async function () {
+      leanStub.rejects(new Error("connection reset by peer"));
+
+      const result = await rewireCreateUser.listKnownDevices({
+        userId: "user_id",
+        tenant: "airqo",
+      });
+
+      expect(result.success).to.be.false;
+      expect(result.status).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
+      expect(result.errors.message).to.equal(
+        "Failed to retrieve known devices"
+      );
+      expect(result.errors.message).to.not.include("connection reset");
+    });
+  });
   describe("listStatistics", function () {
     let origUserModel;
     let listStatisticsStub;

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -687,7 +687,7 @@ const createUserModule = {
         success: false,
         message: "Internal Server Error",
         status: httpStatus.INTERNAL_SERVER_ERROR,
-        errors: { message: error.message },
+        errors: { message: "Failed to retrieve known devices" },
       };
     }
   },
@@ -757,7 +757,7 @@ const createUserModule = {
         success: false,
         message: "Internal Server Error",
         status: httpStatus.INTERNAL_SERVER_ERROR,
-        errors: { message: error.message },
+        errors: { message: "Failed to retrieve email queue" },
       };
     }
   },

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -654,6 +654,43 @@ const createUserModule = {
     }
   },
 
+  listKnownDevices: async ({ userId, tenant }, next) => {
+    try {
+      const user = await UserModel(tenant)
+        .findById(userId)
+        .select("knownDevices")
+        .lean();
+
+      if (!user) {
+        return {
+          success: false,
+          message: "User not found",
+          status: httpStatus.NOT_FOUND,
+          errors: { message: "User not found" },
+        };
+      }
+
+      const knownDevices = [...(user.knownDevices || [])].sort(
+        (a, b) => new Date(b.lastSeenAt) - new Date(a.lastSeenAt),
+      );
+
+      return {
+        success: true,
+        message: "Known devices retrieved successfully",
+        data: knownDevices,
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 listKnownDevices util error: ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
   listLogs: async (request, next) => {
     try {
       const { tenant, limit = 1000, skip = 0 } = request.query;

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -8,6 +8,7 @@ const PermissionModel = require("@models/Permission");
 const { LogModel } = require("@models/log");
 const NetworkModel = require("@models/Network");
 const EmailLogModel = require("@models/EmailLog");
+const EmailQueueModel = require("@models/EmailQueue");
 const bcrypt = require("bcrypt");
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Types.ObjectId;
@@ -682,6 +683,76 @@ const createUserModule = {
       };
     } catch (error) {
       logger.error(`🐛🐛 listKnownDevices util error: ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
+  listEmailQueue: async (request, next) => {
+    try {
+      const { query } = request;
+      const tenant = query.tenant || constants.DEFAULT_TENANT;
+
+      const MAX_LIMIT = 500;
+      const rawSkip = parseInt(query.skip, 10);
+      const rawLimit = parseInt(query.limit, 10);
+      const skip = Number.isFinite(rawSkip) ? Math.max(0, rawSkip) : 0;
+      const limit = Number.isFinite(rawLimit)
+        ? Math.min(MAX_LIMIT, Math.max(1, rawLimit))
+        : 100;
+
+      const filter = {};
+      if (query.status) filter.status = query.status;
+      if (query.email) {
+        filter["mailOptions.to"] = query.email.toLowerCase().trim();
+      }
+      if (query.subject) {
+        const escapedSubject = query.subject
+          .trim()
+          .replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        filter["mailOptions.subject"] = {
+          $regex: escapedSubject,
+          $options: "i",
+        };
+      }
+
+      const EmailQueue = EmailQueueModel(tenant);
+      const [jobs, total] = await Promise.all([
+        EmailQueue.find(filter)
+          .select("-mailOptions.html -mailOptions.attachments")
+          .sort({ createdAt: -1 })
+          .skip(skip)
+          .limit(limit)
+          .lean(),
+        EmailQueue.countDocuments(filter),
+      ]);
+
+      const data = jobs.map((job) => ({
+        _id: job._id,
+        status: job.status,
+        to: job.mailOptions && job.mailOptions.to,
+        subject: job.mailOptions && job.mailOptions.subject,
+        attempts: job.attempts,
+        lastAttemptAt: job.lastAttemptAt,
+        errorMessage: job.errorMessage,
+        metadata: job.metadata,
+        createdAt: job.createdAt,
+        updatedAt: job.updatedAt,
+      }));
+
+      return {
+        success: true,
+        message: "Email queue retrieved successfully",
+        data,
+        meta: { total, skip, limit },
+        status: httpStatus.OK,
+      };
+    } catch (error) {
+      logger.error(`🐛🐛 listEmailQueue util error: ${error.message}`);
       return {
         success: false,
         message: "Internal Server Error",
@@ -7033,6 +7104,14 @@ const createUserModule = {
                 deviceType,
                 location,
                 loginTime: new Date(),
+                // "Queued" is not "delivered" — if the queued job later fails
+                // permanently, this tells the queue processor to undo the
+                // knownDevices insert so the next login from this device
+                // retries the notification instead of staying silently known.
+                rollbackKnownDevice: {
+                  userId: user._id.toString(),
+                  fingerprint,
+                },
               });
 
               if (!mailResult || mailResult.success === false) {

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -1657,6 +1657,37 @@ const submitFeedback = [
 
 const getFeedbackUploadUrl = [validateTenant];
 
+const listEmailQueue = [
+  validateTenant,
+  query("status")
+    .optional()
+    .notEmpty()
+    .withMessage("status must not be empty if provided")
+    .bail()
+    .isIn(["pending", "processing", "failed"])
+    .withMessage("status must be one of: pending, processing, failed"),
+  query("email")
+    .optional()
+    .trim()
+    .isEmail()
+    .withMessage("email filter must be a valid email address"),
+  query("subject")
+    .optional()
+    .trim()
+    .notEmpty()
+    .withMessage("subject must not be empty if provided")
+    .isLength({ max: 200 })
+    .withMessage("subject cannot exceed 200 characters"),
+  query("skip")
+    .optional()
+    .isInt({ min: 0 })
+    .withMessage("skip must be a non-negative integer"),
+  query("limit")
+    .optional()
+    .isInt({ min: 1, max: 500 })
+    .withMessage("limit must be between 1 and 500"),
+];
+
 const listFeedbackSubmissions = [
   validateTenant,
   query("status")
@@ -2074,6 +2105,7 @@ module.exports = {
   refreshPermissions,
   analyzeTokenStrategies,
   getContextPermissions,
+  listEmailQueue,
   debugPermissions,
   initiateAccountDeletion,
   confirmAccountDeletion,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
1. Adds a new authenticated `GET /users/known-devices` endpoint (v2 and v3) that returns the signed-in user's known sign-in devices (fingerprint, OS, browser, device type, last-seen timestamp), sorted most-recent-first. Exposes the existing `knownDevices` field on the User model — no schema change.
2. Adds an admin-only `GET /users/email-queue` endpoint (v2 and v3, gated by `SYSTEM_ADMIN`) to inspect pending/processing/failed jobs in the `EmailQueue` collection (status, recipient, subject, attempts, error message), filterable by status/email/subject — a way to diagnose stuck or failed transactional emails without direct DB or log access.
3. Fixes a silent-failure gap in the new-device email flow: a device's fingerprint was recorded as "known" as soon as its notification email was successfully **queued**, not once it was actually **delivered**. If the queued email later failed permanently (after retries), the device stayed marked "known" forever and the user was never notified, with no way to retry. `EmailQueue` jobs can now carry an optional `metadata.rollbackKnownDevice` context; on permanent failure, the queue processor rolls back the fingerprint so the next login from that device retries detection and notification.

### Why is this change needed?
While investigating reports that no "new sign-in" security emails had ever been observed in the sending mailbox, we found the notification pipeline is fire-and-forget: the login flow only confirms the email was *queued*, not delivered. A downstream SMTP failure (e.g. Gmail throttling/auth issues) would permanently and silently suppress that notification for a given device, with no record surfaced anywhere convenient to check. This PR closes that gap and adds an endpoint to inspect queue state directly, since server logs aren't easily accessible. It also adds the `known-devices` endpoint so the Nexus frontend can eventually build a security-activity view (e.g. a "Check activity" link, similar to Google's sign-in alert email).

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:** auth-service

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified syntax of all changed files (`node -c`) and confirmed no route-path collisions with existing `/:user_id` routes. Ran the full auth-service suite (`npm test`) — 2183 passing, 88 pending, 1 pre-existing unrelated failure (`getDifferenceInMonths` in `ut_date.util.js`, confirmed present on this branch prior to these changes via `git stash`) — no regressions introduced. No new automated tests were added for the two new endpoints or the rollback path, and none of it has been exercised against a running server yet — recommend manual verification (auth token + `GET /api/v2/users/known-devices`, and a `SYSTEM_ADMIN` token + `GET /api/v2/users/email-queue`) before merge.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
- `known-devices` is purely additive (reuses the existing `knownDevices` array); the `email-queue` rollback change touches the shared `createSecurityEmailFunction`/`addToEmailQueue` path but is backward compatible — `metadata` is optional and defaults to `{}`, so every other email type that goes through this path is unaffected.
- `GET /users/email-queue` deliberately excludes `mailOptions.html`/`mailOptions.attachments` from the response to avoid exposing full email bodies/PII over the API; it's restricted to `SYSTEM_ADMIN`.
- A follow-up implementation note will be sent to the Nexus team once this is merged, so they can build a security-activity UI against `known-devices`.

---

## :white_check_mark: Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to view recently recognized sign-in devices.
  * Added an administrative email queue view with filtering, pagination, and job status details.
  * Email queue entries can now include additional context for easier diagnosis.
* **Bug Fixes**
  * Failed security emails now remove associated unconfirmed device records, preventing stale devices from being retained.
* **Tests**
  * Added coverage for recognized-device retrieval, including empty, missing-user, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->