### PR TITLE
Reduce DB writes and log noise in raw online-status jobs uptime sampling

### DIFF
--- a/src/device-registry/bin/jobs/test/ut_update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/test/ut_update-raw-online-status-job.js
@@ -7,6 +7,7 @@ const {
 } = require("@bin/jobs/update-raw-online-status-job");
 const constants = require("@config/constants");
 const DeviceModel = require("@models/Device");
+const DeviceUptimeModel = require("@models/DeviceUptime");
 const createDeviceUtil = require("@utils/device.util");
 const createFeedUtil = require("@utils/feed.util");
 
@@ -49,6 +50,10 @@ describe("updateRawOnlineStatusJob", () => {
     decryptKeyStub = sinon.stub(createDeviceUtil, "decryptKey");
     fetchThingspeakDataStub = sinon.stub(createFeedUtil, "fetchThingspeakData");
     sinon.stub(DeviceModel("airqo"), "estimatedDocumentCount").resolves(1);
+    // updateRawOnlineStatus now also flushes best-effort DeviceUptime
+    // samples (see flushUptimeSamples) — stub it so tests never issue a
+    // real insertMany, matching the pattern for every other model call above.
+    sinon.stub(DeviceUptimeModel("airqo"), "insertMany").resolves([]);
   });
 
   afterEach(() => {

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -196,7 +196,7 @@ const mockNext = (error) => {
   logger.error(`Error passed to mock 'next' function in job: ${error.message}`);
 };
 
-const processDeviceBatch = async (devices, processor) => {
+const processDeviceBatch = async (devices, processor, uptimeSampleSink) => {
   const CONCURRENCY_LIMIT = 5; // Reduced from 8 to prevent overwhelming ThingSpeak
 
   // 1. Get device numbers for airqo devices only — ThingSpeak channels only
@@ -240,13 +240,6 @@ const processDeviceBatch = async (devices, processor) => {
       return 0;
     }
   }
-
-  // Accumulates one online/offline sample per device across every chunk in
-  // this batch (up to BATCH_SIZE devices), flushed in a single insertMany
-  // after the chunk loop below — one DB round trip per batch instead of one
-  // per 5-device chunk, matching the bulk-write batching already used for
-  // the other writes in this job.
-  const uptimeSamples = [];
 
   // 3. Process devices in smaller, concurrent chunks with yielding
   for (let i = 0; i < devices.length; i += CONCURRENCY_LIMIT) {
@@ -300,10 +293,11 @@ const processDeviceBatch = async (devices, processor) => {
     const bulkOps = batchResult.results.filter(Boolean);
 
     // Record each device's just-computed raw online/offline status, keyed by
-    // network, into the batch-level accumulator (flushed once below). This is
-    // the ONE place in the codebase that checks every device's live status
-    // regardless of network — via ThingSpeak for "airqo" devices, via the
-    // network adapter's online_check_via_feed for external manufacturers
+    // network, into the caller-owned sink (flushed periodically across the
+    // whole job run — see updateRawOnlineStatus). This is the ONE place in
+    // the codebase that checks every device's live status regardless of
+    // network — via ThingSpeak for "airqo" devices, via the network
+    // adapter's online_check_via_feed for external manufacturers
     // (AirGradient, IQAir, etc.), and via stale-data fallback otherwise — so
     // it is what makes online-status data (and therefore the leaderboard/
     // verified-partner status) exist for non-AirQo networks at all, not just
@@ -311,23 +305,25 @@ const processDeviceBatch = async (devices, processor) => {
     // threading a new field through every return branch above, so the
     // online/offline determination logic itself is untouched — this only
     // observes its output.
-    const deviceById = new Map(chunk.map((d) => [String(d._id), d]));
-    bulkOps.forEach((op) => {
-      const device = deviceById.get(String(op.updateOne.filter._id));
-      const rawOnlineStatus = op.updateOne.update?.$set?.rawOnlineStatus;
-      if (!device || !device.name || rawOnlineStatus === undefined) {
-        return;
-      }
-      uptimeSamples.push({
-        created_at: new Date(),
-        device_name: device.name,
-        network: device.network,
-        channel_id: device.device_number || undefined,
-        uptime: rawOnlineStatus ? 100 : 0,
-        downtime: rawOnlineStatus ? 0 : 100,
-        status: rawOnlineStatus ? "online" : "offline",
+    if (constants.ENABLE_ONLINE_STATUS_UPTIME_SAMPLING && uptimeSampleSink) {
+      const deviceById = new Map(chunk.map((d) => [String(d._id), d]));
+      bulkOps.forEach((op) => {
+        const device = deviceById.get(String(op.updateOne.filter._id));
+        const rawOnlineStatus = op.updateOne.update?.$set?.rawOnlineStatus;
+        if (!device || !device.name || rawOnlineStatus === undefined) {
+          return;
+        }
+        uptimeSampleSink.push({
+          created_at: new Date(),
+          device_name: device.name,
+          network: device.network,
+          channel_id: device.device_number || undefined,
+          uptime: rawOnlineStatus ? 100 : 0,
+          downtime: rawOnlineStatus ? 0 : 100,
+          status: rawOnlineStatus ? "online" : "offline",
+        });
       });
-    });
+    }
 
     if (bulkOps.length > 0) {
       try {
@@ -399,30 +395,32 @@ const processDeviceBatch = async (devices, processor) => {
     // Yield between chunks
     await processor.yieldControl();
   }
+};
 
-  // Single flush for the whole batch (all chunks above), rather than one
-  // insertMany per 5-device chunk — cuts DB round trips for this write by
-  // roughly CONCURRENCY_LIMIT-fold. Timeout-guarded and non-fatal like the
-  // other bulk writes in this job: a slow/failed insert here never blocks or
-  // fails the actual status update, it only means that batch's samples are
-  // missing from the uptime leaderboard/verification data.
-  if (uptimeSamples.length > 0) {
-    try {
-      const BULK_TIMEOUT = 15000;
-      await Promise.race([
-        DeviceUptimeModel("airqo").insertMany(uptimeSamples, {
-          ordered: false,
-        }),
-        new Promise((_, reject) =>
-          setTimeout(
-            () => reject(new Error("Uptime sample insert timeout")),
-            BULK_TIMEOUT,
-          ),
+// Flushes accumulated uptime samples in one insertMany. Non-fatal and
+// best-effort by design: a slow/failed insert here never blocks or fails the
+// actual device status update above — it only means those samples are
+// missing from the uptime leaderboard/verification data. Logged at `warn`,
+// not `error`, precisely because it's a known-non-critical write; the
+// underlying database health should be judged on the primary status-update
+// writes (DeviceModel/SiteModel bulkWrite), not on this one.
+const flushUptimeSamples = async (samples) => {
+  if (!samples || samples.length === 0) return;
+  try {
+    const BULK_TIMEOUT = 15000;
+    await Promise.race([
+      DeviceUptimeModel("airqo").insertMany(samples, { ordered: false }),
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Uptime sample insert timeout")),
+          BULK_TIMEOUT,
         ),
-      ]);
-    } catch (error) {
-      logger.error(`Uptime sample insert error in batch: ${error.message}`);
-    }
+      ),
+    ]);
+  } catch (error) {
+    logger.warn(
+      `Uptime sample insert error (${samples.length} sample(s) dropped): ${error.message}`,
+    );
   }
 };
 
@@ -1200,6 +1198,19 @@ const updateRawOnlineStatus = async () => {
     let errorCount = 0;
     const MAX_ERRORS = 50; // Stop if too many errors
 
+    // Uptime samples accumulate here across every batch in this run and are
+    // flushed periodically (not per-batch) — for a fleet of a few thousand
+    // devices that cuts DB round trips for this write from ~1 per 50 devices
+    // down to ~1 per 1000, which matters a lot more now that this job checks
+    // every device every hour instead of a narrow subset every 2h.
+    const pendingUptimeSamples = [];
+    const UPTIME_SAMPLE_FLUSH_THRESHOLD = 1000;
+    const maybeFlushUptimeSamples = async () => {
+      if (pendingUptimeSamples.length < UPTIME_SAMPLE_FLUSH_THRESHOLD) return;
+      const toFlush = pendingUptimeSamples.splice(0);
+      await flushUptimeSamples(toFlush);
+    };
+
     try {
       for await (const device of cursor) {
         if (processor.shouldStopExecution()) {
@@ -1211,7 +1222,7 @@ const updateRawOnlineStatus = async () => {
 
         if (batch.length >= BATCH_SIZE) {
           try {
-            await processDeviceBatch(batch, processor);
+            await processDeviceBatch(batch, processor, pendingUptimeSamples);
             totalProcessed += batch.length;
 
             logText(
@@ -1234,6 +1245,7 @@ const updateRawOnlineStatus = async () => {
           }
 
           batch = [];
+          await maybeFlushUptimeSamples();
 
           // Yield between batches to prevent blocking
           await processor.yieldControl();
@@ -1249,7 +1261,7 @@ const updateRawOnlineStatus = async () => {
     // Process the final batch if it's not empty
     if (batch.length > 0 && !processor.shouldStopExecution()) {
       try {
-        await processDeviceBatch(batch, processor);
+        await processDeviceBatch(batch, processor, pendingUptimeSamples);
         totalProcessed += batch.length;
         logText(`Final batch processed. Total: ${totalProcessed}`);
       } catch (finalBatchError) {
@@ -1258,6 +1270,9 @@ const updateRawOnlineStatus = async () => {
         );
       }
     }
+
+    // Flush whatever's left under the periodic threshold above.
+    await flushUptimeSamples(pendingUptimeSamples.splice(0));
 
     // Cleanup pass: find sites that have rawOnlineStatus: true but no active
     // device currently assigned. These are sites recalled before the recall

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -1256,23 +1256,35 @@ const updateRawOnlineStatus = async () => {
       }
     } finally {
       await cursor.close();
-    }
 
-    // Process the final batch if it's not empty
-    if (batch.length > 0 && !processor.shouldStopExecution()) {
+      // Handle the final (possibly partial) batch and flush any pending
+      // uptime samples here, inside the finally, so both still run even if
+      // cursor iteration above threw — otherwise an error mid-stream would
+      // discard up to UPTIME_SAMPLE_FLUSH_THRESHOLD-1 collected samples
+      // when it propagates. Same effective position/order as before on the
+      // success path; this only adds coverage for the error path. Own
+      // try/catch so a failure here can't mask an original error that's
+      // already propagating out of the try block above.
       try {
-        await processDeviceBatch(batch, processor, pendingUptimeSamples);
-        totalProcessed += batch.length;
-        logText(`Final batch processed. Total: ${totalProcessed}`);
-      } catch (finalBatchError) {
+        if (batch.length > 0 && !processor.shouldStopExecution()) {
+          try {
+            await processDeviceBatch(batch, processor, pendingUptimeSamples);
+            totalProcessed += batch.length;
+            logText(`Final batch processed. Total: ${totalProcessed}`);
+          } catch (finalBatchError) {
+            logger.error(
+              `Final batch processing error: ${finalBatchError.message}`,
+            );
+          }
+        }
+
+        await flushUptimeSamples(pendingUptimeSamples.splice(0));
+      } catch (cleanupError) {
         logger.error(
-          `Final batch processing error: ${finalBatchError.message}`,
+          `Error finalizing batch/uptime-sample flush: ${cleanupError.message}`,
         );
       }
     }
-
-    // Flush whatever's left under the periodic threshold above.
-    await flushUptimeSamples(pendingUptimeSamples.splice(0));
 
     // Cleanup pass: find sites that have rawOnlineStatus: true but no active
     // device currently assigned. These are sites recalled before the recall

--- a/src/device-registry/config/constants.js
+++ b/src/device-registry/config/constants.js
@@ -83,6 +83,16 @@ function envConfig(env) {
       false,
     ),
 
+    // update-raw-online-status-job's best-effort DeviceUptime sampling
+    // (leaderboard/verification data). Non-critical — a failure here never
+    // blocks the actual device status update. Kill-switch for turning it off
+    // instantly via env var (no redeploy) if it's ever implicated in DB load
+    // issues, without touching the job's core status-check logic.
+    ENABLE_ONLINE_STATUS_UPTIME_SAMPLING: parseBool(
+      process.env.ENABLE_ONLINE_STATUS_UPTIME_SAMPLING,
+      true,
+    ),
+
     // Cohort/device group-ownership scoping — when true, assigning a device
     // to a cohort is rejected if they don't share a network/group (the
     // "airqo" network/group is exempt). Default off: mismatches are only


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Fixes a log flood that appeared in staging right after the previous PR merged. In `update-raw-online-status-job`, the online-status uptime sampling added last round was inserting into `DeviceUptime` once per 50-device batch — for a full-fleet hourly sweep, that's 50-100+ separate DB round trips every run. This PR:

- Batches those writes across the **whole job run** instead of per-batch: samples now accumulate and flush every 1,000 (plus a final flush for the remainder), cutting DB round trips for this write by roughly 20-50x.
- Downgrades the failure log for this write from `error` to `warn` — it was always designed as best-effort telemetry that never blocks the real device status update, so logging it at `error` guaranteed it would flood the alerting channel on any hiccup.
- Adds `ENABLE_ONLINE_STATUS_UPTIME_SAMPLING` (default `true`) as an instant kill-switch via env var, so this can be silenced without a code redeploy if it's ever implicated in DB load again.

### Why is this change needed?

After merging the previous PR to staging, the Slack notification channel got flooded with repeated `device_uptimes.insertMany() buffering timed out after 10000ms` errors from `update-raw-online-status-job`. Root cause: this job now checks every device's online status hourly (previously a narrower/less frequent job touched this collection at all), and the added uptime-sampling write was structured to hit the database far more often than anything else that writes to this collection — a volume of new round-trip traffic staging's MongoDB tier wasn't absorbing cleanly. This PR reduces that write's frequency and makes its failure mode appropriately quiet, without touching the actual online/offline determination logic.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** `node -c` passes on both changed files. Diffed the full session's changes to `update-raw-online-status-job.js` against the pre-session baseline commit to confirm the online/offline determination logic (`isDeviceRawActive`, `classifyFeedTimestamp`, `processIndividualDevice`, ThingSpeak/adapter routing, etc.) is byte-for-byte unchanged — every change is additive or a call-site parameter pass-through. No live MongoDB access in this environment to reproduce the actual timeout scenario; recommend watching the first staging run after this deploys to confirm the error volume drops.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely a performance/logging change to a best-effort, non-critical write path. The primary device online/offline status update is unaffected.

---

## :memo: Additional Notes

- If the error volume doesn't drop after this deploys, set `ENABLE_ONLINE_STATUS_UPTIME_SAMPLING=false` in staging to disable the write entirely while investigating further (e.g. checking the actual MongoDB connection pool/index state on `device_uptimes` directly).
- This only reduces *frequency* of the write, not the underlying cause if it turns out to be something else (e.g. connection pool sizing, an index build issue) — worth confirming with a clean run before considering this fully resolved.

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable uptime sampling for online status updates, enabled by default.
  * Uptime samples are now accumulated throughout each job run and saved in batches.

* **Bug Fixes**
  * Improved uptime sample persistence reliability with periodic and final flushing.
  * Added a configuration switch to disable optional uptime sampling without affecting status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->