### PR TITLE
Add read-only diagnostics endpoint for device_uptimes index and migration status

### DIFF
--- a/src/device-registry/controllers/uptime.controller.js
+++ b/src/device-registry/controllers/uptime.controller.js
@@ -317,6 +317,43 @@ const uptime = {
       );
     }
   },
+
+  getDeviceUptimeDiagnostics: async (req, res, next) => {
+    try {
+      const errors = extractErrorsFromRequest(req);
+      if (errors) {
+        next(
+          new HttpError("Bad request errors", httpStatus.BAD_REQUEST, errors)
+        );
+        return;
+      }
+
+      const defaultTenant = constants.DEFAULT_TENANT || "airqo";
+      const tenant = isEmpty(req.query.tenant)
+        ? defaultTenant
+        : req.query.tenant;
+
+      const result = await createUptimeUtil.getDeviceUptimeDiagnostics(
+        { tenant },
+        next
+      );
+
+      if (isEmpty(result) || res.headersSent) {
+        return;
+      }
+
+      handleResponse({ result, res });
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message }
+        )
+      );
+    }
+  },
 };
 
 module.exports = uptime;

--- a/src/device-registry/routes/v2/uptime.routes.js
+++ b/src/device-registry/routes/v2/uptime.routes.js
@@ -49,6 +49,16 @@ router.get(
   uptime.getNetworkUptimeLeaderboard
 );
 
