### PR TITLE
Add saved comparisons CRUD resource to auth-service

### DIFF
--- a/src/auth-service/controllers/comparison.controller.js
+++ b/src/auth-service/controllers/comparison.controller.js
@@ -1,0 +1,193 @@
+const comparisonUtil = require("@utils/comparison.util");
+const {
+  logText,
+  HttpError,
+  extractErrorsFromRequest,
+} = require("@utils/shared");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+const httpStatus = require("http-status");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- create-comparison-controller`
+);
+
+const withDefaultTenant = (req) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  req.query.tenant = isEmpty(req.query.tenant) ? defaultTenant : req.query.tenant;
+  return req;
+};
+
+const createComparison = {
+  create: async (req, res, next) => {
+    try {
+      logText("creating comparison.....");
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = withDefaultTenant(req);
+      const result = await comparisonUtil.create(request, next);
+
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success === true) {
+        // createSuccessResponse() always sets status 200 for "create" — this
+        // endpoint's contract requires 201, so it's forced here rather than
+        // deferred to result.status.
+        return res.status(httpStatus.CREATED).json({
+          success: true,
+          message: result.message || "Comparison created",
+          comparison: result.data,
+        });
+      }
+      return res.status(result.status || httpStatus.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: result.message || "",
+        errors: result.errors || { message: "Internal Server Error" },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  list: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = withDefaultTenant(req);
+      const result = await comparisonUtil.list(request, next);
+
+      if (isEmpty(result) || res.headersSent) return;
+      const status = result.status || httpStatus.OK;
+      if (result.success === true) {
+        return res.status(status).json({
+          success: true,
+          message: result.message || "",
+          comparisons: result.data || [],
+          meta: result.meta || {},
+        });
+      }
+      return res.status(status).json({
+        success: false,
+        message: result.message || "",
+        errors: result.errors || { message: "Internal Server Error" },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  getById: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = withDefaultTenant(req);
+      const result = await comparisonUtil.getById(request, next);
+
+      if (isEmpty(result) || res.headersSent) return;
+      const status = result.status || httpStatus.OK;
+      if (result.success === true) {
+        return res.status(status).json({
+          success: true,
+          message: result.message || "",
+          comparison: result.data,
+        });
+      }
+      return res.status(status).json({
+        success: false,
+        message: result.message || "",
+        errors: result.errors || { message: "Internal Server Error" },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  update: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = withDefaultTenant(req);
+      const result = await comparisonUtil.update(request, next);
+
+      if (isEmpty(result) || res.headersSent) return;
+      const status = result.status || httpStatus.OK;
+      if (result.success === true) {
+        return res.status(status).json({
+          success: true,
+          message: result.message || "",
+          comparison: result.data,
+        });
+      }
+      return res.status(status).json({
+        success: false,
+        message: result.message || "",
+        errors: result.errors || { message: "Internal Server Error" },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+
+  delete: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(new HttpError("bad request errors", httpStatus.BAD_REQUEST, errors));
+        return;
+      }
+      const request = withDefaultTenant(req);
+      const result = await comparisonUtil.remove(request, next);
+
+      if (isEmpty(result) || res.headersSent) return;
+      if (result.success === true) {
+        return res.status(httpStatus.NO_CONTENT).send();
+      }
+      const status = result.status || httpStatus.INTERNAL_SERVER_ERROR;
+      return res.status(status).json({
+        success: false,
+        message: result.message || "",
+        errors: result.errors || { message: "Internal Server Error" },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError("Internal Server Error", httpStatus.INTERNAL_SERVER_ERROR, {
+          message: error.message,
+        })
+      );
+    }
+  },
+};
+
+module.exports = createComparison;

--- a/src/auth-service/models/Comparison.js
+++ b/src/auth-service/models/Comparison.js
@@ -1,0 +1,220 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+const isEmpty = require("is-empty");
+const httpStatus = require("http-status");
+const constants = require("@config/constants");
+const { getModelByTenant } = require("@config/database");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- create-comparison-model`
+);
+const { logObject } = require("@utils/shared");
+const {
+  createSuccessResponse,
+  createErrorResponse,
+  createNotFoundResponse,
+  createEmptySuccessResponse,
+} = require("@utils/shared");
+
+// Display snapshot taken at save time — lets a saved comparison still render
+// a meaningful picker pre-selection even if a site is later renamed or
+// removed from the network. The readings endpoint resolves current truth
+// separately, at load time.
+const ComparisonSiteSchema = new Schema(
+  {
+    id: { type: String, required: true },
+    name: { type: String },
+    location: { type: String },
+    city: { type: String },
+    country: { type: String },
+    latitude: { type: Number },
+    longitude: { type: Number },
+  },
+  { _id: false }
+);
+
+const ComparisonSchema = new Schema(
+  {
+    user_id: {
+      type: Schema.Types.ObjectId,
+      required: [true, "user_id is required"],
+    },
+    group_id: {
+      type: Schema.Types.ObjectId,
+      required: [true, "group_id is required"],
+    },
+    name: {
+      type: String,
+      trim: true,
+      required: [true, "name is required"],
+      minlength: 1,
+      maxlength: 120,
+    },
+    // Preserves the user's chosen order (e.g. picker selection order) —
+    // the client expects site_ids back in the same order it sent them.
+    site_ids: {
+      type: [String],
+      required: [true, "site_ids is required"],
+      validate: {
+        validator: (value) => Array.isArray(value) && value.length >= 1 && value.length <= 80,
+        message: "site_ids must contain between 1 and 80 entries",
+      },
+    },
+    sites: { type: [ComparisonSiteSchema], default: [] },
+  },
+  { timestamps: true }
+);
+
+ComparisonSchema.index({ user_id: 1, group_id: 1, updatedAt: -1 });
+
+ComparisonSchema.statics = {
+  async register(args, next) {
+    try {
+      const data = await this.create({ ...args });
+
+      if (!isEmpty(data)) {
+        return createSuccessResponse("create", data, "comparison", {
+          message: "Comparison created",
+        });
+      }
+      return createEmptySuccessResponse(
+        "comparison",
+        "operation successful but comparison NOT successfully created"
+      );
+    } catch (err) {
+      logObject("the error", err);
+      logger.error(`🐛🐛 Internal Server Error -- ${err.message}`);
+
+      if (err.name === "ValidationError") {
+        const response = {};
+        Object.entries(err.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+        });
+        return {
+          success: false,
+          message: "validation errors for some of the provided fields",
+          status: httpStatus.BAD_REQUEST,
+          errors: response,
+        };
+      }
+
+      return createErrorResponse(err, "create", logger, "comparison");
+    }
+  },
+
+  async list({ skip = 0, limit = 20, filter = {} } = {}, next) {
+    try {
+      const totalCount = await this.countDocuments(filter);
+
+      const data = await this.find(filter)
+        .sort({ updatedAt: -1 })
+        .skip(skip ? skip : 0)
+        .limit(limit ? limit : 20)
+        .lean();
+
+      return {
+        success: true,
+        data,
+        message: "successfully listed the comparisons",
+        status: httpStatus.OK,
+        meta: {
+          total: totalCount,
+          total_pages: Math.ceil(totalCount / limit) || 1,
+          page: Math.floor(skip / limit) + 1,
+          limit,
+        },
+      };
+    } catch (error) {
+      return createErrorResponse(error, "list", logger, "comparison");
+    }
+  },
+
+  async modify({ filter = {}, update = {} } = {}, next) {
+    try {
+      const options = { new: true, runValidators: true, context: "query" };
+
+      const updatedComparison = await this.findOneAndUpdate(
+        filter,
+        update,
+        options
+      ).exec();
+
+      if (!isEmpty(updatedComparison)) {
+        return createSuccessResponse(
+          "update",
+          updatedComparison._doc,
+          "comparison"
+        );
+      }
+      return createNotFoundResponse(
+        "comparison",
+        "update",
+        "Comparison does not exist, please crosscheck"
+      );
+    } catch (error) {
+      if (error.name === "ValidationError") {
+        const response = {};
+        Object.entries(error.errors).forEach(([key, value]) => {
+          response[key] = value.message;
+        });
+        return {
+          success: false,
+          message: "validation errors for some of the provided fields",
+          status: httpStatus.BAD_REQUEST,
+          errors: response,
+        };
+      }
+      return createErrorResponse(error, "update", logger, "comparison");
+    }
+  },
+
+  async remove({ filter = {} } = {}, next) {
+    try {
+      const removedComparison = await this.findOneAndRemove(filter).exec();
+
+      if (!isEmpty(removedComparison)) {
+        return createSuccessResponse(
+          "delete",
+          removedComparison._doc,
+          "comparison",
+          { message: "Successfully removed the comparison" }
+        );
+      }
+      return createNotFoundResponse(
+        "comparison",
+        "delete",
+        "Comparison does not exist, please crosscheck"
+      );
+    } catch (error) {
+      return createErrorResponse(error, "delete", logger, "comparison");
+    }
+  },
+};
+
+ComparisonSchema.methods = {
+  toJSON() {
+    return {
+      _id: this._id,
+      id: this._id,
+      user_id: this.user_id,
+      group_id: this.group_id,
+      name: this.name,
+      site_ids: this.site_ids,
+      sites: this.sites,
+      created_at: this.createdAt,
+      updated_at: this.updatedAt,
+    };
+  },
+};
+
+const ComparisonModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant;
+  try {
+    return mongoose.model("comparisons");
+  } catch (error) {
+    return getModelByTenant(dbTenant, "comparison", ComparisonSchema);
+  }
+};
+
+module.exports = ComparisonModel;

