### PR TITLE
Add secure sign-in link email for auth-service

### DIFF
--- a/src/auth-service/config/constants.js
+++ b/src/auth-service/config/constants.js
@@ -108,6 +108,7 @@ function envConfig(env) {
       ? `${nexusBaseUrl}/user/login`
       : undefined,
     FORGOT_PAGE: nexusBaseUrl ? `${nexusBaseUrl}/forgot` : undefined,
+    SIGN_IN_LINK: nexusBaseUrl ? `${nexusBaseUrl}/user/emailLogin` : undefined,
     PLATFORM_BASE_URL: nexusBaseUrl,
 
     // ── Per-environment defaults ──────────────────────────────────────────────

--- a/src/auth-service/controllers/user.controller.js
+++ b/src/auth-service/controllers/user.controller.js
@@ -814,6 +814,43 @@ const userController = {
       handleError(error, next);
     }
   },
+  completeEmailLogin: async (req, res, next) => {
+    try {
+      const request = handleRequest(req, next);
+      if (!request) return;
+      const result = await userUtil.completeSignInWithEmailLink(
+        request,
+        next,
+      );
+
+      if (result && result.success === true) {
+        const { data } = result;
+        const userResponse = {
+          _id: data._id,
+          token: data.token,
+          email: data.email,
+          firstName: data.firstName,
+          lastName: data.lastName,
+          userName: data.userName,
+          privilege: data.privilege,
+          organization: data.organization,
+          long_organization: data.long_organization,
+          profilePicture: data.profilePicture,
+          country: data.country,
+          phoneNumber: data.phoneNumber,
+          interests: data.interests,
+          interestsDescription: data.interestsDescription,
+          verified: data.verified,
+          isActive: data.isActive,
+          authMethods: data.authMethods,
+        };
+        return res.status(httpStatus.OK).json(userResponse);
+      }
+      sendResponse(res, result);
+    } catch (error) {
+      handleError(error, next);
+    }
+  },
   updateForgottenPassword: async (req, res, next) => {
     try {
       const request = handleRequest(req, next);

--- a/src/auth-service/models/User.js
+++ b/src/auth-service/models/User.js
@@ -244,6 +244,8 @@ const UserSchema = new Schema(
     },
     resetPasswordToken: { type: String },
     resetPasswordExpires: { type: Date },
+    signInToken: { type: String },
+    signInTokenExpires: { type: Date },
     jobTitle: {
       type: String,
     },

--- a/src/auth-service/routes/v2/users.routes.js
+++ b/src/auth-service/routes/v2/users.routes.js
@@ -356,6 +356,12 @@ router.post(
   userController.emailAuth,
 );
 
+router.post(
+  "/completeEmailLogin",
+  userValidations.completeEmailLogin,
+  userController.completeEmailLogin,
+);
+
 router.post("/feedback", userValidations.feedback, userController.sendFeedback);
 
 // ================================

--- a/src/auth-service/routes/v3/users.routes.js
+++ b/src/auth-service/routes/v3/users.routes.js
@@ -397,6 +397,12 @@ router.post(
   userController.emailAuth
 );
 
+router.post(
+  "/completeEmailLogin",
+  userValidations.completeEmailLogin,
+  userController.completeEmailLogin
+);
+
 router.post("/feedback", userValidations.feedback, userController.sendFeedback);
 
 router.post(

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -1069,7 +1069,7 @@ module.exports = {
     const content = `<tr>
                                 <td
                                     style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-                                Click the button below to securely sign in to your AirQo account. This link expires in 10 minutes.
+                                Click the button below to securely sign in to your AirQo account. This link is time-sensitive, so please use it soon.
                                     <br /><br />
                                     <a href="${link}" target="_blank">
                                         <div

--- a/src/auth-service/utils/common/email.msgs.util.js
+++ b/src/auth-service/utils/common/email.msgs.util.js
@@ -1065,6 +1065,34 @@ module.exports = {
                             </tr>`;
     return constants.EMAIL_BODY({ email, content });
   },
+  signInLinkEmail: ({ email, link }) => {
+    const content = `<tr>
+                                <td
+                                    style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+                                Click the button below to securely sign in to your AirQo account. This link expires in 10 minutes.
+                                    <br /><br />
+                                    <a href="${link}" target="_blank">
+                                        <div
+                                            style="width: 20%; height: 100%; padding-left: 32px; padding-right: 32px; padding-top: 16px; padding-bottom: 16px; background: #135DFF; border-radius: 1px; justify-content: center; align-items: center; gap: 10px; display: inline-flex">
+                                            <div
+                                                style="text-align: center; color: white; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word">
+                                                Sign in</div>
+                                        </div>
+                                    </a>
+                                    <br /><br />
+                                    Trouble with the button? Paste this URL into your browser:
+                                    <br />
+                                    <a href="${link}" target="_blank">${link}</a>
+                                    <br /><br />
+                                    <div
+                                        style="width: 100%; opacity: 0.60; color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word">
+                                        If you didn't request this, you can safely ignore this email — no changes will be made to your account.</div>
+                                    <br />
+                                    <br />
+                                </td>
+                            </tr>`;
+    return constants.EMAIL_BODY({ email, content });
+  },
   authenticate_email: (token, email) => {
     const content = ` <tr>
                                 <td

--- a/src/auth-service/utils/common/mailer.util.js
+++ b/src/auth-service/utils/common/mailer.util.js
@@ -831,7 +831,7 @@ const getEmailSubject = (functionName, params) => {
     sendPasswordResetEmail: `Password Reset Code: ${params.token || ""}`,
     updateForgottenPassword: "Your AirQo Account Password Reset Successful",
     updateKnownPassword: "Your AirQo Account Password Update Successful",
-    signInWithEmailLink: "Verify your email address!",
+    signInWithEmailLink: "Your secure sign-in link for AirQo",
     deleteMobileAccountEmail: "Confirm Account Deletion - AirQo",
     authenticateEmail: "Changes to your AirQo email",
     compromisedToken:
@@ -1860,7 +1860,8 @@ const mailer = {
   signInWithEmailLink: createMailerFunction(
     "signInWithEmailLink", //
     "CORE_CRITICAL",
-    (params) => msgs.join_by_email(params.email, params.token),
+    (params) =>
+      msgs.signInLinkEmail({ email: params.email, link: params.link }),
   ),
   deleteMobileAccountEmail: createMailerFunction(
     "deleteMobileAccountEmail", //

--- a/src/auth-service/utils/common/test/ut_email.msgs.util.js
+++ b/src/auth-service/utils/common/test/ut_email.msgs.util.js
@@ -309,7 +309,7 @@ describe("email.msgs", () => {
       const content = `<tr>
                                 <td
                                     style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
-                                Click the button below to securely sign in to your AirQo account. This link expires in 10 minutes.
+                                Click the button below to securely sign in to your AirQo account. This link is time-sensitive, so please use it soon.
                                     <br /><br />
                                     <a href="${link}" target="_blank">
                                         <div

--- a/src/auth-service/utils/common/test/ut_email.msgs.util.js
+++ b/src/auth-service/utils/common/test/ut_email.msgs.util.js
@@ -301,6 +301,41 @@ describe("email.msgs", () => {
       expect(result).to.equal(expectedMessage);
     });
   });
+  describe("signInLinkEmail", () => {
+    it("should return the correct signInLinkEmail message with valid inputs", () => {
+      const email = "john.doe@example.com";
+      const link =
+        "https://airqo.net/__/auth/action?apiKey=xyz&mode=signIn&oobCode=abc";
+      const content = `<tr>
+                                <td
+                                    style="color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word;">
+                                Click the button below to securely sign in to your AirQo account. This link expires in 10 minutes.
+                                    <br /><br />
+                                    <a href="${link}" target="_blank">
+                                        <div
+                                            style="width: 20%; height: 100%; padding-left: 32px; padding-right: 32px; padding-top: 16px; padding-bottom: 16px; background: #135DFF; border-radius: 1px; justify-content: center; align-items: center; gap: 10px; display: inline-flex">
+                                            <div
+                                                style="text-align: center; color: white; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word">
+                                                Sign in</div>
+                                        </div>
+                                    </a>
+                                    <br /><br />
+                                    Trouble with the button? Paste this URL into your browser:
+                                    <br />
+                                    <a href="${link}" target="_blank">${link}</a>
+                                    <br /><br />
+                                    <div
+                                        style="width: 100%; opacity: 0.60; color: #344054; font-size: 16px; font-family: Inter; font-weight: 400; line-height: 24px; word-wrap: break-word">
+                                        If you didn't request this, you can safely ignore this email — no changes will be made to your account.</div>
+                                    <br />
+                                    <br />
+                                </td>
+                            </tr>`;
+      const expectedMessage = constants.EMAIL_BODY({ email, content });
+      const result = msgs.signInLinkEmail({ email, link });
+      expect(result).to.equal(expectedMessage);
+    });
+  });
   describe("authenticate_email", () => {
     it("should return the correct authenticate_email message with valid token", () => {
       const email = "john.doe@example.com";

--- a/src/auth-service/utils/common/test/ut_mailer.util.js
+++ b/src/auth-service/utils/common/test/ut_mailer.util.js
@@ -463,6 +463,7 @@ describe("mailer", () => {
   describe("signInWithEmailLink", () => {
     const email = "johndoe@example.com";
     const token = "abcdef123456";
+    const link = "https://airqo.net/__/auth/action?apiKey=xyz&mode=signIn&oobCode=abc";
 
     it("should send the sign-in link email and return a success response", async () => {
       sendMailStub.resolves({ accepted: [email], rejected: [] });
@@ -470,6 +471,7 @@ describe("mailer", () => {
       const result = await mailer.signInWithEmailLink({
         email,
         token,
+        link,
         priority: "high",
       });
 
@@ -477,15 +479,15 @@ describe("mailer", () => {
       expect(sendMailStub.calledOnce).to.be.true;
       const mailOptions = sendMailStub.firstCall.args[0];
       expect(mailOptions.to).to.equal(email);
-      expect(mailOptions.subject).to.equal("Verify your email address!");
-      expect(mailOptions.html).to.equal(msgs.join_by_email(email, token));
+      expect(mailOptions.subject).to.equal("Your secure sign-in link for AirQo");
+      expect(mailOptions.html).to.equal(msgs.signInLinkEmail({ email, link }));
     });
 
     it("should return an internal server error when the transporter rejects the recipient", async () => {
       sendMailStub.resolves({ accepted: [], rejected: [email] });
 
       await expectHttpErrorRejection(
-        mailer.signInWithEmailLink({ email, token, priority: "high" }),
+        mailer.signInWithEmailLink({ email, token, link, priority: "high" }),
         httpStatus.INTERNAL_SERVER_ERROR
       );
     });

--- a/src/auth-service/utils/test/ut_user.util.js
+++ b/src/auth-service/utils/test/ut_user.util.js
@@ -921,6 +921,10 @@ describe("create-user-util", function () {
       },
     };
     let origGenerateNumericToken;
+    let origUserModel;
+    let existsStub;
+    let modifyStub;
+    let internalModule;
 
     beforeEach(() => {
       origGenerateNumericToken = rewireCreateUser.__get__(
@@ -930,6 +934,20 @@ describe("create-user-util", function () {
         "generateNumericToken",
         sinon.stub().returns("54321")
       );
+
+      existsStub = sinon.stub().resolves(true);
+      modifyStub = sinon.stub().resolves({ success: true });
+      origUserModel = rewireCreateUser.__get__("UserModel");
+      rewireCreateUser.__set__("UserModel", () => ({
+        exists: existsStub,
+        modify: modifyStub,
+      }));
+
+      internalModule = rewireCreateUser.__get__("createUserModule");
+      sinon.stub(internalModule, "generateResetToken").returns({
+        success: true,
+        data: "SAMPLECODE",
+      });
     });
 
     afterEach(() => {
@@ -937,17 +955,11 @@ describe("create-user-util", function () {
         "generateNumericToken",
         origGenerateNumericToken
       );
+      rewireCreateUser.__set__("UserModel", origUserModel);
       sinon.restore();
     });
 
     it("should generate the sign-in link with email correctly and send email for authentication", async () => {
-      const generateSignInWithEmailLinkStub = sinon
-        .stub()
-        .resolves("https://example.com/?a=1%26oobCode%3DSAMPLECODE");
-      sinon.stub(firebaseAuthModule, "getAuth").returns({
-        generateSignInWithEmailLink: generateSignInWithEmailLinkStub,
-      });
-
       const authenticateEmailStub = sinon
         .stub(mailer, "authenticateEmail")
         .resolves({ success: true });
@@ -961,26 +973,43 @@ describe("create-user-util", function () {
         message: "process successful, check your email for token",
         status: httpStatus.OK,
         data: {
-          link: "https://example.com/?a=1%26oobCode%3DSAMPLECODE",
+          link: `${constants.SIGN_IN_LINK}?token=SAMPLECODE&email=test%40example.com`,
           token: "54321",
           email: "test@example.com",
           emailLinkCode: "SAMPLECODE",
         },
       });
 
-      sinon.assert.calledOnce(generateSignInWithEmailLinkStub);
+      sinon.assert.calledOnce(existsStub);
+      sinon.assert.calledOnce(modifyStub);
       sinon.assert.calledOnceWithMatch(authenticateEmailStub, {
         email: "test@example.com",
         token: "54321",
       });
     });
 
+    it("should return a 400 error and not send an email when the account does not exist", async () => {
+      existsStub.resolves(false);
+      const authenticateEmailStub = sinon
+        .stub(mailer, "authenticateEmail")
+        .resolves({ success: true });
+      const next = sinon.stub();
+
+      await rewireCreateUser.generateSignInWithEmailLink(
+        sampleRequest,
+        next
+      );
+
+      sinon.assert.calledOnce(next);
+      const err = next.firstCall.args[0];
+      expect(err).to.be.instanceOf(Error);
+      expect(err.statusCode).to.equal(httpStatus.BAD_REQUEST);
+      sinon.assert.notCalled(modifyStub);
+      sinon.assert.notCalled(authenticateEmailStub);
+    });
+
     it("should handle errors and return an error response", async () => {
-      sinon.stub(firebaseAuthModule, "getAuth").returns({
-        generateSignInWithEmailLink: sinon
-          .stub()
-          .rejects(new Error("Some error")),
-      });
+      existsStub.rejects(new Error("Some error"));
       const next = sinon.stub();
 
       await rewireCreateUser.generateSignInWithEmailLink(
@@ -993,6 +1022,74 @@ describe("create-user-util", function () {
       expect(err).to.be.instanceOf(Error);
       expect(err.statusCode).to.equal(httpStatus.INTERNAL_SERVER_ERROR);
       expect(err.message).to.equal("Internal Server Error");
+    });
+  });
+  describe("completeSignInWithEmailLink()", () => {
+    const sampleRequest = {
+      body: {
+        email: "test@example.com",
+        token: "SAMPLECODE",
+      },
+      query: {},
+    };
+    let origUserModel;
+    let findOneAndUpdateStub;
+    let internalModule;
+
+    beforeEach(() => {
+      findOneAndUpdateStub = sinon.stub();
+      origUserModel = rewireCreateUser.__get__("UserModel");
+      rewireCreateUser.__set__("UserModel", () => ({
+        findOneAndUpdate: findOneAndUpdateStub,
+      }));
+      internalModule = rewireCreateUser.__get__("createUserModule");
+    });
+
+    afterEach(() => {
+      rewireCreateUser.__set__("UserModel", origUserModel);
+      sinon.restore();
+    });
+
+    it("should complete sign-in and return the enhanced login response when the token is valid", async () => {
+      findOneAndUpdateStub.resolves({ _id: "u1", email: "test@example.com" });
+      const loginStub = sinon
+        .stub(internalModule, "loginWithEnhancedTokens")
+        .resolves({
+          success: true,
+          status: httpStatus.OK,
+          data: { _id: "u1", email: "test@example.com", token: "JWT abc" },
+        });
+
+      const result = await rewireCreateUser.completeSignInWithEmailLink(
+        sampleRequest
+      );
+
+      expect(result).to.deep.equal({
+        success: true,
+        status: httpStatus.OK,
+        data: { _id: "u1", email: "test@example.com", token: "JWT abc" },
+      });
+      sinon.assert.calledOnceWithMatch(
+        loginStub,
+        { body: { email: "test@example.com" } },
+        sinon.match.any,
+        { skipPasswordCheck: true }
+      );
+    });
+
+    it("should call next with a 400 error when the token is invalid or expired", async () => {
+      findOneAndUpdateStub.resolves(null);
+      const next = sinon.stub();
+
+      await rewireCreateUser.completeSignInWithEmailLink(
+        sampleRequest,
+        next
+      );
+
+      sinon.assert.calledOnce(next);
+      const err = next.firstCall.args[0];
+      expect(err).to.be.instanceOf(Error);
+      expect(err.statusCode).to.equal(httpStatus.BAD_REQUEST);
     });
   });
   describe("delete()", () => {

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -2377,16 +2377,40 @@ const createUserModule = {
       const { body, query } = request;
       const { email } = body;
       const { purpose } = query;
+      const tenant = (query && query.tenant) || "airqo";
 
-      const link = await firebaseAuth.getAuth().generateSignInWithEmailLink(
-        email,
-        constants.ACTION_CODE_SETTINGS,
+      const userExists = await UserModel(tenant).exists({ email });
+      if (!userExists) {
+        return next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message:
+              "Sorry, the provided email does not belong to a registered user. Please make sure you have entered the correct information or sign up for a new account.",
+          }),
+        );
+      }
+
+      const responseFromGenerateToken = createUserModule.generateResetToken();
+      if (responseFromGenerateToken.success !== true) {
+        return responseFromGenerateToken;
+      }
+      const signInToken = responseFromGenerateToken.data;
+
+      const responseFromModifyUser = await UserModel(tenant).modify(
+        {
+          filter: { email },
+          update: {
+            signInToken,
+            signInTokenExpires: Date.now() + 15 * 60 * 1000,
+          },
+        },
+        next,
       );
+      if (!responseFromModifyUser || responseFromModifyUser.success !== true) {
+        return responseFromModifyUser;
+      }
 
-      let linkSegments = link.split("%").filter((segment) => segment);
-      const indexBeforeCode = linkSegments.indexOf("26oobCode", 0);
-      const indexOfCode = indexBeforeCode + 1;
-      let emailLinkCode = linkSegments[indexOfCode].substring(2);
+      const link = `${constants.SIGN_IN_LINK}?token=${signInToken}&email=${encodeURIComponent(email)}`;
+      const emailLinkCode = signInToken;
 
       let responseFromSendEmail = {};
       let token = 10000;
@@ -2444,6 +2468,52 @@ const createUserModule = {
           ),
         );
       }
+    } catch (error) {
+      logger.error(`🐛🐛 Internal Server Error ${error.message}`);
+      return next(
+        new HttpError(
+          "Internal Server Error",
+          httpStatus.INTERNAL_SERVER_ERROR,
+          { message: error.message },
+        ),
+      );
+    }
+  },
+  completeSignInWithEmailLink: async (request, next) => {
+    try {
+      const { email, token } = request.body;
+      const tenant = (request.query && request.query.tenant) || "airqo";
+
+      const user = await UserModel(tenant).findOneAndUpdate(
+        {
+          email,
+          signInToken: token,
+          signInTokenExpires: { $gt: new Date() },
+        },
+        {
+          $set: {
+            signInToken: null,
+            signInTokenExpires: null,
+          },
+        },
+        { new: true, context: "query" },
+      );
+
+      if (!user) {
+        return next(
+          new HttpError("Bad Request Error", httpStatus.BAD_REQUEST, {
+            message: "This sign-in link is invalid or has expired.",
+          }),
+        );
+      }
+
+      const loginResult = await createUserModule.loginWithEnhancedTokens(
+        { body: { email }, query: request.query, headers: request.headers },
+        next,
+        { skipPasswordCheck: true },
+      );
+
+      return loginResult;
     } catch (error) {
       logger.error(`🐛🐛 Internal Server Error ${error.message}`);
       return next(
@@ -6806,8 +6876,9 @@ const createUserModule = {
   /**
    * Enhanced login with comprehensive role/permission data and optimized tokens
    */
-  loginWithEnhancedTokens: async (request, next) => {
+  loginWithEnhancedTokens: async (request, next, options = {}) => {
     try {
+      const { skipPasswordCheck = false } = options;
       const body = request.body || {};
       const query = request.query || {};
       const { email, password, preferredStrategy, includeDebugInfo } = body;
@@ -6821,14 +6892,17 @@ const createUserModule = {
       });
 
       // Input validation
-      if (!email || !password) {
+      if (!email || (!skipPasswordCheck && !password)) {
         return {
           success: false,
           message: "Email and password are required",
           status: httpStatus.BAD_REQUEST,
           errors: {
             email: !email ? "Email is required" : undefined,
-            password: !password ? "Password is required" : undefined,
+            password:
+              !skipPasswordCheck && !password
+                ? "Password is required"
+                : undefined,
           },
         };
       }
@@ -6849,17 +6923,20 @@ const createUserModule = {
         };
       }
 
-      // Verify password
-      const isPasswordValid = await user.authenticateUser(password);
-      if (!isPasswordValid) {
-        return {
-          success: false,
-          message: "Invalid login credentials provided",
-          status: httpStatus.UNAUTHORIZED,
-          errors: {
-            credentials: "The email or password you entered is incorrect.",
-          },
-        };
+      // Verify password (skipped when the caller already established identity
+      // through another verified channel, e.g. a one-time sign-in link token)
+      if (!skipPasswordCheck) {
+        const isPasswordValid = await user.authenticateUser(password);
+        if (!isPasswordValid) {
+          return {
+            success: false,
+            message: "Invalid login credentials provided",
+            status: httpStatus.UNAUTHORIZED,
+            errors: {
+              credentials: "The email or password you entered is incorrect.",
+            },
+          };
+        }
       }
 
       // Centralized verification check
@@ -6897,7 +6974,7 @@ const createUserModule = {
         const userConsented = user?.consent?.analytics === true;
         if (!dnt && userConsented) {
           analyticsService.track(user._id.toString(), "user_logged_in", {
-            method: "email_password",
+            method: skipPasswordCheck ? "email_link" : "email_password",
           });
         }
       } catch (analyticsError) {
@@ -7013,7 +7090,10 @@ const createUserModule = {
           const updatePayload = createUserModule._constructLoginUpdate(
             user,
             strategy,
-            { autoVerify: shouldAutoVerify, stampHasSetPassword: true },
+            {
+              autoVerify: shouldAutoVerify,
+              stampHasSetPassword: !skipPasswordCheck,
+            },
           );
           const updatedUser = await UserModel(dbTenant).findOneAndUpdate(
             { _id: user._id },
@@ -7135,9 +7215,10 @@ const createUserModule = {
 
         authMethods: {
           ...buildAuthMethods(user),
-          // Always true here — we verified the password above to reach this point.
-          // Also covers legacy accounts whose hasSetPassword was never stamped.
-          password: true,
+          // Only override to true when we actually just verified the password
+          // above; a skipped check (e.g. sign-in link) tells us nothing new
+          // about whether this account has a working password.
+          ...(!skipPasswordCheck ? { password: true } : {}),
         },
 
         // --- REMOVED FOR SCALABILITY ---

--- a/src/auth-service/utils/user.util.js
+++ b/src/auth-service/utils/user.util.js
@@ -2410,7 +2410,7 @@ const createUserModule = {
       }
       if (purpose === "login") {
         responseFromSendEmail = await mailer.signInWithEmailLink(
-          { email, token },
+          { email, token, link },
           next,
         );
       }

--- a/src/auth-service/validators/users.validators.js
+++ b/src/auth-service/validators/users.validators.js
@@ -253,6 +253,23 @@ const emailAuth = [
   ],
 ];
 
+const completeEmailLogin = [
+  [
+    body("email")
+      .exists()
+      .withMessage("the email must be provided")
+      .bail()
+      .isEmail()
+      .withMessage("this is not a valid email address"),
+    body("token")
+      .exists()
+      .withMessage("the token must be provided")
+      .bail()
+      .notEmpty()
+      .withMessage("the token should not be empty"),
+  ],
+];
+
 const feedback = oneOf([
   [
     body("email")
@@ -2065,6 +2082,7 @@ module.exports = {
   login,
   emailLogin,
   emailAuth,
+  completeEmailLogin,
   feedback,
   firebaseLookup,
   firebaseCreate,


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a secure, clickable "Sign in" link email for auth-service's email-based sign-in flow, replacing the previous plain 5-digit numeric code. The link is generated and verified entirely in-house (crypto-random token + DB-backed expiry, mirroring the existing password-reset pattern) — no third-party SDK dependency. Also adds the missing completion endpoint (`POST /completeEmailLogin`) needed to actually finish sign-in from the link.

### Why is this change needed?
Two things drove this:
1. Users get a one-click, recognizable secure sign-in email instead of manually copying a numeric code, consistent with AirQo's existing email templates.
2. The original implementation generated a Firebase sign-in link, but (a) this service should not depend on a third-party SDK/subscription it cannot guarantee availability of, and (b) on inspection, nothing in the codebase actually verified that Firebase link or its numeric code — clicking the email or entering the code could not complete sign-in. This PR fixes both: it drops Firebase and makes the flow actually functional end-to-end.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [x] :recycle: Refactor

---

## :building_construction: Affected Services

**Microservices changed:**
- auth-service

---

## :test_tube: Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test summary:**
- Added tests for the new `signInLinkEmail` template (`email.msgs.util.js`) and the updated `signInWithEmailLink` mailer function (`mailer.util.js`).
- Rewrote `generateSignInWithEmailLink` unit tests to stub `UserModel.exists`/`.modify` instead of Firebase, and added tests for the new `completeSignInWithEmailLink` util (valid token, invalid/expired token).
- Verified the password-login path (`loginWithEnhancedTokens`) is unaffected by the new opt-in `skipPasswordCheck` parameter — default `false` preserves existing behavior; no changes needed to any existing tests for it.
- Full `auth-service` unit test suite run locally: all green except one pre-existing, unrelated failure (`getDifferenceInMonths` date-utility test, present before this branch).
- Not yet manually verified end-to-end against a live inbox.

---

## :boom: Breaking Changes
- [ ] **No breaking changes**
- [x] **Has breaking changes** (describe below)

Two intentional, deliberate behavior changes, both required to remove the Firebase dependency:
1. `POST /emailLogin` / `/emailAuth/:purpose?` now require an **existing account** for the given email — a request for an unregistered email returns `400` instead of silently succeeding. (Previously, Firebase would mint a link for any email, registered or not.)
2. The link is now a plain URL (`${SIGN_IN_LINK}?token=...&email=...`), **not** a Firebase dynamic/action link — it no longer auto-opens the mobile app the way a Firebase App Link/Universal Link would. Mobile would need its own universal-link/custom-scheme setup to intercept it (frontend-side, tracked separately).

Everything else is backward compatible:
- `POST /emailLogin` / `/emailAuth/:purpose?` — same request body/params, same response shape (`link`, `token`, `email`, `emailLinkCode` keys unchanged; only how `link`/`emailLinkCode` are computed changed, not their type or presence).
- `POST /completeEmailLogin` is new and purely additive.
- `models/User.js` — two new optional fields (`signInToken`, `signInTokenExpires`); no existing fields touched.
- `loginWithEnhancedTokens` — new third parameter is optional and defaults to preserving current behavior exactly; regular password login is unaffected.
- `mobileAccountDelete` and `auth` purposes of `emailAuth` are functionally unchanged (still numeric-code emails); they only picked up the same account-must-exist requirement as `login`.

---

## :memo: Additional Notes
- New template: `signInLinkEmail({ email, link })` in `utils/common/email.msgs.util.js` — styled AirQo card layout, blue CTA button, no hard-coded expiry claim in the copy (kept generic: "time-sensitive, use it soon") since the exact expiry isn't user-facing API.
- `mailer.util.js`: `signInWithEmailLink` renders `signInLinkEmail` instead of the old numeric-code template; subject changed to "Your secure sign-in link for AirQo".
- `config/constants.js`: added `SIGN_IN_LINK` (`${NEXUS_BASE_URL}/user/emailLogin`), alongside the existing `PWD_RESET`/`FORGOT_PAGE` derived URLs.
- `utils/user.util.js`:
  - `generateSignInWithEmailLink` — looks up the user, generates a token via the existing `generateResetToken()` helper, stores it with a 15-minute expiry, builds the link. No longer touches `firebase-admin`.
  - New `completeSignInWithEmailLink` — atomically consumes the token (single-use `findOneAndUpdate`), then delegates to `loginWithEnhancedTokens` to issue a real login session (same RBAC/device-tracking/analytics pipeline as password login).
- `controllers/user.controller.js`, `routes/v2|v3/users.routes.js`, `validators/users.validators.js`: new `completeEmailLogin` controller/route/validator for `POST /completeEmailLogin`.
- `firebase-admin/auth` is still used elsewhere in this file (social login, user lookup/delete) — only this one flow was migrated off it.
- Frontend integration guide (endpoints, request/response shapes, what mobile/nexus need to do) shared separately with the frontend team.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
