### PR TITLE
Add site picker and comparison readings endpoints

### DIFF
--- a/src/device-registry/controllers/event.controller.js
+++ b/src/device-registry/controllers/event.controller.js
@@ -1222,6 +1222,57 @@ const createEvent = {
       return;
     }
   },
+  compareSiteReadings: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors),
+        );
+        return;
+      }
+
+      const request = {
+        ...req,
+        query: {
+          ...req.query,
+          tenant: isEmpty(req.query.tenant) ? "airqo" : req.query.tenant,
+        },
+      };
+
+      const result = await createEventUtil.compareSiteReadings(request, next);
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      const status = result.status || httpStatus.OK;
+      if (result.success === true) {
+        res.status(status).json({
+          success: true,
+          message: result.message,
+          readings: result.data,
+        });
+      } else {
+        const errorStatus = result.status || httpStatus.INTERNAL_SERVER_ERROR;
+        res.status(errorStatus).json({
+          success: false,
+          errors: result.errors || { message: "" },
+          message: result.message,
+        });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+      return;
+    }
+  },
   listReadingAverages: async (req, res, next) => {
     try {
       const errors = extractErrorsFromRequest(req);

--- a/src/device-registry/controllers/site.controller.js
+++ b/src/device-registry/controllers/site.controller.js
@@ -979,6 +979,51 @@ const siteController = {
       return;
     }
   },
+  listForComparisonPicker: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const request = req;
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      request.query.tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await siteUtil.listForComparisonPicker(request, next);
+
+      if (result.success) {
+        return res.status(result.status || httpStatus.OK).json({
+          success: true,
+          message: result.message,
+          sites: result.data,
+          meta: result.meta || {},
+        });
+      } else {
+        return res
+          .status(result.status || httpStatus.INTERNAL_SERVER_ERROR)
+          .json({
+            success: false,
+            message: result.message,
+            errors: result.errors,
+          });
+      }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
   getMySites: async (req, res, next) => {
     try {
       const errors = extractErrorsFromRequest(req);

--- a/src/device-registry/routes/v2/readings.routes.js
+++ b/src/device-registry/routes/v2/readings.routes.js
@@ -143,6 +143,12 @@ const routes = [
     controller: "recentReadings",
   },
   {
+    method: "post",
+    path: "/comparisons",
+    middlewares: [checkValidation("comparisons")],
+    controller: "compareSiteReadings",
+  },
+  {
     method: "get",
     path: "/worst/devices",
     middlewares: [checkValidation("worstReadingForDevices")],

--- a/src/device-registry/routes/v2/sites.routes.js
+++ b/src/device-registry/routes/v2/sites.routes.js
@@ -18,6 +18,7 @@ const {
   validateGetSiteCountSummary,
   validateBulkUpdateSites,
   validateGetMySites,
+  validateSitesPicker,
 } = require("@validators/site.validators");
 const { validate } = require("@validators/common");
 const { headers, pagination } = require("@validators/common");
@@ -31,6 +32,14 @@ router.get(
   validate,
   pagination(),
   siteController.getMySites
+);
+
+router.get(
+  "/picker",
+  validateTenant,
+  validateSitesPicker,
+  validate,
+  siteController.listForComparisonPicker
 );
 
 /****************************** create sites use-case *************** */

--- a/src/device-registry/routes/v2/test/ut_readings.routes.js
+++ b/src/device-registry/routes/v2/test/ut_readings.routes.js
@@ -39,6 +39,7 @@ describe("readings.routes.js (mounted at /api/v2/devices/readings)", () => {
     "getAirQualityRankings",
     "getRepresentativeAirQualityForGrid",
     "getRepresentativeAirQualityForCohort",
+    "compareSiteReadings",
   ];
 
   let eventController;
@@ -173,6 +174,62 @@ describe("readings.routes.js (mounted at /api/v2/devices/readings)", () => {
       // validator) converts valid ObjectId strings to ObjectId instances —
       // ["String", "String"] here would mean POST skipped that sanitization.
       expect(res.body.siteIdTypes).to.deep.equal(["ObjectID", "ObjectID"]);
+    });
+  });
+
+  describe("POST /comparisons", () => {
+    it("reaches compareSiteReadings for a valid site_ids body array", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .post(`${BASE}/comparisons`)
+        .send({ site_ids: [validSiteId1, validSiteId2] });
+
+      expect(res.status).to.equal(200);
+      expect(eventController.compareSiteReadings).to.have.been.calledOnce;
+    });
+
+    it("returns 400 and never reaches the controller when site_ids is missing", async () => {
+      const app = buildApp();
+
+      const res = await request(app).post(`${BASE}/comparisons`).send({});
+
+      expect(res.status).to.equal(400);
+      expect(eventController.compareSiteReadings).to.not.have.been.called;
+    });
+
+    it("returns 400 for an empty site_ids array", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .post(`${BASE}/comparisons`)
+        .send({ site_ids: [] });
+
+      expect(res.status).to.equal(400);
+      expect(eventController.compareSiteReadings).to.not.have.been.called;
+    });
+
+    it("returns 400 when site_ids contains an invalid ObjectId", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .post(`${BASE}/comparisons`)
+        .send({ site_ids: [validSiteId1, "not-an-object-id"] });
+
+      expect(res.status).to.equal(400);
+      expect(eventController.compareSiteReadings).to.not.have.been.called;
+    });
+
+    it("returns 400 when site_ids exceeds the 100-entry cap", async () => {
+      const app = buildApp();
+      const tooMany = Array.from({ length: 101 }, () => validSiteId1);
+
+      const res = await request(app)
+        .post(`${BASE}/comparisons`)
+        .send({ site_ids: tooMany });
+
+      expect(res.status).to.equal(400);
+      expect(eventController.compareSiteReadings).to.not.have.been.called;
     });
   });
 

