### PR TITLE
Log subscription ID on getSubscriptionStatus Paddle errors

### DIFF
--- a/src/auth-service/utils/transaction.util.js
+++ b/src/auth-service/utils/transaction.util.js
@@ -1498,6 +1498,7 @@ const transactions = {
    */
   getSubscriptionStatus: async (request) => {
     if (!isPaddleConfigured) return PADDLE_NOT_CONFIGURED;
+    let freshUser;
     try {
       const tenant =
         (request.query && request.query.tenant) ||
@@ -1506,7 +1507,7 @@ const transactions = {
 
       // Re-fetch from DB: request.user is decoded from the JWT and may predate
       // the webhook that wrote currentSubscriptionId onto the user document.
-      const freshUser = await UserModel(tenant)
+      freshUser = await UserModel(tenant)
         .findById(request.user._id)
         .select("currentSubscriptionId subscriptionStatus")
         .lean();
@@ -1543,7 +1544,9 @@ const transactions = {
         },
       };
     } catch (error) {
-      logger.error(`getSubscriptionStatus error --- ${stringify(error)}`);
+      logger.error(
+        `getSubscriptionStatus error for user ${request.user._id}, subscriptionId ${freshUser && freshUser.currentSubscriptionId} --- ${stringify(error)}`,
+      );
       return {
         success: false,
         message: "Internal Server Error",


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds the user ID and `currentSubscriptionId` to the error log emitted by `getSubscriptionStatus` when a call to Paddle's `subscriptions.get` fails.

### Why is this change needed?
Staging has been repeatedly logging `getSubscriptionStatus error --- forbidden` from the Paddle SDK, but the log only stringified the Paddle error and gave no way to identify which user or subscription ID triggered it. This blocked diagnosis of whether the failing subscription ID belongs to a different Paddle account/environment than the configured sandbox key. The fix hoists `freshUser` above the `try` block so it stays in scope in the `catch` handler, then includes it in the log line.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** auth-service (`utils/transaction.util.js`)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified the error path retains the correct value of `freshUser` (now declared outside `try`) and no longer throws a `ReferenceError` when the Paddle call fails before or after the DB lookup.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

Log-only change — no behavior change to the API response. Once deployed, the next occurrence of this Paddle `forbidden` error in staging logs will include the offending `currentSubscriptionId`, which can then be cross-checked against the Paddle sandbox dashboard to confirm whether it belongs to a mismatched account/environment.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription status error reporting by including the relevant user and subscription identifiers when available.
  * Ensured additional account context is retained when handling subscription status errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->