### PR TITLE
Add identity headers to verify endpoints for gateway

### DIFF
--- a/src/auth-service/controllers/test/ut_token.controller.js
+++ b/src/auth-service/controllers/test/ut_token.controller.js
@@ -152,6 +152,38 @@ describe("tokenUtil", () => {
       expect(next.calledOnce).to.be.true;
       expect(next.firstCall.args[0].statusCode).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
     });
+
+    it("should attach identity headers but strip user_id from the response body", async () => {
+      sinon.stub(tokenUtil, "verifyToken").resolves({
+        success: true,
+        status: httpStatus.OK,
+        message: "Token valid",
+        data: { allowed_grids: [], allowed_cohorts: [], permissions: [], user_id: "u1" },
+      });
+      const origAttach = createAccessToken.__get__("attachIdentityHeaders");
+      const origUserModel = createAccessToken.__get__("UserModel");
+      const attachStub = sinon.stub().resolves();
+      const findByIdStub = sinon.stub().returns({
+        select: sinon.stub().returns({
+          lean: sinon.stub().resolves({ _id: "u1", group_roles: [] }),
+        }),
+      });
+      createAccessToken.__set__("attachIdentityHeaders", attachStub);
+      createAccessToken.__set__("UserModel", () => ({ findById: findByIdStub }));
+      res.set = sinon.stub();
+
+      try {
+        await createAccessToken.verify(req, res, next);
+
+        expect(attachStub.calledOnce).to.be.true;
+        expect(res.json.calledOnce).to.be.true;
+        const sentBody = res.json.firstCall.args[0];
+        expect(sentBody.data).to.not.have.property("user_id");
+      } finally {
+        createAccessToken.__set__("attachIdentityHeaders", origAttach);
+        createAccessToken.__set__("UserModel", origUserModel);
+      }
+    });
   });
 
   describe("delete", () => {

--- a/src/auth-service/controllers/test/ut_user.controller.js
+++ b/src/auth-service/controllers/test/ut_user.controller.js
@@ -799,6 +799,43 @@ describe("createUserController", () => {
     });
   });
 