--- a/src/auth-service/routes/v2/comparisons.routes.js
+++ b/src/auth-service/routes/v2/comparisons.routes.js
@@ -1,0 +1,46 @@
+// comparisons.routes.js
+const express = require("express");
+const router = express.Router();
+const createComparisonController = require("@controllers/comparison.controller");
+const comparisonValidations = require("@validators/comparisons.validators");
+const { enhancedJWTAuth } = require("@middleware/passport");
+const { headers } = require("@validators/common");
+
+router.use(headers);
+
+router.post(
+  "/",
+  comparisonValidations.create,
+  enhancedJWTAuth,
+  createComparisonController.create
+);
+
+router.get(
+  "/",
+  comparisonValidations.list,
+  enhancedJWTAuth,
+  createComparisonController.list
+);
+
+router.get(
+  "/:comparison_id",
+  comparisonValidations.getById,
+  enhancedJWTAuth,
+  createComparisonController.getById
+);
+
+router.patch(
+  "/:comparison_id",
+  comparisonValidations.update,
+  enhancedJWTAuth,
+  createComparisonController.update
+);
+
+router.delete(
+  "/:comparison_id",
+  comparisonValidations.deleteComparison,
+  enhancedJWTAuth,
+  createComparisonController.delete
+);
+
+module.exports = router;