--- a/src/device-registry/routes/v2/test/ut_sites_picker.routes.js
+++ b/src/device-registry/routes/v2/test/ut_sites_picker.routes.js
@@ -1,0 +1,175 @@
+require("module-alias/register");
+process.env.NODE_ENV = "development";
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const { expect } = chai;
+const proxyquire = require("proxyquire");
+const express = require("express");
+const request = require("supertest");
+
+chai.use(sinonChai);
+
+// Exercises the real router (routes/v2/sites.routes.js) mounted on a real
+// Express app with real validators — only the controller layer is stubbed.
+// Scoped to the new GET /picker route only (see ut_readings.routes.js for
+// the rationale on driving requests through supertest rather than asserting
+// on router internals). The existing ut_sites.routes.js predates the v2
+// refactor and targets modules that no longer exist (@controllers/create-site,
+// @routes/v2/sites) — left untouched here since fixing it is a separate,
+// unrelated concern from the /picker route this file covers.
+describe("sites.routes.js /picker (mounted at /api/v2/devices/sites)", () => {
+  const BASE = "/api/v2/devices/sites";
+  const validGroupId = "624d2f9a994194001ddccbb6";
+
+  // Every method sites.routes.js references directly at module-load time —
+  // all must exist on the stub or router.get()/router.post() throws while
+  // building the route table, before a single request is ever made.
+  const controllerMethods = [
+    "createApproximateCoordinates",
+    "delete",
+    "findNearestSite",
+    "generateMetadata",
+    "getMySites",
+    "getSiteCountSummary",
+    "getSiteDetailsById",
+    "list",
+    "listDataAvailableSites",
+    "listForComparisonPicker",
+    "listNearestWeatherStation",
+    "listNotTransmittingSites",
+    "listOperationalSites",
+    "listSummary",
+    "listTransmittingSites",
+    "listWeatherStations",
+    "refresh",
+    "register",
+    "update",
+    "updateManySites",
+  ];
+
+  let siteController;
+
+  const buildApp = (controllerOverrides = {}) => {
+    siteController = {};
+    controllerMethods.forEach((method) => {
+      siteController[method] = sinon.stub().callsFake((req, res) => {
+        res.status(200).json({ success: true, calledWith: method });
+      });
+    });
+    Object.assign(siteController, controllerOverrides);
+
+    const router = proxyquire("@routes/v2/sites.routes", {
+      "@controllers/site.controller": siteController,
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use(BASE, router);
+    return app;
+  };
+
+  describe("GET /picker", () => {
+    it("reaches listForComparisonPicker for a valid group_id", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get(`${BASE}/picker`)
+        .query({ group_id: validGroupId });
+
+      expect(res.status).to.equal(200);
+      expect(siteController.listForComparisonPicker).to.have.been.calledOnce;
+    });
+
+    it("returns 400 and never reaches the controller when group_id is missing", async () => {
+      const app = buildApp();
+
+      const res = await request(app).get(`${BASE}/picker`);
+
+      expect(res.status).to.equal(400);
+      expect(siteController.listForComparisonPicker).to.not.have.been.called;
+    });
+
+    it("returns 400 when group_id is not a valid ObjectId", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get(`${BASE}/picker`)
+        .query({ group_id: "not-an-object-id" });
+
+      expect(res.status).to.equal(400);
+      expect(siteController.listForComparisonPicker).to.not.have.been.called;
+    });
+
+    it("returns 400 when limit exceeds the 80 cap", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get(`${BASE}/picker`)
+        .query({ group_id: validGroupId, limit: 81 });
+
+      expect(res.status).to.equal(400);
+      expect(siteController.listForComparisonPicker).to.not.have.been.called;
+    });
+
+    it("returns 400 when limit is below 1", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get(`${BASE}/picker`)
+        .query({ group_id: validGroupId, limit: 0 });
+
+      expect(res.status).to.equal(400);
+      expect(siteController.listForComparisonPicker).to.not.have.been.called;
+    });
+
+    it("returns 400 when skip is negative", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get(`${BASE}/picker`)
+        .query({ group_id: validGroupId, skip: -1 });
+
+      expect(res.status).to.equal(400);
+      expect(siteController.listForComparisonPicker).to.not.have.been.called;
+    });
+
+    it("returns 400 for an invalid sort_by value", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get(`${BASE}/picker`)
+        .query({ group_id: validGroupId, sort_by: "name" });
+
+      expect(res.status).to.equal(400);
+      expect(siteController.listForComparisonPicker).to.not.have.been.called;
+    });
+
+    it("returns 400 for an invalid sort_order value", async () => {
+      const app = buildApp();
+
+      const res = await request(app)
+        .get(`${BASE}/picker`)
+        .query({ group_id: validGroupId, sort_order: "up" });
+
+      expect(res.status).to.equal(400);
+      expect(siteController.listForComparisonPicker).to.not.have.been.called;
+    });
+
+    it("accepts valid sort_by/sort_order/limit/skip/search combinations", async () => {
+      const app = buildApp();
+
+      const res = await request(app).get(`${BASE}/picker`).query({
+        group_id: validGroupId,
+        sort_by: "city",
+        sort_order: "desc",
+        limit: 10,
+        skip: 5,
+        search: "kampala",
+      });
+
+      expect(res.status).to.equal(200);
+      expect(siteController.listForComparisonPicker).to.have.been.calledOnce;
+    });
+  });
+});

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -6627,6 +6627,17 @@ const createEvent = {
   },
 };
 