+  describe("verify", () => {
+    let origAttachIdentityHeaders;
+
+    beforeEach(() => {
+      origAttachIdentityHeaders = createUser.__get__("attachIdentityHeaders");
+      res.set = sinon.stub();
+    });
+
+    afterEach(() => {
+      createUser.__set__("attachIdentityHeaders", origAttachIdentityHeaders);
+    });
+
+    it("should attach identity headers and respond 200 with 'this token is valid'", async () => {
+      const attachStub = sinon.stub().resolves();
+      createUser.__set__("attachIdentityHeaders", attachStub);
+      req.user = { _id: "u1", group_roles: [] };
+
+      await createUser.verify(req, res, next);
+
+      expect(attachStub.calledOnce).to.be.true;
+      expect(attachStub.firstCall.args[1]).to.deep.equal(req.user);
+      expect(res.status).to.have.been.calledWith(httpStatus.OK);
+      expect(res.send).to.have.been.calledWith("this token is valid");
+    });
+
+    it("should not respond again when headers were already sent", async () => {
+      const attachStub = sinon.stub().resolves();
+      createUser.__set__("attachIdentityHeaders", attachStub);
+      res.headersSent = true;
+
+      await createUser.verify(req, res, next);
+
+      expect(attachStub.called).to.be.false;
+      expect(res.send.called).to.be.false;
+    });
+  });
+
   describe("verifyFirebaseCustomToken", () => {
     it("should return success response when token is verified", async () => {
       sinon.stub(createUserUtil, "verifyFirebaseCustomToken").resolves({

--- a/src/auth-service/controllers/token.controller.js
+++ b/src/auth-service/controllers/token.controller.js
@@ -289,7 +289,12 @@ const createAccessToken = {
         // Attach the same X-Auth-User-* identity headers the JWT verify
         // path sets, so the nginx gateway forwards identity for
         // token-authenticated requests too (see identity-headers.util.js).
+        // user_id is internal-only: read it here, then strip it from
+        // result.data below so it never reaches the public response body.
         const userId = result.data && result.data.user_id;
+        if (result.data && "user_id" in result.data) {
+          delete result.data.user_id;
+        }
         if (result.success && userId) {
           try {
             const tenant = String(

--- a/src/auth-service/controllers/token.controller.js
+++ b/src/auth-service/controllers/token.controller.js
@@ -14,6 +14,8 @@ const log4js = require("log4js");
 const analyzeIP = require("@middleware/ip-pattern-analysis.middleware");
 const AccessTokenModel = require("@models/AccessToken");
 const FlaggedTokenModel = require("@models/FlaggedToken");
+const UserModel = require("@models/User");
+const { attachIdentityHeaders } = require("@utils/identity-headers.util");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- token-controller`);
 
 function handleResponse({
@@ -284,6 +286,26 @@ const createAccessToken = {
       }
       const status = result.status;
       if (!res.headersSent) {
+        // Attach the same X-Auth-User-* identity headers the JWT verify
+        // path sets, so the nginx gateway forwards identity for
+        // token-authenticated requests too (see identity-headers.util.js).
+        const userId = result.data && result.data.user_id;
+        if (result.success && userId) {
+          try {
+            const tenant = String(
+              request.query.tenant || constants.DEFAULT_TENANT || "airqo",
+            ).toLowerCase();
+            const user = await UserModel(tenant)
+              .findById(userId)
+              .select("group_roles")
+              .lean();
+            await attachIdentityHeaders(res, user, tenant);
+          } catch (identityError) {
+            logger.warn(
+              `Non-critical: identity header attach failed for token verify: ${identityError.message}`,
+            );
+          }
+        }
         // Return full JSON so callers (e.g. device-registry resource binding
         // middleware) can parse the response body, including allowed_grids /
         // allowed_cohorts.  HTTP status code semantics are unchanged, so

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -14,6 +14,7 @@ const constants = require("@config/constants");
 const { AbstractTokenFactory } = require("@services/atf.service");
 const log4js = require("log4js");
 const UserModel = require("@models/User");
+const { attachIdentityHeaders } = require("@utils/identity-headers.util");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- user controller`);
 
 const handleRequest = (req, next) => {
@@ -444,6 +445,10 @@ const userController = {
   verify: async (req, res, next) => {
     try {
       if (!res.headersSent) {
+        const tenant = String(
+          req.query.tenant || req.body.tenant || constants.DEFAULT_TENANT || "airqo",
+        ).toLowerCase();
+        await attachIdentityHeaders(res, req.user, tenant);
         res.status(httpStatus.OK).send("this token is valid");
         return;
       }

--- a/src/auth-service/utils/identity-headers.util.js
+++ b/src/auth-service/utils/identity-headers.util.js
@@ -1,0 +1,61 @@
+/**
+ * identity-headers.util.js
+ *
+ * Attaches identity/group-membership response headers to the two endpoints
+ * the nginx gateway's `auth_request /auth` subrequest calls
+ * (POST /api/v2/users/verify and GET /api/v2/tokens/:token/verify).
+ *
+ * nginx captures these via auth_request_set + proxy_set_header and forwards
+ * them, unspoofable, to backend services (see the global-config.yaml files
+ * under k8s/nginx). This is the ONLY place user/group data is resolved —
+ * backend services never call auth-service themselves and never store this
+ * data; they just read the headers nginx attaches to the current request.
+ *
+ * This response is only ever read by nginx's internal subrequest, never
+ * returned to a browser, so no Access-Control-Expose-Headers is needed.
+ */
+
+const GroupModel = require("@models/Group");
+const log4js = require("log4js");
+const constants = require("@config/constants");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- identity-headers-util`,
+);
+
+/**
+ * Resolve a user's group_roles into grp_title strings and set them, along
+ * with the user id, as response headers.
+ *
+ * Never throws — a lookup failure just means no group headers are attached
+ * (the caller still gets their normal 200/verify response either way).
+ */
+const attachIdentityHeaders = async (res, user, tenant) => {
+  try {
+    if (!user || !user._id) return;
+
+    res.set("X-Auth-User-Id", String(user._id));
+
+    const groupIds = (user.group_roles || [])
+      .map((gr) => gr && gr.group)
+      .filter(Boolean);
+
+    if (groupIds.length === 0) {
+      res.set("X-Auth-User-Groups", "");
+      return;
+    }
+
+    const groups = await GroupModel(tenant)
+      .find({ _id: { $in: groupIds } })
+      .select("grp_title")
+      .lean();
+
+    const groupTitles = groups.map((g) => g.grp_title).filter(Boolean);
+    res.set("X-Auth-User-Groups", groupTitles.join(","));
+  } catch (error) {
+    logger.warn(
+      `Non-critical: attachIdentityHeaders failed (headers omitted): ${error.message}`,
+    );
+  }
+};
+
+module.exports = { attachIdentityHeaders };

--- a/src/auth-service/utils/identity-headers.util.js
+++ b/src/auth-service/utils/identity-headers.util.js
@@ -11,8 +11,11 @@
  * backend services never call auth-service themselves and never store this
  * data; they just read the headers nginx attaches to the current request.
  *
- * This response is only ever read by nginx's internal subrequest, never
- * returned to a browser, so no Access-Control-Expose-Headers is needed.
+ * These headers are intended for nginx's internal auth_request subrequest.
+ * Both endpoints can also be called directly by clients (they're normal
+ * mounted routes, not internal-only), so the headers may be present on a
+ * direct response too — but no Access-Control-Expose-Headers is set, so a
+ * browser's JS cannot read them unless a route explicitly exposes them.
  */
 
 const GroupModel = require("@models/Group");

--- a/src/auth-service/utils/test/ut_identity-headers.util.js
+++ b/src/auth-service/utils/test/ut_identity-headers.util.js
@@ -1,0 +1,86 @@
+require("module-alias/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const rewire = require("rewire");
+
+const rewireIdentityHeaders = rewire("@utils/identity-headers.util");
+
+describe("identity-headers.util", () => {
+  describe("attachIdentityHeaders", () => {
+    let origGroupModel;
+    let res;
+
+    beforeEach(() => {
+      origGroupModel = rewireIdentityHeaders.__get__("GroupModel");
+      res = { set: sinon.stub() };
+    });
+
+    afterEach(() => {
+      rewireIdentityHeaders.__set__("GroupModel", origGroupModel);
+      sinon.restore();
+    });
+
+    it("should set X-Auth-User-Id and X-Auth-User-Groups for a user with groups", async () => {
+      const findStub = sinon.stub().returns({
+        select: sinon.stub().returns({
+          lean: sinon.stub().resolves([
+            { grp_title: "airqo" },
+            { grp_title: "kcca" },
+          ]),
+        }),
+      });
+      rewireIdentityHeaders.__set__("GroupModel", () => ({ find: findStub }));
+
+      const attachIdentityHeaders = rewireIdentityHeaders.__get__(
+        "attachIdentityHeaders",
+      );
+      const user = {
+        _id: "u1",
+        group_roles: [{ group: "g1" }, { group: "g2" }],
+      };
+      await attachIdentityHeaders(res, user, "airqo");
+
+      expect(res.set.calledWith("X-Auth-User-Id", "u1")).to.be.true;
+      expect(res.set.calledWith("X-Auth-User-Groups", "airqo,kcca")).to.be
+        .true;
+    });
+
+    it("should set an empty X-Auth-User-Groups header when the user has no group_roles", async () => {
+      const attachIdentityHeaders = rewireIdentityHeaders.__get__(
+        "attachIdentityHeaders",
+      );
+      const user = { _id: "u2", group_roles: [] };
+      await attachIdentityHeaders(res, user, "airqo");
+
+      expect(res.set.calledWith("X-Auth-User-Id", "u2")).to.be.true;
+      expect(res.set.calledWith("X-Auth-User-Groups", "")).to.be.true;
+    });
+
+    it("should not set any headers when no user is provided", async () => {
+      const attachIdentityHeaders = rewireIdentityHeaders.__get__(
+        "attachIdentityHeaders",
+      );
+      await attachIdentityHeaders(res, null, "airqo");
+
+      expect(res.set.called).to.be.false;
+    });
+
+    it("should not throw when the group lookup fails", async () => {
+      rewireIdentityHeaders.__set__("GroupModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({
+            lean: sinon.stub().rejects(new Error("db down")),
+          }),
+        }),
+      }));
+
+      const attachIdentityHeaders = rewireIdentityHeaders.__get__(
+        "attachIdentityHeaders",
+      );
+      const user = { _id: "u3", group_roles: [{ group: "g1" }] };
+
+      await attachIdentityHeaders(res, user, "airqo");
+      expect(res.set.calledWith("X-Auth-User-Id", "u3")).to.be.true;
+    });
+  });
+});

--- a/src/auth-service/utils/token.util.js
+++ b/src/auth-service/utils/token.util.js
@@ -1985,11 +1985,15 @@ const token = {
 
           // Return resource-binding data so downstream services (e.g.
           // device-registry) can enforce grid/cohort restrictions without a
-          // second DB call.
+          // second DB call. user_id (additive) lets the controller attach
+          // the same X-Auth-User-* identity headers the JWT verify path
+          // sets, so the gateway forwards identity for token-authenticated
+          // requests too.
           return createValidTokenResponse({
             allowed_grids:   accessToken.allowed_grids   || [],
             allowed_cohorts: accessToken.allowed_cohorts || [],
             permissions,
+            user_id: client.user_id || null,
           });
         }
       }


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a shared `attachIdentityHeaders` helper (`utils/identity-headers.util.js`) that resolves an authenticated user's group memberships (`group_roles` → `grp_title`) and sets `X-Auth-User-Id` / `X-Auth-User-Groups` as **response headers** on the two endpoints the nginx gateway's `auth_request` subrequest already calls: `POST /api/v2/users/verify` (JWT session flow) and `GET /api/v2/tokens/:token/verify` (API query-token flow). No existing status codes or response bodies change — this only adds new headers.

### Why is this change needed?
Backend services such as device-registry intentionally hold no JWT/user logic of their own and must never fetch or store user data directly — that's auth-service's job, permanently, per this system's microservice architecture. Today nothing besides the frontend restricts which authenticated user can act on which organization's resources (e.g. assigning a device to a cohort), and the frontend's own checks are inconsistent and trivially bypassed by calling the API directly.

This is PR 1 of 3 (**auth-service → nginx → device-registry**). It lets the gateway — which already authenticates every request via auth-service — also reveal the caller's identity/group membership to downstream services in a way that can't be spoofed, without any service ever needing to call auth-service itself. This PR is self-contained and inert on its own: nothing consumes these headers yet.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [x] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `auth-service` only.

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
New unit tests: `utils/test/ut_identity-headers.util.js` (4 tests — multi-group user, user with no groups, missing user, failed group lookup fails safe without throwing) and a new `verify` describe block in `controllers/test/ut_user.controller.js` (2 tests — headers attached before responding 200, and no double-response when headers are already sent). Full auth-service suite: 2196 passing / 88 pending / 2 failing, both failures pre-existing and unrelated to this change (a date-utility rounding test and an intermittent socket-hang-up in an unrelated roles-validators test). Manual verification: confirmed header values via the new unit tests; recommend a manual `curl` against `POST /api/v2/users/verify` with a valid JWT in staging to visually confirm `X-Auth-User-Id` / `X-Auth-User-Groups` land in the response headers.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This PR is inert by itself — headers are computed and returned, but nothing yet forwards or reads them. PR 2 (nginx) must merge next to forward these headers to backend services; PR 3 (device-registry) then consumes them behind a feature flag. No environment variable or config changes are required for this PR.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication verification responses now include identity information in response headers, including user ID and group titles.
  * Tenant-aware identity headers are supported across token and user verification flows.

* **Bug Fixes**
  * Internal user IDs are no longer exposed in token verification response bodies.
  * Header attachment failures are handled gracefully without interrupting valid verification responses.

* **Tests**
  * Added coverage for successful verification, missing groups or users, lookup failures, and already-sent responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->