### PR TITLE
Fix migration-tracker duplicate-key race on startup

### DIFF
--- a/src/device-registry/migrations/site-location-geospatial-index.js
+++ b/src/device-registry/migrations/site-location-geospatial-index.js
@@ -27,16 +27,31 @@ async function checkMigrationStatus() {
       tenant: TENANT,
     });
 
-    if (!tracker) {
+    if (tracker) {
+      return tracker.status;
+    }
+
+    try {
       await MigrationTrackerModel(TENANT).create({
         name: MIGRATION_NAME,
         tenant: TENANT,
         status: "pending",
       });
       return "pending";
+    } catch (createError) {
+      // Multiple device-registry replicas run startup migrations concurrently.
+      // If another one already inserted the tracker doc between our findOne
+      // and create above, the unique {name,tenant} index rejects ours with
+      // E11000 — that's fine, just read back whatever status won the race.
+      if (createError.code === 11000) {
+        const existing = await MigrationTrackerModel(TENANT).findOne({
+          name: MIGRATION_NAME,
+          tenant: TENANT,
+        });
+        return existing ? existing.status : "pending";
+      }
+      throw createError;
     }
-
-    return tracker.status;
   } catch (error) {
     logger.error(`🐛🐛 Error checking migration status: ${error.message}`);
     throw error;


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes a startup migration crash in `site-location-geospatial-index-migration`. When multiple device-registry replicas start up concurrently, they each race to insert the same `MigrationTracker` document; the pod that loses the race hits the unique `name_1_tenant_1` index and throws an `E11000 duplicate key error`, failing the migration on that pod. `checkMigrationStatus` now catches that specific duplicate-key error and re-reads the tracker doc the winning pod inserted, instead of throwing. Also hardens the location-backfill loop to stop when a batch makes zero progress (rather than only when the batch is smaller than `BATCH_SIZE`), avoiding a possible infinite loop, and rejects negative `radius` values in the nearest-site validator before they reach `$geoNear`.

### Why is this change needed?
This surfaced in staging right after merging the geospatial-index PR: every device-registry replica logged the same `E11000` error for `site-location-geospatial-index-v1` on deploy. It's caused by the startup-migration pattern (shared with `network-status-indexes.js` and `device-uptime-index-fix.js`) not being safe under concurrent replicas racing to create the same tracker doc.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:** device-registry

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:** Syntax-checked the modified migration and validator files. Re-ran the device-registry model, util, and validator test suites — no new failures (the 4 pre-existing failures are unrelated `TENANTS` env-var config issues, present before this change). The duplicate-key race itself isn't covered by a unit test (it requires two concurrent Mongo writes against the same unique index); fix was verified by code inspection against the staging error logs.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
`network-status-indexes.js` and `device-uptime-index-fix.js` share the same `checkMigrationStatus` pattern and are exposed to the identical race, just haven't logged it yet (their migrations likely completed before this one shipped). Not touched in this PR — flagging for a possible follow-up.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