+// Reverse lookup: AQI_CATEGORIES label (e.g. "Moderate", as stored on
+// reading.aqi_category) -> its lowercase category key ("moderate"). The
+// comparisons contract's aqi.color_name is that lowercase key, not a color
+// word — so this derives it from the reading's own already-computed
+// aqi_category rather than recomputing from the raw concentration, which
+// would silently diverge if a custom admin-configured AQI range (see
+// aqiUtil.resolveActiveAqiRanges) was active when the reading was stored.
+const AQI_CATEGORY_LABEL_TO_KEY = Object.fromEntries(
+  Object.entries(constants.AQI_CATEGORIES).map(([key, label]) => [label, key]),
+);
+
 // POST /readings/comparisons — backs the Nexus comparison table. Returns
 // exactly one entry per requested (deduped) site_id: a real reading when the
 // ReadingModel has one, otherwise a has_reading:false placeholder built from
@@ -6730,7 +6741,9 @@ createEvent.compareSiteReadings = async (request, next) => {
                   category:
                     reading.aqi_category || constants.AQI_CATEGORIES.unknown,
                   color_name:
-                    aqiUtil.categoryFromConcentration(pm2_5Value) || "unknown",
+                    AQI_CATEGORY_LABEL_TO_KEY[reading.aqi_category] ||
+                    aqiUtil.categoryFromConcentration(pm2_5Value) ||
+                    "unknown",
                   color: reading.aqi_color || constants.AQI_COLORS.unknown,
                 }
               : null,

--- a/src/device-registry/utils/event.util.js
+++ b/src/device-registry/utils/event.util.js
@@ -6627,6 +6627,172 @@ const createEvent = {
   },
 };
 
+// POST /readings/comparisons — backs the Nexus comparison table. Returns
+// exactly one entry per requested (deduped) site_id: a real reading when the
+// ReadingModel has one, otherwise a has_reading:false placeholder built from
+// the Site collection (or, if the site itself no longer exists, an
+// all-null placeholder flagged with site.site_exists: false). The contract
+// requires the latest reading "regardless of age" — lookbackDays is set to
+// the full 14-day TTL ceiling (see Reading.js expireAfterSeconds) rather than
+// the tighter DIAGNOSTIC_WINDOW_DAYS default other /recent callers rely on,
+// since there is never older data to miss anyway.
+createEvent.compareSiteReadings = async (request, next) => {
+  try {
+    const { tenant } = request.query;
+    const { site_ids } = request.body;
+    const effectiveTenant = isEmpty(tenant)
+      ? constants.DEFAULT_TENANT || "airqo"
+      : tenant;
+
+    const uniqueSiteIds = [
+      ...new Set(site_ids.map((id) => String(id).trim())),
+    ];
+
+    const readingsResponse = await ReadingModel(effectiveTenant).recent({
+      filter: {
+        site_id: { $in: uniqueSiteIds.map((id) => ObjectId(id)) },
+      },
+      skip: 0,
+      limit: uniqueSiteIds.length,
+      lookbackDays: 14,
+    });
+
+    if (readingsResponse.success === false) {
+      return readingsResponse;
+    }
+
+    const readingsBySiteId = new Map();
+    for (const reading of readingsResponse.data || []) {
+      if (reading && reading.site_id) {
+        readingsBySiteId.set(reading.site_id.toString(), reading);
+      }
+    }
+
+    const missingIds = uniqueSiteIds.filter(
+      (id) => !readingsBySiteId.has(id),
+    );
+
+    let sitesById = new Map();
+    if (missingIds.length > 0) {
+      const sites = await SiteModel(effectiveTenant)
+        .find({ _id: { $in: missingIds.map((id) => ObjectId(id)) } })
+        .select("name location_name city country latitude longitude")
+        .lean();
+      sitesById = new Map(sites.map((s) => [s._id.toString(), s]));
+    }
+
+    const round1 = (value) =>
+      typeof value === "number" && !isNaN(value)
+        ? Math.round(value * 10) / 10
+        : null;
+
+    const now = Date.now();
+
+    const readings = uniqueSiteIds.map((siteId) => {
+      const reading = readingsBySiteId.get(siteId);
+
+      if (reading) {
+        const siteDetails = reading.siteDetails || {};
+        const pm2_5Value =
+          reading.pm2_5 && typeof reading.pm2_5.value === "number"
+            ? reading.pm2_5.value
+            : null;
+        const readingTime = reading.time ? new Date(reading.time) : null;
+
+        return {
+          site_id: siteId,
+          site: {
+            name: siteDetails.name || siteDetails.formatted_name || null,
+            location_name: siteDetails.location_name || null,
+            city: siteDetails.city || null,
+            country: siteDetails.country || null,
+            latitude:
+              typeof siteDetails.approximate_latitude === "number"
+                ? siteDetails.approximate_latitude
+                : null,
+            longitude:
+              typeof siteDetails.approximate_longitude === "number"
+                ? siteDetails.approximate_longitude
+                : null,
+          },
+          has_reading: true,
+          time: readingTime ? readingTime.toISOString() : null,
+          time_difference_hours: readingTime
+            ? round1((now - readingTime.getTime()) / 3600000)
+            : null,
+          aqi:
+            pm2_5Value !== null
+              ? {
+                  index:
+                    typeof reading.aqi_index === "number"
+                      ? reading.aqi_index
+                      : aqiUtil.calculatePm25Aqi(pm2_5Value),
+                  category:
+                    reading.aqi_category || constants.AQI_CATEGORIES.unknown,
+                  color_name:
+                    aqiUtil.categoryFromConcentration(pm2_5Value) || "unknown",
+                  color: reading.aqi_color || constants.AQI_COLORS.unknown,
+                }
+              : null,
+          pollutants: {
+            pm2_5: { value: round1(pm2_5Value) },
+            pm10: { value: round1(reading.pm10 && reading.pm10.value) },
+            no2: { value: round1(reading.no2 && reading.no2.value) },
+          },
+        };
+      }
+
+      const site = sitesById.get(siteId);
+
+      return {
+        site_id: siteId,
+        site: site
+          ? {
+              name: site.name || null,
+              location_name: site.location_name || null,
+              city: site.city || null,
+              country: site.country || null,
+              latitude:
+                typeof site.latitude === "number" ? site.latitude : null,
+              longitude:
+                typeof site.longitude === "number" ? site.longitude : null,
+            }
+          : {
+              name: null,
+              location_name: null,
+              city: null,
+              country: null,
+              latitude: null,
+              longitude: null,
+              site_exists: false,
+            },
+        has_reading: false,
+        time: null,
+        time_difference_hours: null,
+        aqi: null,
+        pollutants: null,
+      };
+    });
+
+    return {
+      success: true,
+      message: "Successfully retrieved comparison readings",
+      data: readings,
+      status: httpStatus.OK,
+    };
+  } catch (error) {
+    logger.error(
+      `🐛🐛 Internal Server Error -- compareSiteReadings: ${error.message}`,
+    );
+    return {
+      success: false,
+      message: "Internal Server Error",
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+      errors: { message: error.message },
+    };
+  }
+};
+
 // Backward-compatible aliases — retained so any caller still using the old
 // versioned names continues to work without modification.
 createEvent.transformMeasurements_v2 = createEvent.normalizeMeasurements;

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -2614,7 +2614,7 @@ const listForComparisonPicker = async (request, next) => {
       meta: {
         total: 0,
         total_pages: 0,
-        page: 1,
+        page: Math.floor(skip / limit) + 1,
         skip,
         limit,
       },

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -2583,10 +2583,142 @@ const getMySites = async (request, next) => {
   }
 };
 
