### PR TITLE
Fix AIRQO_SUPER_ADMIN missing group_id in RBAC sync

### DIFF
--- a/src/auth-service/utils/role-permissions.util.js
+++ b/src/auth-service/utils/role-permissions.util.js
@@ -652,28 +652,51 @@ const createOrUpdateRoleWithPermissionSync = async (tenant, roleData) => {
         currentPermissionIds.length === expectedPermissionIds.length &&
         currentPermissionIds.every((id) => expectedPermissionIds.includes(id));
 
-      if (!arePermissionsSynced) {
-        logObject(
-          `📝 Permissions for role ${roleData.role_name} are out of sync. Updating...`,
-        );
+      // Legacy roles (created before the group-based RBAC model) can exist
+      // with no group_id at all — only a network_id. Backfill it here rather
+      // than only on creation, otherwise a role that already existed by name
+      // never gets migrated and silently stays invisible to any group_id
+      // filtered lookup. roleData.group_id is resolved by the caller from
+      // grp_title (see getOrCreateAirqoGroup), never a hardcoded ObjectId, so
+      // this stays correct across environments/migrations.
+      const needsGroupIdBackfill = !existingRole.group_id && !!roleData.group_id;
+
+      if (!arePermissionsSynced || needsGroupIdBackfill) {
+        const update = {
+          role_description: roleData.role_description,
+          role_permissions: permissionIds,
+          role_status: "ACTIVE",
+          updatedAt: new Date(),
+        };
+        if (needsGroupIdBackfill) {
+          logObject(
+            `🔧 Role ${roleData.role_name} is missing group_id. Backfilling from resolved group...`,
+          );
+          update.group_id = roleData.group_id;
+        }
+        if (!arePermissionsSynced) {
+          logObject(
+            `📝 Permissions for role ${roleData.role_name} are out of sync. Updating...`,
+          );
+        }
         const updatedRole = await RoleModel(tenant).findByIdAndUpdate(
           existingRole._id,
-          {
-            role_description: roleData.role_description,
-            role_permissions: permissionIds,
-            role_status: "ACTIVE",
-            updatedAt: new Date(),
-          },
+          update,
           { new: true },
         );
         return {
           success: true,
           data: updatedRole,
-          message: `Role ${roleData.role_name} permissions synchronized`,
+          message: `Role ${roleData.role_name} ${
+            arePermissionsSynced
+              ? "group_id backfilled"
+              : "permissions synchronized"
+          }`,
           action: "updated",
           status: httpStatus.OK,
           role_name: roleData.role_name,
           permissions_synced: expectedPermissionIds.length,
+          group_id_backfilled: needsGroupIdBackfill,
         };
       } else {
         logObject(

--- a/src/auth-service/utils/role-permissions.util.js
+++ b/src/auth-service/utils/role-permissions.util.js
@@ -662,22 +662,25 @@ const createOrUpdateRoleWithPermissionSync = async (tenant, roleData) => {
       const needsGroupIdBackfill = !existingRole.group_id && !!roleData.group_id;
 
       if (!arePermissionsSynced || needsGroupIdBackfill) {
-        const update = {
-          role_description: roleData.role_description,
-          role_permissions: permissionIds,
-          role_status: "ACTIVE",
-          updatedAt: new Date(),
-        };
+        const update = { updatedAt: new Date() };
+
+        // Only touch permissions/status when they're actually out of sync —
+        // a group_id-only backfill must not force an otherwise-untouched
+        // role's status to ACTIVE (e.g. one that was deliberately set to
+        // INACTIVE).
+        if (!arePermissionsSynced) {
+          logObject(
+            `📝 Permissions for role ${roleData.role_name} are out of sync. Updating...`,
+          );
+          update.role_description = roleData.role_description;
+          update.role_permissions = permissionIds;
+          update.role_status = "ACTIVE";
+        }
         if (needsGroupIdBackfill) {
           logObject(
             `🔧 Role ${roleData.role_name} is missing group_id. Backfilling from resolved group...`,
           );
           update.group_id = roleData.group_id;
-        }
-        if (!arePermissionsSynced) {
-          logObject(
-            `📝 Permissions for role ${roleData.role_name} are out of sync. Updating...`,
-          );
         }
         const updatedRole = await RoleModel(tenant).findByIdAndUpdate(
           existingRole._id,
@@ -688,9 +691,11 @@ const createOrUpdateRoleWithPermissionSync = async (tenant, roleData) => {
           success: true,
           data: updatedRole,
           message: `Role ${roleData.role_name} ${
-            arePermissionsSynced
-              ? "group_id backfilled"
-              : "permissions synchronized"
+            !arePermissionsSynced && needsGroupIdBackfill
+              ? "permissions synchronized and group_id backfilled"
+              : needsGroupIdBackfill
+                ? "group_id backfilled"
+                : "permissions synchronized"
           }`,
           action: "updated",
           status: httpStatus.OK,

--- a/src/auth-service/utils/test/ut_role-permissions.util.js
+++ b/src/auth-service/utils/test/ut_role-permissions.util.js
@@ -292,6 +292,94 @@ describe("role-permissions util", () => {
     });
   });
 
+  describe("createOrUpdateRoleWithPermissionSync()", () => {
+    const createOrUpdateRoleWithPermissionSync = rewireRPU.__get__(
+      "createOrUpdateRoleWithPermissionSync",
+    );
+
+    it("should backfill group_id on an existing role that is missing it, even when permissions are already synced", async () => {
+      const findByIdAndUpdateStub = sinon.stub().resolves({
+        _id: "r1",
+        role_name: "AIRQO_SUPER_ADMIN",
+        group_id: "g1",
+      });
+
+      rewireRPU.__set__("RoleModel", () => ({
+        findOne: sinon.stub().returns({
+          lean: sinon.stub().resolves({
+            _id: "r1",
+            role_name: "AIRQO_SUPER_ADMIN",
+            role_code: "AIRQO_SUPER_ADMIN",
+            role_permissions: ["p1"],
+            // legacy role created before the group-based RBAC model
+            group_id: undefined,
+          }),
+        }),
+        findByIdAndUpdate: findByIdAndUpdateStub,
+      }));
+
+      rewireRPU.__set__("PermissionModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({
+            lean: sinon.stub().resolves([{ _id: "p1", permission: "SUPER_ADMIN" }]),
+          }),
+        }),
+      }));
+
+      const result = await createOrUpdateRoleWithPermissionSync("airqo", {
+        role_name: "AIRQO_SUPER_ADMIN",
+        role_code: "AIRQO_SUPER_ADMIN",
+        role_description: "desc",
+        permissions: ["SUPER_ADMIN"],
+        group_id: "g1", // resolved upstream via grp_title lookup, not hardcoded
+      });
+
+      expect(findByIdAndUpdateStub.calledOnce).to.equal(true);
+      expect(findByIdAndUpdateStub.firstCall.args[1]).to.have.property(
+        "group_id",
+        "g1",
+      );
+      expect(result.action).to.equal("updated");
+      expect(result.group_id_backfilled).to.equal(true);
+    });
+
+    it("should not touch group_id on an existing role that already has one", async () => {
+      const findByIdAndUpdateStub = sinon.stub();
+
+      rewireRPU.__set__("RoleModel", () => ({
+        findOne: sinon.stub().returns({
+          lean: sinon.stub().resolves({
+            _id: "r1",
+            role_name: "AIRQO_SUPER_ADMIN",
+            role_code: "AIRQO_SUPER_ADMIN",
+            role_permissions: ["p1"],
+            group_id: "already-set-group-id",
+          }),
+        }),
+        findByIdAndUpdate: findByIdAndUpdateStub,
+      }));
+
+      rewireRPU.__set__("PermissionModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({
+            lean: sinon.stub().resolves([{ _id: "p1", permission: "SUPER_ADMIN" }]),
+          }),
+        }),
+      }));
+
+      const result = await createOrUpdateRoleWithPermissionSync("airqo", {
+        role_name: "AIRQO_SUPER_ADMIN",
+        role_code: "AIRQO_SUPER_ADMIN",
+        role_description: "desc",
+        permissions: ["SUPER_ADMIN"],
+        group_id: "g1",
+      });
+
+      expect(findByIdAndUpdateStub.called).to.equal(false);
+      expect(result.action).to.equal("unchanged");
+    });
+  });
+
   describe("setupDefaultPermissions()", () => {
     it("should resolve without throwing when models are stubbed", async () => {
       rewireRPU.__set__("RoleModel", () => ({

--- a/src/auth-service/utils/test/ut_role-permissions.util.js
+++ b/src/auth-service/utils/test/ut_role-permissions.util.js
@@ -339,11 +339,110 @@ describe("role-permissions util", () => {
         "group_id",
         "g1",
       );
+      // A group_id-only backfill must not force role_status/permissions —
+      // those are only touched when they're actually out of sync.
+      expect(findByIdAndUpdateStub.firstCall.args[1]).to.not.have.property(
+        "role_status",
+      );
       expect(result.action).to.equal("updated");
       expect(result.group_id_backfilled).to.equal(true);
+      expect(result.message).to.equal(
+        "Role AIRQO_SUPER_ADMIN group_id backfilled",
+      );
     });
 
-    it("should not touch group_id on an existing role that already has one", async () => {
+    it("should preserve an existing role's role_status when only backfilling group_id (not force ACTIVE)", async () => {
+      const findByIdAndUpdateStub = sinon.stub().callsFake((id, update) =>
+        Promise.resolve({
+          _id: "r1",
+          role_name: "AIRQO_SUPER_ADMIN",
+          role_status: "INACTIVE", // untouched by the update object
+          group_id: update.group_id,
+        }),
+      );
+
+      rewireRPU.__set__("RoleModel", () => ({
+        findOne: sinon.stub().returns({
+          lean: sinon.stub().resolves({
+            _id: "r1",
+            role_name: "AIRQO_SUPER_ADMIN",
+            role_code: "AIRQO_SUPER_ADMIN",
+            role_permissions: ["p1"],
+            role_status: "INACTIVE",
+            group_id: undefined,
+          }),
+        }),
+        findByIdAndUpdate: findByIdAndUpdateStub,
+      }));
+
+      rewireRPU.__set__("PermissionModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({
+            lean: sinon.stub().resolves([{ _id: "p1", permission: "SUPER_ADMIN" }]),
+          }),
+        }),
+      }));
+
+      const result = await createOrUpdateRoleWithPermissionSync("airqo", {
+        role_name: "AIRQO_SUPER_ADMIN",
+        role_code: "AIRQO_SUPER_ADMIN",
+        role_description: "desc",
+        permissions: ["SUPER_ADMIN"],
+        group_id: "g1",
+      });
+
+      expect(findByIdAndUpdateStub.firstCall.args[1]).to.not.have.property(
+        "role_status",
+      );
+      expect(result.data.role_status).to.equal("INACTIVE");
+    });
+
+    it("should not overwrite an existing group_id when only permissions are out of sync", async () => {
+      const findByIdAndUpdateStub = sinon.stub().resolves({
+        _id: "r1",
+        role_name: "AIRQO_SUPER_ADMIN",
+        group_id: "already-set-group-id",
+      });
+
+      rewireRPU.__set__("RoleModel", () => ({
+        findOne: sinon.stub().returns({
+          lean: sinon.stub().resolves({
+            _id: "r1",
+            role_name: "AIRQO_SUPER_ADMIN",
+            role_code: "AIRQO_SUPER_ADMIN",
+            role_permissions: [], // out of sync vs. expected ["p1"]
+            group_id: "already-set-group-id",
+          }),
+        }),
+        findByIdAndUpdate: findByIdAndUpdateStub,
+      }));
+
+      rewireRPU.__set__("PermissionModel", () => ({
+        find: sinon.stub().returns({
+          select: sinon.stub().returns({
+            lean: sinon.stub().resolves([{ _id: "p1", permission: "SUPER_ADMIN" }]),
+          }),
+        }),
+      }));
+
+      const result = await createOrUpdateRoleWithPermissionSync("airqo", {
+        role_name: "AIRQO_SUPER_ADMIN",
+        role_code: "AIRQO_SUPER_ADMIN",
+        role_description: "desc",
+        permissions: ["SUPER_ADMIN"],
+        group_id: "g1", // must NOT be applied — existingRole already has one
+      });
+
+      expect(findByIdAndUpdateStub.calledOnce).to.equal(true);
+      expect(findByIdAndUpdateStub.firstCall.args[1]).to.not.have.property(
+        "group_id",
+      );
+      expect(result.message).to.equal(
+        "Role AIRQO_SUPER_ADMIN permissions synchronized",
+      );
+    });
+
+    it("should remain unchanged when group_id and permissions are already correct", async () => {
       const findByIdAndUpdateStub = sinon.stub();
 
       rewireRPU.__set__("RoleModel", () => ({


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Backfills the `group_id` field on existing roles during the RBAC permission sync (`createOrUpdateRoleWithPermissionSync`) that runs on every auth-service startup. Previously, if a role already existed by `role_name`/`role_code`, the update path only refreshed its permissions and status — it never set `group_id`, so a legacy role missing that field stayed missing it forever, on every restart, in every environment.

### Why is this change needed?
In staging, `AIRQO_SUPER_ADMIN` was not appearing in the assignable-roles dropdown on the nexus frontend, even though the role existed, was `ACTIVE`, and several users already held it. Root cause: this role was created before the group-based RBAC model existed and only carried a legacy `network_id`, never a `group_id`. Any lookup filtered by `group_id` (like the frontend's `GET /users/roles?group_id=<id>`) excluded it, while a lookup by `role_name` alone still displayed a resolved "airqo" group via an unrelated legacy display fallback — masking the missing field. The startup RBAC sync should have self-healed this but never wrote `group_id` on its update branch. This fix closes that gap using the group already resolved by `grp_title` upstream, so no hardcoded ObjectIds are involved and the fix applies correctly regardless of environment.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- auth-service

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added two regression tests for `createOrUpdateRoleWithPermissionSync` covering (1) `group_id` is backfilled when missing on an existing role even if permissions are already synced, and (2) an existing `group_id` is never overwritten. Full `utils/test/ut_role-permissions.util.js` suite passes; ran the broader unit suite and confirmed the only failure (`getDifferenceInMonths` in `ut_date.util.js`) is pre-existing and unrelated to this change. Not yet manually verified against a live staging restart.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
Diagnosed via API calls (no direct DB access) by comparing `GET /users/roles?role_name=AIRQO_SUPER_ADMIN` against `GET /users/roles?group_id=<airqo-group-id>` in staging — the role appeared in the first but not the second, confirming a `group_id` mismatch rather than a frontend, status, or duplicate-group issue. Since this runs inside `initializeRBAC()` on every service startup, deploying this fix will self-heal the affected role in staging on the next restart with no manual data patch required.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Existing roles with missing group information are now automatically updated with the correct group.
  * Existing role status is preserved when only group information is backfilled.
  * Permissions are synchronized without altering group information when the group is already correct.
  * Roles with synchronized permissions and complete group information are left unchanged.
  * Update responses now clearly indicate whether group information was backfilled, permissions were synchronized, or no changes were needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->