### PR TITLE
Suppress repeated ops-alerts for transactions stuck failing to register

### DIFF
--- a/src/auth-service/models/OpsAlertLog.js
+++ b/src/auth-service/models/OpsAlertLog.js
@@ -1,0 +1,36 @@
+const mongoose = require("mongoose");
+const { getModelByTenant } = require("@config/database");
+const constants = require("@config/constants");
+const isEmpty = require("is-empty");
+
+const OpsAlertLogSchema = new mongoose.Schema(
+  {
+    hash: {
+      type: String,
+      required: true,
+      unique: true, // unique: true already creates an index; index: true is redundant and removed
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+    // Per-document TTL: MongoDB deletes the document when this date is reached.
+    // expireAfterSeconds: 0 means "delete at the moment stored in this field",
+    // allowing each document to carry its own retention window.
+    expiresAt: {
+      type: Date,
+      required: true,
+      index: { expireAfterSeconds: 0 },
+    },
+  },
+  { timestamps: false },
+);
+
+const OpsAlertLogModel = (tenant) => {
+  const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+  const dbTenant = isEmpty(tenant) ? defaultTenant : tenant.toLowerCase();
+
+  return getModelByTenant(dbTenant, "ops_alert_log", OpsAlertLogSchema);
+};
+
+module.exports = OpsAlertLogModel;

--- a/src/auth-service/utils/common/ops-alert-dedup.util.js
+++ b/src/auth-service/utils/common/ops-alert-dedup.util.js
@@ -1,0 +1,68 @@
+const crypto = require("crypto");
+const OpsAlertLogModel = require("@models/OpsAlertLog");
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- ops-alert-dedup`,
+);
+
+class OpsAlertDeduplicator {
+  constructor(options = {}) {
+    this.ttlSeconds = options.ttlSeconds || 3600;
+    this.keyPrefix = options.keyPrefix || "ops_alert_dedup";
+  }
+
+  generateAlertKey(identifier) {
+    const keyHash = crypto
+      .createHash("sha256")
+      .update(String(identifier))
+      .digest("hex");
+    return `${this.keyPrefix}:${keyHash}`;
+  }
+
+  /**
+   * Atomically check whether an alert for this identifier was already sent
+   * within the cooldown window, and mark it sent if not. Uses MongoDB's
+   * unique index as the distributed lock — safe across multiple pods.
+   *
+   * @param {string} identifier - Whatever uniquely identifies this alert
+   *   (e.g. a Paddle transaction id) — repeated calls with the same
+   *   identifier within the TTL window are treated as duplicates.
+   * @param {object} [opts]
+   * @param {string} [opts.tenant]        - Tenant to scope the log collection
+   * @param {number} [opts.ttlSeconds]    - Cooldown window (default: class ttlSeconds)
+   * @returns {Promise<boolean>} true = send the alert, false = duplicate, skip it
+   */
+  async shouldAlert(identifier, { tenant, ttlSeconds } = {}) {
+    try {
+      const key = this.generateAlertKey(identifier);
+      const OpsAlertLog = OpsAlertLogModel(tenant);
+      const effectiveTtl = ttlSeconds ?? this.ttlSeconds;
+      const expiresAt = new Date(Date.now() + effectiveTtl * 1000);
+
+      // Atomic insert: succeeds only if `hash` is unique.
+      // A duplicate key error (11000) means this alert already fired recently.
+      await new OpsAlertLog({ hash: key, expiresAt }).save();
+      return true;
+    } catch (error) {
+      if (error.code === 11000) {
+        logger.info(`Duplicate ops alert suppressed for: ${identifier}`);
+        return false;
+      }
+
+      // Any other DB error: fail open so real alerts are never silently dropped.
+      logger.error(
+        `DB dedup check failed, failing open to allow alert: ${error.message}`,
+        { identifier },
+      );
+      return true;
+    }
+  }
+}
+
+const opsAlertDeduplicator = new OpsAlertDeduplicator({
+  ttlSeconds: 3600,
+  keyPrefix: "airqo_ops_alert_dedup",
+});
+
+module.exports = { OpsAlertDeduplicator, opsAlertDeduplicator };

--- a/src/auth-service/utils/common/ops-alert-dedup.util.js
+++ b/src/auth-service/utils/common/ops-alert-dedup.util.js
@@ -38,11 +38,22 @@ class OpsAlertDeduplicator {
       const key = this.generateAlertKey(identifier);
       const OpsAlertLog = OpsAlertLogModel(tenant);
       const effectiveTtl = ttlSeconds ?? this.ttlSeconds;
-      const expiresAt = new Date(Date.now() + effectiveTtl * 1000);
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + effectiveTtl * 1000);
 
-      // Atomic insert: succeeds only if `hash` is unique.
-      // A duplicate key error (11000) means this alert already fired recently.
-      await new OpsAlertLog({ hash: key, expiresAt }).save();
+      // Atomic renew-or-create: the filter only matches a document that
+      // doesn't exist yet, or whose cooldown has already logically expired.
+      // This doesn't rely on Mongo's TTL monitor having physically deleted
+      // the stale doc yet (that sweep runs periodically, e.g. every ~60s,
+      // and can lag behind `expiresAt`) — expiry is evaluated here instead.
+      // If a still-active document exists, the filter won't match it, so the
+      // upsert's insert attempt collides with the unique index instead;
+      // that E11000 is read as "still within cooldown, suppress".
+      await OpsAlertLog.findOneAndUpdate(
+        { hash: key, expiresAt: { $lte: now } },
+        { $set: { hash: key, createdAt: now, expiresAt } },
+        { upsert: true },
+      );
       return true;
     } catch (error) {
       if (error.code === 11000) {

--- a/src/auth-service/utils/test/ut_transaction.util.js
+++ b/src/auth-service/utils/test/ut_transaction.util.js
@@ -770,6 +770,7 @@ describe("transactions.getSubscriptionStatus", () => {
 describe("transactions.notifyAdminOfTransactionError", () => {
   let localTransactions;
   let opsLoggerErrorStub;
+  let shouldAlertStub;
 
   before(() => {
     // log4js.getLogger returns a new object per call, so we must intercept it
@@ -782,13 +783,26 @@ describe("transactions.notifyAdminOfTransactionError", () => {
     delete require.cache[require.resolve("@utils/transaction.util")];
     localTransactions = require("@utils/transaction.util");
     getLoggerStub.restore();
+
+    // Same module instance transaction.util.js imports — stubbing it here
+    // reaches the code under test without touching MongoDB.
+    const {
+      opsAlertDeduplicator,
+    } = require("@utils/common/ops-alert-dedup.util");
+    shouldAlertStub = sinon.stub(opsAlertDeduplicator, "shouldAlert");
+  });
+
+  after(() => {
+    shouldAlertStub.restore();
   });
 
   afterEach(() => {
     opsLoggerErrorStub.resetHistory();
+    shouldAlertStub.reset();
   });
 
   it("logs TRANSACTION_COMPLETION_FAILED with message and transactionId via opsLogger", async () => {
+    shouldAlertStub.resolves(true);
     const error = new Error("Payment gateway timeout");
     const eventData = { id: "txn_abc123", customer_id: "cust_xyz" };
 
@@ -804,10 +818,23 @@ describe("transactions.notifyAdminOfTransactionError", () => {
   });
 
   it("uses undefined transactionId when eventData is absent", async () => {
+    shouldAlertStub.resolves(true);
+
     await localTransactions.notifyAdminOfTransactionError(new Error("Unknown failure"), undefined);
 
     sinon.assert.calledOnce(opsLoggerErrorStub);
     const [, payload] = opsLoggerErrorStub.firstCall.args;
     expect(payload.transactionId).to.be.undefined;
+  });
+
+  it("suppresses the alert when the same transaction was already alerted on recently", async () => {
+    shouldAlertStub.resolves(false);
+    const error = new Error("Payment gateway timeout");
+    const eventData = { id: "txn_repeat", customer_id: "cust_xyz" };
+
+    await localTransactions.notifyAdminOfTransactionError(error, eventData);
+
+    sinon.assert.calledWith(shouldAlertStub, "transaction-error:txn_repeat");
+    sinon.assert.notCalled(opsLoggerErrorStub);
   });
 });

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -14,6 +14,9 @@ const logger = log4js.getLogger(
 const opsLogger = log4js.getLogger("ops-alerts");
 const { logObject, logText, HttpError } = require("@utils/shared");
 const { paddleClient, isPaddleConfigured } = require("@config/paddle");
+const {
+  opsAlertDeduplicator,
+} = require("@utils/common/ops-alert-dedup.util");
 
 // Standard response returned by any function that calls Paddle when credentials
 // are not configured. Lets the service start and all non-Paddle endpoints work.
@@ -576,9 +579,21 @@ const transactions = {
     // Email notification not yet implemented.
   },
   notifyAdminOfTransactionError: async (error, eventData) => {
+    const transactionId = eventData?.id;
+
+    // A transaction that keeps failing to register (for a reason other than
+    // "already exists") has no persisted row for processWebhook's existence
+    // check to short-circuit on, so Paddle's ~20-25min webhook redelivery
+    // would otherwise re-fire this alert unchanged for hours. Cool down
+    // repeat alerts for the same transaction instead of paging on every retry.
+    const shouldAlert = transactionId
+      ? await opsAlertDeduplicator.shouldAlert(`transaction-error:${transactionId}`)
+      : true;
+    if (!shouldAlert) return;
+
     opsLogger.error("TRANSACTION_COMPLETION_FAILED", {
       message: error.message,
-      transactionId: eventData?.id,
+      transactionId,
     });
   },
   handleFailedTransaction: async (eventData) => {

--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -578,7 +578,7 @@ const transactions = {
   sendTransactionCompletionNotification: async (_transactionMetadata) => {
     // Email notification not yet implemented.
   },
-  notifyAdminOfTransactionError: async (error, eventData) => {
+  notifyAdminOfTransactionError: async (error, eventData, tenant) => {
     const transactionId = eventData?.id;
 
     // A transaction that keeps failing to register (for a reason other than
@@ -587,7 +587,10 @@ const transactions = {
     // would otherwise re-fire this alert unchanged for hours. Cool down
     // repeat alerts for the same transaction instead of paging on every retry.
     const shouldAlert = transactionId
-      ? await opsAlertDeduplicator.shouldAlert(`transaction-error:${transactionId}`)
+      ? await opsAlertDeduplicator.shouldAlert(
+          `transaction-error:${transactionId}`,
+          { tenant },
+        )
       : true;
     if (!shouldAlert) return;
 
@@ -596,7 +599,7 @@ const transactions = {
       transactionId,
     });
   },
-  handleFailedTransaction: async (eventData) => {
+  handleFailedTransaction: async (eventData, tenant) => {
     try {
       logObject("Failed Transaction Event", eventData);
 
@@ -616,6 +619,7 @@ const transactions = {
       await transactions.notifyAdminOfTransactionError(
         new Error(`Payment failed for transaction ${eventData.id}`),
         eventData,
+        tenant,
       );
     } catch (error) {
       logger.error("Failed transaction processing error", {
@@ -675,7 +679,7 @@ const transactions = {
       });
 
       // You might want to implement retry logic or send an alert
-      await transactions.notifyAdminOfTransactionError(error, eventData);
+      await transactions.notifyAdminOfTransactionError(error, eventData, tenant);
     }
   },
 
@@ -804,7 +808,10 @@ const transactions = {
           );
           break;
         case "transaction.payment_failed":
-          await transactions.handleFailedTransaction(normalizedTransaction);
+          await transactions.handleFailedTransaction(
+            normalizedTransaction,
+            tenant,
+          );
           break;
         case "subscription.updated":
           await transactions.handleSubscriptionUpdated(event.data, tenant);


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
<!-- Brief summary of the changes -->
Adds a cooldown-based deduplication guard around the `TRANSACTION_COMPLETION_FAILED` ops-alert in the Paddle transaction webhook flow. A new `OpsAlertLog` model (TTL-indexed Mongo collection, mirroring the existing `SentEmailLog` dedup pattern) and `opsAlertDeduplicator` util track which transaction IDs were alerted on recently; `notifyAdminOfTransactionError` now skips re-firing the alert for the same transaction within a 1-hour window.

### Why is this change needed?
<!-- Explain the motivation/problem this solves -->
A production transaction (`txn_01m0z8gn6r7w5znq05whdpef3d`) kept failing to register due to a `paddle_transaction_id` duplicate-key conflict. Because no valid row ever got persisted for it, the existing "already recorded" webhook short-circuit couldn't catch it, so Paddle's webhook redelivery (~every 20-25 min) re-triggered the same ops-alert and registration error for hours. This closes that residual gap so a stuck/failing transaction pages once per cooldown window instead of on every retry.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- auth-service (`models/OpsAlertLog.js`, `utils/common/ops-alert-dedup.util.js`, `utils/transaction.util.js`)

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Added test coverage in `utils/test/ut_transaction.util.js` for `notifyAdminOfTransactionError`, including a new case asserting the alert is suppressed on a repeat call for the same transaction ID. All tests in this describe block pass. The full auth-service suite has 8 pre-existing failures unrelated to this change (date-util and validator tests); none touch transactions, Paddle, or the new alert-dedup code.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
<!-- Any additional context, dependencies, or concerns -->
Cooldown window is set to 1 hour and can be tuned via `opsAlertDeduplicator`'s `ttlSeconds` option if ops wants alerts more/less frequent while an issue is unresolved. The dedup collection (`ops_alert_log`) is TTL-indexed and self-cleans; no manual maintenance needed.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deduplication for transaction failure alerts to prevent repeated notifications during a configurable period.
  * Alerts remain available when no transaction ID is provided.
  * Added tenant-aware alert tracking with automatic expiration.

* **Bug Fixes**
  * Improved transaction failure alert details by including the associated transaction ID.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->