--- a/src/auth-service/routes/v2/index.js
+++ b/src/auth-service/routes/v2/index.js
@@ -113,6 +113,12 @@ const authRoutes = [
     description: "User favorites management",
   },
   {
+    path: "/comparisons",
+    route: "@routes/v2/comparisons.routes",
+    name: "comparisons",
+    description: "Saved site comparisons management",
+  },
+  {
     path: "/roles",
     route: "@routes/v2/roles.routes",
     name: "roles",
@@ -402,7 +408,7 @@ function getCategoryForRoute(routeName) {
     core: ["users", "roles", "permissions", "tokens"],
     oauth: ["clients", "scopes", "tokens"],
     management: ["networks", "departments", "groups", "tenant-settings"],
-    user_data: ["preferences", "favorites", "locationHistory", "searchHistory"],
+    user_data: ["preferences", "favorites", "comparisons", "locationHistory", "searchHistory"],
     system: ["analytics", "maintenances", "types", "defaults"],
     requests: [
       "requests",

--- a/src/auth-service/utils/comparison.util.js
+++ b/src/auth-service/utils/comparison.util.js
@@ -1,0 +1,277 @@
+const httpStatus = require("http-status");
+const isEmpty = require("is-empty");
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Types.ObjectId;
+const ComparisonModel = require("@models/Comparison");
+const RBACService = require("@services/rbac.service");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- create-comparison-util`
+);
+
+/**
+ * Reshapes a Comparison doc (Mongoose document, `._doc`, or `.lean()`
+ * plain object — the model layer returns all three depending on the
+ * operation) into the contract's resource shape: `id` instead of `_id`,
+ * `created_at`/`updated_at` instead of `createdAt`/`updatedAt`.
+ */
+const toComparisonResponse = (doc) => {
+  if (!doc) return doc;
+  const plain = typeof doc.toObject === "function" ? doc.toObject() : doc;
+  return {
+    id: String(plain._id),
+    user_id: String(plain.user_id),
+    group_id: String(plain.group_id),
+    name: plain.name,
+    site_ids: plain.site_ids,
+    sites: plain.sites,
+    created_at: plain.createdAt,
+    updated_at: plain.updatedAt,
+  };
+};
+
+/**
+ * Builds the `sites` display snapshot from whatever the client sent in
+ * `sites` (its own picker rows already carry name/location/city/country/
+ * lat/lng — see device-registry's GET /sites/picker). Client-authoritative
+ * by design: auth-service does not call device-registry to resolve/verify
+ * site details — AirQo services stay independent, and a service never calls
+ * another service's endpoints to enrich its own data. If the frontend wants
+ * fresher/normalized site info it re-fetches by id itself. Any site_id with
+ * no matching entry in the supplied `sites` falls back to a bare {id}
+ * placeholder rather than failing the save.
+ */
+const buildSiteSnapshots = (siteIds, suppliedSites) => {
+  const bySiteId = new Map(
+    (Array.isArray(suppliedSites) ? suppliedSites : [])
+      .filter((s) => s && s.id)
+      .map((s) => [String(s.id), s])
+  );
+
+  return siteIds.map((id) => {
+    const s = bySiteId.get(id) || {};
+    return {
+      id,
+      name: s.name || null,
+      location: s.location || null,
+      city: s.city || null,
+      country: s.country || null,
+      latitude: typeof s.latitude === "number" ? s.latitude : null,
+      longitude: typeof s.longitude === "number" ? s.longitude : null,
+    };
+  });
+};
+
+const verifyGroupMembership = async (tenant, userId, groupId) => {
+  const rbacService = RBACService.getInstance(tenant);
+  const isSystemSuperAdmin = await rbacService.isSystemSuperAdmin(userId);
+  if (isSystemSuperAdmin) {
+    return true;
+  }
+  return rbacService.isGroupMember(userId, groupId);
+};
+
+const comparisons = {
+  create: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { group_id, name, site_ids, sites } = request.body;
+      const userId = request.user._id;
+
+      const isMember = await verifyGroupMembership(tenant, userId, group_id);
+      if (!isMember) {
+        return {
+          success: false,
+          message: "Forbidden",
+          status: httpStatus.FORBIDDEN,
+          errors: { message: "You do not belong to the specified group" },
+        };
+      }
+
+      const uniqueSiteIds = [...new Set(site_ids)];
+
+      const result = await ComparisonModel(tenant).register({
+        user_id: userId,
+        group_id: ObjectId(group_id),
+        name,
+        site_ids: uniqueSiteIds,
+        sites: buildSiteSnapshots(uniqueSiteIds, sites),
+      });
+
+      if (result.success) {
+        result.data = toComparisonResponse(result.data);
+      }
+      return result;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
+  list: async (request, next) => {
+    try {
+      const { tenant, group_id, search } = request.query;
+      const skip = parseInt(request.query.skip, 10) || 0;
+      const limit = parseInt(request.query.limit, 10) || 20;
+      const userId = request.user._id;
+
+      const isMember = await verifyGroupMembership(tenant, userId, group_id);
+      if (!isMember) {
+        return {
+          success: false,
+          message: "Forbidden",
+          status: httpStatus.FORBIDDEN,
+          errors: { message: "You do not belong to the specified group" },
+        };
+      }
+
+      const filter = { user_id: ObjectId(userId), group_id: ObjectId(group_id) };
+      if (!isEmpty(search)) {
+        filter.name = new RegExp(search.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+      }
+
+      const result = await ComparisonModel(tenant).list({ skip, limit, filter });
+      if (result.success) {
+        result.data = (result.data || []).map(toComparisonResponse);
+      }
+      return result;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
+  /**
+   * Fetches one comparison and enforces ownership. Returns a tagged result
+   * ({ success:false, status:404 } vs. 403) rather than throwing, so
+   * getById/update/remove all report the exact status the contract requires
+   * (404 unknown id, 403 someone else's comparison).
+   */
+  _findOwned: async (tenant, comparisonId, userId) => {
+    const doc = await ComparisonModel(tenant).findById(comparisonId).lean();
+    if (isEmpty(doc)) {
+      return {
+        success: false,
+        status: httpStatus.NOT_FOUND,
+        message: "Comparison not found",
+        errors: { message: "Comparison does not exist" },
+      };
+    }
+    if (doc.user_id.toString() !== userId.toString()) {
+      return {
+        success: false,
+        status: httpStatus.FORBIDDEN,
+        message: "Forbidden",
+        errors: { message: "This comparison belongs to another user" },
+      };
+    }
+    return { success: true, data: doc };
+  },
+
+  // GET /comparisons/{id} returns the saved selection only — readings are
+  // not resolved here. Loading a saved comparison is a two-call sequence on
+  // the client: GET this, then POST the returned site_ids to device-registry's
+  // /readings/comparisons. auth-service does not call device-registry itself
+  // (see buildSiteSnapshots comment — services stay independent; only ids
+  // cross the boundary, the frontend composes the calls).
+  getById: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { comparison_id } = request.params;
+      const userId = request.user._id;
+
+      const owned = await comparisons._findOwned(tenant, comparison_id, userId);
+      if (owned.success) {
+        owned.data = toComparisonResponse(owned.data);
+      }
+      return owned;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
+  update: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { comparison_id } = request.params;
+      const { name, site_ids, sites } = request.body;
+      const userId = request.user._id;
+
+      const owned = await comparisons._findOwned(tenant, comparison_id, userId);
+      if (!owned.success) {
+        return owned;
+      }
+
+      const update = {};
+      if (!isEmpty(name)) {
+        update.name = name;
+      }
+      if (Array.isArray(site_ids)) {
+        const uniqueSiteIds = [...new Set(site_ids)];
+        update.site_ids = uniqueSiteIds;
+        update.sites = buildSiteSnapshots(uniqueSiteIds, sites);
+      }
+
+      const result = await ComparisonModel(tenant).modify({
+        filter: { _id: comparison_id },
+        update,
+      });
+      if (result.success) {
+        result.data = toComparisonResponse(result.data);
+      }
+      return result;
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+
+  remove: async (request, next) => {
+    try {
+      const { tenant } = request.query;
+      const { comparison_id } = request.params;
+      const userId = request.user._id;
+
+      const owned = await comparisons._findOwned(tenant, comparison_id, userId);
+      if (!owned.success) {
+        return owned;
+      }
+
+      return await ComparisonModel(tenant).remove({
+        filter: { _id: comparison_id },
+      });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error -- ${error.message}`);
+      return {
+        success: false,
+        message: "Internal Server Error",
+        status: httpStatus.INTERNAL_SERVER_ERROR,
+        errors: { message: error.message },
+      };
+    }
+  },
+};
+
+module.exports = comparisons;

