### PR TITLE
Forward authenticated user identity headers to services

### DIFF
--- a/k8s/nginx/development/global-config.yaml
+++ b/k8s/nginx/development/global-config.yaml
@@ -8,6 +8,10 @@ data:
   client-max-body-size: "350m"
   location-snippets: "  
     auth_request /auth;
+    auth_request_set $auth_user_id $upstream_http_x_auth_user_id;
+    auth_request_set $auth_user_groups $upstream_http_x_auth_user_groups;
+    proxy_set_header X-Auth-User-Id $auth_user_id;
+    proxy_set_header X-Auth-User-Groups $auth_user_groups;
     error_page 500 = @custom_internal_server_error;
     error_page 404 = @custom_page_not_found;
     error_page 403 = @custom_access_denied;

--- a/k8s/nginx/production/global-config.yaml
+++ b/k8s/nginx/production/global-config.yaml
@@ -12,6 +12,10 @@ data:
   set-real-ip-from: "10.250.0.65"
   location-snippets: "
     auth_request /auth;
+    auth_request_set $auth_user_id $upstream_http_x_auth_user_id;
+    auth_request_set $auth_user_groups $upstream_http_x_auth_user_groups;
+    proxy_set_header X-Auth-User-Id $auth_user_id;
+    proxy_set_header X-Auth-User-Groups $auth_user_groups;
     error_page 500 = @custom_internal_server_error;
     error_page 404 = @custom_page_not_found;
     error_page 403 = @custom_access_denied;

--- a/k8s/nginx/staging/global-config.yaml
+++ b/k8s/nginx/staging/global-config.yaml
@@ -12,6 +12,10 @@ data:
   set-real-ip-from: "10.250.8.62"
   location-snippets: "  
     auth_request /auth;
+    auth_request_set $auth_user_id $upstream_http_x_auth_user_id;
+    auth_request_set $auth_user_groups $upstream_http_x_auth_user_groups;
+    proxy_set_header X-Auth-User-Id $auth_user_id;
+    proxy_set_header X-Auth-User-Groups $auth_user_groups;
     error_page 500 = @custom_internal_server_error;
     error_page 404 = @custom_page_not_found;
     error_page 403 = @custom_access_denied;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Extends the nginx gateway's `location-snippets` (`k8s/nginx/{production,staging,development}/global-config.yaml`) so that, right after the existing `auth_request /auth` subrequest to auth-service, it also captures the new `X-Auth-User-Id` / `X-Auth-User-Groups` response headers via `auth_request_set` and forwards them to the proxied backend using `proxy_set_header` — which always **overwrites** whatever a client attempted to send under those header names, so identity cannot be spoofed by a direct caller.

### Why is this change needed?
This is the transport layer connecting the identity headers auth-service now computes (PR 1, `auth-identity`) to the backend service that will use them (PR 3, `cohort-authz`, device-registry). Nothing in this PR changes authentication or authorization outcomes by itself — it only makes identity data available to backends that choose to read it. This is PR 2 of 3 (**auth-service → nginx → device-registry**).

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** No application code — infrastructure/routing config only (`k8s/nginx/production`, `k8s/nginx/staging`, `k8s/nginx/development`). Because `location-snippets` is injected into every proxied location, this technically applies gateway-wide (auth-service, device-registry, analytics, predict, calibrate, view, spatial, beacon), but only adds two currently-unused headers — no other service reads them yet.

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Not applicable at the unit-test level (infrastructure config, not application code). Validated that all three modified `global-config.yaml` files still parse as valid YAML. Recommend, after this is applied in staging, confirming the ingress controller reloads cleanly and doing a manual request through the gateway to any `/api/v2/...` endpoint with a valid JWT, then checking (e.g. via a temporary debug log in a backend pod) that `X-Auth-User-Id` / `X-Auth-User-Groups` arrive as request headers.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

`proxy_set_header` only adds two new headers here — it doesn't alter routing, error pages, or existing `auth_request` behavior for any path, including anonymous/public paths (which will simply carry empty values for these two headers).

---

## :memo: Additional Notes
Depends on PR 1 (`auth-identity`, auth-service) being merged and deployed to the corresponding environment first — otherwise these headers just forward as empty values (harmless, but non-functional). Not meaningfully testable end-to-end in staging until that PR is live there.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