+// GET /sites/picker — the Nexus "Compare locations" site picker: paginated,
+// searchable, sortable, and scoped to a single group_id via the same
+// group -> cohort -> CohortSiteSnapshot -> site resolution getMySites uses
+// above (group_ids plural there vs. a single required group_id here, since
+// the picker is always scoped to the caller's one active group).
+const SITE_PICKER_SORT_FIELDS = {
+  location: "location_name",
+  city: "city",
+  country: "country",
+};
+
+const listForComparisonPicker = async (request, next) => {
+  try {
+    const { tenant } = request.query;
+    const {
+      group_id,
+      search,
+      sort_by = "location",
+      sort_order = "asc",
+    } = request.query;
+    const limit = Math.min(parseInt(request.query.limit, 10) || 6, 80);
+    const skip = Math.max(parseInt(request.query.skip, 10) || 0, 0);
+
+    const emptyResult = (message) => ({
+      success: true,
+      message,
+      data: [],
+      status: httpStatus.OK,
+      meta: {
+        total: 0,
+        total_pages: 1,
+        page: 1,
+        limit,
+      },
+    });
+
+    // 1. Resolve group_id -> linked cohorts
+    const groupCohorts = await CohortModel(tenant)
+      .find({ grp_id: ObjectId(group_id) })
+      .select("_id")
+      .lean();
+    const cohortIds = groupCohorts.map((c) => c._id);
+
+    if (cohortIds.length === 0) {
+      return emptyResult("Sites retrieved successfully");
+    }
+
+    // 2. Resolve cohorts -> site_ids
+    const snapshots = await CohortSiteSnapshotModel(tenant)
+      .find({ cohort_id: { $in: cohortIds }, tenant })
+      .select("site_id")
+      .lean();
+    const siteIds = [
+      ...new Map(
+        snapshots.map((s) => [s.site_id.toString(), s.site_id]),
+      ).values(),
+    ];
+
+    if (siteIds.length === 0) {
+      return emptyResult("Sites retrieved successfully");
+    }
+
+    // 3. Paginated, searchable, sortable site fetch
+    const siteFilter = { _id: { $in: siteIds } };
+    if (!isEmpty(search)) {
+      const regex = new RegExp(search.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+      siteFilter.$or = [
+        { name: regex },
+        { location_name: regex },
+        { city: regex },
+        { country: regex },
+      ];
+    }
+
+    const sortField = SITE_PICKER_SORT_FIELDS[sort_by] || "location_name";
+    const sortDirection = sort_order === "desc" ? -1 : 1;
+
+    const [total, sites] = await Promise.all([
+      SiteModel(tenant).countDocuments(siteFilter),
+      SiteModel(tenant)
+        .find(siteFilter)
+        .select("name location_name city country latitude longitude")
+        .sort({ [sortField]: sortDirection })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+    ]);
+
+    const data = sites.map((site) => ({
+      id: site._id.toString(),
+      name: site.name || null,
+      location: site.location_name || null,
+      city: site.city || null,
+      country: site.country || null,
+      latitude: typeof site.latitude === "number" ? site.latitude : null,
+      longitude: typeof site.longitude === "number" ? site.longitude : null,
+    }));
+
+    return {
+      success: true,
+      message: "Sites retrieved successfully",
+      data,
+      status: httpStatus.OK,
+      meta: {
+        total,
+        total_pages: Math.ceil(total / limit) || 1,
+        page: Math.floor(skip / limit) + 1,
+        limit,
+      },
+    };
+  } catch (error) {
+    logger.error(`🐛🐛 Internal Server Error -- listForComparisonPicker: ${error.message}`);
+
+    if (error.name === "CastError") {
+      return {
+        success: false,
+        message: "Bad Request Error",
+        status: httpStatus.BAD_REQUEST,
+        errors: { message: "group_id has an invalid format" },
+      };
+    }
+
+    return {
+      success: false,
+      message: "Internal Server Error",
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+      errors: { message: error.message },
+    };
+  }
+};
+
 module.exports = {
   ...createSite,
   getSiteCountSummary,
   computeSiteDataProvider,
   refreshSiteDataProvider,
   getMySites,
+  listForComparisonPicker,
 };

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -2613,8 +2613,9 @@ const listForComparisonPicker = async (request, next) => {
       status: httpStatus.OK,
       meta: {
         total: 0,
-        total_pages: 1,
+        total_pages: 0,
         page: 1,
+        skip,
         limit,
       },
     });