--- a/src/auth-service/validators/comparisons.validators.js
+++ b/src/auth-service/validators/comparisons.validators.js
@@ -1,0 +1,145 @@
+// comparisons.validators.js
+const { query, body, param, oneOf } = require("express-validator");
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Types.ObjectId;
+const constants = require("@config/constants");
+
+const validateTenant = oneOf([
+  query("tenant")
+    .optional()
+    .notEmpty()
+    .withMessage("tenant should not be empty if provided")
+    .trim()
+    .toLowerCase()
+    .bail()
+    .isIn(constants.TENANTS)
+    .withMessage("the tenant value is not among the expected ones"),
+]);
+
+const siteIdsBody = (fieldPath = "site_ids", optional = false) => {
+  const arrayCheck = body(fieldPath).isArray({ min: 1, max: 80 }).withMessage(
+    `${fieldPath} must contain between 1 and 80 entries`
+  );
+  const entryCheck = body(`${fieldPath}.*`)
+    .isString()
+    .withMessage(`each entry in ${fieldPath} must be a string`)
+    .trim()
+    .notEmpty()
+    .withMessage(`each entry in ${fieldPath} must not be empty`);
+
+  return optional
+    ? [arrayCheck.optional(), entryCheck.optional()]
+    : [arrayCheck, entryCheck];
+};
+
+// Optional client-supplied display snapshot for each site (name/location/
+// city/country/lat/lng) — the same row shape device-registry's
+// GET /sites/picker returns. auth-service does not call device-registry to
+// resolve or verify these; it stores what the client sends as-is (see
+// buildSiteSnapshots in comparison.util.js) so the two services never call
+// each other directly.
+const sitesBody = (fieldPath = "sites") => [
+  body(fieldPath)
+    .optional()
+    .isArray({ max: 80 })
+    .withMessage(`${fieldPath} must be an array of at most 80 entries`),
+  body(`${fieldPath}.*.id`)
+    .optional()
+    .isString()
+    .withMessage("each site snapshot entry must include a string id")
+    .trim()
+    .notEmpty(),
+  body(`${fieldPath}.*.name`).optional().isString().trim(),
+  body(`${fieldPath}.*.location`).optional().isString().trim(),
+  body(`${fieldPath}.*.city`).optional().isString().trim(),
+  body(`${fieldPath}.*.country`).optional().isString().trim(),
+  body(`${fieldPath}.*.latitude`)
+    .optional()
+    .isFloat({ min: -90, max: 90 })
+    .withMessage("latitude must be between -90 and 90"),
+  body(`${fieldPath}.*.longitude`)
+    .optional()
+    .isFloat({ min: -180, max: 180 })
+    .withMessage("longitude must be between -180 and 180"),
+];
+
+const create = [
+  validateTenant,
+  body("group_id")
+    .exists()
+    .withMessage("group_id is missing in your request")
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage("group_id must be an object ID"),
+  body("name")
+    .exists()
+    .withMessage("name is missing in your request")
+    .bail()
+    .trim()
+    .isLength({ min: 1, max: 120 })
+    .withMessage("name must be between 1 and 120 characters"),
+  ...siteIdsBody("site_ids"),
+  ...sitesBody("sites"),
+];
+
+const list = [
+  validateTenant,
+  query("group_id")
+    .exists()
+    .withMessage("group_id is missing in your request")
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage("group_id must be an object ID"),
+  query("limit").optional().isInt({ min: 1, max: 100 }).toInt(),
+  query("skip").optional().isInt({ min: 0 }).toInt(),
+  query("search").optional().isString().trim(),
+];
+
+const comparisonIdParam = [
+  param("comparison_id")
+    .exists()
+    .withMessage(
+      "the comparison_id param is missing in the request path"
+    )
+    .bail()
+    .trim()
+    .isMongoId()
+    .withMessage("comparison_id must be an object ID"),
+];
+
+const getById = [validateTenant, ...comparisonIdParam];
+
+const update = [
+  validateTenant,
+  ...comparisonIdParam,
+  (req, res, next) => {
+    if (!Object.keys(req.body || {}).length) {
+      return res.status(400).json({
+        success: false,
+        message: "bad request errors",
+        errors: { message: "request body must contain name and/or site_ids" },
+      });
+    }
+    next();
+  },
+  body("name")
+    .optional()
+    .trim()
+    .isLength({ min: 1, max: 120 })
+    .withMessage("name must be between 1 and 120 characters"),
+  ...siteIdsBody("site_ids", true),
+  ...sitesBody("sites"),
+];
+
+const deleteComparison = [validateTenant, ...comparisonIdParam];
+
+module.exports = {
+  tenant: validateTenant,
+  create,
+  list,
+  getById,
+  update,
+  deleteComparison,
+};

