### PR TITLE
Fix nearest-site search: sort, online_status, partner networks

### DIFF
--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -1069,7 +1069,7 @@ siteSchema.statics = {
       }
 
       const pipeline = await this.aggregate()
-        .match({ ...filter, network: "airqo" })
+        .match({ ...filter })
         .lookup({
           from: "devices",
           localField: "_id",
@@ -1384,3 +1384,8 @@ const SiteModel = (tenant) => {
 };
 
 module.exports = SiteModel;
+// Exposed so tests can call a static directly (e.g.
+// SiteModel.statics.listAirQoActive.call(fakeModel, args, next)) against a
+// plain mocked `this` — no mongoose model compilation or DB connection
+// needed, unlike SiteModel(tenant) which requires one via getModelByTenant.
+module.exports.statics = siteSchema.statics;

--- a/src/device-registry/models/test/ut_site.model.js
+++ b/src/device-registry/models/test/ut_site.model.js
@@ -223,4 +223,60 @@ describe("the Site Model", function() {
         : done();
     });
   });
+
+  // listAirQoActive is a plain async function living on siteSchema.statics
+  // that only ever touches `this.aggregate()`. Rather than going through
+  // mongoose at all, call it with .call() against a bare mocked `this` —
+  // ordinary function mocking, no schema compilation, no DB connection.
+  describe("listAirQoActive", function() {
+    function buildAggregateChain(response) {
+      const captured = { matchCalls: [] };
+      const chain = {};
+      chain.match = sinon.stub().callsFake((query) => {
+        captured.matchCalls.push(query);
+        return chain;
+      });
+      ["lookup", "unwind", "addFields", "sort", "project", "skip", "limit", "allowDiskUse"].forEach(
+        (method) => {
+          chain[method] = sinon.stub().callsFake(() => chain);
+        }
+      );
+      chain.then = (resolve) => resolve(response);
+      return { chain, captured };
+    }
+
+    function fakeModel(response) {
+      const { chain, captured } = buildAggregateChain(response);
+      return { model: { aggregate: sinon.stub().returns(chain) }, captured };
+    }
+
+    it("does not restrict results to the airqo network", async function() {
+      const { model, captured } = fakeModel([]);
+      const next = sinon.stub();
+
+      const result = await SiteSchema.statics.listAirQoActive.call(
+        model,
+        { filter: {} },
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      const [siteMatchStage] = captured.matchCalls;
+      expect(siteMatchStage).to.not.have.property("network");
+    });
+
+    it("preserves an explicit partner-network filter instead of overriding it to airqo", async function() {
+      const { model, captured } = fakeModel([]);
+      const next = sinon.stub();
+
+      await SiteSchema.statics.listAirQoActive.call(
+        model,
+        { filter: { network: "partner_network" } },
+        next
+      );
+
+      const [siteMatchStage] = captured.matchCalls;
+      expect(siteMatchStage).to.deep.equal({ network: "partner_network" });
+    });
+  });
 });

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -2208,7 +2208,7 @@ const createSite = {
   },
   findNearestSitesByCoordinates: async (request, next) => {
     try {
-      let { radius, latitude, longitude, tenant } = {
+      let { radius, latitude, longitude, tenant, online_status, limit } = {
         ...request.body,
         ...request.query,
         ...request.params,
@@ -2226,6 +2226,13 @@ const createSite = {
         let nearest_sites = [];
         sites.forEach((site) => {
           if ("latitude" in site && "longitude" in site) {
+            if (online_status === "online" && site.isOnline !== true) {
+              return;
+            }
+            if (online_status === "offline" && site.isOnline !== false) {
+              return;
+            }
+
             const distanceBetweenTwoPoints = distance.calculateDistance(
               {
                 latitude1: latitude,
@@ -2237,11 +2244,16 @@ const createSite = {
             );
 
             if (distanceBetweenTwoPoints < radius) {
-              site["distance"] = distanceBetweenTwoPoints;
+              site["distance_km"] = distanceBetweenTwoPoints;
               nearest_sites.push(site);
             }
           }
         });
+
+        nearest_sites.sort((a, b) => a["distance_km"] - b["distance_km"]);
+
+        const maxResults = Math.min(Number(limit) || 20, 100);
+        nearest_sites = nearest_sites.slice(0, maxResults);
 
         logObject("nearest_sites", nearest_sites);
 

--- a/src/device-registry/utils/test/ut_site.util.js
+++ b/src/device-registry/utils/test/ut_site.util.js
@@ -747,6 +747,16 @@ describe("createSite Util Functions", () => {
   });
 
   describe("findNearestSitesByCoordinates", () => {
+    let sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
     it("should find nearest sites", async () => {
       const radius = 10;
       const latitude = 0.1;
@@ -780,6 +790,156 @@ describe("createSite Util Functions", () => {
 
       // On DB error, the catch block calls next(HttpError) without returning
       expect(result !== undefined || next.called).to.be.true;
+    });
+
+    // Mock @models/Site via proxyquire (same approach as listForComparisonPicker
+    // below) rather than stubbing SiteModel(tenant) directly — the latter requires
+    // a live mongoose connection lookup and throws "Query database connection not
+    // established" in this test environment.
+    describe("with a mocked site model", () => {
+      const proxyquire = require("proxyquire");
+      let proxiedSiteUtil;
+      let listAirQoActiveStub;
+      let next;
+
+      beforeEach(() => {
+        listAirQoActiveStub = sinon.stub();
+        proxiedSiteUtil = proxyquire("../site.util", {
+          "@models/Site": () => ({
+            listAirQoActive: listAirQoActiveStub,
+          }),
+        });
+        next = sinon.stub();
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it("sorts results by distance ascending and tags them with distance_km", async () => {
+        const sites = [
+          { _id: "far", latitude: 5, longitude: 5, isOnline: true },
+          { _id: "near", latitude: 0.01, longitude: 0.01, isOnline: true },
+          { _id: "mid", latitude: 1, longitude: 1, isOnline: true },
+        ];
+        listAirQoActiveStub.resolves({
+          success: true,
+          data: sites,
+          status: httpStatus.OK,
+        });
+
+        const result = await proxiedSiteUtil.findNearestSitesByCoordinates(
+          {
+            body: {},
+            query: { radius: 10000, latitude: 0, longitude: 0, tenant: "airqo" },
+            params: {},
+          },
+          next
+        );
+
+        expect(result.success).to.equal(true);
+        expect(result.data.map((s) => s._id)).to.deep.equal([
+          "near",
+          "mid",
+          "far",
+        ]);
+        result.data.forEach((s) => {
+          expect(s).to.have.property("distance_km");
+          expect(s).to.not.have.property("distance");
+        });
+      });
+
+      it("filters by online_status when provided", async () => {
+        const sites = [
+          { _id: "onlineSite", latitude: 0.01, longitude: 0.01, isOnline: true },
+          {
+            _id: "offlineSite",
+            latitude: 0.02,
+            longitude: 0.02,
+            isOnline: false,
+          },
+        ];
+        listAirQoActiveStub.resolves({
+          success: true,
+          data: sites,
+          status: httpStatus.OK,
+        });
+
+        const result = await proxiedSiteUtil.findNearestSitesByCoordinates(
+          {
+            body: {},
+            query: {
+              radius: 10000,
+              latitude: 0,
+              longitude: 0,
+              tenant: "airqo",
+              online_status: "online",
+            },
+            params: {},
+          },
+          next
+        );
+
+        expect(result.data.map((s) => s._id)).to.deep.equal(["onlineSite"]);
+      });
+
+      it("caps the number of results at the requested limit", async () => {
+        const sites = [0, 1, 2, 3, 4].map((i) => ({
+          _id: `site-${i}`,
+          latitude: 0.01 * (i + 1),
+          longitude: 0.01 * (i + 1),
+          isOnline: true,
+        }));
+        listAirQoActiveStub.resolves({
+          success: true,
+          data: sites,
+          status: httpStatus.OK,
+        });
+
+        const result = await proxiedSiteUtil.findNearestSitesByCoordinates(
+          {
+            body: {},
+            query: {
+              radius: 10000,
+              latitude: 0,
+              longitude: 0,
+              tenant: "airqo",
+              limit: 2,
+            },
+            params: {},
+          },
+          next
+        );
+
+        expect(result.data).to.have.lengthOf(2);
+        expect(result.data.map((s) => s._id)).to.deep.equal([
+          "site-0",
+          "site-1",
+        ]);
+      });
+
+      it("excludes sites at or beyond the radius", async () => {
+        const sites = [
+          { _id: "inRange", latitude: 0.01, longitude: 0.01, isOnline: true },
+          { _id: "outOfRange", latitude: 10, longitude: 10, isOnline: true },
+        ];
+        listAirQoActiveStub.resolves({
+          success: true,
+          data: sites,
+          status: httpStatus.OK,
+        });
+
+        const result = await proxiedSiteUtil.findNearestSitesByCoordinates(
+          {
+            body: {},
+            query: { radius: 5, latitude: 0, longitude: 0, tenant: "airqo" },
+            params: {},
+          },
+          next
+        );
+
+        expect(result.data.map((s) => s._id)).to.deep.equal(["inRange"]);
+      });
     });
   });
 

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -486,6 +486,17 @@ const validateNearestSite = [
     .withMessage("the radius must be a number")
     .bail()
     .toFloat(),
+  query("online_status")
+    .optional()
+    .notEmpty()
+    .withMessage("the online_status should not be empty if provided")
+    .bail()
+    .trim()
+    .toLowerCase()
+    .isIn(["online", "offline"])
+    .withMessage(
+      "the online_status value is not among the expected ones which include: online, offline",
+    ),
 ];
 
 const validateBulkUpdateSites = [


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the backend `GET /sites/nearest` endpoint in device-registry:
- Sorts returned sites by distance ascending (was unsorted)
- Renames the distance field to `distance_km` (was `distance`)
- Honors the `online_status` query param (`online`/`offline`) instead of silently ignoring it
- Caps the number of results returned
- Makes partner-network sites eligible as "nearest" candidates instead of being hardcoded to the `airqo` network only

Also adds unit test coverage for all of the above, including new tests for `SiteModel.listAirQoActive`'s aggregation filter that mock the model directly (no DB connection required).

### Why is this change needed?
While auditing the endpoint in response to a researcher support question, we found it was built but never actually wired up to any client (dead code) and had several correctness bugs that would need fixing before it could be documented publicly or used by any client. The team also confirmed partner-network sites should be eligible as nearest-site candidates, not just AirQo's own network.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** device-registry

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Added tests in `utils/test/ut_site.util.js` covering sort order, `online_status` filtering, result-limit capping, and radius exclusion for `findNearestSitesByCoordinates`. Added tests in `models/test/ut_site.model.js` for `SiteModel.listAirQoActive`'s network scoping, calling the static directly against a mocked `this` (no live DB connection needed). Verified the new model-level tests actually catch a regression by reverting the fix locally and confirming they fail. Full existing suites for both files pass.

---

## :boom: Breaking Changes
- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

The nearest-site response field was renamed from `distance` to `distance_km`. There are currently no known live consumers of this endpoint (confirmed dead code on the mobile side), so real-world impact should be minimal, but any future integration should use the new field name.

---

## :memo: Additional Notes
Deferred to a later PR: adding a GeoJSON/`2dsphere` index for DB-level radius filtering (currently filters in JS after fetching candidate sites), and publishing this as a documented public endpoint.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced nearest-site searches with online/offline status filtering.
  - Results are sorted by distance, include distance in kilometers, and support configurable limits up to 100 sites.
  - Searches now exclude sites outside the requested radius.
  - Added validation for the `online_status` query parameter, accepting only `online` or `offline`.

- **Bug Fixes**
  - Active-site listings now respect the requested network filter instead of always restricting results to the AirQo network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->