### PR TITLE
Guard new-device email login link against missing base URL

### DIFF
--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -686,7 +686,7 @@ module.exports = {
       ? `<p><strong>Location:</strong> ${escapeHtml(location)}</p>`
       : "";
     const loginPageLine = constants.LOGIN_PAGE
-      ? `<p>If you are using the AirQo web platform, <a href="${constants.LOGIN_PAGE}">click here</a> to review your account security settings.</p>`
+      ? `<p>If you are using the AirQo web platform, <a href="${escapeHtml(constants.LOGIN_PAGE)}">click here</a> to review your account security settings.</p>`
       : "";
     const content = `
     <tr>

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -685,6 +685,9 @@ module.exports = {
     const locationLine = location
       ? `<p><strong>Location:</strong> ${escapeHtml(location)}</p>`
       : "";
+    const loginPageLine = constants.LOGIN_PAGE
+      ? `<p>If you are using the AirQo web platform, <a href="${constants.LOGIN_PAGE}">click here</a> to review your account security settings.</p>`
+      : "";
     const content = `
     <tr>
       <td style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
@@ -693,7 +696,7 @@ module.exports = {
         ${locationLine}
         <p><strong>Time:</strong> ${timeStr}</p>
         <p>If this was you, you can safely ignore this email. If you don't recognise this activity, please change your password immediately and contact our support team at <a href="mailto:support@airqo.net">support@airqo.net</a>.</p>
-        <p>If you are using the AirQo web platform, <a href="${constants.LOGIN_PAGE}">click here</a> to review your account security settings.</p>
+        ${loginPageLine}
       </td>
     </tr>
     `;

--- a/src/auth-service/utils/common/test/ut_email.msgs.util.js
+++ b/src/auth-service/utils/common/test/ut_email.msgs.util.js
@@ -861,4 +861,54 @@ describe("email.msgs", () => {
       expect(result).to.be.a("string");
     });
   });
+
+  describe("newDeviceLogin", () => {
+    const baseArgs = {
+      firstName: "John",
+      lastName: "Doe",
+      email: "user@example.com",
+      os: "macOS",
+      browser: "Chrome",
+      deviceType: "desktop",
+      loginTime: new Date("2026-01-01T00:00:00Z"),
+    };
+
+    it("should include the login-page line when LOGIN_PAGE is configured", () => {
+      const saved = constants.LOGIN_PAGE;
+      constants.LOGIN_PAGE = "https://nexus.airqo.net/user/login";
+      try {
+        const result = msgs.newDeviceLogin(baseArgs);
+        expect(result).to.include(
+          '<a href="https://nexus.airqo.net/user/login">click here</a>'
+        );
+      } finally {
+        constants.LOGIN_PAGE = saved;
+      }
+    });
+
+    it("should omit the login-page line when LOGIN_PAGE is not configured", () => {
+      const saved = constants.LOGIN_PAGE;
+      constants.LOGIN_PAGE = undefined;
+      try {
+        const result = msgs.newDeviceLogin(baseArgs);
+        expect(result).to.not.include("click here");
+        expect(result).to.not.include("href=\"undefined\"");
+      } finally {
+        constants.LOGIN_PAGE = saved;
+      }
+    });
+
+    it("should HTML-escape a LOGIN_PAGE value containing metacharacters", () => {
+      const saved = constants.LOGIN_PAGE;
+      constants.LOGIN_PAGE = '"><script>alert(1)</script>';
+      try {
+        const result = msgs.newDeviceLogin(baseArgs);
+        expect(result).to.not.include('href="">');
+        expect(result).to.not.include("<script>alert(1)</script>");
+        expect(result).to.include("&lt;script&gt;");
+      } finally {
+        constants.LOGIN_PAGE = saved;
+      }
+    });
+  });
 });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Guards the "click here" login-page link in the new-device sign-in security email (`newDeviceLogin` template) so it's omitted entirely when the platform base URL isn't configured, instead of rendering a broken `href="undefined"` link.

### Why is this change needed?
`constants.LOGIN_PAGE` is only set when the `NEXUS_BASE_URL` env var is present; if it's ever unset, the email template would silently emit a dead link with no error surfaced anywhere. This follows the same conditional-rendering pattern already used for the location line in the same template.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:** auth-service

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Verified syntax (`node -c`) and ran the full auth-service suite (`npm test`) — 2187 passing, 88 pending, 1 pre-existing unrelated failure (`getDifferenceInMonths` in `ut_date.util.js`), no regressions. No dedicated unit test added for this specific branch — the `newDeviceLogin` template has no existing test coverage at all (a pre-existing gap, not introduced here). Recommend a quick manual check: render the email with `NEXUS_BASE_URL` unset and confirm the login-page line is omitted rather than broken.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
Small, isolated fix — only touches the email template's conditional rendering, no API or schema changes. Uses the exact same pattern as the existing `locationLine` guard in the same function.

---

## :white_check_mark: Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New-device login emails now show the security-settings guidance only when the login page is enabled.
  * Removed irrelevant login instructions when that feature is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->