--- a/src/auth-service/validators/comparisons.validators.js
+++ b/src/auth-service/validators/comparisons.validators.js
@@ -1,7 +1,5 @@
 // comparisons.validators.js
 const { query, body, param, oneOf } = require("express-validator");
-const mongoose = require("mongoose");
-const ObjectId = mongoose.Types.ObjectId;
 const constants = require("@config/constants");
 
 const validateTenant = oneOf([
@@ -43,12 +41,16 @@ const sitesBody = (fieldPath = "sites") => [
     .optional()
     .isArray({ max: 80 })
     .withMessage(`${fieldPath} must be an array of at most 80 entries`),
+  // Not .optional(): the wildcard only matches entries that actually exist,
+  // so this has no effect when `sites` itself is absent — but any entry
+  // that IS present must carry a non-empty id, since buildSiteSnapshots()
+  // keys its lookup by id and silently drops entries without one.
   body(`${fieldPath}.*.id`)
-    .optional()
     .isString()
     .withMessage("each site snapshot entry must include a string id")
     .trim()
-    .notEmpty(),
+    .notEmpty()
+    .withMessage("site snapshot id must not be empty"),
   body(`${fieldPath}.*.name`).optional().isString().trim(),
   body(`${fieldPath}.*.location`).optional().isString().trim(),
   body(`${fieldPath}.*.city`).optional().isString().trim(),
@@ -115,7 +117,14 @@ const update = [
   validateTenant,
   ...comparisonIdParam,
   (req, res, next) => {
-    if (!Object.keys(req.body || {}).length) {
+    const body = req.body || {};
+    const hasName = typeof body.name === "string" && body.name.trim().length > 0;
+    const hasSiteIds = Array.isArray(body.site_ids);
+    // `sites` alone (no name/site_ids) is deliberately not enough here —
+    // update() only ever writes update.sites alongside update.site_ids, so
+    // a sites-only body would otherwise pass this check and then silently
+    // no-op against the database.
+    if (!hasName && !hasSiteIds) {
       return res.status(400).json({
         success: false,
         message: "bad request errors",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a new `comparisons` resource to auth-service (mounted at
`/api/v2/users/comparisons`) so a user can save, list, load, rename/edit, and
delete named site comparisons for the AirQo Nexus "Compare locations"
feature:

- `POST /comparisons` — create (group-membership checked via `RBACService`)
- `GET /comparisons?group_id=...` — list the caller's saved comparisons for a group
- `GET /comparisons/:id` — load one (404 unknown, 403 someone else's)
- `PATCH /comparisons/:id` — rename and/or replace the site list
- `DELETE /comparisons/:id` — 204, idempotent

Every route requires bearer JWT auth (`Authorization: JWT <token>`);
`user_id` is always taken from the authenticated token, never the request
body. The `sites` display snapshot (name/location/city/country/lat/lng) is
supplied by the client at save time and stored as-is — auth-service does not
call device-registry to resolve or verify it.

### Why is this change needed?

The Nexus Comparison tab needs to persist a user's chosen site selection
under a name and reload it later (picker pre-selected) without re-picking
sites from scratch. This completes that feature's backend: the companion
device-registry PR (site picker + latest-readings-per-site endpoints, raised
separately) supplies the live data; this PR supplies the "save for later"
half. The two services intentionally never call each other — the frontend
composes both.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `auth-service` only.

Depends on nothing new from `device-registry`, but is meant to be used
alongside the `comparison-api` branch/PR (site picker + comparison readings
endpoints) already raised for that service — see that PR's description for
the other half of this feature.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** New code was checked with `node --check` for syntax
correctness only, and modeled closely on this service's existing
`favorites`/`preferences` resources (same model/util/controller/validator/
route layering, same auth middleware, same response envelope conventions).
No unit tests have been added yet for this resource and no live/manual
request testing has been done — please add coverage (following the existing
`favorites`/`preferences` test suites as a template) and run a manual smoke
test against a real environment before merging.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely additive: one new route mount added to `routes/v2/index.js`, no
existing endpoint, model, or response shape was touched.

---

## :memo: Additional Notes

- Group membership is verified with `RBACService.isGroupMember` on `create`
  and `list` (403 if the caller isn't in the given `group_id`); `getById`/
  `update`/`delete` are scoped by resource ownership instead (a comparison
  already encodes its owning user + group).
- No new environment variables are required — an earlier draft of this PR
  called out to device-registry to resolve site snapshots and to serve a
  combined `?include_readings=true` load; both were removed so that no
  AirQo service calls another service's endpoints directly. The frontend is
  expected to compose the two calls itself when reopening a saved
  comparison.
- Duplicate comparison names are intentionally allowed (matches the Nexus
  feature spec's own recommendation) — no uniqueness constraint on `name`.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