@@ -2647,8 +2648,12 @@ const listForComparisonPicker = async (request, next) => {
 
     // 3. Paginated, searchable, sortable site fetch
     const siteFilter = { _id: { $in: siteIds } };
-    if (!isEmpty(search)) {
-      const regex = new RegExp(search.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+    const trimmedSearch = typeof search === "string" ? search.trim() : "";
+    if (!isEmpty(trimmedSearch)) {
+      const regex = new RegExp(
+        trimmedSearch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+        "i",
+      );
       siteFilter.$or = [
         { name: regex },
         { location_name: regex },
@@ -2688,8 +2693,9 @@ const listForComparisonPicker = async (request, next) => {
       status: httpStatus.OK,
       meta: {
         total,
-        total_pages: Math.ceil(total / limit) || 1,
+        total_pages: Math.ceil(total / limit),
         page: Math.floor(skip / limit) + 1,
+        skip,
         limit,
       },
     };

--- a/src/device-registry/utils/test/ut_event.util.js
+++ b/src/device-registry/utils/test/ut_event.util.js
@@ -3622,4 +3622,226 @@ describe("create Event utils", function() {
       expect(request.query.device_id).to.equal("device-1");
     });
   });
+
+  // POST /readings/comparisons — one reading entry guaranteed per requested
+  // site_id, real reading or a has_reading:false placeholder.
+  describe("compareSiteReadings", () => {
+    const proxyquire = require("proxyquire");
+    let proxiedEventUtil;
+    let recentStub;
+    let siteFindStub;
+    let siteSelectStub;
+    let siteLeanStub;
+    let next;
+
+    const siteA = "624d2f9a994194001ddccbb6"; // has a reading
+    const siteB = "623d84340e8054001eaaaa13"; // no reading, site still exists
+    const siteC = "6a1b2c3d4e5f60718293a4b5"; // no reading, site no longer exists
+
+    beforeEach(() => {
+      recentStub = sinon.stub().resolves({ success: true, data: [] });
+      siteLeanStub = sinon.stub().resolves([]);
+      siteSelectStub = sinon.stub().returns({ lean: siteLeanStub });
+      siteFindStub = sinon.stub().returns({ select: siteSelectStub });
+
+      proxiedEventUtil = proxyquire("../event.util", {
+        "@models/Reading": () => ({ recent: recentStub }),
+        "@models/Site": () => ({ find: siteFindStub }),
+      });
+      next = sinon.stub();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("dedupes repeated site_ids and returns exactly one entry per unique id, in first-occurrence order", async () => {
+      recentStub.resolves({ success: true, data: [] });
+      siteLeanStub.resolves([]);
+
+      const result = await proxiedEventUtil.compareSiteReadings(
+        {
+          query: { tenant: "airqo" },
+          body: { site_ids: [siteA, siteB, siteA, siteC] },
+        },
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.have.lengthOf(3);
+      expect(result.data.map((r) => r.site_id)).to.deep.equal([
+        siteA,
+        siteB,
+        siteC,
+      ]);
+
+      // recent() must be asked for the full 14-day TTL window, not the
+      // tighter DIAGNOSTIC_WINDOW_DAYS default other /recent callers use.
+      expect(recentStub.calledOnce).to.be.true;
+      expect(recentStub.args[0][0].lookbackDays).to.equal(14);
+      expect(recentStub.args[0][0].filter.site_id.$in).to.have.lengthOf(3);
+    });
+
+    it("maps a matched reading to has_reading:true with rounded pollutants and a color_name derived from aqi_category, not the raw color name", async () => {
+      const readingTime = new Date(Date.now() - 24 * 60 * 1000); // 24 min ago
+      recentStub.resolves({
+        success: true,
+        data: [
+          {
+            site_id: siteA,
+            time: readingTime,
+            pm2_5: { value: 24.34 },
+            pm10: { value: 41.0 },
+            // no2 intentionally absent
+            siteDetails: {
+              name: "Mukono Health Centre III",
+              location_name: "Mukono",
+              city: "Mukono",
+              country: "Uganda",
+              approximate_latitude: 0.3533,
+              approximate_longitude: 32.7553,
+            },
+            aqi_index: 72,
+            aqi_category: "Moderate",
+            aqi_color: "ECAA06",
+          },
+        ],
+      });
+
+      const result = await proxiedEventUtil.compareSiteReadings(
+        { query: { tenant: "airqo" }, body: { site_ids: [siteA] } },
+        next
+      );
+
+      const row = result.data[0];
+      expect(row.has_reading).to.equal(true);
+      expect(row.site).to.deep.equal({
+        name: "Mukono Health Centre III",
+        location_name: "Mukono",
+        city: "Mukono",
+        country: "Uganda",
+        latitude: 0.3533,
+        longitude: 32.7553,
+      });
+      expect(row.pollutants).to.deep.equal({
+        pm2_5: { value: 24.3 },
+        pm10: { value: 41 },
+        no2: { value: null },
+      });
+      expect(row.aqi.index).to.equal(72);
+      expect(row.aqi.category).to.equal("Moderate");
+      expect(row.aqi.color).to.equal("ECAA06");
+      // "Moderate" -> "moderate": the contract's color_name is the lowercase
+      // category key, not a human color word (AQI_COLOR_NAMES.moderate is
+      // "Yellow") — and it must come from this reading's own aqi_category,
+      // not a fresh recompute that could disagree under a custom AQI config.
+      expect(row.aqi.color_name).to.equal("moderate");
+      expect(row.time_difference_hours).to.be.closeTo(0.4, 0.05);
+    });
+
+    it("falls back to categoryFromConcentration for color_name when aqi_category is missing", async () => {
+      recentStub.resolves({
+        success: true,
+        data: [
+          {
+            site_id: siteA,
+            time: new Date(),
+            pm2_5: { value: 5 }, // within the "good" band
+            siteDetails: {},
+          },
+        ],
+      });
+
+      const result = await proxiedEventUtil.compareSiteReadings(
+        { query: { tenant: "airqo" }, body: { site_ids: [siteA] } },
+        next
+      );
+
+      expect(result.data[0].aqi.color_name).to.equal("good");
+    });
+
+    it("returns a has_reading:false row backed by the Site collection when a site has no matching reading", async () => {
+      recentStub.resolves({ success: true, data: [] });
+      siteLeanStub.resolves([
+        {
+          _id: siteB,
+          name: "Bwaise Police Post",
+          location_name: "Bwaise",
+          city: "Kampala",
+          country: "Uganda",
+          latitude: 0.3512,
+          longitude: 32.5678,
+        },
+      ]);
+
+      const result = await proxiedEventUtil.compareSiteReadings(
+        { query: { tenant: "airqo" }, body: { site_ids: [siteB] } },
+        next
+      );
+
+      const row = result.data[0];
+      expect(row.has_reading).to.equal(false);
+      expect(row.time).to.be.null;
+      expect(row.aqi).to.be.null;
+      expect(row.pollutants).to.be.null;
+      expect(row.site).to.deep.equal({
+        name: "Bwaise Police Post",
+        location_name: "Bwaise",
+        city: "Kampala",
+        country: "Uganda",
+        latitude: 0.3512,
+        longitude: 32.5678,
+      });
+      expect(row.site.site_exists).to.be.undefined;
+    });
+
+    it("flags site.site_exists:false when a site has no reading and no longer exists in the Site collection", async () => {
+      recentStub.resolves({ success: true, data: [] });
+      siteLeanStub.resolves([]); // siteC not found anywhere
+
+      const result = await proxiedEventUtil.compareSiteReadings(
+        { query: { tenant: "airqo" }, body: { site_ids: [siteC] } },
+        next
+      );
+
+      const row = result.data[0];
+      expect(row.has_reading).to.equal(false);
+      expect(row.site.site_exists).to.equal(false);
+      expect(row.site.name).to.be.null;
+    });
+
+    it("only queries the Site collection for sites missing a reading, not for every requested site", async () => {
+      recentStub.resolves({
+        success: true,
+        data: [{ site_id: siteA, time: new Date(), pm2_5: { value: 10 }, siteDetails: {} }],
+      });
+      siteLeanStub.resolves([]);
+
+      await proxiedEventUtil.compareSiteReadings(
+        { query: { tenant: "airqo" }, body: { site_ids: [siteA, siteB] } },
+        next
+      );
+
+      expect(siteFindStub.calledOnce).to.be.true;
+      const missingIdFilter = siteFindStub.args[0][0]._id.$in;
+      expect(missingIdFilter).to.have.lengthOf(1);
+      expect(missingIdFilter[0].toString()).to.equal(siteB);
+    });
+
+    it("returns an error result (without throwing) when ReadingModel.recent fails", async () => {
+      recentStub.resolves({
+        success: false,
+        status: 500,
+        message: "Internal Server Error",
+        errors: { message: "db unavailable" },
+      });
+
+      const result = await proxiedEventUtil.compareSiteReadings(
+        { query: { tenant: "airqo" }, body: { site_ids: [siteA] } },
+        next
+      );
+
+      expect(result.success).to.equal(false);
+    });
+  });
 });

--- a/src/device-registry/utils/test/ut_site.util.js
+++ b/src/device-registry/utils/test/ut_site.util.js
@@ -839,4 +839,226 @@ describe("createSite Util Functions", () => {
       expect(next.calledOnce).to.be.true;
     });
   });
+
+  // GET /sites/picker — the Nexus "Compare locations" site picker.
+  describe("listForComparisonPicker", () => {
+    const proxyquire = require("proxyquire");
+    let proxiedSiteUtil;
+    let cohortLeanStub;
+    let snapshotLeanStub;
+    let siteCountStub;
+    let siteSortStub;
+    let siteSkipStub;
+    let siteLimitStub;
+    let siteLeanStub;
+    let siteFindStub;
+    let next;
+
+    const groupId = "624d2f9a994194001ddccbb6";
+    const cohortId1 = "60d5f77bcf86cd799439011";
+    const cohortId2 = "60d5f77bcf86cd799439012";
+    const siteId1 = "623d84340e8054001eaaaa13";
+    const siteId2 = "6a1b2c3d4e5f60718293a4b5";
+
+    const buildRequest = (query = {}) => ({
+      query: { tenant: "airqo", group_id: groupId, ...query },
+    });
+
+    beforeEach(() => {
+      cohortLeanStub = sinon.stub().resolves([]);
+      snapshotLeanStub = sinon.stub().resolves([]);
+      siteLeanStub = sinon.stub().resolves([]);
+      siteLimitStub = sinon.stub().returns({ lean: siteLeanStub });
+      siteSkipStub = sinon.stub().returns({ limit: siteLimitStub });
+      siteSortStub = sinon.stub().returns({ skip: siteSkipStub });
+      siteFindStub = sinon.stub().returns({ sort: siteSortStub });
+      // .select(...) is called right after .find(...) for both site queries
+      // below — chain it onto whatever .find() returned so both the
+      // sort/skip/limit/lean path (the paginated list) and a direct .lean()
+      // (not used here, but keeps the stub shape honest) stay reachable.
+      const siteSelectStub = sinon.stub().callsFake(() => ({
+        sort: siteSortStub,
+      }));
+      siteCountStub = sinon.stub().resolves(0);
+
+      proxiedSiteUtil = proxyquire("../site.util", {
+        "@models/Cohort": () => ({
+          find: sinon.stub().returns({
+            select: sinon.stub().returns({ lean: cohortLeanStub }),
+          }),
+        }),
+        "@models/CohortSiteSnapshot": () => ({
+          find: sinon.stub().returns({
+            select: sinon.stub().returns({ lean: snapshotLeanStub }),
+          }),
+        }),
+        "@models/Site": () => ({
+          countDocuments: siteCountStub,
+          find: sinon.stub().returns({ select: siteSelectStub }),
+        }),
+      });
+      next = sinon.stub();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("returns an empty, zero-page result when group_id resolves to no cohorts", async () => {
+      cohortLeanStub.resolves([]);
+
+      const result = await proxiedSiteUtil.listForComparisonPicker(
+        buildRequest(),
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.deep.equal([]);
+      expect(result.meta).to.deep.equal({
+        total: 0,
+        total_pages: 0,
+        page: 1,
+        skip: 0,
+        limit: 6,
+      });
+      expect(siteCountStub.called).to.be.false;
+    });
+
+    it("returns an empty, zero-page result when the resolved cohorts have no site snapshots", async () => {
+      cohortLeanStub.resolves([{ _id: cohortId1 }]);
+      snapshotLeanStub.resolves([]);
+
+      const result = await proxiedSiteUtil.listForComparisonPicker(
+        buildRequest(),
+        next
+      );
+
+      expect(result.data).to.deep.equal([]);
+      expect(result.meta.total_pages).to.equal(0);
+    });
+
+    it("dedupes site_ids across snapshots and returns paginated, mapped site rows", async () => {
+      cohortLeanStub.resolves([{ _id: cohortId1 }, { _id: cohortId2 }]);
+      // Same site_id linked via two different cohorts — must be deduped
+      // before hitting SiteModel.
+      snapshotLeanStub.resolves([
+        { site_id: siteId1 },
+        { site_id: siteId1 },
+        { site_id: siteId2 },
+      ]);
+      siteCountStub.resolves(2);
+      siteLeanStub.resolves([
+        {
+          _id: siteId1,
+          name: "Mukono Health Centre III",
+          location_name: "Mukono",
+          city: "Mukono",
+          country: "Uganda",
+          latitude: 0.3533,
+          longitude: 32.7553,
+        },
+      ]);
+
+      const result = await proxiedSiteUtil.listForComparisonPicker(
+        buildRequest({ limit: 10, skip: 0 }),
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      expect(result.data).to.deep.equal([
+        {
+          id: siteId1,
+          name: "Mukono Health Centre III",
+          location: "Mukono",
+          city: "Mukono",
+          country: "Uganda",
+          latitude: 0.3533,
+          longitude: 32.7553,
+        },
+      ]);
+      expect(result.meta).to.deep.equal({
+        total: 2,
+        total_pages: 1,
+        page: 1,
+        skip: 0,
+        limit: 10,
+      });
+
+      const siteFilterArg = siteCountStub.args[0][0];
+      expect(siteFilterArg._id.$in).to.have.lengthOf(2);
+    });
+
+    it("caps limit at 80 and defaults it to 6 when not provided", async () => {
+      cohortLeanStub.resolves([{ _id: cohortId1 }]);
+      snapshotLeanStub.resolves([{ site_id: siteId1 }]);
+
+      await proxiedSiteUtil.listForComparisonPicker(
+        buildRequest({ limit: 500 }),
+        next
+      );
+      expect(siteLimitStub.args[0][0]).to.equal(80);
+
+      await proxiedSiteUtil.listForComparisonPicker(buildRequest(), next);
+      expect(siteLimitStub.args[1][0]).to.equal(6);
+    });
+
+    it("only applies the $or search filter for a non-blank, trimmed search term", async () => {
+      cohortLeanStub.resolves([{ _id: cohortId1 }]);
+      snapshotLeanStub.resolves([{ site_id: siteId1 }]);
+      const siteFindSpy = sinon.stub().returns({
+        select: sinon.stub().callsFake(() => ({ sort: siteSortStub })),
+      });
+      proxiedSiteUtil = proxyquire("../site.util", {
+        "@models/Cohort": () => ({
+          find: sinon.stub().returns({
+            select: sinon.stub().returns({ lean: cohortLeanStub }),
+          }),
+        }),
+        "@models/CohortSiteSnapshot": () => ({
+          find: sinon.stub().returns({
+            select: sinon.stub().returns({ lean: snapshotLeanStub }),
+          }),
+        }),
+        "@models/Site": () => ({
+          countDocuments: siteCountStub,
+          find: siteFindSpy,
+        }),
+      });
+
+      // Whitespace-only search must NOT add an $or filter.
+      await proxiedSiteUtil.listForComparisonPicker(
+        buildRequest({ search: "   " }),
+        next
+      );
+      expect(siteFindSpy.args[0][0].$or).to.be.undefined;
+
+      // A real search term must add the $or filter.
+      await proxiedSiteUtil.listForComparisonPicker(
+        buildRequest({ search: "kampala" }),
+        next
+      );
+      expect(siteFindSpy.args[1][0].$or).to.be.an("array");
+    });
+
+    it("maps sort_by to the underlying field and sort_order to a mongo direction", async () => {
+      cohortLeanStub.resolves([{ _id: cohortId1 }]);
+      snapshotLeanStub.resolves([{ site_id: siteId1 }]);
+
+      await proxiedSiteUtil.listForComparisonPicker(
+        buildRequest({ sort_by: "city", sort_order: "desc" }),
+        next
+      );
+
+      expect(siteSortStub.args[0][0]).to.deep.equal({ city: -1 });
+    });
+
+    it("defaults sorting to location_name ascending when sort_by/sort_order are omitted", async () => {
+      cohortLeanStub.resolves([{ _id: cohortId1 }]);
+      snapshotLeanStub.resolves([{ site_id: siteId1 }]);
+
+      await proxiedSiteUtil.listForComparisonPicker(buildRequest(), next);
+
+      expect(siteSortStub.args[0][0]).to.deep.equal({ location_name: 1 });
+    });
+  });
 });

--- a/src/device-registry/utils/test/ut_site.util.js
+++ b/src/device-registry/utils/test/ut_site.util.js
@@ -937,6 +937,17 @@ describe("createSite Util Functions", () => {
       expect(result.meta.total_pages).to.equal(0);
     });
 
+    it("reports the actually-requested page (not always 1) on an empty result", async () => {
+      cohortLeanStub.resolves([]);
+
+      const result = await proxiedSiteUtil.listForComparisonPicker(
+        buildRequest({ skip: 12, limit: 6 }),
+        next
+      );
+
+      expect(result.meta.page).to.equal(3);
+    });
+
     it("dedupes site_ids across snapshots and returns paginated, mapped site rows", async () => {
       cohortLeanStub.resolves([{ _id: cohortId1 }, { _id: cohortId2 }]);
       // Same site_id linked via two different cohorts — must be deduped

--- a/src/device-registry/validators/readings.validators.js
+++ b/src/device-registry/validators/readings.validators.js
@@ -842,6 +842,27 @@ const readingsValidations = {
     const middleware = createValidationMiddleware(validationRules);
     executeMiddlewareSequentially(middleware, req, res, next);
   },
+
+  // POST /readings/comparisons — latest reading per requested site, one
+  // entry guaranteed per id (site_ids.* not deduped here; the util layer
+  // dedupes server-side per the comparisons contract).
+  comparisons: (req, res, next) => {
+    const validationRules = [
+      ...commonValidations.tenant,
+      body("site_ids")
+        .exists()
+        .withMessage("site_ids is required")
+        .bail()
+        .isArray({ min: 1, max: 100 })
+        .withMessage("site_ids must contain between 1 and 100 entries"),
+      body("site_ids.*")
+        .isMongoId()
+        .withMessage("each entry in site_ids must be a valid ObjectId"),
+    ];
+
+    const middleware = createValidationMiddleware(validationRules);
+    executeMiddlewareSequentially(middleware, req, res, next);
+  },
 };
 
 const validateGetRepresentativeAQForGrid = [

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -567,6 +567,38 @@ const validateGetMySites = [
     .customSanitizer((value) => ObjectId(value)),
 ];
 
+// GET /sites/picker — the Nexus "Compare locations" site picker. Contract:
+// group_id required, limit default 6 capped at 80, sort_by restricted to the
+// fields the picker actually offers (Location/City/Country).
+const validateSitesPicker = [
+  query("group_id")
+    .exists()
+    .withMessage("group_id is required")
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage("group_id must be an object ID"),
+  query("limit")
+    .optional()
+    .isInt({ min: 1, max: 80 })
+    .withMessage("limit must be between 1 and 80")
+    .toInt(),
+  query("skip")
+    .optional()
+    .isInt({ min: 0 })
+    .withMessage("skip must be >= 0")
+    .toInt(),
+  query("search").optional().isString().withMessage("search must be a string").trim(),
+  query("sort_by")
+    .optional()
+    .isIn(["location", "city", "country"])
+    .withMessage("sort_by must be one of: location, city, country"),
+  query("sort_order")
+    .optional()
+    .isIn(["asc", "desc"])
+    .withMessage("sort_order must be one of: asc, desc"),
+];
+
 const validateGetSiteCountSummary = [
   query("group_id")
     .optional()
@@ -618,4 +650,5 @@ module.exports = {
   validateSiteIdParam,
   validateCategoryField,
   validateGetMySites,
+  validateSitesPicker,
 };


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds two new read-only endpoints to device-registry backing the AirQo Nexus
"Compare locations" feature:

- `GET /api/v2/devices/sites/picker` — a paginated, searchable, sortable,
  group-scoped site list for the comparison site picker (default page size 6,
  capped at 80).
- `POST /api/v2/devices/readings/comparisons` — given a list of `site_ids`,
  returns exactly one reading entry per requested site (a real latest
  reading, or a `has_reading:false` placeholder when a site has no recent
  reading or no longer exists), with AQI index/category/color and
  PM2.5/PM10/NO2 values.

Both endpoints are purely additive — no existing route, controller, or
validator behaviour was changed.

### Why is this change needed?

The Nexus Comparison tab is currently disabled in the UI pending this
backend contract. It needs a site picker scoped to the user's group and a
readings endpoint that guarantees one row per selected site (including
"no reading" sites, which must render as an honest row rather than being
silently dropped) — neither of which the existing site-listing or
`/readings/recent` endpoints provide as-is.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only.

A companion PR for `auth-service` (new saved-comparisons CRUD resource that
consumes these two endpoints from the frontend) will follow separately.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** New code was checked with `node --check` for syntax
correctness and cross-referenced against existing sibling endpoints
(`getMySites`, `/readings/recent`) for pattern consistency. No unit tests
were added and no live/manual request testing has been done yet — please run
the existing device-registry test suite and a manual smoke test against a
real environment before merging.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Both endpoints are new routes; no existing endpoint, model field, or
response shape was modified.

---

## :memo: Additional Notes

- Neither endpoint adds authentication to device-registry — consistent with
  the rest of this service, auth is handled upstream at the nginx gateway.
  Site scoping for the picker is enforced via `group_id` → cohort →
  `CohortSiteSnapshot` resolution (the same mechanism `getMySites` already
  uses), not via a JWT/group-membership check.
- No new environment variables are required for this PR.
- `latitude`/`longitude` returned by the readings-comparison endpoint come
  from the reading's embedded (approximate) site snapshot rather than the
  Site collection's exact coordinates, to avoid an extra query per request.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a site picker for selecting locations available for comparison, with search, sorting, and pagination.
  * Added comparison readings for up to 100 selected sites.
  * Comparison results include recent readings, air quality details, site metadata, and clear indicators when readings or sites are unavailable.
  * Added validation to provide clearer feedback for invalid comparison requests and picker filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->