### PR TITLE
Fix invalid regex crash in cohort device search

### DIFF
--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -32,6 +32,9 @@ const buildDeviceSetKey = (deviceIds) => {
 
 const AIRQO_NETWORK = "airqo";
 
+const escapeRegex = (str) =>
+  String(str).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 // A device may be assigned to a cohort only if they share network/group
 // ownership, unless either side is the "airqo" network/group — AirQo staff
 // legitimately manage cross-organization monitoring cohorts.
@@ -2560,7 +2563,7 @@ const createCohort = {
         tenant,
       };
       if (search) {
-        filter.name = { $regex: search, $options: "i" };
+        filter.name = { $regex: escapeRegex(search), $options: "i" };
       }
       if (status) {
         filter.status = status;

--- a/src/device-registry/utils/cohort.util.js
+++ b/src/device-registry/utils/cohort.util.js
@@ -2703,7 +2703,7 @@ const createCohort = {
         tenant,
       };
       if (search) {
-        const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const escapedSearch = escapeRegex(search);
         filter.$or = [
           { name: { $regex: escapedSearch, $options: "i" } },
           { search_name: { $regex: escapedSearch, $options: "i" } },

--- a/src/device-registry/utils/test/ut_cohort.util.js
+++ b/src/device-registry/utils/test/ut_cohort.util.js
@@ -807,4 +807,74 @@ describe("createCohort", () => {
       expect(next.calledOnce).to.be.true;
     });
   });
+
+  describe("listCachedDevices", () => {
+    const proxyquire = require("proxyquire");
+    const cohortObjectId = new mongoose.Types.ObjectId();
+
+    // Wires @models/Cohort and @models/CohortDeviceSnapshot to in-memory
+    // stubs so the search-regex behavior can be exercised without a real
+    // DB connection. `capture` records the filter passed to find()/
+    // countDocuments() so the test can assert on the escaped $regex value.
+    const buildProxiedCohortUtil = ({ coveredCohortIds, capture }) =>
+      proxyquire("../cohort.util", {
+        "@models/Cohort": () => ({
+          find: () => ({
+            select: () => ({
+              lean: () =>
+                Promise.resolve([
+                  { _id: cohortObjectId, cohort_slug: "test-cohort" },
+                ]),
+            }),
+          }),
+        }),
+        "@models/CohortDeviceSnapshot": () => ({
+          distinct: () => ({
+            maxTimeMS: () => Promise.resolve(coveredCohortIds),
+          }),
+          countDocuments: (filter) => {
+            capture.countFilter = filter;
+            return { maxTimeMS: () => Promise.resolve(0) };
+          },
+          find: (filter) => {
+            capture.findFilter = filter;
+            return {
+              skip: () => ({
+                limit: () => ({
+                  select: () => ({
+                    lean: () => ({
+                      maxTimeMS: () => Promise.resolve([]),
+                    }),
+                  }),
+                }),
+              }),
+            };
+          },
+        }),
+      });
+
+    it("should escape regex metacharacters in search instead of throwing", async () => {
+      const capture = {};
+      const proxiedCohortUtil = buildProxiedCohortUtil({
+        coveredCohortIds: [cohortObjectId],
+        capture,
+      });
+      const next = sinon.stub();
+
+      const result = await proxiedCohortUtil.listCachedDevices(
+        {
+          body: { cohort_ids: [cohortObjectId.toString()] },
+          // Trailing backslash previously reproduced:
+          // "Regular expression is invalid: \ at end of pattern"
+          query: { tenant: "airqo", search: "sensor\\" },
+        },
+        next
+      );
+
+      expect(next.called).to.be.false;
+      expect(result.success).to.be.true;
+      expect(capture.findFilter.name.$regex).to.equal("sensor\\\\");
+      expect(capture.countFilter.name.$regex).to.equal("sensor\\\\");
+    });
+  });
 });


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Escapes user-supplied `search` query values before using them to build a MongoDB `$regex` filter in `listCachedDevices` (cohort.util.js). Special regex characters (e.g. a trailing `\`) are now treated as literal text instead of regex syntax.

### Why is this change needed?
Production logs showed repeated errors: `Regular expression is invalid: \ at end of pattern`, thrown whenever a `search` value containing an unescaped backslash (or other regex metacharacter) reached the `$regex` filter. This also left the endpoint open to regex-injection/ReDoS via unsanitized user input.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- device-registry

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified that a `search` value ending in `\` (previously reproducing the production error) no longer throws and is matched as a literal substring.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
Reuses the same regex-escaping approach already applied elsewhere in device-registry (`generate-filter.js`).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cached-device searches now treat user-entered text literally, improving results when search terms contain special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->