### PR TITLE
Add geospatial index for nearest-site search

### DIFF
--- a/src/device-registry/bin/jobs/run-migrations.js
+++ b/src/device-registry/bin/jobs/run-migrations.js
@@ -7,6 +7,7 @@ const SiteModel = require("@models/Site");
 // Import all migrations
 const networkStatusMigration = require("@migrations/network-status-indexes");
 const deviceUptimeIndexFixMigration = require("@migrations/device-uptime-index-fix");
+const siteLocationGeospatialIndexMigration = require("@migrations/site-location-geospatial-index");
 
 // One-time cleanup: remove geocoding failure tracking fields that were made
 // obsolete when the backfill job was simplified to use isOnline + createdAt
@@ -74,6 +75,14 @@ async function runStartupMigrations() {
     await resetGeocodingExclusionFields();
   } catch (error) {
     logger.error(`🐛🐛 resetGeocodingExclusionFields failed: ${error.message}`);
+  }
+
+  try {
+    await siteLocationGeospatialIndexMigration.executeMigration();
+  } catch (error) {
+    logger.error(
+      `🐛🐛 siteLocationGeospatialIndexMigration failed: ${error.message}`
+    );
   }
 }
 

--- a/src/device-registry/migrations/site-location-geospatial-index.js
+++ b/src/device-registry/migrations/site-location-geospatial-index.js
@@ -1,0 +1,224 @@
+// migrations/site-location-geospatial-index.js
+//
+// Backfills the GeoJSON `location` field (see models/Site.js) on sites
+// created before it existed, then creates the 2dsphere index it backs.
+// Going forward, `location` is set on creation by the Site pre-save hook —
+// this migration only needs to run once, for the pre-existing backlog.
+const constants = require("@config/constants");
+const log4js = require("log4js");
+const logger = log4js.getLogger(
+  `${constants.ENVIRONMENT} -- site-location-geospatial-index-migration`
+);
+const MigrationTrackerModel = require("@models/MigrationTracker");
+const { getRawTenantDB, connectToMongoDB } = require("@config/database");
+
+const MIGRATION_NAME = "site-location-geospatial-index-v1";
+const BATCH_SIZE = 500;
+// This service only ever runs against one tenant — the real multi-tenant
+// design was abandoned; "airqo" is the database's permanent identity, not a
+// placeholder. No tenant loop/array here on purpose (see project memory on
+// tenant handling) — a single direct run against the default tenant.
+const TENANT = constants.DEFAULT_TENANT || "airqo";
+
+async function checkMigrationStatus() {
+  try {
+    const tracker = await MigrationTrackerModel(TENANT).findOne({
+      name: MIGRATION_NAME,
+      tenant: TENANT,
+    });
+
+    if (!tracker) {
+      await MigrationTrackerModel(TENANT).create({
+        name: MIGRATION_NAME,
+        tenant: TENANT,
+        status: "pending",
+      });
+      return "pending";
+    }
+
+    return tracker.status;
+  } catch (error) {
+    logger.error(`🐛🐛 Error checking migration status: ${error.message}`);
+    throw error;
+  }
+}
+
+async function updateMigrationStatus(status, error = null) {
+  try {
+    const update = {
+      status,
+      ...(status === "running" && { startedAt: new Date() }),
+      ...(status === "completed" && { completedAt: new Date() }),
+      ...(error && { error: error.message }),
+    };
+
+    await MigrationTrackerModel(TENANT).findOneAndUpdate(
+      { name: MIGRATION_NAME, tenant: TENANT },
+      update,
+      { new: true }
+    );
+  } catch (error) {
+    logger.error(`🐛🐛 Error updating migration status: ${error.message}`);
+    throw error;
+  }
+}
+
+async function backfillLocations(collection) {
+  const filter = {
+    latitude: { $type: "number" },
+    longitude: { $type: "number" },
+    location: { $exists: false },
+  };
+
+  let totalBackfilled = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const sites = await collection
+      .find(filter, { projection: { _id: 1, latitude: 1, longitude: 1 } })
+      .limit(BATCH_SIZE)
+      .toArray();
+
+    if (sites.length === 0) {
+      break;
+    }
+
+    const bulkOps = sites.map((site) => ({
+      updateOne: {
+        filter: { _id: site._id },
+        update: {
+          $set: {
+            location: {
+              type: "Point",
+              coordinates: [site.longitude, site.latitude],
+            },
+          },
+        },
+      },
+    }));
+
+    const result = await collection.bulkWrite(bulkOps, { ordered: false });
+    totalBackfilled += result.modifiedCount || 0;
+
+    // Batch fully processed and filter still matches the same count means
+    // every remaining match failed to update (shouldn't happen, but avoids
+    // an infinite loop if it ever does).
+    if (sites.length < BATCH_SIZE) {
+      break;
+    }
+  }
+
+  return totalBackfilled;
+}
+
+async function migrateSiteLocations() {
+  try {
+    const tenantDB = getRawTenantDB(TENANT);
+    const collectionName = "sites";
+
+    const collections = await tenantDB.db
+      .listCollections({ name: collectionName })
+      .toArray();
+    if (collections.length === 0) {
+      logger.info(`sites collection does not exist yet; nothing to do.`);
+      return;
+    }
+
+    const collection = tenantDB.db.collection(collectionName);
+
+    const backfilledCount = await backfillLocations(collection);
+    if (backfilledCount > 0) {
+      logger.info(
+        `Backfilled 'location' on ${backfilledCount} site(s) from latitude/longitude.`
+      );
+    }
+
+    await collection.createIndex(
+      { location: "2dsphere" },
+      { name: "location_2dsphere" }
+    );
+    logger.info(`location 2dsphere index verified on ${collectionName}.`);
+  } catch (error) {
+    logger.error(
+      `🐛🐛 Error migrating site locations: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+async function runMigration() {
+  try {
+    const status = await checkMigrationStatus();
+    if (status === "completed") {
+      return;
+    }
+
+    await updateMigrationStatus("running");
+    await migrateSiteLocations();
+    await updateMigrationStatus("completed");
+  } catch (error) {
+    logger.error(`🐛🐛 Migration failed: ${error.message}`);
+    await updateMigrationStatus("failed", error);
+    throw error;
+  }
+}
+
+async function executeMigration() {
+  try {
+    await runMigration();
+    return true;
+  } catch (error) {
+    logger.error(`🐛🐛 Migration error: ${error.message}`);
+    throw error;
+  }
+}
+
+module.exports = {
+  runMigration,
+  executeMigration,
+  MIGRATION_NAME,
+};
+
+// Special case for running this script directly via CLI — does not
+// interfere with the application when imported as a module.
+if (require.main === module) {
+  const { commandDB, queryDB } = connectToMongoDB();
+
+  const run = async () => {
+    let exitCode = 0;
+    try {
+      await executeMigration();
+      logger.info("Migration completed successfully.");
+    } catch (error) {
+      logger.error(`🐛🐛 Migration failed with error: ${error.message}`);
+      exitCode = 1;
+    } finally {
+      logger.info("Closing database connections and exiting script.");
+      try {
+        await Promise.all([
+          commandDB && commandDB.close ? commandDB.close() : Promise.resolve(),
+          queryDB && queryDB.close ? queryDB.close() : Promise.resolve(),
+        ]);
+        logger.info("Database connections closed.");
+      } catch (closeError) {
+        logger.error(`Error closing connections: ${closeError.message}`);
+        exitCode = 1;
+      }
+      process.exit(exitCode);
+    }
+  };
+
+  if (queryDB.readyState === 1) {
+    logger.info("MongoDB connection is ready. Running migration...");
+    run();
+  } else {
+    logger.info("Waiting for MongoDB connection to be ready...");
+    queryDB.once("open", () => {
+      logger.info("MongoDB connection opened. Running migration...");
+      run();
+    });
+    queryDB.on("error", (err) => {
+      logger.error(`MongoDB connection error: ${err.message}. Exiting.`);
+      process.exit(1);
+    });
+  }
+}

--- a/src/device-registry/migrations/site-location-geospatial-index.js
+++ b/src/device-registry/migrations/site-location-geospatial-index.js
@@ -97,12 +97,13 @@ async function backfillLocations(collection) {
     }));
 
     const result = await collection.bulkWrite(bulkOps, { ordered: false });
-    totalBackfilled += result.modifiedCount || 0;
+    const modifiedCount = result.modifiedCount || 0;
+    totalBackfilled += modifiedCount;
 
-    // Batch fully processed and filter still matches the same count means
-    // every remaining match failed to update (shouldn't happen, but avoids
-    // an infinite loop if it ever does).
-    if (sites.length < BATCH_SIZE) {
+    // Stop once a pass makes no progress — a full batch that modifies zero
+    // documents means every remaining match is stuck (e.g. failing $set),
+    // and re-fetching the same docs forever would otherwise infinite-loop.
+    if (modifiedCount === 0 || sites.length < BATCH_SIZE) {
       break;
     }
   }

--- a/src/device-registry/models/Site.js
+++ b/src/device-registry/models/Site.js
@@ -154,6 +154,14 @@ const siteSchema = new Schema(
       required: [true, "approximate_longitude is required!"],
       immutable: true,
     },
+    // GeoJSON mirror of latitude/longitude, kept in sync by the pre-save hook
+    // below. Exists solely so a 2dsphere index can back $geoNear queries
+    // (e.g. nearest-site search) — Mongo can't geo-index plain lat/lng
+    // number fields.
+    location: {
+      type: { type: String, enum: ["Point"], default: "Point" },
+      coordinates: { type: [Number], default: undefined },
+    },
     approximate_distance_in_km: {
       type: Number,
       required: [true, "approximate_distance_in_km is required!"],
@@ -499,6 +507,53 @@ const checkDuplicates = (arr, fieldName) => {
   return null;
 };
 
+// Shared by listAirQoActive and findNearestSites: both pipelines look up the
+// same latest_deployment_activity/latest_maintenance_activity/activities
+// arrays and need them flattened/summarized the same way.
+const attachActivityMetadata = (response) => {
+  if (isEmpty(response)) {
+    return response;
+  }
+  response.forEach((site) => {
+    site.latest_deployment_activity =
+      site.latest_deployment_activity &&
+      site.latest_deployment_activity.length > 0
+        ? site.latest_deployment_activity[0]
+        : null;
+
+    site.latest_maintenance_activity =
+      site.latest_maintenance_activity &&
+      site.latest_maintenance_activity.length > 0
+        ? site.latest_maintenance_activity[0]
+        : null;
+
+    if (site.activities && site.activities.length > 0) {
+      const activitiesByType = {};
+      const latestActivitiesByType = {};
+
+      site.activities.forEach((activity) => {
+        const type = activity.activityType || "unknown";
+        activitiesByType[type] = (activitiesByType[type] || 0) + 1;
+
+        if (
+          !latestActivitiesByType[type] ||
+          new Date(activity.createdAt) >
+            new Date(latestActivitiesByType[type].createdAt)
+        ) {
+          latestActivitiesByType[type] = activity;
+        }
+      });
+
+      site.activities_by_type = activitiesByType;
+      site.latest_activities_by_type = latestActivitiesByType;
+    } else {
+      site.activities_by_type = {};
+      site.latest_activities_by_type = {};
+    }
+  });
+  return response;
+};
+
 siteSchema.pre(
   ["updateOne", "findOneAndUpdate", "updateMany", "update", "save"],
   function(next) {
@@ -563,6 +618,15 @@ siteSchema.pre(
     }
 
     if (this.isNew) {
+      // latitude/longitude are immutable (rejected above on update), so this
+      // only ever needs to run once at creation time.
+      if (typeof this.latitude === "number" && typeof this.longitude === "number") {
+        this.location = {
+          type: "Point",
+          coordinates: [this.longitude, this.latitude],
+        };
+      }
+
       // Prepare site_codes array
       this.site_codes = [
         this._id,
@@ -600,6 +664,9 @@ siteSchema.pre(
 
 siteSchema.index({ lat_long: 1 }, { unique: true });
 siteSchema.index({ generated_name: 1 }, { unique: true });
+// Backs $geoNear radius/sort queries (nearest-site search) so Mongo can use
+// the index instead of scanning + JS-side Haversine filtering.
+siteSchema.index({ location: "2dsphere" });
 siteSchema.index({ createdAt: -1 });
 // Index for stale entity checks
 siteSchema.index({ "onlineStatusAccuracy.lastCheck": 1 });
@@ -1156,45 +1223,7 @@ siteSchema.statics = {
 
       // Process activities in JavaScript for consistency
       if (!isEmpty(response)) {
-        response.forEach((site) => {
-          // Process latest activities to extract single objects
-          site.latest_deployment_activity =
-            site.latest_deployment_activity &&
-            site.latest_deployment_activity.length > 0
-              ? site.latest_deployment_activity[0]
-              : null;
-
-          site.latest_maintenance_activity =
-            site.latest_maintenance_activity &&
-            site.latest_maintenance_activity.length > 0
-              ? site.latest_maintenance_activity[0]
-              : null;
-
-          // Create activities by type mapping
-          if (site.activities && site.activities.length > 0) {
-            const activitiesByType = {};
-            const latestActivitiesByType = {};
-
-            site.activities.forEach((activity) => {
-              const type = activity.activityType || "unknown";
-              activitiesByType[type] = (activitiesByType[type] || 0) + 1;
-
-              if (
-                !latestActivitiesByType[type] ||
-                new Date(activity.createdAt) >
-                  new Date(latestActivitiesByType[type].createdAt)
-              ) {
-                latestActivitiesByType[type] = activity;
-              }
-            });
-
-            site.activities_by_type = activitiesByType;
-            site.latest_activities_by_type = latestActivitiesByType;
-          } else {
-            site.activities_by_type = {};
-            site.latest_activities_by_type = {};
-          }
-        });
+        attachActivityMetadata(response);
 
         return {
           success: true,
@@ -1210,6 +1239,135 @@ siteSchema.statics = {
           status: httpStatus.OK,
         };
       }
+    } catch (error) {
+      const stingifiedMessage = JSON.stringify(error ? error : "");
+      logger.error(`🐛🐛 Internal Server Error -- ${stingifiedMessage}`);
+
+      next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+
+  // Radius search backing GET /sites/nearest. Uses the `location` 2dsphere
+  // index via $geoNear so Mongo does the radius filtering and distance sort,
+  // instead of fetching up to 1000 sites and Haversine-filtering them in JS.
+  async findNearestSites(
+    { longitude, latitude, radius, filter = {}, limit = 20 } = {},
+    next,
+  ) {
+    try {
+      const inclusionProjection = {
+        ...constants.SITES_INCLUSION_PROJECTION,
+        distance_km: 1,
+      };
+      const exclusionProjection = constants.SITES_EXCLUSION_PROJECTION("none");
+      const maxResults = Math.min(Number(limit) || 20, 100);
+
+      const pipeline = await this.aggregate()
+        .near({
+          near: {
+            type: "Point",
+            coordinates: [Number(longitude), Number(latitude)],
+          },
+          distanceField: "distance_km",
+          distanceMultiplier: 0.001, // meters -> km
+          maxDistance: Number(radius) * 1000, // km -> meters
+          spherical: true,
+          query: { ...filter, lat_long: { $ne: "4_4" } },
+        })
+        .lookup({
+          from: "devices",
+          localField: "_id",
+          foreignField: "site_id",
+          as: "devices",
+        })
+        .unwind("$devices")
+        .match({ devices: { $exists: true, $ne: [] } })
+        .lookup({
+          from: "grids",
+          localField: "grids",
+          foreignField: "_id",
+          as: "grids",
+        })
+        .lookup({
+          from: "airqlouds",
+          localField: "airqlouds",
+          foreignField: "_id",
+          as: "airqlouds",
+        })
+        .lookup({
+          from: "activities",
+          localField: "_id",
+          foreignField: "site_id",
+          as: "activities",
+        })
+        .lookup({
+          from: "activities",
+          let: { siteId: "$_id" },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [
+                    { $eq: ["$site_id", "$$siteId"] },
+                    { $eq: ["$activityType", "deployment"] },
+                  ],
+                },
+              },
+            },
+            { $sort: { createdAt: -1 } },
+            { $limit: 1 },
+          ],
+          as: "latest_deployment_activity",
+        })
+        .lookup({
+          from: "activities",
+          let: { siteId: "$_id" },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [
+                    { $eq: ["$site_id", "$$siteId"] },
+                    { $eq: ["$activityType", "maintenance"] },
+                  ],
+                },
+              },
+            },
+            { $sort: { createdAt: -1 } },
+            { $limit: 1 },
+          ],
+          as: "latest_maintenance_activity",
+        })
+        .addFields({
+          total_activities: {
+            $cond: [{ $isArray: "$activities" }, { $size: "$activities" }, 0],
+          },
+        })
+        // $geoNear already sorted nearest-first; cap here rather than after
+        // the JS loop the old implementation used.
+        .limit(maxResults)
+        .project(inclusionProjection)
+        .project(exclusionProjection)
+        .allowDiskUse(true);
+
+      const response = await pipeline;
+
+      if (!isEmpty(response)) {
+        attachActivityMetadata(response);
+      }
+
+      return {
+        success: true,
+        message: "successfully retrieved the nearest sites",
+        data: response,
+        status: httpStatus.OK,
+      };
     } catch (error) {
       const stingifiedMessage = JSON.stringify(error ? error : "");
       logger.error(`🐛🐛 Internal Server Error -- ${stingifiedMessage}`);

--- a/src/device-registry/models/test/ut_site.model.js
+++ b/src/device-registry/models/test/ut_site.model.js
@@ -279,4 +279,80 @@ describe("the Site Model", function() {
       expect(siteMatchStage).to.deep.equal({ network: "partner_network" });
     });
   });
+
+  // findNearestSites backs GET /sites/nearest via a $geoNear-first aggregate
+  // pipeline (see models/Site.js) instead of the old fetch-1000-then-Haversine
+  // approach. Same call-with-mocked-`this` approach as listAirQoActive above.
+  describe("findNearestSites", function() {
+    function buildGeoAggregateChain(response) {
+      const captured = { nearCalls: [] };
+      const chain = {};
+      chain.near = sinon.stub().callsFake((options) => {
+        captured.nearCalls.push(options);
+        return chain;
+      });
+      [
+        "match",
+        "lookup",
+        "unwind",
+        "addFields",
+        "project",
+        "limit",
+        "allowDiskUse",
+      ].forEach((method) => {
+        chain[method] = sinon.stub().callsFake(() => chain);
+      });
+      chain.then = (resolve) => resolve(response);
+      return { chain, captured };
+    }
+
+    function fakeGeoModel(response) {
+      const { chain, captured } = buildGeoAggregateChain(response);
+      return { model: { aggregate: sinon.stub().returns(chain) }, captured };
+    }
+
+    it("issues a $geoNear stage as the first pipeline stage with the given coordinates and radius", async function() {
+      const { model, captured } = fakeGeoModel([]);
+      const next = sinon.stub();
+
+      const result = await SiteSchema.statics.findNearestSites.call(
+        model,
+        { longitude: 32.1, latitude: 0.1, radius: 10, filter: {} },
+        next
+      );
+
+      expect(result.success).to.equal(true);
+      const [geoNearStage] = captured.nearCalls;
+      expect(geoNearStage.near).to.deep.equal({
+        type: "Point",
+        coordinates: [32.1, 0.1],
+      });
+      expect(geoNearStage.maxDistance).to.equal(10000);
+      expect(geoNearStage.spherical).to.equal(true);
+      expect(geoNearStage.distanceField).to.equal("distance_km");
+    });
+
+    it("folds the caller-supplied filter (e.g. network, isOnline) into the $geoNear query", async function() {
+      const { model, captured } = fakeGeoModel([]);
+      const next = sinon.stub();
+
+      await SiteSchema.statics.findNearestSites.call(
+        model,
+        {
+          longitude: 0,
+          latitude: 0,
+          radius: 5,
+          filter: { network: "partner_network", isOnline: true },
+        },
+        next
+      );
+
+      const [geoNearStage] = captured.nearCalls;
+      expect(geoNearStage.query).to.deep.equal({
+        network: "partner_network",
+        isOnline: true,
+        lat_long: { $ne: "4_4" },
+      });
+    });
+  });
 });

--- a/src/device-registry/utils/site.util.js
+++ b/src/device-registry/utils/site.util.js
@@ -2208,64 +2208,27 @@ const createSite = {
   },
   findNearestSitesByCoordinates: async (request, next) => {
     try {
-      let { radius, latitude, longitude, tenant, online_status, limit } = {
+      let { radius, latitude, longitude, tenant, limit } = {
         ...request.body,
         ...request.query,
         ...request.params,
       };
-      const responseFromListSites = await createSite.listAirQoActive(
-        request,
+      const filter = generateFilter.sites(request, next);
+
+      const responseFromFindNearestSites = await SiteModel(
+        tenant,
+      ).findNearestSites(
+        {
+          longitude,
+          latitude,
+          radius,
+          filter,
+          limit,
+        },
         next,
       );
 
-      if (responseFromListSites.success === true) {
-        let sites = responseFromListSites.data;
-        let status = responseFromListSites.status
-          ? responseFromListSites.status
-          : "";
-        let nearest_sites = [];
-        sites.forEach((site) => {
-          if ("latitude" in site && "longitude" in site) {
-            if (online_status === "online" && site.isOnline !== true) {
-              return;
-            }
-            if (online_status === "offline" && site.isOnline !== false) {
-              return;
-            }
-
-            const distanceBetweenTwoPoints = distance.calculateDistance(
-              {
-                latitude1: latitude,
-                longitude1: longitude,
-                latitude2: site["latitude"],
-                longitude2: site["longitude"],
-              },
-              next,
-            );
-
-            if (distanceBetweenTwoPoints < radius) {
-              site["distance_km"] = distanceBetweenTwoPoints;
-              nearest_sites.push(site);
-            }
-          }
-        });
-
-        nearest_sites.sort((a, b) => a["distance_km"] - b["distance_km"]);
-
-        const maxResults = Math.min(Number(limit) || 20, 100);
-        nearest_sites = nearest_sites.slice(0, maxResults);
-
-        logObject("nearest_sites", nearest_sites);
-
-        return {
-          success: true,
-          data: nearest_sites,
-          message: "successfully retrieved the nearest sites",
-          status,
-        };
-      } else if (responseFromListSites.success === false) {
-        return responseFromListSites;
-      }
+      return responseFromFindNearestSites;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       next(

--- a/src/device-registry/utils/test/ut_site.util.js
+++ b/src/device-registry/utils/test/ut_site.util.js
@@ -796,17 +796,23 @@ describe("createSite Util Functions", () => {
     // below) rather than stubbing SiteModel(tenant) directly — the latter requires
     // a live mongoose connection lookup and throws "Query database connection not
     // established" in this test environment.
+    //
+    // Radius filtering, distance sort and the result-count cap now happen
+    // inside the $geoNear-backed SiteModel.findNearestSites static (see
+    // models/Site.js), not in this util — so these tests assert that the
+    // util builds the right query args and passes the model's response
+    // through unchanged, rather than re-testing geo math here.
     describe("with a mocked site model", () => {
       const proxyquire = require("proxyquire");
       let proxiedSiteUtil;
-      let listAirQoActiveStub;
+      let findNearestSitesStub;
       let next;
 
       beforeEach(() => {
-        listAirQoActiveStub = sinon.stub();
+        findNearestSitesStub = sinon.stub();
         proxiedSiteUtil = proxyquire("../site.util", {
           "@models/Site": () => ({
-            listAirQoActive: listAirQoActiveStub,
+            findNearestSites: findNearestSitesStub,
           }),
         });
         next = sinon.stub();
@@ -816,50 +822,9 @@ describe("createSite Util Functions", () => {
         sinon.restore();
       });
 
-      it("sorts results by distance ascending and tags them with distance_km", async () => {
-        const sites = [
-          { _id: "far", latitude: 5, longitude: 5, isOnline: true },
-          { _id: "near", latitude: 0.01, longitude: 0.01, isOnline: true },
-          { _id: "mid", latitude: 1, longitude: 1, isOnline: true },
-        ];
-        listAirQoActiveStub.resolves({
-          success: true,
-          data: sites,
-          status: httpStatus.OK,
-        });
-
-        const result = await proxiedSiteUtil.findNearestSitesByCoordinates(
-          {
-            body: {},
-            query: { radius: 10000, latitude: 0, longitude: 0, tenant: "airqo" },
-            params: {},
-          },
-          next
-        );
-
-        expect(result.success).to.equal(true);
-        expect(result.data.map((s) => s._id)).to.deep.equal([
-          "near",
-          "mid",
-          "far",
-        ]);
-        result.data.forEach((s) => {
-          expect(s).to.have.property("distance_km");
-          expect(s).to.not.have.property("distance");
-        });
-      });
-
-      it("filters by online_status when provided", async () => {
-        const sites = [
-          { _id: "onlineSite", latitude: 0.01, longitude: 0.01, isOnline: true },
-          {
-            _id: "offlineSite",
-            latitude: 0.02,
-            longitude: 0.02,
-            isOnline: false,
-          },
-        ];
-        listAirQoActiveStub.resolves({
+      it("delegates to SiteModel.findNearestSites with the request's coordinates, radius and limit", async () => {
+        const sites = [{ _id: "near", distance_km: 0.5 }];
+        findNearestSitesStub.resolves({
           success: true,
           data: sites,
           status: httpStatus.OK,
@@ -869,7 +834,40 @@ describe("createSite Util Functions", () => {
           {
             body: {},
             query: {
-              radius: 10000,
+              radius: 10,
+              latitude: 0.1,
+              longitude: 32.1,
+              tenant: "airqo",
+              limit: 5,
+            },
+            params: {},
+          },
+          next
+        );
+
+        expect(findNearestSitesStub.calledOnce).to.be.true;
+        const args = findNearestSitesStub.firstCall.args[0];
+        expect(args.latitude).to.equal(0.1);
+        expect(args.longitude).to.equal(32.1);
+        expect(args.radius).to.equal(10);
+        expect(args.limit).to.equal(5);
+
+        expect(result.success).to.equal(true);
+        expect(result.data).to.deep.equal(sites);
+      });
+
+      it("passes online_status through as an isOnline filter", async () => {
+        findNearestSitesStub.resolves({
+          success: true,
+          data: [],
+          status: httpStatus.OK,
+        });
+
+        await proxiedSiteUtil.findNearestSitesByCoordinates(
+          {
+            body: {},
+            query: {
+              radius: 10,
               latitude: 0,
               longitude: 0,
               tenant: "airqo",
@@ -880,65 +878,28 @@ describe("createSite Util Functions", () => {
           next
         );
 
-        expect(result.data.map((s) => s._id)).to.deep.equal(["onlineSite"]);
+        const args = findNearestSitesStub.firstCall.args[0];
+        expect(args.filter.isOnline).to.equal(true);
       });
 
-      it("caps the number of results at the requested limit", async () => {
-        const sites = [0, 1, 2, 3, 4].map((i) => ({
-          _id: `site-${i}`,
-          latitude: 0.01 * (i + 1),
-          longitude: 0.01 * (i + 1),
-          isOnline: true,
-        }));
-        listAirQoActiveStub.resolves({
-          success: true,
-          data: sites,
-          status: httpStatus.OK,
-        });
+      it("returns the model's failure response unchanged", async () => {
+        const failureResponse = {
+          success: false,
+          message: "Internal Server Error",
+          status: httpStatus.INTERNAL_SERVER_ERROR,
+        };
+        findNearestSitesStub.resolves(failureResponse);
 
         const result = await proxiedSiteUtil.findNearestSitesByCoordinates(
           {
             body: {},
-            query: {
-              radius: 10000,
-              latitude: 0,
-              longitude: 0,
-              tenant: "airqo",
-              limit: 2,
-            },
+            query: { radius: 10, latitude: 0, longitude: 0, tenant: "airqo" },
             params: {},
           },
           next
         );
 
-        expect(result.data).to.have.lengthOf(2);
-        expect(result.data.map((s) => s._id)).to.deep.equal([
-          "site-0",
-          "site-1",
-        ]);
-      });
-
-      it("excludes sites at or beyond the radius", async () => {
-        const sites = [
-          { _id: "inRange", latitude: 0.01, longitude: 0.01, isOnline: true },
-          { _id: "outOfRange", latitude: 10, longitude: 10, isOnline: true },
-        ];
-        listAirQoActiveStub.resolves({
-          success: true,
-          data: sites,
-          status: httpStatus.OK,
-        });
-
-        const result = await proxiedSiteUtil.findNearestSitesByCoordinates(
-          {
-            body: {},
-            query: { radius: 5, latitude: 0, longitude: 0, tenant: "airqo" },
-            params: {},
-          },
-          next
-        );
-
-        expect(result.data.map((s) => s._id)).to.deep.equal(["inRange"]);
+        expect(result).to.deep.equal(failureResponse);
       });
     });
   });

--- a/src/device-registry/validators/site.validators.js
+++ b/src/device-registry/validators/site.validators.js
@@ -482,8 +482,8 @@ const validateNearestSite = [
     .withMessage("the radius is missing in request")
     .bail()
     .trim()
-    .isFloat()
-    .withMessage("the radius must be a number")
+    .isFloat({ min: 0 })
+    .withMessage("the radius must be a non-negative number")
     .bail()
     .toFloat(),
   query("online_status")


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a GeoJSON `location` field (with a `2dsphere` index) to the Site model and replaces the nearest-site search's JS-side Haversine filter/sort — previously run over up to ~1000 fetched sites — with a `$geoNear`-backed aggregation (`SiteModel.findNearestSites`) that does radius filtering and distance sorting in MongoDB. Includes a startup migration that backfills `location` on existing sites from their `latitude`/`longitude` and creates the index.

### Why is this change needed?
The Phase 1 nearest-site fix (PR #7065) was functionally correct but not DB-indexed, fetching up to ~1000 sites per request and filtering/sorting them in application code. This closes out that deferred, explicitly-flagged pending work so the endpoint scales with network size instead of degrading as more sites are added.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:** device-registry

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Updated `models/test/ut_site.model.js` and `utils/test/ut_site.util.js` to cover the new `$geoNear` pipeline (stage ordering, coordinates/radius/filter passthrough) and the simplified `findNearestSitesByCoordinates` delegation. Ran the device-registry model, util, and validator suites (945 passing) — the 4 pre-existing failures are unrelated `TENANTS` env-var config issues in this environment, confirmed present on `staging` before this change. Manual/live-DB testing not performed in this session.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

Internal-only change — same request params, response shape, and sort order as before, so no docs-site update is required.

---

## :memo: Additional Notes
The `location` backfill + index-creation migration runs automatically on service startup (registered in `bin/jobs/run-migrations.js`), tracked via `MigrationTracker` so it only runs once. New sites get `location` set on creation via the existing pre-save hook (safe since `latitude`/`longitude` are immutable). Scoped from the backend portion of the team's `NEAREST_SITE_IMPLEMENTATION_GUIDE.md` working doc, which has been updated to drop the now-completed backend section.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location-based site search with geographic coordinates, radius filtering, distance sorting, and result limits.
  * Sites now support GeoJSON location data and spatial indexing for faster nearby searches.
  * Site activity information is available in a consolidated format.

* **Bug Fixes**
  * Site locations are automatically populated from available latitude and longitude data.
  * Invalid negative search-radius values are now rejected with clearer validation feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->