### PR TITLE
Fix MongoDB cursor timeout in raw online status job

### DIFF
--- a/src/device-registry/bin/jobs/test/ut_update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/test/ut_update-raw-online-status-job.js
@@ -122,14 +122,19 @@ describe("updateRawOnlineStatusJob", () => {
       });
 
       // Default call for the cursor
+      const setOptionsStub = sinon.stub().returns({ cursor: () => cursor });
       findStub.returns({
         select: () => ({
-          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+          lean: () => ({
+            batchSize: () => ({ setOptions: setOptionsStub }),
+          }),
         }),
       });
 
       await updateRawOnlineStatus();
 
+      expect(setOptionsStub.calledOnceWith({ noCursorTimeout: true })).to.be
+        .true;
       expect(deviceModelStub.calledOnce).to.be.true;
       const bulkWriteArgs = deviceModelStub.firstCall.args[0];
       const updateOperation = bulkWriteArgs[0].updateOne.update;
@@ -157,7 +162,9 @@ describe("updateRawOnlineStatusJob", () => {
       // Default call for the cursor
       findStub.returns({
         select: () => ({
-          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+          lean: () => ({
+            batchSize: () => ({ setOptions: () => ({ cursor: () => cursor }) }),
+          }),
         }),
       });
 
@@ -191,7 +198,9 @@ describe("updateRawOnlineStatusJob", () => {
       // Default call for the cursor
       findStub.returns({
         select: () => ({
-          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+          lean: () => ({
+            batchSize: () => ({ setOptions: () => ({ cursor: () => cursor }) }),
+          }),
         }),
       });
 
@@ -221,7 +230,9 @@ describe("updateRawOnlineStatusJob", () => {
       });
       findStub.returns({
         select: () => ({
-          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+          lean: () => ({
+            batchSize: () => ({ setOptions: () => ({ cursor: () => cursor }) }),
+          }),
         }),
       });
 
@@ -262,7 +273,9 @@ describe("updateRawOnlineStatusJob", () => {
       });
       findStub.returns({
         select: () => ({
-          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+          lean: () => ({
+            batchSize: () => ({ setOptions: () => ({ cursor: () => cursor }) }),
+          }),
         }),
       });
 
@@ -300,7 +313,9 @@ describe("updateRawOnlineStatusJob", () => {
       });
       findStub.returns({
         select: () => ({
-          lean: () => ({ batchSize: () => ({ cursor: () => cursor }) }),
+          lean: () => ({
+            batchSize: () => ({ setOptions: () => ({ cursor: () => cursor }) }),
+          }),
         }),
       });
 

--- a/src/device-registry/bin/jobs/update-raw-online-status-job.js
+++ b/src/device-registry/bin/jobs/update-raw-online-status-job.js
@@ -1183,7 +1183,12 @@ const updateRawOnlineStatus = async () => {
     const countLog = totalDevices > 0 ? `~${totalDevices}` : "all";
     logText(`Found ${countLog} devices to process in batches of ${BATCH_SIZE}`);
 
-    // Use cursor with smaller memory footprint
+    // Use cursor with smaller memory footprint. noCursorTimeout is required
+    // because processing a single batch (ThingSpeak/external-API fetches at
+    // concurrency 5, each up to 30s) can exceed MongoDB's default idle-cursor
+    // timeout between getMore calls, which otherwise kills the cursor mid-run
+    // ("cursor id ... not found"). Safe here since the cursor is always
+    // closed in the finally block below regardless of how the loop exits.
     const cursor = DeviceModel("airqo")
       .find({})
       .select(
@@ -1191,6 +1196,7 @@ const updateRawOnlineStatus = async () => {
       )
       .lean()
       .batchSize(BATCH_SIZE) // Add batch size for cursor
+      .setOptions({ noCursorTimeout: true })
       .cursor();
 
     let batch = [];


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds `noCursorTimeout: true` to the device cursor used by `update-raw-online-status-job` so MongoDB doesn't expire it mid-run. The cursor is already unconditionally closed in the job's `finally` block, so this is safe.

### Why is this change needed?
Production and staging logs showed repeated `MongoError: cursor id ... not found` errors in `update-raw-online-status-job`. Root cause: the job opens a live cursor (`batchSize: 50`) and, between `getMore` calls, processes each batch of 50 devices (ThingSpeak/external-API fetches at concurrency 5, each with up to a 30s timeout). When enough devices in a batch are slow or timing out, that single batch can take longer than MongoDB's default idle-cursor timeout, so the next `getMore` fails and the job aborts partway through the fleet.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- device-registry (`bin/jobs/update-raw-online-status-job.js`)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Reviewed the job's cursor lifecycle to confirm `cursor.close()` still runs in every exit path (success, error, and early stop), so `noCursorTimeout` cannot leak an open cursor. Will monitor prod/staging logs post-deploy to confirm `cursor id ... not found` errors stop recurring.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This addresses the job-crash symptom only. The underlying alert of ~60% of devices not transmitting (from `network-status-check-job`) is a separate, device/connectivity-level issue and was not addressed by this change.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for long-running device status updates by preventing database cursors from timing out during batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->