+// Read-only diagnostics for the device_uptimes buffering-timeout
+// investigation — reports migration status + real current indexes on
+// device_uptimes, straight from the raw driver. Temporary/investigative;
+// safe to remove once the underlying issue is confirmed resolved.
+router.get(
+  "/diagnostics",
+  uptimeValidations.getDiagnostics,
+  uptime.getDeviceUptimeDiagnostics
+);
+
 router.get("/health", pagination(), (req, res) => {
   console.info("health status OK");
   return res.status(200).json({

--- a/src/device-registry/utils/uptime.util.js
+++ b/src/device-registry/utils/uptime.util.js
@@ -679,7 +679,7 @@ const createUptime = {
   // real index list on device_uptimes straight from the raw driver — so this
   // can be checked over HTTP without DB shell or pod-log access. Two
   // independent lookups, each wrapped so one failing doesn't hide the other.
-  getDeviceUptimeDiagnostics: async (params, next) => {
+  getDeviceUptimeDiagnostics: async (params) => {
     const tenant = params.tenant || constants.DEFAULT_TENANT || "airqo";
 
     let migration;

--- a/src/device-registry/utils/uptime.util.js
+++ b/src/device-registry/utils/uptime.util.js
@@ -10,6 +10,8 @@ const isEmpty = require("is-empty");
 const logger = log4js.getLogger(`${constants.ENVIRONMENT} -- uptime-util`);
 const { logObject, HttpError } = require("@utils/shared");
 const httpStatus = require("http-status");
+const MigrationTrackerModel = require("@models/MigrationTracker");
+const { getRawTenantDB } = require("@config/database");
 
 const createUptime = {
   bigQueryClient: new BigQuery(),
@@ -669,6 +671,69 @@ const createUptime = {
         )
       );
     }
+  },
+
+  // Read-only diagnostics for the device_uptimes buffering-timeout
+  // investigation: reports whether the index-fix migration
+  // (migrations/device-uptime-index-fix.js) actually ran, and the *current*
+  // real index list on device_uptimes straight from the raw driver — so this
+  // can be checked over HTTP without DB shell or pod-log access. Two
+  // independent lookups, each wrapped so one failing doesn't hide the other.
+  getDeviceUptimeDiagnostics: async (params, next) => {
+    const tenant = params.tenant || constants.DEFAULT_TENANT || "airqo";
+
+    let migration;
+    try {
+      const tracker = await MigrationTrackerModel(tenant)
+        .findOne({ name: "device-uptime-index-fix-v1", tenant })
+        .lean();
+      migration = tracker
+        ? {
+            status: tracker.status,
+            startedAt: tracker.startedAt,
+            completedAt: tracker.completedAt,
+            error: tracker.error || null,
+          }
+        : { status: "not_found" };
+    } catch (migrationError) {
+      migration = { status: "lookup_failed", error: migrationError.message };
+    }
+
+    let device_uptimes_indexes;
+    try {
+      const tenantDB = getRawTenantDB(tenant);
+      const collections = await tenantDB.db
+        .listCollections({ name: "device_uptimes" })
+        .toArray();
+
+      if (collections.length === 0) {
+        device_uptimes_indexes = { collection_exists: false };
+      } else {
+        const rawIndexes = await tenantDB.db
+          .collection("device_uptimes")
+          .indexes();
+        device_uptimes_indexes = {
+          collection_exists: true,
+          indexes: rawIndexes.map((idx) => ({
+            name: idx.name,
+            key: idx.key,
+            expireAfterSeconds:
+              idx.expireAfterSeconds !== undefined
+                ? idx.expireAfterSeconds
+                : null,
+          })),
+        };
+      }
+    } catch (indexError) {
+      device_uptimes_indexes = { error: indexError.message };
+    }
+
+    return {
+      success: true,
+      message: "Diagnostics retrieved",
+      status: httpStatus.OK,
+      data: { tenant, migration, device_uptimes_indexes },
+    };
   },
 };
 

--- a/src/device-registry/validators/uptime.validators.js
+++ b/src/device-registry/validators/uptime.validators.js
@@ -197,6 +197,10 @@ const uptimeValidations = {
     ...commonValidations.rounding,
     commonValidations.errorChecker,
   ],
+  getDiagnostics: [
+    ...commonValidations.tenant,
+    commonValidations.errorChecker,
+  ],
 };
 
 module.exports = uptimeValidations;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a read-only diagnostics endpoint, `GET /api/v2/devices/uptime/diagnostics`, that reports:
1. Whether `migrations/device-uptime-index-fix.js` (from the previous PR) actually ran, and what it found — pulled from its `MigrationTracker` record.
2. The **current, real** index list on `device_uptimes`, fetched directly via the raw MongoDB driver rather than through the Mongoose model that's currently exhibiting the buffering-timeout issue.

### Why is this change needed?

Staging is still throwing `device_uptimes.aggregate() buffering timed out after 10000ms` on every read against `device_uptimes` (`/uptime/leaderboard`, `/uptime/leaderboard/network`, and the pre-existing `/uptime/device`), consistently, over several hours — while the hourly job's writes to the same collection keep succeeding. We don't have direct DB or full pod-log access to confirm whether the earlier index-fix migration actually ran, ran and failed, or ran and found nothing to fix. This endpoint answers that over a single HTTP request instead of continuing to guess from Slack error logs alone, and works independently of whatever is currently broken on the Mongoose-level model (it uses the raw driver for the index lookup specifically because of that).

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

*(Diagnostic tooling in support of an ongoing incident investigation, not itself a fix.)*

---

## :building_construction: Affected Services

**Microservices changed:** `device-registry` only.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

**Test summary:** `node -c` passes on all four changed files. No live database in this environment to exercise the endpoint end-to-end — verification is the point of shipping it: hit it on staging after deploy and read the response directly.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Purely additive — one new route, one new controller action, one new util function, one new validator. Nothing existing is touched.

---

## :memo: Additional Notes

- This is investigative/temporary tooling for the active `device_uptimes` buffering-timeout issue — safe to remove once that's confirmed resolved.
- Staging runs 2 replicas (`replicaCount: 2`); since requests may be load-balanced (or pinned via HTTP keep-alive) to either pod, it's worth calling this endpoint a few times in a row to check whether both pods report the same state.
- No auth on this route, consistent with the rest of device-registry (see the "A NOTE ON AUTH" banner in `utils/device.util.js`) — it returns index metadata and migration status only, nothing sensitive (no connection strings/credentials).

---

## :white_check_mark: Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only uptime diagnostics endpoint for reviewing tenant migration status and current `device_uptimes` indexes.
  * Added tenant query validation, including a default tenant when none is provided.
  * Diagnostics responses now report lookup results independently, allowing partial information when one check fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->